### PR TITLE
Don't cache and don't forward hop-by-hop headers

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -131,27 +131,6 @@ enum {
 	TFW_CACHE_REPLICA,
 };
 
-/*
- * Non-cacheable hop-by-hop response headers in terms of RFC 2068.
- * The table is used if server doesn't specify Cache-Control no-cache
- * directive (RFC 7234 5.2.2.2) explicitly.
- *
- * Server header isn't defined as hop-by-hop by the RFC, but we don't show
- * protected server to world.
- *
- * We don't store the headers in cache and create then from scratch.
- * Adding a header is faster then modify it, so this speeds up headers
- * adjusting as well as saves cache storage.
- *
- * TODO process Cache-Control no-cache
- */
-static const int hbh_hdrs[] = {
-	[0 ... TFW_HTTP_HDR_RAW]	= 0,
-	[TFW_HTTP_HDR_SERVER]		= 1,
-	[TFW_HTTP_HDR_CONNECTION]	= 1,
-	[TFW_HTTP_HDR_KEEP_ALIVE]	= 1,
-};
-
 typedef struct {
 	int		cpu[NR_CPUS];
 	atomic_t	cpu_idx;
@@ -719,7 +698,7 @@ tfw_cache_copy_hdr(char **p, TdbVRec **trec, TfwStr *src, size_t *tot_len)
  */
 static int
 tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwHttpReq *req,
-		    size_t tot_len, const unsigned int * const hbh_hdrs_raw)
+		    size_t tot_len)
 {
 	long n;
 	char *p;
@@ -758,10 +737,7 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwHttpReq *req,
 	FOR_EACH_HDR_FIELD(field, end1, resp) {
 		n = field - resp->h_tbl->tbl;
 		/* Skip hop-by-hop headers. */
-		h = (n < TFW_HTTP_HDR_RAW && hbh_hdrs[n]) ? &empty : field;
-		if (n >= TFW_HTTP_HDR_RAW && hbh_hdrs_raw
-		    && hbh_hdrs_raw[n-TFW_HTTP_HDR_RAW])
-			h = &empty;
+		h = (field->flags & TFW_STR_HBH_HDR) ? &empty : field;
 		n = tfw_cache_copy_hdr(&p, &trec, h, &tot_len);
 		if (n < 0) {
 			TFW_ERR("Cache: cannot copy HTTP header\n");
@@ -802,8 +778,7 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwHttpReq *req,
 }
 
 static size_t
-__cache_entry_size(TfwHttpResp *resp, TfwHttpReq *req,
-		   const unsigned int * const hbh_hdrs_raw)
+__cache_entry_size(TfwHttpResp *resp, TfwHttpReq *req)
 {
 	long n;
 	size_t size = CE_BODY_SIZE;
@@ -813,16 +788,11 @@ __cache_entry_size(TfwHttpResp *resp, TfwHttpReq *req,
 	size += req->uri_path.len;
 	size += req->h_tbl->tbl[TFW_HTTP_HDR_HOST].len;
 
-
 	/* Add all the headers size */
 	FOR_EACH_HDR_FIELD(hdr, hdr_end, resp) {
 		/* Skip hop-by-hop headers. */
 		n = hdr - resp->h_tbl->tbl;
-
-		h = (n < TFW_HTTP_HDR_RAW && hbh_hdrs[n]) ? &empty : hdr;
-		if (n >= TFW_HTTP_HDR_RAW && hbh_hdrs_raw
-		    && hbh_hdrs_raw[n-TFW_HTTP_HDR_RAW])
-			h = &empty;
+		h = (hdr->flags & TFW_STR_HBH_HDR) ? &empty : hdr;
 
 		if (!TFW_STR_DUP(h)) {
 			size += sizeof(TfwCStr);
@@ -849,10 +819,10 @@ __cache_entry_size(TfwHttpResp *resp, TfwHttpReq *req,
 
 static void
 __cache_add_node(TDB *db, TfwHttpResp *resp, TfwHttpReq *req,
-		 unsigned long key, const unsigned int * const hbh_hdrs_raw)
+		 unsigned long key)
 {
 	TfwCacheEntry *ce, cdata = {{}};
-	size_t data_len = __cache_entry_size(resp, req, hbh_hdrs_raw);
+	size_t data_len = __cache_entry_size(resp, req);
 	size_t len = data_len;
 
 	/*
@@ -868,7 +838,7 @@ __cache_add_node(TDB *db, TfwHttpResp *resp, TfwHttpReq *req,
 	TFW_DBG3("cache db=%p resp=%p/req=%p/ce=%p: alloc_len=%lu\n",
 		 db, resp, req, ce, len);
 
-	if (tfw_cache_copy_resp(ce, resp, req, data_len, hbh_hdrs_raw)) {
+	if (tfw_cache_copy_resp(ce, resp, req, data_len)) {
 		/* TODO delete the probably partially built TDB entry. */
 	}
 
@@ -879,28 +849,18 @@ tfw_cache_add(TfwHttpResp *resp, TfwHttpReq *req, tfw_http_cache_cb_t action)
 {
 	unsigned long key;
 	bool keep_skb = false;
-	unsigned int *hbh_hds_raw = NULL;
 
 	if (!cache_cfg.cache || !tfw_cache_msg_cacheable(req))
 		goto out;
 	if (!tfw_cache_employ_resp(req, resp))
 		goto out;
 
-	if (resp->flags & TFW_HTTP_CONN_EXTRA) {
-		/* Fill hop-by-hop identifiers for RAW headers */
-		hbh_hds_raw = kcalloc(resp->h_tbl->off - TFW_HTTP_HDR_RAW,
-				      sizeof(unsigned int), GFP_ATOMIC);
-		if (hbh_hds_raw)
-			tfw_http_find_hbh_hdrs((TfwHttpMsg *)resp, hbh_hds_raw);
-		else
-			goto out;
-	}
-
+	tfw_http_msg_mark_hbh_hdrs((TfwHttpMsg *)resp);
 	key = tfw_http_req_key_calc(req);
 
 	if (cache_cfg.cache == TFW_CACHE_SHARD) {
 		BUG_ON(req->node != numa_node_id());
-		__cache_add_node(node_db(), resp, req, key, hbh_hds_raw);
+		__cache_add_node(node_db(), resp, req, key);
 	} else {
 		int nid;
 		/*
@@ -908,8 +868,7 @@ tfw_cache_add(TfwHttpResp *resp, TfwHttpReq *req, tfw_http_cache_cb_t action)
 		 * rather than in softirq...
 		 */
 		for_each_node_with_cpus(nid)
-			__cache_add_node(c_nodes[nid].db, resp, req, key,
-					 hbh_hds_raw);
+			__cache_add_node(c_nodes[nid].db, resp, req, key);
 	}
 
 	/*
@@ -919,8 +878,6 @@ tfw_cache_add(TfwHttpResp *resp, TfwHttpReq *req, tfw_http_cache_cb_t action)
 	 */
 
 out:
-	if (hbh_hds_raw)
-		kfree(hbh_hds_raw);
 	((TfwMsg *)resp)->ss_flags |= keep_skb ? SS_F_KEEP_SKB : 0;
 	action(req, resp);
 }

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -147,8 +147,9 @@ enum {
  */
 static const int hbh_hdrs[] = {
 	[0 ... TFW_HTTP_HDR_RAW]	= 0,
-        [TFW_HTTP_HDR_SERVER]		= 1,
+	[TFW_HTTP_HDR_SERVER]		= 1,
 	[TFW_HTTP_HDR_CONNECTION]	= 1,
+	[TFW_HTTP_HDR_KEEP_ALIVE]	= 1,
 };
 
 typedef struct {

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -600,7 +600,7 @@ tfw_http_set_hdr_connection(TfwHttpMsg *hm, int conn_flg)
 	}
 }
 
-/*
+/**
  * Add/Replace/Remove Keep-Alive header field to/from HTTP message.
  */
 static int
@@ -613,7 +613,7 @@ tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, int conn_flg)
 
 	switch (conn_flg) {
 	case TFW_HTTP_CONN_CLOSE:
-		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive", TFW_HTTP_HDR_RAW);
+		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive", TFW_HTTP_HDR_KEEP_ALIVE);
 		if (unlikely(r && r != -ENOENT)) {
 			TFW_WARN("Cannot delete Keep-Alive header (%d)\n", r);
 			return r;

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -713,15 +713,15 @@ tfw_http_adjust_req(TfwHttpReq *req)
 	__init_req_ss_flags(req);
 
 	r = tfw_http_add_x_forwarded_for(hm);
-	if (unlikely(r))
+	if (r)
 		return r;
 
 	r = tfw_http_add_hdr_via(hm);
-	if (unlikely(r))
+	if (r)
 		return r;
 
 	r = tfw_http_msg_rm_hbh_hdrs(hm);
-	if (unlikely(r))
+	if (r)
 		return r;
 
 	return tfw_http_set_hdr_connection(hm, TFW_HTTP_CONN_KA);
@@ -739,19 +739,19 @@ tfw_http_adjust_resp(TfwHttpResp *resp, TfwHttpReq *req)
 	__init_resp_ss_flags(resp, req);
 
 	r = tfw_http_sess_resp_process(resp, req);
-	if (unlikely(r))
+	if (r)
 		return r;
 
 	r = tfw_http_set_hdr_keep_alive(hm, conn_flg);
-	if (unlikely(r))
+	if (r)
 		return r;
 
 	r = tfw_http_msg_rm_hbh_hdrs(hm);
-	if (unlikely(r))
+	if (r)
 		return r;
 
 	r = tfw_http_set_hdr_connection(hm, conn_flg);
-	if (unlikely(r))
+	if (r)
 		return r;
 
 	r = tfw_http_add_hdr_via(hm);
@@ -760,14 +760,14 @@ tfw_http_adjust_resp(TfwHttpResp *resp, TfwHttpReq *req)
 		/* TODO: ajust for #215 */
 		TfwStr wh = {.ptr = S_WARN_110, .len = SLEN(S_WARN_110),.eolen = 2};
 		r = tfw_http_msg_hdr_add(hm, &wh);
-		if (unlikely(r))
+		if (r)
 			return r;
 #undef S_WARN_110
 	}
 
 	if (!(resp->flags & TFW_HTTP_HAS_HDR_DATE)) {
 		r =  tfw_http_set_hdr_date(hm);
-		if (unlikely(r))
+		if (r)
 			return r;
 	}
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -720,7 +720,7 @@ tfw_http_adjust_req(TfwHttpReq *req)
 	if (unlikely(r))
 		return r;
 
-	r = tfw_http_rm_hbh_hdrs(hm);
+	r = tfw_http_msg_rm_hbh_hdrs(hm);
 	if (unlikely(r))
 		return r;
 
@@ -746,7 +746,7 @@ tfw_http_adjust_resp(TfwHttpResp *resp, TfwHttpReq *req)
 	if (unlikely(r))
 		return r;
 
-	r = tfw_http_rm_hbh_hdrs(hm);
+	r = tfw_http_msg_rm_hbh_hdrs(hm);
 	if (unlikely(r))
 		return r;
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -583,7 +583,8 @@ tfw_http_set_hdr_date(TfwHttpMsg *hm)
 static int
 tfw_http_set_hdr_connection(TfwHttpMsg *hm, int conn_flg)
 {
-	if (((hm->flags & __TFW_HTTP_CONN_MASK) == conn_flg)
+	if (!(hm->flags & TFW_HTTP_CONN_EXTRA)
+	    && ((hm->flags & __TFW_HTTP_CONN_MASK) == conn_flg)
 	    && (!TFW_STR_EMPTY(&hm->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION])))
 		return 0;
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -742,11 +742,11 @@ tfw_http_adjust_resp(TfwHttpResp *resp, TfwHttpReq *req)
 	if (r)
 		return r;
 
-	r = tfw_http_set_hdr_keep_alive(hm, conn_flg);
+	r = tfw_http_msg_rm_hbh_hdrs(hm);
 	if (r)
 		return r;
 
-	r = tfw_http_msg_rm_hbh_hdrs(hm);
+	r = tfw_http_set_hdr_keep_alive(hm, conn_flg);
 	if (r)
 		return r;
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -197,6 +197,7 @@ typedef enum {
 
 	TFW_HTTP_HDR_CONNECTION = TFW_HTTP_HDR_NONSINGULAR,
 	TFW_HTTP_HDR_X_FORWARDED_FOR,
+	TFW_HTTP_HDR_KEEP_ALIVE,
 
 	/* Start of list of generic (raw) headers. */
 	TFW_HTTP_HDR_RAW,
@@ -278,7 +279,8 @@ typedef struct {
 	TfwConnection	*conn;						\
 	void (*destructor)(void *msg);					\
 	TfwStr		crlf;						\
-	TfwStr		body;
+	TfwStr		body;						\
+	unsigned int	keep_alive;
 
 /**
  * A helper structure for operations common for requests and responses.
@@ -337,7 +339,6 @@ typedef struct {
 	TFW_HTTP_MSG_COMMON;
 	TfwStr			s_line;
 	unsigned short		status;
-	unsigned int		keep_alive;
 	time_t			date;
 } TfwHttpResp;
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -220,7 +220,8 @@ typedef struct {
 #define TFW_HTTP_CONN_CLOSE		0x000001
 #define TFW_HTTP_CONN_KA		0x000002
 #define __TFW_HTTP_CONN_MASK		(TFW_HTTP_CONN_CLOSE | TFW_HTTP_CONN_KA)
-#define TFW_HTTP_CHUNKED		0x000004
+#define TFW_HTTP_CONN_EXTRA		0x000004 /* Hop-by-hop headers are set */
+#define TFW_HTTP_CHUNKED		0x000008
 
 /* Request flags */
 #define TFW_HTTP_HAS_STICKY		0x000100

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -39,6 +39,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 		[TFW_HTTP_HDR_CONTENT_TYPE] = SLEN("Content-Type:"),
 		[TFW_HTTP_HDR_CONNECTION] = SLEN("Connection:"),
 		[TFW_HTTP_HDR_X_FORWARDED_FOR] = SLEN("X-Forwarded-For:"),
+		[TFW_HTTP_HDR_KEEP_ALIVE] = SLEN("Keep-Alive:"),
 		[TFW_HTTP_HDR_USER_AGENT] = SLEN("User-Agent:"),
 		[TFW_HTTP_HDR_SERVER]	= SLEN("Server:"),
 		[TFW_HTTP_HDR_COOKIE]	= SLEN("Cookie:"),

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -155,10 +155,10 @@ __hdr_is_singular(const TfwStr *hdr)
  * an HTTP message. Duplicate of a singular header fields is a bug worth
  * blocking the whole HTTP message.
  */
-static int
+static unsigned int
 __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 {
-	int id;
+	unsigned int id;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 
 	for (id = TFW_HTTP_HDR_RAW; id < ht->off; ++id) {
@@ -200,7 +200,7 @@ tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start)
  * HTTP message headers list.
  */
 int
-tfw_http_msg_hdr_close(TfwHttpMsg *hm, int id)
+tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 {
 	TfwStr *h;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
@@ -344,7 +344,7 @@ tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm)
  * Add new header @hdr to the message @hm just before CRLF.
  */
 static int
-__hdr_add(TfwHttpMsg *hm, const TfwStr *hdr, int hid)
+__hdr_add(TfwHttpMsg *hm, const TfwStr *hdr, unsigned int hid)
 {
 	int r;
 	TfwStr it = {};
@@ -406,7 +406,7 @@ __hdr_expand(TfwHttpMsg *hm, TfwStr *orig_hdr, const TfwStr *hdr, bool append)
  * Delete header with identifier @hid from skb data and header table.
  */
 static int
-__hdr_del(TfwHttpMsg *hm, int hid)
+__hdr_del(TfwHttpMsg *hm, unsigned int hid)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *dup, *end, *hdr = &ht->tbl[hid];
@@ -443,7 +443,7 @@ __hdr_del(TfwHttpMsg *hm, int hid)
  */
 static int
 __hdr_sub(TfwHttpMsg *hm, char *name, size_t n_len, char *val, size_t v_len,
-	  int hid)
+	  unsigned int hid)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *dst, *tmp, *end, *orig_hdr = &ht->tbl[hid];
@@ -509,7 +509,7 @@ cleanup:
  */
 int
 tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
-		      char *val, size_t v_len, int hid, bool append)
+		      char *val, size_t v_len, unsigned int hid, bool append)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *orig_hdr;
@@ -578,7 +578,7 @@ tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 int
 tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr)
 {
-	int hid;
+	unsigned int hid;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 
 	hid = ht->off;

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -918,6 +918,13 @@ int tfw_http_msg_rm_hbh_hdrs(TfwHttpMsg *hm)
 
 	/* Removing must be from end to beginning */
 	for (i = hm->h_tbl->off -1; i >= 0; --i) {
+		/*
+		 * Don't remove keep-alive header:
+		 * @tfw_http_set_hdr_keep_alive will remove it if necessary
+		 */
+		if (i == TFW_HTTP_HDR_KEEP_ALIVE)
+			continue;
+
 		if (hm->h_tbl->tbl[i].flags & TFW_STR_HBH_HDR) {
 			r = __hdr_del(hm, i);
 			if (unlikely(r))

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -168,9 +168,12 @@ __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 			h = TFW_STR_CHUNK(h, 0);
 		if (tfw_stricmpspn(hdr, h, ':'))
 			continue;
+		break;
+	}
+
+	if (id <  ht->off) {
 		if (__hdr_is_singular(hdr))
 			hm->flags |= TFW_HTTP_FIELD_DUPENTRY;
-		break;
 	}
 
 	return id;

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -86,7 +86,7 @@ int tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm);
 TfwHttpMsg *tfw_http_msg_alloc(int type);
 void tfw_http_msg_free(TfwHttpMsg *m);
 
-int tfw_http_rm_hbh_hdrs(TfwHttpMsg *hm);
-int tfw_http_find_hbh_hdrs(TfwHttpMsg *hm, unsigned int *idxs);
+void tfw_http_msg_mark_hbh_hdrs(TfwHttpMsg *hm);
+int tfw_http_msg_rm_hbh_hdrs(TfwHttpMsg *hm);
 
 #endif /* __TFW_HTTP_MSG_H__ */

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -65,7 +65,7 @@ int __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str, void *data,
 
 int tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr);
 int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
-			  char *val, size_t v_len, int hid, bool append);
+			  char *val, size_t v_len, unsigned int hid, bool append);
 
 #define TFW_HTTP_MSG_HDR_XFRM(hm, name, val, hid, append)		\
 	tfw_http_msg_hdr_xfrm(hm, name, sizeof(name) - 1, val,		\
@@ -80,7 +80,7 @@ int tfw_http_msg_add_data(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,
 			  const TfwStr *data);
 
 void tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start);
-int tfw_http_msg_hdr_close(TfwHttpMsg *hm, int id);
+int tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id);
 int tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm);
 
 TfwHttpMsg *tfw_http_msg_alloc(int type);

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -87,5 +87,6 @@ TfwHttpMsg *tfw_http_msg_alloc(int type);
 void tfw_http_msg_free(TfwHttpMsg *m);
 
 int tfw_http_rm_hbh_hdrs(TfwHttpMsg *hm);
+int tfw_http_find_hbh_hdrs(TfwHttpMsg *hm, unsigned int *idxs);
 
 #endif /* __TFW_HTTP_MSG_H__ */

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -86,4 +86,6 @@ int tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm);
 TfwHttpMsg *tfw_http_msg_alloc(int type);
 void tfw_http_msg_free(TfwHttpMsg *m);
 
+int tfw_http_rm_hbh_hdrs(TfwHttpMsg *hm);
+
 #endif /* __TFW_HTTP_MSG_H__ */

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -508,7 +508,7 @@ enum {
 			TRY_STR_INIT();					\
 			__FSM_I_MOVE_fixup(state, __fsm_n, 0);		\
 		}							\
-		tfw_http_msg_hdr_chunk_fixup(msg, data, len);		\
+		__msg_hdr_chunk_fixup(data, len);			\
 		return CSTR_POSTPONE;					\
 	}
 
@@ -935,7 +935,7 @@ __parse_connection(TfwHttpMsg *hm, unsigned char *data, size_t len)
 			__FSM_I_MOVE_fixup(I_EoT, __fsm_sz, TFW_STR_VALUE);
 		if (IS_CRLF(c)) {
 			if (likely(__fsm_sz)) {
-				tfw_http_msg_hdr_chunk_fixup(msg, p, __fsm_sz);
+				__msg_hdr_chunk_fixup(p, __fsm_sz);
 				__FSM_I_chunk_flags(TFW_STR_VALUE);
 			}
 			return __data_off(p + __fsm_sz);

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -318,6 +318,67 @@ tfw_stricmpspn(const TfwStr *s1, const TfwStr *s2, int stop)
 EXPORT_SYMBOL(tfw_stricmpspn);
 
 /**
+ * Generic function for comparing first @len symbols in TfwStrs.
+ * @s1,@s2 may be either plain or compound, but must be longer than @len symbols
+ * Do not use it for duplicate strings, rather call it for each duplicate
+ * substring separately.
+ *
+ * @return true if the strings are equal and false otherwise.
+ */
+bool tfw_str_eq(const TfwStr *s1, const TfwStr *s2, unsigned long len)
+{
+	unsigned int i1, i2;
+	const TfwStr *c1, *c2;
+	unsigned long n, off1, off2;
+
+	BUG_ON(s1->len && !s1->ptr);
+	BUG_ON(s2->len && !s2->ptr);
+	BUG_ON((s1->flags | s2->flags) & TFW_STR_DUPLICATE);
+
+	if (!len)
+		return true;
+
+	if ((s1->len < len) || (s2->len < len)) {
+		return false;
+	}
+
+	i1 = i2 = 0;
+	off1 = off2 = 0;
+	n = min(s1->len, s2->len);
+	c1 = TFW_STR_CHUNK(s1, 0);
+	c2 = TFW_STR_CHUNK(s2, 0);
+
+	while (n) {
+		int r;
+		unsigned long cn = min(c1->len - off1, c2->len - off2);
+
+		r = tfw_stricmp((char *)c1->ptr + off1,
+				(char *)c2->ptr + off2, cn);
+		if (r)
+			return false;
+
+		n -= cn;
+		if (cn == c1->len - off1) {
+			off1 = 0;
+			++i1;
+			c1 = TFW_STR_CHUNK(s1, i1);
+		} else {
+			off1 += cn;
+		}
+		if (cn == c2->len - off2) {
+			off2 = 0;
+			++i2;
+			c2 = TFW_STR_CHUNK(s2, i2);
+		} else {
+			off2 += cn;
+		}
+		BUG_ON(n && (!c1 || !c2));
+	}
+	return true;
+}
+EXPORT_SYMBOL(tfw_str_eq);
+
+/**
  * Generic function for comparing TfwStr and C strings.
  *
  * @str may be either plain or compound.
@@ -509,6 +570,27 @@ tfw_str_to_cstr(const TfwStr *str, char *out_buf, int buf_size)
 	return (pos - out_buf);
 }
 EXPORT_SYMBOL(tfw_str_to_cstr);
+
+/**
+ * Returns symbol at position @idx. If @idx overflows string borders, return 0
+ */
+char tfw_str_at_index(const TfwStr *str, unsigned long idx)
+{
+	const TfwStr *chunk, *end;
+
+	if (idx > str->len)
+		return 0;
+
+	TFW_STR_FOR_EACH_CHUNK(chunk, str, end) {
+		if (idx > chunk->len)
+			idx -= chunk->len;
+		else
+			return ((char *)chunk->ptr)[idx];
+	}
+	return 0;
+}
+EXPORT_SYMBOL(tfw_str_at_index);
+
 
 #ifdef DEBUG
 void

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -344,6 +344,7 @@ int tfw_strcpy(TfwStr *dst, const TfwStr *src);
 int tfw_strcat(TfwPool *pool, TfwStr *dst, TfwStr *src);
 
 int tfw_stricmpspn(const TfwStr *s1, const TfwStr *s2, int stop);
+bool tfw_str_eq(const TfwStr *s1, const TfwStr *s2, unsigned long len);
 bool tfw_str_eq_cstr(const TfwStr *str, const char *cstr, int cstr_len,
                      tfw_str_eq_flags_t flags);
 bool tfw_str_eq_cstr_pos(const TfwStr *str, const char *pos, const char *cstr,
@@ -352,6 +353,8 @@ bool tfw_str_eq_cstr_off(const TfwStr *str, ssize_t offset, const char *cstr,
 			 int cstr_len, tfw_str_eq_flags_t flags);
 
 size_t tfw_str_to_cstr(const TfwStr *str, char *out_buf, int buf_size);
+
+char tfw_str_at_index(const TfwStr *str, unsigned long idx);
 
 #ifdef DEBUG
 void tfw_str_dprint(TfwStr *str, const char *msg);

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -173,6 +173,8 @@ tfw_stricmp_2lc(const char *s1, const char *s2, size_t len)
 #define TFW_STR_NAME		0x04
 /* Some value starts at the string chunk. */
 #define TFW_STR_VALUE		0x08
+/* The string represents hop-by-hop header. */
+#define TFW_STR_HBH_HDR		0x10
 
 /*
  * @ptr		- pointer to string data or array of nested strings;

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -459,9 +459,8 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 TEST(http_parser, fills_hdr_tbl_for_resp)
 {
 	TfwHttpHdrTbl *ht;
-	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_te, *h_age, *h_date, *h_exp,
-	       *h_ka;
-	TfwStr h_connection, h_contlen, h_conttype, h_srv;
+	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_te, *h_age, *h_date, *h_exp;
+	TfwStr h_connection, h_contlen, h_conttype, h_srv, h_ka;
 
 	/* Expected values for special headers. */
 	const char *s_connection = "Keep-Alive";
@@ -476,7 +475,7 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 			   "max-age=5, private, no-cache, ext=foo";
 	const char *s_te = "Transfer-Encoding: compress, deflate, gzip";
 	const char *s_exp = "Expires: Tue, 31 Jan 2012 15:02:53 GMT";
-	const char *s_ka = "Keep-Alive: timeout=600, max=65526";
+	const char *s_ka = "timeout=600, max=65526";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_age = "Age: 12  ";
 	const char *s_date = "Date: Sun, 9 Sep 2001 01:46:40 GMT\t";
@@ -523,21 +522,22 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					&h_conttype);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_SERVER],
 					TFW_HTTP_HDR_SERVER, &h_srv);
+		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_KEEP_ALIVE],
+					TFW_HTTP_HDR_KEEP_ALIVE, &h_ka);
 
 		/*
 		 * Common (raw) headers: 10 dummies, Cache-Control,
-		 * Expires, Keep-Alive, Transfer-Encoding, Age, Date.
+		 * Expires, Transfer-Encoding, Age, Date.
 		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 15);
 
 		h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
 		h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
 		h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
 		h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
-		h_ka = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
-		h_te = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
-		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
-		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 15];
+		h_te = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
+		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
+		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
 
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_connection, s_connection,
 					    strlen(s_connection), 0));
@@ -547,6 +547,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					    strlen(s_ct), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_srv, s_srv,
 					    strlen(s_srv), 0));
+		EXPECT_TRUE(tfw_str_eq_cstr(&h_ka, s_ka,
+					    strlen(s_ka), 0));
 
 		EXPECT_TRUE(tfw_str_eq_cstr(h_dummy4, s_dummy4,
 					    strlen(s_dummy4), 0));
@@ -556,8 +558,6 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					    strlen(s_dummy9), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_exp, s_exp,
 					    strlen(s_exp), 0));
-		EXPECT_TRUE(tfw_str_eq_cstr(h_ka, s_ka,
-					    strlen(s_ka), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_te, s_te,
 					    strlen(s_te), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_age, s_age,

--- a/tempesta_fw/t/unit/test_tfw_str.c
+++ b/tempesta_fw/t/unit/test_tfw_str.c
@@ -450,6 +450,62 @@ TEST(tfw_stricmpspn, handles_different_size_strs)
 	EXPECT_ZERO(tfw_stricmpspn(&s1, &s2, 'r'));
 }
 
+TEST(tfw_str_eq, returns_true_only_for_equal_plain_strs)
+{
+	TFW_STR(str, "foo123 barbaz");
+
+	TFW_STR(match, "foo123 barbaz");
+	TFW_STR(diff1, "aoo123 barbaz");
+	TFW_STR(diff2, "foo123 barbaa");
+	TFW_STR(crop,  "foo123 barba");
+	TFW_STR(extra, "foo123 barbazz");
+	TFW_STR(casei, "Foo123 barbaz");
+
+	EXPECT_TRUE(tfw_str_eq(match, str, str->len));
+	EXPECT_FALSE(tfw_str_eq(diff1, str, str->len));
+	EXPECT_FALSE(tfw_str_eq(diff2, str, str->len));
+	EXPECT_FALSE(tfw_str_eq(crop,  str, str->len));
+	EXPECT_TRUE(tfw_str_eq(extra, str, str->len));
+	EXPECT_TRUE(tfw_str_eq(casei, str, str->len));
+}
+
+TEST(tfw_str_eq, returns_true_only_for_equal_compound_strs)
+{
+	TfwStr *str = make_compound_str("foo123 barbaz");
+
+	TfwStr *match = make_compound_str("foo123 barbaz");
+	TfwStr *diff1 = make_compound_str("aoo123 barbaz");
+	TfwStr *diff2 = make_compound_str("foo123 barbaa");
+	TfwStr *crop = make_compound_str( "foo123 barba");
+	TfwStr *extra = make_compound_str("foo123 barbazz");
+	TfwStr *casei = make_compound_str("Foo123 barbaz");
+
+	EXPECT_TRUE(tfw_str_eq(match, str, str->len));
+	EXPECT_FALSE(tfw_str_eq(diff1, str, str->len));
+	EXPECT_FALSE(tfw_str_eq(diff2, str, str->len));
+	EXPECT_FALSE(tfw_str_eq(crop,  str, str->len));
+	EXPECT_TRUE(tfw_str_eq(extra, str, str->len));
+	EXPECT_TRUE(tfw_str_eq(casei, str, str->len));
+}
+
+TEST(tfw_str_eq, handles_empty_strs)
+{
+	TfwStr s1 = {
+		.len	= 0,
+		.ptr	= "garbage"
+	};
+	TfwStr s2 = {
+		.len	= 0,
+		.ptr	= "trash"
+	};
+	TFW_STR(s3, "abcdefghijklmnopqrst");
+
+	EXPECT_TRUE(tfw_str_eq(&s1, &s2, 0));
+	EXPECT_FALSE(tfw_str_eq(&s1, &s2, s3->len));
+	EXPECT_TRUE(tfw_str_eq(&s1, s3, 0));
+	EXPECT_FALSE(tfw_str_eq(&s1, s3, s3->len));
+}
+
 TEST(tfw_str_eq_cstr, returns_true_only_for_equal_strs)
 {
 	const char *cstr = "foo123 barbaz";
@@ -735,6 +791,22 @@ TEST(tfw_str_eq_cstr_off, compound)
 
 }
 
+TEST(tfw_str_at_index, plain)
+{
+	TfwStr *fox = make_plain_str(foxstr);
+
+	EXPECT_TRUE(foxstr[10] == tfw_str_at_index(fox, 10));
+	EXPECT_TRUE(0 == tfw_str_at_index(fox, fox->len));
+}
+
+TEST(tfw_str_at_index, compound)
+{
+	TfwStr *fox = make_compound_str(foxstr);
+
+	EXPECT_TRUE(foxstr[10] == tfw_str_at_index(fox, 10));
+	EXPECT_TRUE(0 == tfw_str_at_index(fox, fox->len));
+}
+
 TEST_SUITE(tfw_str)
 {
 	TEST_SETUP(create_str_pool);
@@ -760,6 +832,10 @@ TEST_SUITE(tfw_str)
 	TEST_RUN(tfw_stricmpspn, handles_empty_strs);
 	TEST_RUN(tfw_stricmpspn, handles_different_size_strs);
 
+	TEST_RUN(tfw_str_eq, returns_true_only_for_equal_plain_strs);
+	TEST_RUN(tfw_str_eq, returns_true_only_for_equal_compound_strs);
+	TEST_RUN(tfw_str_eq, handles_empty_strs);
+
 	TEST_RUN(tfw_str_eq_cstr, returns_true_only_for_equal_strs);
 	TEST_RUN(tfw_str_eq_cstr, handles_plain_str);
 	TEST_RUN(tfw_str_eq_cstr, handles_unterminated_strs);
@@ -772,4 +848,7 @@ TEST_SUITE(tfw_str)
 	TEST_RUN(tfw_str_eq_cstr_off, plain);
 	TEST_RUN(tfw_str_eq_cstr_pos, compound);
 	TEST_RUN(tfw_str_eq_cstr_off, compound);
+
+	TEST_RUN(tfw_str_at_index, plain);
+	TEST_RUN(tfw_str_at_index, compound);
 }

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -128,7 +128,7 @@ module_exit(ttls_exit);
 
 MODULE_AUTHOR("Tempesta Technologies");
 MODULE_VERSION("2.3.0");
-MODULE_LICENSE("GPLv2");
+MODULE_LICENSE("GPL v2");
 
 /*
  * ------------------------------------------------------------------------


### PR DESCRIPTION
Fix issue #409 

Main changes:
- Update http parser to save _Connection_ header string as list of header names tagged with flag `TFW_STR_VALUE`. Most common tokens `keep-alive` and `close` and also delimiters are not marked with this flag: first processed as special header as most common one, others don't point to any headers.  `TFW_HTTP_CONN_EXTRA` flag for whole message is set if _Connection_ contains more than just `keep-alive` or `close`
- `Keep-alive` header is set as special. That helps not to slow down performance by multiple string comparisons if `Keep-alive` is the only header set by _Connection_. Corresponding unit test was updated.
- Remove hop-by-hop headers when forwarding messages from client to server and vice-versa
- Don't cache hop-by-hop headers for server responses.