### PR TITLE
Correctly handle msg->crlf.

### DIFF
--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -222,7 +222,6 @@ typedef struct {
 #define TFW_HTTP_CONN_KA		0x000002
 #define __TFW_HTTP_CONN_MASK		(TFW_HTTP_CONN_CLOSE | TFW_HTTP_CONN_KA)
 #define TFW_HTTP_CHUNKED		0x000004
-#define __TFW_HTTP_CHUNKED_LAST		0x000008
 
 /* Request flags */
 #define TFW_HTTP_HAS_STICKY		0x000100

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -152,9 +152,10 @@ typedef struct {
  * @state	- current parser state;
  * @_i_st	- helping (interior) state;
  * @to_read	- remaining number of bytes to read;
+ * @_acc	- integer accumulator for parsing chunked integers;
+ * @_date	- accumulator for a date in date related headers;
  * @_hdr_tag	- stores header id which must be closed on generic EoL handling
  *		  (see RGEN_EOL());
- * @_acc	- integer accumulator for parsing chunked integers;
  * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
  * @hdr		- currently parsed header.
  */
@@ -197,6 +198,7 @@ typedef enum {
 
 	TFW_HTTP_HDR_CONNECTION = TFW_HTTP_HDR_NONSINGULAR,
 	TFW_HTTP_HDR_X_FORWARDED_FOR,
+	TFW_HTTP_HDR_TRANSFER_ENCODING,
 
 	/* Start of list of generic (raw) headers. */
 	TFW_HTTP_HDR_RAW,
@@ -220,6 +222,7 @@ typedef struct {
 #define TFW_HTTP_CONN_KA		0x000002
 #define __TFW_HTTP_CONN_MASK		(TFW_HTTP_CONN_CLOSE | TFW_HTTP_CONN_KA)
 #define TFW_HTTP_CHUNKED		0x000004
+#define __TFW_HTTP_CHUNKED_LAST		0x000008
 
 /* Request flags */
 #define TFW_HTTP_HAS_STICKY		0x000100

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -466,7 +466,8 @@ enum {
 	I_ContLen, /* Content-Length */
 	I_ContType, /* Content-Type */
 	I_TransEncod, /* Transfer-Encoding */
-	I_TransEncodExt,
+	I_TransEncodChunked,
+	I_TransEncodOther,
 
 	I_EoT, /* end of term */
 };
@@ -697,25 +698,28 @@ __FSM_STATE(RGen_HdrOtherV) {						\
 /* Process according RFC 7230 3.3.3 */
 #define TFW_HTTP_INIT_REQ_BODY_PARSING()				\
 __FSM_STATE(RGen_BodyInit) {						\
+	TfwStr *tbl = msg->h_tbl->tbl;					\
+									\
 	TFW_DBG3("parse request body: flags=%#x content_length=%lu\n",	\
 		 msg->flags, msg->content_length);			\
 									\
-	/*								\
-	 * TODO: If both "Transfer-Encoding:" and "Content-Length:"	\
-	 * headers are present,	then issue an error or remove		\
-	 * "Content-Length:" header.					\
-	 */								\
-	/*								\
-	 * TODO: If "Transfer-Encoding:" header is present,		\
-	 * then "chunked" coding must be the last in the list.		\
-	 */								\
-	if (msg->flags & TFW_HTTP_CHUNKED)				\
-		__FSM_MOVE_nofixup(RGen_BodyStart);			\
-	/*								\
-	 * TODO: If "Transfer-Encoding:" header is present and		\
-	 * there's NO "chunked" coding, then send 400 response		\
-	 * (Bad Request) and close the connection.			\
-	 */								\
+	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_TRANSFER_ENCODING])) {	\
+		/* The alternative: remove "Content-Length" header. */	\
+		if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH]))	\
+			return TFW_BLOCK;				\
+		if (msg->flags & TFW_HTTP_CHUNKED) {			\
+			/* "chunked" must be the last in the list. */	\
+			if (!(msg->flags & __TFW_HTTP_CHUNKED_LAST))	\
+				return TFW_BLOCK;			\
+			__FSM_MOVE_nofixup(RGen_BodyStart);		\
+		}							\
+		/*							\
+		 * TODO: If "Transfer-Encoding:" header is present and	\
+		 * there's NO "chunked" coding, then send 400 response	\
+		 * (Bad Request) and close the connection.		\
+		 */							\
+		return TFW_BLOCK;					\
+	}								\
 	if (msg->content_length) {					\
 		parser->to_read = msg->content_length;			\
 		__FSM_MOVE_nofixup(RGen_BodyStart);			\
@@ -729,6 +733,7 @@ __FSM_STATE(RGen_BodyInit) {						\
 /* Process according RFC 7230 3.3.3 */
 #define TFW_HTTP_INIT_RESP_BODY_PARSING()				\
 __FSM_STATE(RGen_BodyInit) {						\
+	TfwStr *tbl = msg->h_tbl->tbl;					\
 	TfwHttpResp *resp = (TfwHttpResp *)msg;				\
 									\
 	TFW_DBG3("parse response body: flags=%#x content_length=%lu\n",	\
@@ -744,23 +749,19 @@ __FSM_STATE(RGen_BodyInit) {						\
 		r = TFW_PASS;						\
 		FSM_EXIT();						\
 	}								\
-	/*								\
-	 * TODO: If both "Transfer-Encoding:" and "Content-Length:"	\
-	 * headers are present,	then issue an error or remove		\
-	 * "Content-Length:" header.					\
-	 */								\
-	/*								\
-	 * TODO: If "Transfer-Encoding:" header is present,		\
-	 * then "chunked" coding must be the last in the list.		\
-	 */								\
-	if (msg->flags & TFW_HTTP_CHUNKED)				\
-		__FSM_MOVE_nofixup(RGen_BodyStart);			\
-	/*								\
-	 * TODO: If "Transfer-Encoding:" header is present and		\
-	 * there's NO "chunked" coding, then process the body		\
-	 * until the connection is closed.				\
-	 */								\
-	if (!TFW_STR_EMPTY(&msg->h_tbl->tbl[TFW_HTTP_HDR_CONTENT_LENGTH])) \
+	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_TRANSFER_ENCODING])) {	\
+		/* The alternative: remove "Content-Length" header. */	\
+		if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH]))	\
+			return TFW_BLOCK;				\
+		if (msg->flags & TFW_HTTP_CHUNKED) {			\
+			/* "chunked" must be the last in the list. */	\
+			if (!(msg->flags & __TFW_HTTP_CHUNKED_LAST))	\
+				return TFW_BLOCK;			\
+			__FSM_MOVE_nofixup(RGen_BodyStart);		\
+		}							\
+		__FSM_MOVE_nofixup(Resp_BodyUnlimStart);		\
+	}								\
+	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH]))		\
 	{								\
 		if (msg->content_length) {				\
 			parser->to_read = msg->content_length;		\
@@ -1031,37 +1032,40 @@ __parse_transfer_encoding(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	 * According to RFC 7230 section 3.3.1:
 	 *
 	 * TODO: In a response:
-	 * A server MUST NOT send a Transfer-Encoding header field in any
-	 * response with a status code of 1xx (Informational) or 204 (No
-	 * Content).  A server MUST NOT send a Transfer-Encoding header
-	 * field in any 2xx (Successful) response to a CONNECT request.
-	 *
-	 * TODO: A sender MUST NOT apply chunked more than once to a message
-	 * body (i.e., chunking an already chunked message is not allowed).
-	 *
-	 * TODO: in a request:
-	 * If any transfer coding other than chunked is applied to a request
-	 * payload body, the sender MUST apply chunked as the final transfer
-	 * coding to ensure that the message is properly framed.
-	 *
-	 * In a response, it's permissible to not have chunked transfer
-	 * coding. In that case the message is terminated by closing the
-	 * connection.
+	 * A server MUST NOT send a Transfer-Encoding header field
+	 * in any 2xx (Successful) response to a CONNECT request.
 	 */
 	__FSM_STATE(I_TransEncod) {
-		TRY_STR_LAMBDA("chunked", {
-			msg->flags |= TFW_HTTP_CHUNKED;
-		}, I_EoT);
-		TRY_STR_INIT();
-		__FSM_I_MOVE_n(I_TransEncodExt, 0);
+		TfwHttpResp *resp = (TfwHttpResp *)hm;
+		if ((resp->status - 101U < 99U) || (resp->status == 204))
+			return CSTR_NEQ;
+		__FSM_I_JMP(I_TransEncodChunked);
 	}
 
-	__FSM_STATE(I_TransEncodExt) {
+	__FSM_STATE(I_TransEncodChunked) {
+		/*
+		 * A sender MUST NOT apply chunked more than once
+		 * to a message body (i.e., chunking an already
+		 * chunked message is not allowed). RFC 7230 3.3.1.
+		 */
+		TRY_STR_LAMBDA("chunked", {
+			if (unlikely(msg->flags & TFW_HTTP_CHUNKED))
+				return CSTR_NEQ;
+			msg->flags |= TFW_HTTP_CHUNKED
+				      | __TFW_HTTP_CHUNKED_LAST;
+		}, I_EoT);
+		TRY_STR_INIT();
+		__FSM_I_MOVE_n(I_TransEncodOther, 0);
+	}
+
+	__FSM_STATE(I_TransEncodOther) {
 		/*
 		 * TODO: process transfer encodings: gzip, deflate, identity,
 		 * compress;
 		 */
-		__FSM_I_MATCH_MOVE(token, I_TransEncodExt);
+		__FSM_I_MATCH_MOVE(token, I_TransEncodOther);
+		if (__fsm_sz)
+			msg->flags &= ~__TFW_HTTP_CHUNKED_LAST;
 		c = *(p + __fsm_sz);
 		if (IS_WS(c) || c == ',')
 			__FSM_I_MOVE_n(I_EoT, __fsm_sz + 1);
@@ -1075,7 +1079,7 @@ __parse_transfer_encoding(TfwHttpMsg *hm, unsigned char *data, size_t len)
 		if (IS_WS(c) || c == ',')
 			__FSM_I_MOVE(I_EoT);
 		if (IS_TOKEN(c))
-			__FSM_I_MOVE_n(I_TransEncod, 0);
+			__FSM_I_MOVE_n(I_TransEncodChunked, 0);
 		if (IS_CRLF(c))
 			return __data_off(p);
 		return CSTR_NEQ;
@@ -1114,7 +1118,7 @@ enum {
 	Req_UriSchHttpColonSlash,
 	/* RFC 3986, 3.2:
 	 * authority = [userinfo@]host[:port]
-	 * We have special state for parsing :port, so
+	 * We have a special state for parsing :port, so
 	 * in Req_UriAuthority* we parse [userinfo@]host.
 	 */
 	Req_UriAuthorityStart,
@@ -2091,9 +2095,8 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 			__FSM_MOVE(Req_HdrP);
 		case 't':
 			if (likely(__data_available(p, 18)
-				   && C8_INT_LCM(p, 't', 'r', 'a', 'n',
-					   	    's', 'f', 'e', 'r')
-				   && *(p + 8) == '-'
+				   && C8_INT_LCM(p + 1, 'r', 'a', 'n', 's',
+							'f', 'e', 'r', '-')
 				   && C8_INT_LCM(p + 9, 'e', 'n', 'c', 'o',
 							'd', 'i', 'n', 'g')
 				   && *(p + 17) == ':'))
@@ -2117,10 +2120,9 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 			__FSM_MOVE(Req_HdrX);
 		case 'u':
 			if (likely(__data_available(p, 11)
-				   && C4_INT_LCM(p, 'u', 's', 'e', 'r')
-				   && *(p + 4) == '-'
-				   && C4_INT_LCM(p + 5, 'a', 'g', 'e', 'n')
-				   && *(p + 9) == 't'
+				   && C8_INT_LCM(p + 1, 's', 'e', 'r', '-',
+							'a', 'g', 'e', 'n')
+				   && TFW_LC(*(p + 9)) == 't'
 				   && *(p + 10) == ':'))
 			{
 				parser->_i_st = Req_HdrUser_AgentV;
@@ -2189,8 +2191,9 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 				  req, __req_parse_pragma);
 
 	/* 'Transfer-Encoding:*OWS' is read, process field-value. */
-	TFW_HTTP_PARSE_RAWHDR_VAL(Req_HdrTransfer_EncodingV, I_TransEncod,
-				  msg, __parse_transfer_encoding);
+	TFW_HTTP_PARSE_SPECHDR_VAL(Req_HdrTransfer_EncodingV, I_TransEncod,
+				  msg, __parse_transfer_encoding,
+				  TFW_HTTP_HDR_TRANSFER_ENCODING);
 
 	/* 'X-Forwarded-For:*OWS' is read, process field-value. */
 	TFW_HTTP_PARSE_SPECHDR_VAL(Req_HdrX_Forwarded_ForV, Req_I_XFF,
@@ -3499,8 +3502,9 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 				   __resp_parse_server, TFW_HTTP_HDR_SERVER);
 
 	/* 'Transfer-Encoding:*OWS' is read, process field-value. */
-	TFW_HTTP_PARSE_RAWHDR_VAL(Resp_HdrTransfer_EncodingV, I_TransEncod,
-				  msg, __parse_transfer_encoding);
+	TFW_HTTP_PARSE_SPECHDR_VAL(Resp_HdrTransfer_EncodingV, I_TransEncod,
+				   msg, __parse_transfer_encoding,
+				   TFW_HTTP_HDR_TRANSFER_ENCODING);
 
 	RGEN_HDR_OTHER();
 	RGEN_OWS();

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -741,7 +741,7 @@ __FSM_STATE(RGen_BodyInit) {						\
 									\
 	/* There's no body. */						\
 	/* TODO: Add (req == CONNECT && resp == 2xx) */			\
-	if (resp->status - 101U < 99U || resp->status == 204		\
+	if (resp->status - 100U < 100U || resp->status == 204		\
 	    || resp->status == 304 || msg->flags & TFW_HTTP_VOID_BODY)	\
 	{								\
 		/* There is no body. */					\
@@ -1036,9 +1036,11 @@ __parse_transfer_encoding(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	 * in any 2xx (Successful) response to a CONNECT request.
 	 */
 	__FSM_STATE(I_TransEncod) {
-		TfwHttpResp *resp = (TfwHttpResp *)hm;
-		if ((resp->status - 101U < 99U) || (resp->status == 204))
-			return CSTR_NEQ;
+		if (TFW_CONN_TYPE(hm->conn) & Conn_Srv) {
+			unsigned int status = ((TfwHttpResp *)hm)->status;
+			if ((status - 100U < 100U) || (status == 204))
+				return CSTR_NEQ;
+		}
 		__FSM_I_JMP(I_TransEncodChunked);
 	}
 

--- a/tempesta_fw/t/fuzzer.c
+++ b/tempesta_fw/t/fuzzer.c
@@ -21,6 +21,7 @@
  */
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/random.h>
 #include <linux/string.h>
 #include <linux/slab.h>
 
@@ -33,14 +34,19 @@ MODULE_VERSION("0.1.2");
 MODULE_LICENSE("GPL");
 
 #define FUZZ_MSG_F_INVAL	FUZZ_INVALID
-#define FUZZ_MSG_F_EMPTY_BODY	0x02
+#define FUZZ_MSG_F_EMPTY_BODY	0x10
+#define FUZZ_MSG_F_SHIFT	8
 
+/*
+ * @sval	- string value of the field contents;
+ * @flags	- message and contents related flags;
+ */
 typedef struct {
-	char		*s;
-	unsigned int	rval;
+	char		*sval;
+	unsigned int	flags;
 } FuzzMsg;
 
-#define FUZZ_MSG_INVAL(m)	((m).rval & FUZZ_MSG_F_INVAL)
+#define FUZZ_MSG_INVAL(m)	((m).flags & FUZZ_MSG_F_INVAL)
 
 static FuzzMsg spaces[] = {
 	{""}
@@ -57,11 +63,17 @@ static FuzzMsg uri_file[] = {
 static FuzzMsg versions[] = {
 	{"1.0"}, {"1.1"}, {"0.9", FUZZ_MSG_F_INVAL}
 };
+#define FUZZ_FLD_F_STATUS_100		(0x0001 << FUZZ_MSG_F_SHIFT)
+#define FUZZ_FLD_F_STATUS_204		(0x0002 << FUZZ_MSG_F_SHIFT)
+#define FUZZ_FLD_F_STATUS_304		(0x0004 << FUZZ_MSG_F_SHIFT)
 static FuzzMsg resp_code[] = {
-	{"100 Continue"}, {"200 OK"}, {"302 Found"},
-	{"304 Not Modified", FUZZ_MSG_F_EMPTY_BODY},
-	{"400 Bad Request"}, {"403 Forbidden"}, {"404 Not Found"},
-	{"500 Internal Server Error"}
+	{"100 Continue", FUZZ_FLD_F_STATUS_100 | FUZZ_MSG_F_EMPTY_BODY},
+	{"200 OK"},
+	{"204 No Content", FUZZ_FLD_F_STATUS_204 | FUZZ_MSG_F_EMPTY_BODY},
+	{"302 Found"},
+	{"304 Not Modified", FUZZ_FLD_F_STATUS_304 | FUZZ_MSG_F_EMPTY_BODY},
+	{"400 Bad Request"}, {"403 Forbidden"},
+	{"404 Not Found"}, {"500 Internal Server Error"}
 };
 static FuzzMsg conn_val[] = {
 	{"keep-alive"}, {"close"}, {"upgrade"}
@@ -80,8 +92,11 @@ static FuzzMsg content_len[] = {
 	{"10000"}, {"0"}, {"-42", FUZZ_MSG_F_INVAL},
 	{"146"}, {"0100"}, {"100500"}
 };
+#define FUZZ_FLD_F_CHUNKED		(0x0001 << FUZZ_MSG_F_SHIFT)
+#define FUZZ_FLD_F_CHUNKED_LAST		(0x0002 << FUZZ_MSG_F_SHIFT)
 static FuzzMsg transfer_encoding[] = {
-	{"chunked"}, {"identity"}, {"compress"}, {"deflate"}, {"gzip"}
+	{"chunked", FUZZ_FLD_F_CHUNKED},
+	{"identity"}, {"compress"}, {"deflate"}, {"gzip"}
 };
 static FuzzMsg accept[] = {
 	{"text/plain"}, {"text/html;q=0.5"}, {"application/xhtml+xml"},
@@ -119,64 +134,107 @@ static FuzzMsg expires[] = {
 	{"Tue, 999 Jan 2012 15:02:53 GMT", FUZZ_MSG_F_INVAL}
 };
 
-static FuzzMsg *vals[] = {
-	spaces,
-	methods,
-	versions,
-	resp_code,
-	uri_path_start,
-	uri_file,
-	conn_val,
-	ua_val,
-	host_val,
-	host_val,
-	content_type,
-	content_len,
-	transfer_encoding,
-	accept,
-	accept_language,
-	accept_encoding,
-	accept_ranges,
-	cookie,
-	set_cookie,
-	etag,
-	server,
-	cache_control,
-	expires,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-};
+/*
+ * A function that makes sure that the header field value is compatible
+ * with the RFC. That is needed in complex cases where the correctness
+ * may depend on internal or auxiliary values.
+ * The function must return the flags of the field ORed with the result
+ * of either FUZZ_VALID or FUZZ_INVALID.
+ */
+typedef unsigned int (*fld_func)(TfwFuzzContext *ctx,
+				 int type, int fld, int val);
 
-static char * keys[] = {
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	"Connection:",
-	"User-agent:",
-	"Host:",
-	"X-Forwarded-For:",
-	"Content-Type:",
-	"Content-Length:",
-	"Transfer-Encoding:",
-	"Accept:",
-	"Accept-Language:",
-	"Accept-Encoding:",
-	"Accept-Ranges:",
-	"Cookie:",
-	"Set-Cookie:",
-	"ETag:",
-	"Server:",
-	"Cache-Control:",
-	"Expires:",
-	NULL,
-	NULL,
-	NULL,
-	NULL,
+/*
+ * Check various conditions that put limitations on correct values of
+ * "Transfer-Encoding" header field. Mark the field as invalid in cases
+ * where the parser considers the value of this header field incorrect.
+ */
+static unsigned int
+fld_transfer_encoding(TfwFuzzContext *ctx, int type, int fld, int val)
+{
+	unsigned int fld_data_flags;
+
+	BUG_ON(fld != TRANSFER_ENCODING);
+	BUG_ON(val >= sizeof(transfer_encoding) / sizeof(FuzzMsg));
+
+	fld_data_flags = transfer_encoding[val].flags;
+
+	/*
+	 * In responses this header field may not be present
+	 * if the response status code is one of 1xx or 204.
+	 */
+	if (type == FUZZ_RESP) {
+		if (ctx->fld_flags[RESP_CODE]
+		    & (FUZZ_FLD_F_STATUS_100 | FUZZ_FLD_F_STATUS_204))
+			return fld_data_flags | FUZZ_INVALID;
+	}
+	/*
+	 * "chunked" coding may not be repeated. Also, mark cases
+	 * where "chunked" coding is the last coding. That is used
+	 * in verifications later.
+	 */
+	if (ctx->fld_flags[TRANSFER_ENCODING] & FUZZ_FLD_F_CHUNKED) {
+		if (fld_data_flags & FUZZ_FLD_F_CHUNKED)
+			return fld_data_flags | FUZZ_INVALID;
+		ctx->fld_flags[TRANSFER_ENCODING] &= ~FUZZ_FLD_F_CHUNKED_LAST;
+	} else if (fld_data_flags & FUZZ_FLD_F_CHUNKED) {
+		fld_data_flags |= FUZZ_FLD_F_CHUNKED_LAST;
+	}
+
+	return fld_data_flags | FUZZ_VALID;
+}
+
+/*
+ * The "Expires:" header field is generated only for responses. The value
+ * is the date in a special format. If the date is invalid in this header
+ * field, then the value is considered a date in the past, as if already
+ * expired.
+ */
+static unsigned int
+fld_expires(TfwFuzzContext *ctx, int type, int fld, int val)
+{
+	BUG_ON(type != FUZZ_RESP);
+	BUG_ON(fld != EXPIRES);
+	BUG_ON(val >= sizeof(expires) / sizeof(FuzzMsg));
+
+	return FUZZ_VALID;
+}
+
+/*
+ * @key		- the header field name;
+ * @vals	- the list of various values of the header field;
+ * @func	- the function to check the correctness of the values;
+ */
+static struct {
+	char		*key;
+	FuzzMsg		*vals;
+	fld_func	func;
+} fld_data[N_FIELDS] = {
+	[0 ... N_FIELDS-1] = { 0 },
+	[SPACES]		= { NULL, spaces },
+	[METHOD]		= { NULL, methods },
+	[HTTP_VER]		= { NULL, versions },
+	[RESP_CODE]		= { NULL, resp_code },
+	[URI_PATH_START]	= { NULL, uri_path_start },
+	[URI_FILE]		= { NULL, uri_file },
+	[CONNECTION]		= { "Connection:", conn_val },
+	[USER_AGENT]		= { "User-Agent:", ua_val },
+	[HOST]			= { "Host:", host_val },
+	[X_FORWARDED_FOR]	= { "X-Forwarded-For:", host_val },
+	[CONTENT_TYPE]		= { "Content-Type:", content_type },
+	[CONTENT_LENGTH]	= { "Content-Length:", content_len },
+	[TRANSFER_ENCODING]	= { "Transfer-Encoding:", transfer_encoding,
+				    fld_transfer_encoding },
+	[ACCEPT]		= { "Accept:", accept },
+	[ACCEPT_LANGUAGE]	= { "Accept-Language:", accept_language },
+	[ACCEPT_ENCODING]	= { "Accept-Encoding:", accept_encoding },
+	[ACCEPT_RANGES]		= { "Accept-Ranges:", accept_ranges },
+	[COOKIE]		= { "Cookie:", cookie },
+	[SET_COOKIE]		= { "Set-Cookie:", set_cookie },
+	[ETAG]			= { "ETag:", etag },
+	[SERVER]		= { "Server:", server },
+	[CACHE_CONTROL]		= { "Cache-Control:", cache_control },
+	[EXPIRES]		= { "Expires:", expires, fld_expires },
 };
 
 #define A_URI "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
@@ -199,14 +257,22 @@ static char * keys[] = {
 #define MAX_DUPLICATES 9
 #define INVALID_BODY_PERIOD 5
 
+/*
+ * @size	- the number of possible values;
+ * @over	- the number of generated values;
+ * @a_val	- the valid alphabet for generated values;
+ * @a_inval	- an invalid alphabet for generated values;
+ * @singular	- only for headers: 0 = nonsingular, 1 = singular;
+ * @dissipation	- duplicate header may have a different value: 0 = yes, 1 = no;
+ * @max_val_len	- the maximum length of the value;
+ */
 static struct {
-	int size;        /* the number of present values */
-	int over;        /* the number of generated values */
-	char *a_val;     /* the valid alphabet for generated values */
-	char *a_inval;   /* an invalid alphabet for generated values */
-	int singular;    /* only for headers; 0 - nonsingular, 1 - singular */
-	int dissipation; /* may be duplicates header has diferent values?;
-			   0 - no, 1 - yes */
+	int size;
+	int over;
+	char *a_val;
+	char *a_inval;
+	int singular;
+	int dissipation;
 	int max_val_len;
 } gen_vector[N_FIELDS] = {
 	/* SPACES */
@@ -223,7 +289,7 @@ static struct {
 	{sizeof(uri_file) / sizeof(FuzzMsg), 2, A_URI, A_URI_INVAL},
 	/* CONNECTION */
 	{sizeof(conn_val) / sizeof(FuzzMsg), 0, NULL, NULL, 0, 0},
-	/* USER_AGENT*/
+	/* USER_AGENT */
 	{sizeof(ua_val) / sizeof(FuzzMsg), 2, A_UA, A_UA_INVAL, 1, 1},
 	/* HOST */
 	{sizeof(host_val) / sizeof(FuzzMsg), 2, A_HOST, A_HOST_INVAL, 1, 1},
@@ -235,7 +301,7 @@ static struct {
 	{sizeof(content_len) / sizeof(FuzzMsg), 2, "0123456789", A_URI, 1, 1,
 		MAX_CONTENT_LENGTH_LEN},
 	/* TRANSFER_ENCODING */
-	{sizeof(transfer_encoding) / sizeof(FuzzMsg), 0, NULL, NULL, 1, 1},
+	{sizeof(transfer_encoding) / sizeof(FuzzMsg), 0, NULL, NULL, 0, 0},
 	/* ACCEPT */
 	{sizeof(accept) / sizeof(FuzzMsg), 0, NULL, NULL, 0, 1},
 	/* ACCEPT_LANGUAGE */
@@ -280,9 +346,9 @@ gen_vector_move(TfwFuzzContext *ctx, int i)
 			if (gen_vector_move(ctx, i + 1) == FUZZ_END)
 				return FUZZ_END;
 		}
-	} while (ctx->is_only_valid && vals[i]
+	} while (ctx->is_only_valid && fld_data[i].vals
 		 && ctx->i[i] < gen_vector[i].size
-		 && FUZZ_MSG_INVAL(vals[i][ctx->i[i]]));
+		 && FUZZ_MSG_INVAL(fld_data[i].vals[ctx->i[i]]));
 
 	return FUZZ_VALID;
 }
@@ -319,29 +385,33 @@ add_rand_string(char **p, char *end, int n, const char *seed)
 }
 
 static unsigned int
-__add_field(TfwFuzzContext *ctx, char **p, char *end, int t, int n)
+__add_field(TfwFuzzContext *ctx, int type, char **p, char *end, int t, int n)
 {
-	FuzzMsg *val;
-
 	BUG_ON(t < 0);
 	BUG_ON(t >= TRANSFER_ENCODING_NUM);
 
-	val = vals[t];
-
-	BUG_ON(!val);
+	BUG_ON(!fld_data[t].vals);
 
 	if (n < gen_vector[t].size) {
-		FuzzMsg r = val[n];
-		add_string(p, end, r.s);
+		unsigned int r;
+		FuzzMsg fmsg = fld_data[t].vals[n];
 
-		if (t == TRANSFER_ENCODING && !n)
-			ctx->is_chunked_body = true;
+		add_string(p, end, fmsg.sval);
 
-		if (FUZZ_MSG_INVAL(r))
-			TFW_DBG("generate ivalid field %d for header %d\n",
+		if (fld_data[t].func)
+			r = fld_data[t].func(ctx, type, t, n);
+		else
+			r = fmsg.flags;
+
+		if (r & FUZZ_MSG_F_INVAL) {
+			TFW_DBG("generate invalid field %d for header %d\n",
 				 n, t);
+			r |= FUZZ_INVALID;
+		}
 
-		return r.rval;
+		ctx->fld_flags[t] |= r;
+
+		return r;
 	} else {
 		char *v = *p;
 		int len = n * 256;
@@ -365,7 +435,7 @@ __add_field(TfwFuzzContext *ctx, char **p, char *end, int t, int n)
 		}
 
 		if (r == FUZZ_INVALID)
-			TFW_DBG("generate ivalid random field for header %d\n",
+			TFW_DBG("generate invalid random field for header %d\n",
 				t);
 
 		return r;
@@ -373,46 +443,55 @@ __add_field(TfwFuzzContext *ctx, char **p, char *end, int t, int n)
 }
 
 static unsigned int
-add_field(TfwFuzzContext *ctx, char **p, char *end, int t)
+add_field(TfwFuzzContext *ctx, int type, char **p, char *end, int t)
 {
-	return __add_field(ctx, p, end, t, ctx->i[t]);
+	return __add_field(ctx, type, p, end, t, ctx->i[t]);
 }
 
 static unsigned int
-__add_header(TfwFuzzContext *ctx, char **p, char *end, int t, int n)
+__add_header(TfwFuzzContext *ctx, int type, char **p, char *end, int t, int n)
 {
 	unsigned int v = 0, i;
-	char *key;
 
 	BUG_ON(t < 0);
 	BUG_ON(t >= TRANSFER_ENCODING_NUM);
 
-	key = keys[t];
+	BUG_ON(!fld_data[t].key);
 
-	BUG_ON(!key);
-
-	add_string(p, end, key);
-	v |= add_field(ctx, p, end, SPACES);
-	v |= add_field(ctx, p, end, t);
+	add_string(p, end, fld_data[t].key);
+	v |= add_field(ctx, type, p, end, SPACES);
+	v |= add_field(ctx, type, p, end, t);
 	for (i = 0; i < n; ++i) {
 		addch(p, end, ',');
-		v |= add_field(ctx, p, end, SPACES);
-		v |= __add_field(ctx, p, end, t, (i * 256) %
+		v |= add_field(ctx, type, p, end, SPACES);
+		v |= __add_field(ctx, type, p, end, t, (i * 256) %
 			(gen_vector[t].size + gen_vector[t].over));
 	}
 
 	add_string(p, end, "\r\n");
 
 	if (v & FUZZ_INVALID)
-		TFW_DBG("generate ivalid header %d\n", t);
+		TFW_DBG("generate invalid header %d\n", t);
+
+	ctx->hdr_flags |= 1 << t;
 
 	return v;
 }
 
 static unsigned int
-add_header(TfwFuzzContext *ctx, char **p, char *end, int t)
+__add_header_rand(TfwFuzzContext *ctx, int type,
+		  char **p, char *end, int t, int n)
 {
-	return __add_header(ctx, p, end, t, 0);
+	unsigned int rand;
+
+	get_random_bytes(&rand, sizeof(rand));
+	return rand % 2 ? __add_header(ctx, type, p, end, t, n) : FUZZ_VALID;
+}
+
+static unsigned int
+add_header(TfwFuzzContext *ctx, int type, char **p, char *end, int t)
+{
+	return __add_header(ctx, type, p, end, t, 0);
 }
 
 static unsigned int
@@ -424,10 +503,10 @@ add_body(TfwFuzzContext *ctx, char **p, char *end, int type)
 
 	i = ctx->i[CONTENT_LENGTH];
 	len_str = (i < gen_vector[CONTENT_LENGTH].size)
-		  ? (content_len[i].rval & FUZZ_MSG_F_INVAL)
+		  ? (content_len[i].flags & FUZZ_MSG_F_INVAL)
 		    ? "500" /* Generate content of arbitrary size for invalid
 			     * Content-Length value. */
-		    : content_len[i].s
+		    : content_len[i].sval
 		  : ctx->content_length;
 
 	err = kstrtoul(len_str, 10, &len);
@@ -437,10 +516,8 @@ add_body(TfwFuzzContext *ctx, char **p, char *end, int type)
 		return FUZZ_INVALID;
 	}
 
-	if (!ctx->is_chunked_body) {
-		if (!ctx->is_only_valid && len
-		    && !(i % INVALID_BODY_PERIOD))
-		{
+	if (!(ctx->fld_flags[TRANSFER_ENCODING] & FUZZ_FLD_F_CHUNKED)) {
+		if (!ctx->is_only_valid && len && !(i % INVALID_BODY_PERIOD)) {
 			len /= 2;
 			ret = FUZZ_INVALID;
 			TFW_DBG("1/2 invalid body %lu\n", len);
@@ -492,7 +569,8 @@ add_body(TfwFuzzContext *ctx, char **p, char *end, int type)
 }
 
 static unsigned int
-__add_duplicates(TfwFuzzContext *ctx, char **p, char *end, int t, int n)
+__add_duplicates(TfwFuzzContext *ctx, int type,
+		 char **p, char *end, int t, int n)
 {
 	int i, tmp = 0;
 	unsigned int v = FUZZ_VALID;
@@ -509,7 +587,7 @@ __add_duplicates(TfwFuzzContext *ctx, char **p, char *end, int t, int n)
 			ctx->i[t] = (ctx->i[t] + i) % gen_vector[t].size;
 		}
 
-		v |= __add_header(ctx, p, end, t, n);
+		v |= __add_header(ctx, type, p, end, t, n);
 
 		if (gen_vector[t].dissipation)
 			ctx->i[t] = tmp;
@@ -524,27 +602,74 @@ __add_duplicates(TfwFuzzContext *ctx, char **p, char *end, int t, int n)
 }
 
 static unsigned int
-add_duplicates(TfwFuzzContext *ctx, char **p, char *end, int t)
+add_duplicates(TfwFuzzContext *ctx, int type, char **p, char *end, int t)
 {
-	return __add_duplicates(ctx, p, end, t, 0);
+	return __add_duplicates(ctx, type, p, end, t, 0);
+}
+
+/*
+ * Make sure that header fields and values in the set of headers
+ * are compatible with each other.
+ */
+static bool
+fuzz_hdrs_compatible(TfwFuzzContext *ctx, int type, unsigned int v)
+{
+	/*
+	 * RFC 7230 3.3.3: Any response with a 1xx (Informational),
+	 * 204 (No Content), or 304 (Not Modified) status code is
+	 * always terminated by the first empty line after the header
+	 * fields, regardless of the header fields present in the
+	 * message, and thus cannot contain a message body.
+	 */
+	if (type & FUZZ_RESP) {
+		if ((ctx->fld_flags[METHOD]
+		     & (FUZZ_FLD_F_STATUS_100
+			| FUZZ_FLD_F_STATUS_204
+			| FUZZ_FLD_F_STATUS_304))
+		    || (v & FUZZ_MSG_F_EMPTY_BODY))
+		{
+			return true;
+		}
+	}
+	/*
+	 * RFC 7230 3.3.2: A sender MUST NOT send a Content-Length
+	 * header field in any message that contains a Transfer-Encoding
+	 * header field.
+	 */
+	if (ctx->hdr_flags & (1 << TRANSFER_ENCODING)) {
+		unsigned int te_flags = ctx->fld_flags[TRANSFER_ENCODING];
+		if (ctx->hdr_flags & (1 << CONTENT_LENGTH))
+			return false;
+		if (te_flags & FUZZ_FLD_F_CHUNKED) {
+			if (!(te_flags & FUZZ_FLD_F_CHUNKED_LAST))
+				return false;
+		} else if (type == FUZZ_REQ) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 void
 fuzz_init(TfwFuzzContext *ctx, bool is_only_valid)
 {
+	/* Ensure that there's a bit for each header field. */
+	BUILD_BUG_ON(sizeof(ctx->hdr_flags) > N_FIELDS);
+
 	memset(ctx->i, 0, sizeof(ctx->i));
 	ctx->is_only_valid = is_only_valid;
-	ctx->is_chunked_body = false;
 	ctx->curr_duplicates = 0;
 }
 EXPORT_SYMBOL(fuzz_init);
 
 /**
- * @returns FUZZ_VALID if the result is a valid request, FUZZ_INVALID if it's
- * invalid, FUZZ_END if the request sequence is over.
+ * @returns FUZZ_VALID if the result is a valid HTTP message, FUZZ_INVALID
+ * if the result is an invalid HTTP message, FUZZ_END if the HTTP message
+ * sequence is over.
  *
  * @move is how many gen_vector's elements should be changed each time a new
- * request is generated, should be >= 1.
+ * HTTP message is generated, should be >= 1.
  */
 int
 fuzz_gen(TfwFuzzContext *ctx, char *str, char *end, field_t start,
@@ -553,90 +678,91 @@ fuzz_gen(TfwFuzzContext *ctx, char *str, char *end, field_t start,
 	int i, n, ret = FUZZ_VALID;
 	unsigned int v = 0;
 
-	ctx->is_chunked_body = false;
+	ctx->hdr_flags = 0;
+	memset(ctx->fld_flags, 0, sizeof(ctx->fld_flags));
 
 	if (str == NULL)
 		return -EINVAL;
 
 	if (type == FUZZ_REQ) {
-		v |= add_field(ctx, &str, end, METHOD);
+		v |= add_field(ctx, type, &str, end, METHOD);
 		addch(&str, end, ' ');
 
-		v |= add_field(ctx, &str, end, URI_PATH_START);
+		v |= add_field(ctx, type, &str, end, URI_PATH_START);
 		addch(&str, end, '/');
-		v |= add_field(ctx, &str, end, HOST);
+		v |= add_field(ctx, type, &str, end, HOST);
 		for (i = 0; i < ctx->i[URI_PATH_DEPTH] + 1; ++i) {
 			addch(&str, end, '/');
-			v |= add_field(ctx, &str, end, URI_FILE);
+			v |= add_field(ctx, type, &str, end, URI_FILE);
 		}
 		addch(&str, end, ' ');
 	}
 
 	add_string(&str, end, "HTTP/");
-	v |= add_field(ctx, &str, end, HTTP_VER);
+	v |= add_field(ctx, type, &str, end, HTTP_VER);
 
 	if (type == FUZZ_RESP) {
 		addch(&str, end, ' ');
-		v |= add_field(ctx, &str, end, SPACES);
-		v |= add_field(ctx, &str, end, RESP_CODE);
+		v |= add_field(ctx, type, &str, end, SPACES);
+		v |= add_field(ctx, type, &str, end, RESP_CODE);
 	}
 
 	add_string(&str, end, "\r\n");
 
 	if (type == FUZZ_REQ) {
-		v |= add_header(ctx, &str, end, HOST);
-		v |= add_duplicates(ctx, &str, end, HOST);
+		v |= add_header(ctx, type, &str, end, HOST);
+		v |= add_duplicates(ctx, type, &str, end, HOST);
 
-		v |= add_header(ctx, &str, end, ACCEPT);
-		v |= add_duplicates(ctx, &str, end, ACCEPT);
+		v |= add_header(ctx, type, &str, end, ACCEPT);
+		v |= add_duplicates(ctx, type, &str, end, ACCEPT);
 
-		v |= add_header(ctx, &str, end, ACCEPT_LANGUAGE);
-		v |= add_duplicates(ctx, &str, end, ACCEPT_LANGUAGE);
+		v |= add_header(ctx, type, &str, end, ACCEPT_LANGUAGE);
+		v |= add_duplicates(ctx, type, &str, end, ACCEPT_LANGUAGE);
 
-		v |= add_header(ctx, &str, end, ACCEPT_ENCODING);
-		v |= add_duplicates(ctx, &str, end, ACCEPT_ENCODING);
+		v |= add_header(ctx, type, &str, end, ACCEPT_ENCODING);
+		v |= add_duplicates(ctx, type, &str, end, ACCEPT_ENCODING);
 
-		v |= add_header(ctx, &str, end, COOKIE);
-		v |= add_duplicates(ctx, &str, end, COOKIE);
+		v |= add_header(ctx, type, &str, end, COOKIE);
+		v |= add_duplicates(ctx, type, &str, end, COOKIE);
 
-		v |= add_header(ctx, &str, end, X_FORWARDED_FOR);
-		v |= add_duplicates(ctx, &str, end, X_FORWARDED_FOR);
+		v |= add_header(ctx, type, &str, end, X_FORWARDED_FOR);
+		v |= add_duplicates(ctx, type, &str, end, X_FORWARDED_FOR);
 
-		v |= add_header(ctx, &str, end, USER_AGENT);
-		v |= add_duplicates(ctx, &str, end, USER_AGENT);
+		v |= add_header(ctx, type, &str, end, USER_AGENT);
+		v |= add_duplicates(ctx, type, &str, end, USER_AGENT);
 	}
 	else if (type == FUZZ_RESP) {
-		v |= add_header(ctx, &str, end, ACCEPT_RANGES);
-		v |= add_duplicates(ctx, &str, end, ACCEPT_RANGES);
+		v |= add_header(ctx, type, &str, end, ACCEPT_RANGES);
+		v |= add_duplicates(ctx, type, &str, end, ACCEPT_RANGES);
 
-		v |= add_header(ctx, &str, end, SET_COOKIE);
-		v |= add_duplicates(ctx, &str, end, SET_COOKIE);
+		v |= add_header(ctx, type, &str, end, SET_COOKIE);
+		v |= add_duplicates(ctx, type, &str, end, SET_COOKIE);
 
-		v |= add_header(ctx, &str, end, ETAG);
-		v |= add_duplicates(ctx, &str, end, ETAG);
+		v |= add_header(ctx, type, &str, end, ETAG);
+		v |= add_duplicates(ctx, type, &str, end, ETAG);
 
-		v |= add_header(ctx, &str, end, SERVER);
-		v |= add_duplicates(ctx, &str, end, SERVER);
+		v |= add_header(ctx, type, &str, end, SERVER);
+		v |= add_duplicates(ctx, type, &str, end, SERVER);
 
-		v |= add_header(ctx, &str, end, EXPIRES);
-		v |= add_duplicates(ctx, &str, end, EXPIRES);
-
-		n = ctx->i[TRANSFER_ENCODING_NUM];
-		v |= __add_header(ctx, &str, end, TRANSFER_ENCODING, n);
-		v |= __add_duplicates(ctx, &str, end, TRANSFER_ENCODING, n);
+		v |= add_header(ctx, type, &str, end, EXPIRES);
+		v |= add_duplicates(ctx, type, &str, end, EXPIRES);
 	}
 
-	v |= add_header(ctx, &str, end, CONNECTION);
-	v |= add_duplicates(ctx, &str, end, CONNECTION);
+	n = ctx->i[TRANSFER_ENCODING_NUM];
+	v |= __add_header_rand(ctx, type, &str, end, TRANSFER_ENCODING, n);
+	v |= __add_duplicates(ctx, type, &str, end, TRANSFER_ENCODING, n);
 
-	v |= add_header(ctx, &str, end, CONTENT_TYPE);
-	v |= add_duplicates(ctx, &str, end, CONTENT_TYPE);
+	v |= add_header(ctx, type, &str, end, CONNECTION);
+	v |= add_duplicates(ctx, type, &str, end, CONNECTION);
 
-	v |= add_header(ctx, &str, end, CONTENT_LENGTH);
-	v |= add_duplicates(ctx, &str, end, CONTENT_LENGTH);
+	v |= add_header(ctx, type, &str, end, CONTENT_TYPE);
+	v |= add_duplicates(ctx, type, &str, end, CONTENT_TYPE);
 
-	v |= add_header(ctx, &str, end, CACHE_CONTROL);
-	v |= add_duplicates(ctx, &str, end, CACHE_CONTROL);
+	v |= add_header(ctx, type, &str, end, CONTENT_LENGTH);
+	v |= add_duplicates(ctx, type, &str, end, CONTENT_LENGTH);
+
+	v |= add_header(ctx, type, &str, end, CACHE_CONTROL);
+	v |= add_duplicates(ctx, type, &str, end, CACHE_CONTROL);
 
 	add_string(&str, end, "\r\n");
 
@@ -653,6 +779,9 @@ fuzz_gen(TfwFuzzContext *ctx, char *str, char *end, field_t start,
 		v |= FUZZ_INVALID;
 		*(end - 1) = '\0';
 	}
+
+	if (!(v & FUZZ_INVALID) && !fuzz_hdrs_compatible(ctx, type, v))
+		v |= FUZZ_INVALID;
 
 	for (i = 0; i < move; i++) {
 		ret = gen_vector_move(ctx, start);

--- a/tempesta_fw/t/fuzzer.h
+++ b/tempesta_fw/t/fuzzer.h
@@ -59,17 +59,21 @@ typedef enum {
 	EXPIRES,
 	TRANSFER_ENCODING_NUM,
 	URI_PATH_DEPTH,
-	DUPLICATES,
 	BODY_CHUNKS_NUM,
 	N_FIELDS,
 } field_t;
 
+/*
+ * @hdr_flags		- a flag for each header;
+ * @fld_flags		- message and contents flags;
+ */
 typedef struct {
 	int i[N_FIELDS];
 	bool is_only_valid;
-	bool is_chunked_body;
 	char content_length[MAX_CONTENT_LENGTH_LEN + 1];
 	int curr_duplicates;
+	unsigned int hdr_flags;
+	unsigned int fld_flags[N_FIELDS];
 } TfwFuzzContext;
 
 void fuzz_init(TfwFuzzContext *context, bool is_only_valid);

--- a/tempesta_fw/t/unit/helpers.c
+++ b/tempesta_fw/t/unit/helpers.c
@@ -33,8 +33,7 @@
  */
 #include "http_msg.h"
 
-TfwConnection conn_req = { .proto.type = Conn_HttpClnt };
-TfwConnection conn_resp = { .proto.type = Conn_HttpSrv };
+static TfwConnection conn_req, conn_resp;
 
 TfwHttpReq *
 test_req_alloc(size_t data_len)
@@ -49,6 +48,9 @@ test_req_alloc(size_t data_len)
 	req = (TfwHttpReq *)tfw_http_msg_create(NULL, &it, Conn_HttpClnt,
 						data_len);
 	BUG_ON(!req);
+
+	memset(&conn_req, 0, sizeof(TfwConnection));
+	conn_req.proto.type = Conn_HttpClnt;
 	req->conn = &conn_req;
 
 	return req;
@@ -73,6 +75,9 @@ test_resp_alloc(size_t data_len)
 	resp = (TfwHttpResp *)tfw_http_msg_create(NULL, &it, Conn_HttpSrv,
 						  data_len);
 	BUG_ON(!resp);
+
+	memset(&conn_resp, 0, sizeof(TfwConnection));
+	conn_resp.proto.type = Conn_HttpSrv;
 	resp->conn = &conn_resp;
 
 	return resp;

--- a/tempesta_fw/t/unit/helpers.c
+++ b/tempesta_fw/t/unit/helpers.c
@@ -33,6 +33,9 @@
  */
 #include "http_msg.h"
 
+TfwConnection conn_req = { .proto.type = Conn_HttpClnt };
+TfwConnection conn_resp = { .proto.type = Conn_HttpSrv };
+
 TfwHttpReq *
 test_req_alloc(size_t data_len)
 {
@@ -46,6 +49,7 @@ test_req_alloc(size_t data_len)
 	req = (TfwHttpReq *)tfw_http_msg_create(NULL, &it, Conn_HttpClnt,
 						data_len);
 	BUG_ON(!req);
+	req->conn = &conn_req;
 
 	return req;
 }
@@ -69,6 +73,7 @@ test_resp_alloc(size_t data_len)
 	resp = (TfwHttpResp *)tfw_http_msg_create(NULL, &it, Conn_HttpSrv,
 						  data_len);
 	BUG_ON(!resp);
+	resp->conn = &conn_resp;
 
 	return resp;
 }

--- a/tempesta_fw/t/unit/test_cfg.c
+++ b/tempesta_fw/t/unit/test_cfg.c
@@ -117,7 +117,7 @@ cleanup_incr_ctr(TfwCfgSpec *cs)
  * ------------------------------------------------------------------------
  */
 
-TEST(cfg_paresr, invokes_specified_handler)
+TEST(cfg_parser, invokes_specified_handler)
 {
 	int ctr = 0;
 
@@ -1033,7 +1033,7 @@ TEST(tfw_cfg_handle_children, propagates_cleanup_to_nested_specs)
 
 TEST_SUITE(cfg)
 {
-	TEST_RUN(cfg_paresr, invokes_specified_handler);
+	TEST_RUN(cfg_parser, invokes_specified_handler);
 	TEST_RUN(cfg_parser, allows_repeating_entries);
 	TEST_RUN(cfg_parser, allows_optional_entries);
 	TEST_RUN(cfg_parser, puts_parsed_vals_to_entry);

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -273,6 +273,46 @@ TEST(http_parser, mangled_messages)
 			 "Host: test\r\n"
 			 "Connection: close, \"foo\"\r\n"
 			 "\r\n");
+	/*
+	 * "Content-Length:" and "Transfer-Encoding:" header fields
+	 * may not be present together in a request.
+	 */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "Content-Length: 4\r\n"
+			 "Transfer-Encoding: chunked\r\n"
+			 "\r\n"
+			 "4\r\n"
+			 "12345\r\n"
+			 "0\r\n"
+			 "\r\n");
+	/*
+	 * "chunked" coding must be present in a request if there's
+	 * any other coding (i.e. "Transfer-Encoding" is present).
+	 */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "Transfer-Encoding: gzip\r\n"
+			 "\r\n"
+			 "4\r\n"
+			 "12345\r\n");
+
+	/* "chunked" conding must be the last coding. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "Transfer-Encoding: chunked, gzip\r\n"
+			 "\r\n"
+			 "4\r\n"
+			 "12345\r\n"
+			 "0\r\n"
+			 "\r\n");
+
+	/* "chunked" coding may not be applied twice. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "Transfer-Encoding: gzip, chunked\r\n"
+			 "Transfer-Encoding: chunked\r\n"
+			 "\r\n"
+			 "4\r\n"
+			 "12345\r\n"
+			 "0\r\n"
+			 "\r\n");
 
 	EXPECT_BLOCK_RESP("HTTP/1.0 200 OK\r\n"
 			 "Content-Type: foo/aa-\x19np\r\n"
@@ -281,6 +321,44 @@ TEST(http_parser, mangled_messages)
 	EXPECT_BLOCK_RESP("HTTP/1.0 200 OK\r\n"
 			  "Content-Length: 0\r\n"
 			  "X-Foo: t\x7fst\r\n"
+			  "\r\n");
+	/*
+	 * "Content-Length:" and "Transfer-Encoding:" header fields
+	 * may not be present together in a response.
+	 */
+	EXPECT_BLOCK_RESP("HTTP/1.0 200 OK\r\n"
+			  "Content-Length: 7\r\n"
+			  "Server: test server\r\n"
+			  "Transfer-Encoding: chunked\r\n"
+			  "\r\n"
+			  "7\r\n"
+			  "1234567\r\n"
+			  "0\r\n"
+			  "\r\n");
+	/*
+	 * "chunked" coding may be missing in a response, but that
+	 * means "unlimited body" which is tested by other means.
+	 */
+
+	/* "chunked" coding must be the last coding. */
+	EXPECT_BLOCK_RESP("HTTP/1.0 200 OK\r\n"
+			  "Server: test server\r\n"
+			  "Transfer-Encoding: chunked, gzip\r\n"
+			  "\r\n"
+			  "7\r\n"
+			  "1234567\r\n"
+			  "0\r\n"
+			  "\r\n");
+
+	/* "chunked" coding may not be applied twice. */
+	EXPECT_BLOCK_RESP("HTTP/1.0 200 OK\r\n"
+			  "Server: test server\r\n"
+			  "Transfer-Encoding: gzip, chunked\r\n"
+			  "Transfer-Encoding: chunked\r\n"
+			  "\r\n"
+			  "7\r\n"
+			  "1234567\r\n"
+			  "0\r\n"
 			  "\r\n");
 }
 
@@ -298,46 +376,51 @@ TEST(http_parser, alphabets)
 
 	/* Trailing SP in request. */
 	FOR_REQ("GET /foo HTTP/1.1\r\n"
+		"Host: localhost\t  \r\n"
 		"User-Agent: Wget/1.13.4 (linux-gnu)\t  \r\n"
 		"Accept: */*\t \r\n"
-		"Host: localhost\t  \r\n"
 		"Connection: Keep-Alive \t \r\n"
 		"X-Custom-Hdr: custom header values \t  \r\n"
 		"X-Forwarded-For: 127.0.0.1, example.com    \t \r\n"
-		"Content-Length: 0  \t \r\n"
 		"Content-Type: text/html; charset=iso-8859-1  \t \r\n"
 		"Cache-Control: max-age=0, private, min-fresh=42 \t \r\n"
-		"Transfer-Encoding: compress, deflate, gzip\t  \r\n"
+		"Transfer-Encoding: compress, deflate, gzip, chunked\t  \r\n"
 		"Cookie: session=42; theme=dark  \t \r\n"
+		"\r\n"
+		"3\r\n"
+		"123\r\n"
+		"0\r\n"
 		"\r\n");
 
 	/* Trailing SP in response. */
 	FOR_RESP("HTTP/1.1 200 OK\r\n"
 		"Connection: Keep-Alive \t \r\n"
 		"X-header: 6  \t  \t \r\n"
-		"Content-Length: 0 \t \r\n"
 		"Content-Type: text/html; charset=iso-8859-1 \t \r\n"
 		"Cache-Control: max-age=0, private, min-fresh=42 \t \r\n"
 		"Expires: Tue, 31 Jan 2012 15:02:53 GMT \t \r\n"
 		"Keep-Alive: timeout=600, max=65526 \t \r\n"
-		"Transfer-Encoding: compress, deflate, gzip \t \r\n"
+		"Transfer-Encoding: compress, deflate, gzip, chunked \t \r\n"
 		"Server: Apache/2.4.6 (CentOS)  \t  \r\n"
+		"\r\n"
+		"4\r\n"
+		"1234\r\n"
+		"0\r\n"
 		"\r\n");
 }
 
 TEST(http_parser, fills_hdr_tbl_for_req)
 {
 	TfwHttpHdrTbl *ht;
-	TfwStr *h_accept, *h_xch, *h_dummy4, *h_dummy9, *h_cc, *h_te, *h_pragma,
+	TfwStr *h_accept, *h_xch, *h_dummy4, *h_dummy9, *h_cc, *h_pragma,
 	       *h_auth;
-	TfwStr h_host, h_connection, h_contlen, h_conttype, h_xff,
-	       h_user_agent, h_cookie;
+	TfwStr h_host, h_connection, h_conttype, h_xff, h_user_agent, h_cookie,
+	       h_te;
 
 	/* Expected values for special headers. */
 	const char *s_host = "localhost";
 	const char *s_connection = "Keep-Alive";
 	const char *s_xff = "127.0.0.1, example.com";
-	const char *s_cl = "0";
 	const char *s_ct = "text/html; charset=iso-8859-1";
 	const char *s_user_agent = "Wget/1.13.4 (linux-gnu)";
 	const char *s_cookie = "session=42; theme=dark";
@@ -347,7 +430,7 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
 	const char *s_cc  = "Cache-Control: max-age=1, no-store, min-fresh=30";
-	const char *s_te  = "Transfer-Encoding: compress, deflate, gzip";
+	const char *s_te  = "Transfer-Encoding: compress, gzip, chunked";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_pragma =  "Pragma: no-cache, fooo ";
 	const char *s_auth =  "Authorization: "
@@ -367,17 +450,20 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 		"Dummy4: 4\r\n"
 		"Dummy5: 5\r\n"
 		"Dummy6: 6\r\n"
-		"Content-Length: 0\r\n"
 		"Content-Type: text/html; charset=iso-8859-1\r\n"
 		"Dummy7: 7\r\n"
 		"Dummy8: 8\r\n" /* That is done to check table reallocation. */
 		"Dummy9: 9\r\n"
 		"Cache-Control: max-age=1, no-store, min-fresh=30\r\n"
 		"Pragma: no-cache, fooo \r\n"
-		"Transfer-Encoding: compress, deflate, gzip\r\n"
+		"Transfer-Encoding: compress, gzip, chunked\r\n"
 		"Cookie: session=42; theme=dark\r\n"
 		"Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\t \n"
-		"\r\n")
+		"\r\n"
+		"6\r\n"
+		"123456\r\n"
+		"0\r\n"
+		"\r\n");
 	{
 		ht = req->h_tbl;
 
@@ -387,9 +473,6 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 		tfw_http_msg_clnthdr_val(&ht->tbl[TFW_HTTP_HDR_CONNECTION],
 					 TFW_HTTP_HDR_CONNECTION,
 					 &h_connection);
-		tfw_http_msg_clnthdr_val(&ht->tbl[TFW_HTTP_HDR_CONTENT_LENGTH],
-					 TFW_HTTP_HDR_CONTENT_LENGTH,
-					 &h_contlen);
 		tfw_http_msg_clnthdr_val(&ht->tbl[TFW_HTTP_HDR_CONTENT_TYPE],
 					 TFW_HTTP_HDR_CONTENT_TYPE,
 					 &h_conttype);
@@ -398,11 +481,13 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 		tfw_http_msg_clnthdr_val(&ht->tbl[TFW_HTTP_HDR_USER_AGENT],
 					 TFW_HTTP_HDR_USER_AGENT,
 					 &h_user_agent);
+		tfw_http_msg_clnthdr_val(&ht->tbl[TFW_HTTP_HDR_TRANSFER_ENCODING],
+					 TFW_HTTP_HDR_TRANSFER_ENCODING, &h_te);
 		tfw_http_msg_clnthdr_val(&ht->tbl[TFW_HTTP_HDR_COOKIE],
 					 TFW_HTTP_HDR_COOKIE, &h_cookie);
 
 		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 15);
 
 		h_accept = &ht->tbl[TFW_HTTP_HDR_RAW + 0];
 		h_xch = &ht->tbl[TFW_HTTP_HDR_RAW + 1];
@@ -410,21 +495,20 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 		h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
 		h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
 		h_pragma = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
-		h_te = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
-		h_auth = &ht->tbl[TFW_HTTP_HDR_RAW + 15];
+		h_auth = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
 
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_host, s_host,
 					    strlen(s_host), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_connection, s_connection,
 					    strlen(s_connection), 0));
-		EXPECT_TRUE(tfw_str_eq_cstr(&h_contlen, s_cl,
-					    strlen(s_cl), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_conttype, s_ct,
 					    strlen(s_ct), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_xff, s_xff,
 					    strlen(s_xff), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_user_agent, s_user_agent,
 					    strlen(s_user_agent), 0));
+		EXPECT_TRUE(tfw_str_eq_cstr(&h_te, s_te,
+					    strlen(s_te), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_cookie, s_cookie,
 					    strlen(s_cookie), 0));
 
@@ -438,8 +522,6 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 					    strlen(s_dummy9), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_cc, s_cc,
 					    strlen(s_cc), 0));
-		EXPECT_TRUE(tfw_str_eq_cstr(h_te, s_te,
-					    strlen(s_te), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_pragma, s_pragma,
 					    strlen(s_pragma), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_auth, s_auth,
@@ -459,13 +541,11 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 TEST(http_parser, fills_hdr_tbl_for_resp)
 {
 	TfwHttpHdrTbl *ht;
-	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_te, *h_age, *h_date, *h_exp,
-	       *h_ka;
-	TfwStr h_connection, h_contlen, h_conttype, h_srv;
+	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_age, *h_date, *h_exp, *h_ka;
+	TfwStr h_connection, h_conttype, h_srv, h_te;
 
 	/* Expected values for special headers. */
 	const char *s_connection = "Keep-Alive";
-	const char *s_cl = "3";
 	const char *s_ct = "text/html; charset=iso-8859-1";
 	const char *s_srv = "Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"
 			    " mod_fcgid/2.3.9";
@@ -474,7 +554,7 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 	const char *s_dummy4 = "Dummy4: 4";
 	const char *s_cc = "Cache-Control: "
 			   "max-age=5, private, no-cache, ext=foo";
-	const char *s_te = "Transfer-Encoding: compress, deflate, gzip";
+	const char *s_te = "Transfer-Encoding: compress, gzip, chunked";
 	const char *s_exp = "Expires: Tue, 31 Jan 2012 15:02:53 GMT";
 	const char *s_ka = "Keep-Alive: timeout=600, max=65526";
 	/* Trailing spaces are stored within header strings. */
@@ -490,7 +570,6 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		"Dummy4: 4\r\n"
 		"Dummy5: 5\r\n"
 		"Dummy6: 6\r\n"
-		"Content-Length: 3\r\n"
 		"Content-Type: text/html; charset=iso-8859-1\r\n"
 		"Dummy7: 7\r\n"
 		"Dummy8: 8\r\n"
@@ -498,13 +577,16 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		"Dummy9: 9\r\n" /* That is done to check table reallocation. */
 		"Expires: Tue, 31 Jan 2012 15:02:53 GMT\r\n"
 		"Keep-Alive: timeout=600, max=65526\r\n"
-		"Transfer-Encoding: compress, deflate, gzip\r\n"
+		"Transfer-Encoding: compress, gzip, chunked\r\n"
 		"Server: Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"
 		        " mod_fcgid/2.3.9\r\n"
 		"Age: 12  \n"
 		"Date: Sun, 9 Sep 2001 01:46:40 GMT\t\n"
 		"\r\n"
-		"012")
+		"3\r\n"
+		"012\r\n"
+		"0\r\n"
+		"\r\n");
 	{
 		ht = resp->h_tbl;
 
@@ -515,38 +597,36 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_CONNECTION],
 					TFW_HTTP_HDR_CONNECTION,
 					&h_connection);
-		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_CONTENT_LENGTH],
-					TFW_HTTP_HDR_CONTENT_LENGTH,
-					&h_contlen);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_CONTENT_TYPE],
 					TFW_HTTP_HDR_CONTENT_TYPE,
 					&h_conttype);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_SERVER],
 					TFW_HTTP_HDR_SERVER, &h_srv);
+		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_TRANSFER_ENCODING],
+					TFW_HTTP_HDR_TRANSFER_ENCODING, &h_te);
 
 		/*
 		 * Common (raw) headers: 10 dummies, Cache-Control,
 		 * Expires, Keep-Alive, Transfer-Encoding, Age, Date.
 		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 15);
 
 		h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
 		h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
 		h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
 		h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
 		h_ka = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
-		h_te = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
-		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
-		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 15];
+		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
+		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
 
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_connection, s_connection,
 					    strlen(s_connection), 0));
-		EXPECT_TRUE(tfw_str_eq_cstr(&h_contlen, s_cl,
-					    strlen(s_cl), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_conttype, s_ct,
 					    strlen(s_ct), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_srv, s_srv,
 					    strlen(s_srv), 0));
+		EXPECT_TRUE(tfw_str_eq_cstr(&h_te, s_te,
+					    strlen(s_te), 0));
 
 		EXPECT_TRUE(tfw_str_eq_cstr(h_dummy4, s_dummy4,
 					    strlen(s_dummy4), 0));
@@ -558,14 +638,11 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					    strlen(s_exp), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_ka, s_ka,
 					    strlen(s_ka), 0));
-		EXPECT_TRUE(tfw_str_eq_cstr(h_te, s_te,
-					    strlen(s_te), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_age, s_age,
 					    strlen(s_age), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_date, s_date,
 					    strlen(s_date), 0));
 
-		EXPECT_TRUE(resp->content_length == 3);
 		EXPECT_TRUE(resp->status == 200);
 		EXPECT_TRUE(resp->cache_ctl.flags & TFW_HTTP_CC_PRIVATE);
 		EXPECT_TRUE(resp->cache_ctl.flags & TFW_HTTP_CC_NO_CACHE);

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -774,7 +774,6 @@ TEST(http_parser, chunked)
 
 	FOR_REQ("POST / HTTP/1.1\r\n"
 		"Host:\r\n"
-		"Content-Length: 5\r\n"
 		"Transfer-Encoding: chunked\r\n"
 		"\r\n"
 		"5;cext=val\r\n"
@@ -799,7 +798,6 @@ TEST(http_parser, chunked)
 	}
 
 	FOR_RESP("HTTP/1.1 200 OK\r\n"
-		 "Content-Length: 100\r\n"
 		 "Transfer-Encoding: chunked\r\n"
 		 "\n"
 		 "5\r\n"

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -123,13 +123,11 @@ do_split_and_parse(unsigned char *str, int type)
 #define TRY_PARSE_EXPECT_PASS(str, type)			\
 ({ 								\
 	int _err = do_split_and_parse(str, type);		\
-	if (_err == TFW_BLOCK || _err == TFW_POSTPONE) {	\
-		chunks = 1;					\
+	if (_err == TFW_BLOCK || _err == TFW_POSTPONE)		\
 		TEST_FAIL("can't parse %s (code=%d):\n%s",	\
 			  (type == FUZZ_REQ ? "request" :	\
 				              "response"),	\
 			  _err, (str)); 			\
-	}							\
 	_err == TFW_PASS;					\
 })
 


### PR DESCRIPTION
- Do not add extra chunks to msg->crlf in case of a chunked body
  and trailing headers.
- In tests, do not send "Content-Length:" header together with
  "Transfer-Encoding:" header.
- Check that the parsed body length matches the value specified
  in "Content-Length:" header only for messages with linear body
  (not chunked).