### PR TITLE
Ik dont cache hbh headers

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -147,8 +147,8 @@ enum {
  */
 static const int hbh_hdrs[] = {
 	[0 ... TFW_HTTP_HDR_RAW]	= 0,
-        [TFW_HTTP_HDR_SERVER]		= 1,
-	[TFW_HTTP_HDR_CONNECTION]	= 1,
+	[TFW_HTTP_HDR_SERVER]		= 1,
+	[TFW_HTTP_HDR_CONNECTION]	= !TFW_RM_HBH_HDRS_IN_SIRQ,
 	[TFW_HTTP_HDR_KEEP_ALIVE]	= 1,
 };
 

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -149,6 +149,7 @@ static const int hbh_hdrs[] = {
 	[0 ... TFW_HTTP_HDR_RAW]	= 0,
         [TFW_HTTP_HDR_SERVER]		= 1,
 	[TFW_HTTP_HDR_CONNECTION]	= 1,
+	[TFW_HTTP_HDR_KEEP_ALIVE]	= 1,
 };
 
 typedef struct {

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -62,6 +62,7 @@ int ghprio; /* GFSM hook priority. */
 #define S_H_CONN_KA		S_F_CONNECTION S_V_CONN_KA S_CRLFCRLF
 #define S_H_CONN_CLOSE		S_F_CONNECTION S_V_CONN_CLOSE S_CRLFCRLF
 
+#define TFW_CONN_HDR_MAX_SIZE	512
 /*
  * Prepare current date in the format required for HTTP "Date:"
  * header field. See RFC 2616 section 3.3.
@@ -672,6 +673,11 @@ tfw_http_rm_hbh_headers(TfwHttpMsg *hm, int conn_flg)
 
 	/* Connection header should not contain a lot of data */
 	len = conn_val.len;
+
+	/* Deny too big headers to prevent from memory exhaustion */
+	if (len >= TFW_CONN_HDR_MAX_SIZE)
+		return -EFBIG;
+
 	if (TFW_STR_PLAIN(&conn_val)) {
 		conn_val_cstr = conn_val.ptr;
 	}

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -610,7 +610,8 @@ tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, int conn_flg)
 
 	switch (conn_flg) {
 	case TFW_HTTP_CONN_CLOSE:
-		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive", TFW_HTTP_HDR_KEEP_ALIVE);
+		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive",
+					 TFW_HTTP_HDR_KEEP_ALIVE);
 		if (unlikely(r && r != -ENOENT)) {
 			TFW_WARN("Cannot delete Keep-Alive header (%d)\n", r);
 			return r;
@@ -646,11 +647,11 @@ tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, int conn_flg)
 static int
 tfw_http_rm_hbh_headers(TfwHttpMsg *hm, int conn_flg)
 {
-	int r;
+	int r = 0;
 	TfwStr conn_val;
 	char *conn_val_cstr, *pos;
 	size_t len;
-	char * w_pos = NULL;
+	char *w_pos = NULL;
 	size_t w_len = 0;
 	bool rm_hdr = false;
 
@@ -666,7 +667,7 @@ tfw_http_rm_hbh_headers(TfwHttpMsg *hm, int conn_flg)
 	__http_msg_hdr_val(&hm->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION],
 			   TFW_HTTP_HDR_CONNECTION,
 			   &conn_val,
-			   false /* unused */ );
+			   false /* unused */);
 
 	if (TFW_STR_EMPTY(&conn_val))
 		return 0;
@@ -689,10 +690,8 @@ tfw_http_rm_hbh_headers(TfwHttpMsg *hm, int conn_flg)
 		len = tfw_str_to_cstr(&conn_val, conn_val_cstr, (int)len+1);
 	}
 
-	for (pos = conn_val_cstr; pos <= conn_val_cstr + len; ++pos)
-	{
-		switch (*pos)
-		{
+	for (pos = conn_val_cstr; pos <= conn_val_cstr + len; ++pos) {
+		switch (*pos) {
 		case ' ':
 		case '\t':
 		case ',':
@@ -717,10 +716,10 @@ tfw_http_rm_hbh_headers(TfwHttpMsg *hm, int conn_flg)
 		if (rm_hdr && (w_pos != NULL)) {
 			rm_hdr = false;
 
-			if ((w_len != sizeof ("Keep-Alive") - 1)
+			if ((w_len != sizeof("Keep-Alive") - 1)
 			    || (*w_pos != 'k' && *w_pos != 'K')
 			    || strncasecmp(w_pos, "Keep-Alive",
-					   sizeof ("Keep-Alive") - 1)) {
+					   sizeof("Keep-Alive") - 1)) {
 				r = tfw_http_msg_hdr_xfrm(hm,
 							  w_pos, w_len,
 							  NULL, 0,

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -823,7 +823,7 @@ tfw_http_adjust_req(TfwHttpReq *req)
 		return r;
 
 	r = tfw_http_rm_hbh_headers(hm, TFW_HTTP_CONN_KA);
-	if (r < 0)
+	if (r)
 		return r;
 
 	return tfw_http_set_hdr_connection(hm, TFW_HTTP_CONN_KA);
@@ -841,15 +841,15 @@ tfw_http_adjust_resp(TfwHttpResp *resp, TfwHttpReq *req)
 	__init_resp_ss_flags(resp, req);
 
 	r = tfw_http_sess_resp_process(resp, req);
-	if (r < 0)
+	if (r)
 		return r;
 
 	r = tfw_http_rm_hbh_headers(hm, conn_flg);
-	if (r < 0)
+	if (r)
 		return r;
 
 	r = tfw_http_set_hdr_connection(hm, conn_flg);
-	if (r < 0)
+	if (r)
 		return r;
 
 	r = tfw_http_add_hdr_via(hm);
@@ -865,7 +865,7 @@ tfw_http_adjust_resp(TfwHttpResp *resp, TfwHttpReq *req)
 
 	if (!(resp->flags & TFW_HTTP_HAS_HDR_DATE)) {
 		r =  tfw_http_set_hdr_date(hm);
-		if (r < 0)
+		if (r)
 			return r;
 	}
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -597,7 +597,7 @@ tfw_http_set_hdr_connection(TfwHttpMsg *hm, int conn_flg)
 	}
 }
 
-/*
+/**
  * Add/Replace/Remove Keep-Alive header field to/from HTTP message.
  */
 static int
@@ -610,7 +610,7 @@ tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, int conn_flg)
 
 	switch (conn_flg) {
 	case TFW_HTTP_CONN_CLOSE:
-		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive", TFW_HTTP_HDR_RAW);
+		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive", TFW_HTTP_HDR_KEEP_ALIVE);
 		if (unlikely(r && r != -ENOENT)) {
 			TFW_WARN("Cannot delete Keep-Alive header (%d)\n", r);
 			return r;

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -411,4 +411,22 @@ int tfw_http_sess_obtain(TfwHttpReq *req);
 int tfw_http_sess_resp_process(TfwHttpResp *resp, TfwHttpReq *req);
 void tfw_http_sess_put(TfwHttpSess *sess);
 
+/**
+ * Hop-by-hop headers should be removed before message is cached but
+ * that can affect performance.
+ *
+ * Caching messages is done inside of SoftIRQs and removing hop-by-hop
+ * headers there can slow down packet processing. Serving requests
+ * from cache will have no need for removing hbh from responces.
+ *
+ * If we do not remove hbh headers before caching, then Connection header
+ * is also must be stored in cache. Parsing Connection header is the only
+ * way to remove hop-by-hop headers. For more information refer to
+ * RFC7230 Section-6.1
+ *
+ * TODO: Choose the right option according to performance testing:
+ * store unwanted headers in cache or burden SoftIRQ with exta tasks?
+*/
+#define TFW_RM_HBH_HDRS_IN_SIRQ 1
+
 #endif /* __TFW_HTTP_H__ */

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -197,6 +197,7 @@ typedef enum {
 
 	TFW_HTTP_HDR_CONNECTION = TFW_HTTP_HDR_NONSINGULAR,
 	TFW_HTTP_HDR_X_FORWARDED_FOR,
+	TFW_HTTP_HDR_KEEP_ALIVE,
 
 	/* Start of list of generic (raw) headers. */
 	TFW_HTTP_HDR_RAW,
@@ -278,7 +279,8 @@ typedef struct {
 	TfwConnection	*conn;						\
 	void (*destructor)(void *msg);					\
 	TfwStr		crlf;						\
-	TfwStr		body;
+	TfwStr		body;						\
+	unsigned int	keep_alive;
 
 /**
  * A helper structure for operations common for requests and responses.
@@ -337,7 +339,6 @@ typedef struct {
 	TFW_HTTP_MSG_COMMON;
 	TfwStr			s_line;
 	unsigned short		status;
-	unsigned int		keep_alive;
 	time_t			date;
 } TfwHttpResp;
 

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -155,10 +155,10 @@ __hdr_is_singular(const TfwStr *hdr)
  * an HTTP message. Duplicate of a singular header fields is a bug worth
  * blocking the whole HTTP message.
  */
-static int
+static unsigned int
 __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 {
-	int id;
+	unsigned int id;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 
 	for (id = TFW_HTTP_HDR_RAW; id < ht->off; ++id) {
@@ -199,7 +199,7 @@ tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start)
  * HTTP message headers list.
  */
 int
-tfw_http_msg_hdr_close(TfwHttpMsg *hm, int id)
+tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 {
 	TfwStr *h;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
@@ -334,7 +334,7 @@ tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm)
  * Add new header @hdr to the message @hm just before CRLF.
  */
 static int
-__hdr_add(TfwHttpMsg *hm, const TfwStr *hdr, int hid)
+__hdr_add(TfwHttpMsg *hm, const TfwStr *hdr, unsigned int hid)
 {
 	int r;
 	TfwStr it = {};
@@ -396,7 +396,7 @@ __hdr_expand(TfwHttpMsg *hm, TfwStr *orig_hdr, const TfwStr *hdr, bool append)
  * Delete header with identifier @hid from skb data and header table.
  */
 static int
-__hdr_del(TfwHttpMsg *hm, int hid)
+__hdr_del(TfwHttpMsg *hm, unsigned int hid)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *dup, *end, *hdr = &ht->tbl[hid];
@@ -433,7 +433,7 @@ __hdr_del(TfwHttpMsg *hm, int hid)
  */
 static int
 __hdr_sub(TfwHttpMsg *hm, char *name, size_t n_len, char *val, size_t v_len,
-	  int hid)
+	  unsigned int hid)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *dst, *tmp, *end, *orig_hdr = &ht->tbl[hid];
@@ -499,7 +499,7 @@ cleanup:
  */
 int
 tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
-		      char *val, size_t v_len, int hid, bool append)
+		      char *val, size_t v_len, unsigned int hid, bool append)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *orig_hdr;
@@ -568,7 +568,7 @@ tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 int
 tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr)
 {
-	int hid;
+	unsigned int hid;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 
 	hid = ht->off;

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -39,6 +39,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 		[TFW_HTTP_HDR_CONTENT_TYPE] = SLEN("Content-Type:"),
 		[TFW_HTTP_HDR_CONNECTION] = SLEN("Connection:"),
 		[TFW_HTTP_HDR_X_FORWARDED_FOR] = SLEN("X-Forwarded-For:"),
+		[TFW_HTTP_HDR_KEEP_ALIVE] = SLEN("Keep-Alive:"),
 		[TFW_HTTP_HDR_USER_AGENT] = SLEN("User-Agent:"),
 		[TFW_HTTP_HDR_SERVER]	= SLEN("Server:"),
 		[TFW_HTTP_HDR_COOKIE]	= SLEN("Cookie:"),

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -168,9 +168,12 @@ __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 			h = TFW_STR_CHUNK(h, 0);
 		if (tfw_stricmpspn(hdr, h, ':'))
 			continue;
+		break;
+	}
+
+	if (id <  ht->off) {
 		if (__hdr_is_singular(hdr))
 			hm->flags |= TFW_HTTP_FIELD_DUPENTRY;
-		break;
 	}
 
 	return id;

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -77,7 +77,7 @@ tfw_http_msg_hdr_chunk_fixup(TfwHttpMsg *hm, char *data, int len)
 
 int tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr);
 int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
-			  char *val, size_t v_len, int hid, bool append);
+			  char *val, size_t v_len, unsigned int hid, bool append);
 
 #define TFW_HTTP_MSG_HDR_XFRM(hm, name, val, hid, append)		\
 	tfw_http_msg_hdr_xfrm(hm, name, sizeof(name) - 1, val,		\
@@ -92,7 +92,7 @@ int tfw_http_msg_add_data(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,
 			  const TfwStr *data);
 
 void tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start);
-int tfw_http_msg_hdr_close(TfwHttpMsg *hm, int id);
+int tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id);
 int tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm);
 
 TfwHttpMsg *tfw_http_msg_alloc(int type);

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -367,7 +367,7 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 {
 	TfwHttpHdrTbl *ht;
 	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_te;
-	TfwStr h_connection, h_contlen, h_conttype, h_srv;
+	TfwStr h_connection, h_contlen, h_conttype, h_srv, h_ka;
 
 	/* Expected values for special headers. */
 	const char *s_connection = "Keep-Alive";
@@ -375,6 +375,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 	const char *s_ct = "text/html; charset=iso-8859-1";
 	const char *s_srv = "Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"
 			    " mod_fcgid/2.3.9";
+	const char *s_ka = "timeout=600, max=65526";
+
 	/* Expected values for raw headers. */
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
@@ -420,17 +422,19 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					&h_conttype);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_SERVER],
 					TFW_HTTP_HDR_SERVER, &h_srv);
+		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_KEEP_ALIVE],
+					TFW_HTTP_HDR_KEEP_ALIVE, &h_ka);
 
 		/*
 		 * Common (raw) headers: 10 dummies, Cache-Control,
-		 * Expires, Keep-Alive, Transfer-Encoding.
+		 * Expires, Transfer-Encoding.
 		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 14);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 13);
 
 		h_dummy4     = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
 		h_cc         = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
 		h_dummy9     = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
-		h_te         = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
+		h_te         = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
 
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_connection, s_connection,
 					    strlen(s_connection), 0));
@@ -440,6 +444,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					    strlen(s_ct), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_srv, s_srv,
 					    strlen(s_srv), 0));
+		EXPECT_TRUE(tfw_str_eq_cstr(&h_ka, s_ka,
+					    strlen(s_ka), 0));
 
 		EXPECT_TRUE(tfw_str_eq_cstr(h_dummy4, s_dummy4,
 					    strlen(s_dummy4), 0));

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -128,7 +128,7 @@ module_exit(ttls_exit);
 
 MODULE_AUTHOR("Tempesta Technologies");
 MODULE_VERSION("2.3.0");
-MODULE_LICENSE("GPLv2");
+MODULE_LICENSE("GPL v2");
 
 /*
  * ------------------------------------------------------------------------


### PR DESCRIPTION
Fix issue #409

Notes about unit tests:
- `test_http_parser.c: parses_req_uri` Requests like "GET http://natsys-lab.com/* HTTP/1.1\r\n\r\n" causes crashes. Same Behaviour on master branch
- `test_http_parser.c:  fills_hdr_tbl_for_resp` gives 137 assertions on `tfw_str_eq_cstr()` for keep-alive header. Actually the same situation on master, but keep-alive header is not checked on master. Do not know the reason, going to work on in during my next assignment.
