### PR TITLE
http parser: fix parsing connection termination during response witho…

### DIFF
--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -768,6 +768,13 @@ __FSM_STATE(RGen_BodyInit) {						\
 		FSM_EXIT();						\
 	}								\
 	/* Process the body until the connection is closed. */		\
+	/*								\
+	 * TODO: Currently Tempesta fully assembles response before	\
+	 * transmitting it to a client. This behaviour is considered	\
+	 * dangerous and the issue must be solved in generic way:	\
+	 * Tempesta must use chunked transfer encoding for proxied	\
+	 * responses w/o lengths. Refer issue #534 for more information	\
+	 */								\
 	__FSM_MOVE_nofixup(Resp_BodyUnlimStart);			\
 }
 

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -3208,16 +3208,19 @@ tfw_http_parse_terminate(TfwHttpMsg *hm)
 	if (hm->parser.state == Resp_BodyUnlimRead
 	    || hm->parser.state == Resp_BodyUnlimStart)
 	{
-		char c_len[20] = {0};
+		char c_len[TFW_ULTOA_BUF_SIZ] = {0};
+		size_t digs;
 		int r;
 
 		BUG_ON(hm->body.flags & TFW_STR_COMPLETE);
 		hm->body.flags |= TFW_STR_COMPLETE;
 		hm->content_length = hm->body.len;
-		sprintf(c_len, "%lu", hm->content_length);
-		r = tfw_http_msg_hdr_xfrm(hm, "Content-Length:",
-					  sizeof("Content-Length:") - 1,
-					  c_len, strlen(c_len),
+		if (!(digs = tfw_ultoa(hm->content_length, c_len,
+				       TFW_ULTOA_BUF_SIZ)))
+			return false;
+		r = tfw_http_msg_hdr_xfrm(hm, "Content-Length",
+					  sizeof("Content-Length") - 1,
+					  c_len, digs,
 					  TFW_HTTP_HDR_CONTENT_LENGTH, 0);
 		return (r == 0);
 	}

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -3199,7 +3199,9 @@ tfw_http_parse_terminate(TfwHttpMsg *hm)
 	BUG_ON(!hm);
 	BUG_ON(!(TFW_CONN_TYPE(hm->conn) & Conn_Srv));
 
-	if (hm->parser.state == Resp_BodyUnlimRead) {
+	if (hm->parser.state == Resp_BodyUnlimRead
+	    || hm->parser.state == Resp_BodyUnlimStart)
+	{
 		BUG_ON(hm->body.flags & TFW_STR_COMPLETE);
 		hm->body.flags |= TFW_STR_COMPLETE;
 		hm->content_length = hm->body.len;

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -25,6 +25,78 @@
 #include "htype.h"
 #include "str.h"
 
+/**
+ * Quickly get number of digits - 1, e.g. returns '0' for '7' and '2' for '333'.
+ * It's assumed that small numbers are likely.
+ */
+static inline unsigned int
+__dig_num(unsigned long a)
+{
+	if (a < 10)
+		return 0;
+	if (a < 100)
+		return 1;
+	if (a < 1000)
+		return 2;
+	if (a < 10000)
+		return 3;
+	if (a < 100000)
+		return 4;
+	if (a < 1000000)
+		return 5;
+	if (a < 10000000)
+		return 6;
+	if (a < 100000000)
+		return 7;
+	if (a < 1000000000)
+		return 8;
+	if (a < 10000000000)
+		return 9;
+	if (a < 100000000000UL)
+		return 10;
+	if (a < 1000000000000UL)
+		return 11;
+	if (a < 10000000000000UL)
+		return 12;
+	if (a < 100000000000000UL)
+		return 13;
+	if (a < 1000000000000000UL)
+		return 14;
+	if (a < 10000000000000000UL)
+		return 15;
+	if (a < 100000000000000000UL)
+		return 16;
+	if (a < 1000000000000000000UL)
+		return 17;
+	if (a < 10000000000000000000UL)
+		return 18;
+	return 19;
+}
+
+/**
+ * Convert an integer @ai to a string @buf, don't insert training '\0'.
+ * @len - maximum string length.
+ * @return number of characters written.
+ */
+size_t
+tfw_ultoa(unsigned long ai, char *buf, unsigned int len)
+{
+	size_t n = __dig_num(ai);
+	char *p = buf + n;
+
+	if (unlikely(n + 1 > len))
+		return 0;
+
+	do {
+		/* Compiled to only one MUL instruction with -O2. */
+		*p-- = "0123456789"[ai % 10];
+		ai /= 10;
+	} while (ai);
+
+	return n + 1;
+}
+EXPORT_SYMBOL(tfw_ultoa);
+
 void
 tfw_str_del_chunk(TfwStr *str, int id)
 {

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -151,6 +151,10 @@ tfw_stricmp_2lc(const char *s1, const char *s2, size_t len)
 }
 #endif
 
+/* Buffer size to hold all possible values of unsigned long */
+#define TFW_ULTOA_BUF_SIZ 20
+size_t tfw_ultoa(unsigned long ai, char *buf, unsigned int len);
+
 /*
  * ------------------------------------------------------------------------
  *	Tempesta chunked strings

--- a/tempesta_fw/t/unit/test_tfw_str.c
+++ b/tempesta_fw/t/unit/test_tfw_str.c
@@ -243,6 +243,33 @@ TEST(cstr, simd_stricmp)
 
 }
 
+TEST(cstr, ultoa)
+{
+	char buf[TFW_ULTOA_BUF_SIZ + 1] = {0};
+
+	EXPECT_TRUE(tfw_ultoa(0, buf, TFW_ULTOA_BUF_SIZ) == 1);
+	EXPECT_ZERO(tfw_stricmp(buf, "0", 2));
+
+	memset(buf, 0, TFW_ULTOA_BUF_SIZ + 1);
+	EXPECT_TRUE(tfw_ultoa(5, buf, TFW_ULTOA_BUF_SIZ) == 1);
+	EXPECT_ZERO(tfw_stricmp(buf, "5", 2));
+
+	memset(buf, 0, TFW_ULTOA_BUF_SIZ + 1);
+	EXPECT_TRUE(tfw_ultoa(58743, buf, TFW_ULTOA_BUF_SIZ) == 5);
+	EXPECT_ZERO(tfw_stricmp(buf, "58743", 6));
+
+	memset(buf, 0, TFW_ULTOA_BUF_SIZ + 1);
+	EXPECT_TRUE(tfw_ultoa(0xaabbccff, buf, TFW_ULTOA_BUF_SIZ) == 10);
+	EXPECT_ZERO(tfw_stricmp(buf, "2864434431", 11));
+
+	memset(buf, 0, TFW_ULTOA_BUF_SIZ + 1);
+	EXPECT_TRUE(tfw_ultoa(18446744073709551615UL,
+			      buf, TFW_ULTOA_BUF_SIZ) == 20);
+	EXPECT_ZERO(tfw_stricmp(buf, "18446744073709551615", 21));
+
+	EXPECT_ZERO(tfw_ultoa(589, buf, 2));
+}
+
 TEST(tfw_strcpy, zero_src)
 {
 	TfwStr s1 = {
@@ -744,6 +771,8 @@ TEST_SUITE(tfw_str)
 	TEST_RUN(cstr, simd_match);
 	TEST_RUN(cstr, simd_strtolower);
 	TEST_RUN(cstr, simd_stricmp);
+
+	TEST_RUN(cstr, ultoa);
 
 	TEST_RUN(tfw_strcpy, zero_src);
 	TEST_RUN(tfw_strcpy, zero_dst);


### PR DESCRIPTION
…ut known lenght

For responses without Content-Length header parser during
`TFW_HTTP_INIT_RESP_BODY_PARSING()` procedure switches its state to
`Resp_BodyUnlimStart` state. If response body is present parser will
switch to `Resp_BodyUnlimRead` state. When server will terminate
connection to indicate that end of response is reached, message will
be forwarded to client.

But if no body is present, parser will never reach `Resp_BodyUnlimRead`
state and message will not be forwarded to client.

fix issue #629 