### PR TITLE
#576: fix infinite loop on work queue push()

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -862,6 +862,11 @@ do_cache:
 	cpu = tfw_cache_sched_cpu(req);
 	ct = &per_cpu(cache_wq, cpu);
 
+	/*
+	 * TODO don't queue the cache work if we should process it on this
+	 * CPU: we can do everything right now.
+	 */
+
 	TFW_DBG2("Cache: schedule tasklet w/ work: to_cpu=%d from_cpu=%d"
 		 " req=%p resp=%p key=%lx\n", cpu, smp_processor_id(),
 		 cw.req, cw.resp, cw.key);

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -477,7 +477,7 @@ tfw_http_conn_cli_dropfree(TfwHttpMsg *hmreq)
 	BUG_ON(!(TFW_CONN_TYPE(hmreq->conn) & Conn_Clnt));
 
 	if (hmreq->flags & TFW_HTTP_CONN_CLOSE)
-		ss_close(hmreq->conn->sk);
+		ss_close_sync(hmreq->conn->sk, true);
 	tfw_http_conn_msg_free(hmreq);
 }
 

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -61,10 +61,9 @@ tfw_sock_cli_keepalive_timer_cb(unsigned long data)
 	/* Close socket asynchronously to avoid deadlock on del_timer_sync(). */
 	if (ss_close(conn->sk)) {
 		TfwCliConnection *cli_conn = (TfwCliConnection *)conn;
-		/* Try to close the connection bit later. */
+		/* Try to close the connection 1 second later. */
 		mod_timer(&cli_conn->ka_timer,
-			  jiffies + msecs_to_jiffies(tfw_cli_cfg_ka_timeout
-						     * 1000));
+			  jiffies + msecs_to_jiffies(1000));
 	}
 }
 
@@ -100,7 +99,7 @@ tfw_cli_conn_release(TfwConnection *conn)
 {
 	TfwCliConnection *cli_conn = (TfwCliConnection *)conn;
 
-	del_singleshot_timer_sync(&cli_conn->ka_timer);
+	del_timer_sync(&cli_conn->ka_timer);
 
 	if (likely(conn->sk))
 		tfw_connection_unlink_to_sk(conn);

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -21,7 +21,6 @@
  * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 #include <linux/net.h>
-#include <linux/kthread.h>
 #include <linux/wait.h>
 #include <linux/freezer.h>
 #include <net/inet_sock.h>

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -169,7 +169,6 @@ tfw_sock_srv_connect_try(TfwSrvConnection *srv_conn)
 	if (r) {
 		TFW_ERR("Unable to initiate a connect to server: %d\n", r);
 		ss_close_sync(sk);
-		tfw_connection_unlink_from_sk(sk);
 		return r;
 	}
 

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -68,6 +68,9 @@ ss_sock_live(struct sock *sk)
 	return sk->sk_state == TCP_ESTABLISHED;
 }
 
+#define ss_close(sk)			__ss_close(sk, false, true)
+#define ss_close_sync(sk, need_drop)	__ss_close(sk, true, need_drop)
+
 int ss_hooks_register(SsHooks* hooks);
 void ss_hooks_unregister(SsHooks* hooks);
 
@@ -76,8 +79,7 @@ void ss_proto_inherit(const SsProto *parent, SsProto *child, int child_type);
 void ss_set_callbacks(struct sock *sk);
 void ss_set_listen(struct sock *sk);
 int ss_send(struct sock *sk, SsSkbList *skb_list, bool pass_skb);
-int ss_close(struct sock *sk);
-void ss_close_sync(struct sock *sk);
+int __ss_close(struct sock *sk, bool sync, bool need_drop);
 int ss_sock_create(int family, int type, int protocol, struct sock **res);
 void ss_release(struct sock *sk);
 int ss_connect(struct sock *sk, struct sockaddr *addr, int addrlen, int flags);

--- a/tempesta_fw/t/sync_sockets/kernel/sync_kserver.c
+++ b/tempesta_fw/t/sync_sockets/kernel/sync_kserver.c
@@ -6,7 +6,7 @@
  * kworker threads.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2016 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -14,8 +14,8 @@
  * or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with
@@ -179,7 +179,7 @@ kserver_exit(void)
 
 	for (ci = 0; ci < atomic_read(&conn_i); ++ci)
 		if (conn[ci])
-			ss_close(conn[ci]);
+			ss_close_sync(conn[ci], true);
 
 	/*
 	 * FIXME at this point the module can crash if there is some active


### PR DESCRIPTION
Fix https://github.com/tempesta-tech/tempesta/issues/576#issuecomment-230177421: do not try to push() socket close work synchronously if current context is the work queue consumer