### PR TITLE
HttpMsg: fix raw header removal

### DIFF
--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -414,7 +414,7 @@ __hdr_del(TfwHttpMsg *hm, int hid)
 	} else {
 		if (hid < ht->off - 1)
 			memmove(&ht->tbl[hid], &ht->tbl[hid + 1],
-				ht->off - hid - 1);
+				(ht->off - hid - 1) * sizeof(TfwStr));
 		--ht->off;
 	}
 


### PR DESCRIPTION
Fix bug: removing RAW http header from `TfwHttpMsg` using `tfw_http_msg_hdr_xfrm()` function call cause memory corruption.