### PR TITLE
Performance optimization

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1088,6 +1088,15 @@ tfw_cache_build_resp_body(TDB *db, TfwHttpResp *resp, TdbVRec *trec,
  * (copy the list of skbs is faster than scan TDB and build TfwHttpResp).
  * TLS should encrypt the data in already prepared skbs.
  *
+ * Basically, skb copy/clonning involves skb creation, so it seems performance
+ * of response body creation won't change since now we just reuse TDB pages.
+ * Perfromace benchmarks and profiling shows that cache_req_process_node()
+ * is the bottleneck, so the problem is either in tfw_cache_dbce_get() or this
+ * function, in headers compilation.
+ * Also it seems cachig prebuilt responses requires introducing
+ * TfwCacheEntry->resp pointer to avoid additional indexing data structure.
+ * However, the pointer must be zeroed on TDB shutdown and recovery.
+ *
  * TODO use iterator and passed skbs to be called from net_tx_action.
  */
 static TfwHttpResp *

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -1119,12 +1119,6 @@ ss_tx_action(void)
 	while (!tfw_wq_pop(this_cpu_ptr(&si_wq), &sw)) {
 		struct sock *sk = sw.sk;
 
-		if (unlikely(spin_is_locked(&sk->sk_lock.slock)))
-			SS_WARN("Socket is used by two cpus, action=%d"
-				" state=%d sk_cpu=%d curr_cpu=%d\n",
-				sw.action, sk->sk_state,
-				sk->sk_incoming_cpu, smp_processor_id());
-
 		bh_lock_sock(sk);
 		switch (sw.action) {
 		case SS_SEND:


### PR DESCRIPTION
Do not queue cache work for local CPU: 25% better performance on single connection and now we have almost linear scalability on 2K-32K connections; also remove old debug prints