### PR TITLE
place object file names each on a new line in Makefiles

### DIFF
--- a/tempesta_fw/Makefile
+++ b/tempesta_fw/Makefile
@@ -22,10 +22,32 @@ ifneq ($(NDEBUG), 1)
 EXTRA_CFLAGS += -DDEBUG -O0 -g3
 endif
 
-obj-m	= tempesta_fw.o
-tempesta_fw-objs = addr.o cache.o classifier.o client.o connection.o debugfs.o \
-		   filter.o gfsm.o  hash.o http.o http_match.o http_msg.o \
-		   http_parser.o if.o main.o pool.o sched.o server.o session.o \
-		   sock_backend.o sock_frontend.o stress.o str.o
+obj-m	= tempesta_fw.o 
+
+tempesta_fw-objs = \
+	addr.o \
+	cache.o \
+	classifier.o \
+	client.o \
+	connection.o \
+	debugfs.o \
+	filter.o \
+	gfsm.o \
+	hash.o \
+	http.o \
+	http_match.o \
+	http_msg.o \
+	http_parser.o \
+	if.o \
+	main.o \
+	pool.o \
+	sched.o \
+	server.o \
+	session.o \
+	sock_backend.o \
+	sock_frontend.o \
+	stress.o \
+	str.o \
+
 
 obj-m	+= log/ classifier/ stress/ sched/ filter/ t/

--- a/tempesta_fw/t/Makefile
+++ b/tempesta_fw/t/Makefile
@@ -20,5 +20,11 @@ EXTRA_CFLAGS += -Werror -O0 -g3 -DDEBUG -I$(src)/../ \
 		-I$(src)/../../tempesta_db -I$(src)/../../sync_socket
 
 obj-m += tfw_test.o
-tfw_test-objs = main.o test.o helpers.o test_hash.o test_http_match.o \
-		test_tfw_str.o test_http_parser.o
+tfw_test-objs = \
+	helpers.o \
+	main.o \
+	test.o \
+	test_hash.o \
+	test_http_match.o \
+	test_http_parser.o \
+	test_tfw_str.o \


### PR DESCRIPTION
That is done to avoid conflicts.
Often two parallel branches add new files to the build, so they have to
modify the same line in a Makefile. That causes a merge conflict.
This commit makes file names appear each on a new line, so the chance of
a conflict is reduced.
