### PR TITLE
Correctly save the body of a message. (#630)

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1066,7 +1066,7 @@ tfw_cache_build_resp_body(TDB *db, TfwHttpResp *resp, TdbVRec *trec,
 		} else {
 			p = NULL;
 		}
-		if (__tfw_http_msg_add_data_ptr((TfwHttpMsg *)resp,
+		if (__tfw_http_msg_add_str_data((TfwHttpMsg *)resp,
 						&resp->body, p, f_size,
 						it->skb))
 			return - ENOMEM;

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -966,6 +966,7 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 			 * The request is fully parsed,
 			 * fall through and process it.
 			 */
+			BUG_ON(req->content_length != req->body.len);
 			;
 		}
 
@@ -1363,6 +1364,7 @@ tfw_http_resp_process(TfwConnection *conn, struct sk_buff *skb,
 			 * The response is fully parsed,
 			 * fall through and process it.
 			 */
+			BUG_ON(hmresp->content_length != hmresp->body.len);
 			;
 		}
 

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -291,7 +291,7 @@ done:
  * that just now by facing CRLF at the start of the current data chunk.
  */
 int
-__tfw_http_msg_add_data_ptr(TfwHttpMsg *hm, TfwStr *str, void *data,
+__tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str, void *data,
 			    size_t len, struct sk_buff *skb)
 {
 	BUG_ON(str->flags & (TFW_STR_DUPLICATE | TFW_STR_COMPLETE));
@@ -302,7 +302,7 @@ __tfw_http_msg_add_data_ptr(TfwHttpMsg *hm, TfwStr *str, void *data,
 
 	if (TFW_STR_EMPTY(str)) {
 		if (!str->ptr)
-			__tfw_http_msg_set_data(hm, str, data, skb);
+			__tfw_http_msg_set_str_data(str, data, skb);
 		str->len = data + len - str->ptr;
 		BUG_ON(!str->len);
 	}
@@ -312,7 +312,7 @@ __tfw_http_msg_add_data_ptr(TfwHttpMsg *hm, TfwStr *str, void *data,
 			TFW_WARN("Cannot grow HTTP data string\n");
 			return -ENOMEM;
 		}
-		__tfw_http_msg_set_data(hm, sn, data, skb);
+		__tfw_http_msg_set_str_data(sn, data, skb);
 		tfw_str_updlen(str, data + len);
 	}
 
@@ -744,7 +744,7 @@ next_frag:
 	skb_frag_size_add(frag, n_copy);
 	ss_skb_adjust_data_len(it->skb, n_copy);
 
-	if (__tfw_http_msg_add_data_ptr(hm, field, p, n_copy, it->skb))
+	if (__tfw_http_msg_add_str_data(hm, field, p, n_copy, it->skb))
 		return -ENOMEM;
 
 	if (d_size > f_room) {

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -63,18 +63,6 @@ int __tfw_http_msg_add_data_ptr(TfwHttpMsg *hm, TfwStr *str, void *data,
 #define tfw_http_msg_add_data_ptr(hm, str, data, len)			\
 	__tfw_http_msg_add_data_ptr(hm, str, data, len, NULL)
 
-/**
- * Fixup the new data chunk to currently parsed HTTP header.
- *
- * @len might be 0 if the header was fully read, but we have realized
- * thatj ust now by facing CRLF at the start of the current data chunk.
- */
-static inline void
-tfw_http_msg_hdr_chunk_fixup(TfwHttpMsg *hm, char *data, int len)
-{
-	tfw_http_msg_add_data_ptr(hm, &hm->parser.hdr, data, len);
-}
-
 int tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr);
 int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 			  char *val, size_t v_len, int hid, bool append);

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -34,12 +34,14 @@ typedef struct {
 } TfwMsgIter;
 
 static inline void
-__tfw_http_msg_set_data(TfwHttpMsg *hm, TfwStr *str, void *data,
-			struct sk_buff *skb)
+__tfw_http_msg_set_str_data(TfwStr *str, void *data, struct sk_buff *skb)
 {
 	str->ptr = data;
-	str->skb = skb ? : ss_skb_peek_tail(&hm->msg.skb_list);
+	str->skb = skb;
 }
+#define tfw_http_msg_set_str_data(hm, str, data)			\
+	__tfw_http_msg_set_str_data(str, data,				\
+				    ss_skb_peek_tail(&hm->msg.skb_list))
 
 void __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client);
 
@@ -55,13 +57,11 @@ tfw_http_msg_srvhdr_val(TfwStr *hdr, unsigned id, TfwStr *val)
 	__http_msg_hdr_val(hdr, id, val, false);
 }
 
-#define tfw_http_msg_set_data(hm, str, data)				\
-	__tfw_http_msg_set_data(hm, str, data, NULL)
-
-int __tfw_http_msg_add_data_ptr(TfwHttpMsg *hm, TfwStr *str, void *data,
+int __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str, void *data,
 				size_t len, struct sk_buff *skb);
-#define tfw_http_msg_add_data_ptr(hm, str, data, len)			\
-	__tfw_http_msg_add_data_ptr(hm, str, data, len, NULL)
+#define tfw_http_msg_add_str_data(hm, str, data, len)			\
+	__tfw_http_msg_add_str_data(hm, str, data, len,			\
+				    ss_skb_peek_tail(&hm->msg.skb_list))
 
 int tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr);
 int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -66,8 +66,8 @@ int __tfw_http_msg_add_data_ptr(TfwHttpMsg *hm, TfwStr *str, void *data,
 /**
  * Fixup the new data chunk to currently parsed HTTP header.
  *
- * @len could be 0 if the header was fully read, but we realized this only
- * now by facinng CRLF at begin of current data chunk.
+ * @len might be 0 if the header was fully read, but we have realized
+ * thatj ust now by facing CRLF at the start of the current data chunk.
  */
 static inline void
 tfw_http_msg_hdr_chunk_fixup(TfwHttpMsg *hm, char *data, int len)


### PR DESCRIPTION
Remove the condition that prevented saving parts of the body.
Use BUG_ON() to enforce the correct length of the body.