### PR TITLE
Don't cache and don't forward hop-by-hop headers

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -147,8 +147,9 @@ enum {
  */
 static const int hbh_hdrs[] = {
 	[0 ... TFW_HTTP_HDR_RAW]	= 0,
-        [TFW_HTTP_HDR_SERVER]		= 1,
+	[TFW_HTTP_HDR_SERVER]		= 1,
 	[TFW_HTTP_HDR_CONNECTION]	= 1,
+	[TFW_HTTP_HDR_KEEP_ALIVE]	= 1,
 };
 
 typedef struct {

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -131,27 +131,6 @@ enum {
 	TFW_CACHE_REPLICA,
 };
 
-/*
- * Non-cacheable hop-by-hop response headers in terms of RFC 2068.
- * The table is used if server doesn't specify Cache-Control no-cache
- * directive (RFC 7234 5.2.2.2) explicitly.
- *
- * Server header isn't defined as hop-by-hop by the RFC, but we don't show
- * protected server to world.
- *
- * We don't store the headers in cache and create then from scratch.
- * Adding a header is faster then modify it, so this speeds up headers
- * adjusting as well as saves cache storage.
- *
- * TODO process Cache-Control no-cache
- */
-static const int hbh_hdrs[] = {
-	[0 ... TFW_HTTP_HDR_RAW]	= 0,
-	[TFW_HTTP_HDR_SERVER]		= 1,
-	[TFW_HTTP_HDR_CONNECTION]	= 1,
-	[TFW_HTTP_HDR_KEEP_ALIVE]	= 1,
-};
-
 typedef struct {
 	int		cpu[NR_CPUS];
 	atomic_t	cpu_idx;
@@ -767,7 +746,14 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwHttpReq *req,
 	FOR_EACH_HDR_FIELD(field, end1, resp) {
 		n = field - resp->h_tbl->tbl;
 		/* Skip hop-by-hop headers. */
-		h = (n < TFW_HTTP_HDR_RAW && hbh_hdrs[n]) ? &empty : field;
+		if (!(field->flags & TFW_STR_HBH_HDR)) {
+			h = field;
+		} else if (n < TFW_HTTP_HDR_RAW) {
+			h = &empty;
+		} else {
+			--ce->hdr_num;
+			continue;
+		}
 		n = tfw_cache_copy_hdr(&p, &trec, h, &tot_len);
 		if (n < 0) {
 			TFW_ERR("Cache: cannot copy HTTP header\n");
@@ -822,7 +808,13 @@ __cache_entry_size(TfwHttpResp *resp, TfwHttpReq *req)
 	FOR_EACH_HDR_FIELD(hdr, hdr_end, resp) {
 		/* Skip hop-by-hop headers. */
 		n = hdr - resp->h_tbl->tbl;
-		h = (n < TFW_HTTP_HDR_RAW && hbh_hdrs[n]) ? &empty : hdr;
+		if (!(hdr->flags & TFW_STR_HBH_HDR))
+			h = hdr;
+		else if (n < TFW_HTTP_HDR_RAW)
+			h = &empty;
+		else
+			continue;
+
 		if (!TFW_STR_DUP(h)) {
 			size += sizeof(TfwCStr);
 			size += h->len ? (h->len + SLEN(S_CRLF)) : 0;

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -744,11 +744,10 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwHttpReq *req,
 	ce->hdr_len = 0;
 	ce->hdr_num = resp->h_tbl->off;
 	FOR_EACH_HDR_FIELD(field, end1, resp) {
-		n = field - resp->h_tbl->tbl;
 		/* Skip hop-by-hop headers. */
 		if (!(field->flags & TFW_STR_HBH_HDR)) {
 			h = field;
-		} else if (n < TFW_HTTP_HDR_RAW) {
+		} else if (field - resp->h_tbl->tbl < TFW_HTTP_HDR_RAW) {
 			h = &empty;
 		} else {
 			--ce->hdr_num;
@@ -796,7 +795,6 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwHttpReq *req,
 static size_t
 __cache_entry_size(TfwHttpResp *resp, TfwHttpReq *req)
 {
-	long n;
 	size_t size = CE_BODY_SIZE;
 	TfwStr *h, *hdr, *hdr_end, *dup, *dup_end, empty = {};
 
@@ -807,10 +805,9 @@ __cache_entry_size(TfwHttpResp *resp, TfwHttpReq *req)
 	/* Add all the headers size */
 	FOR_EACH_HDR_FIELD(hdr, hdr_end, resp) {
 		/* Skip hop-by-hop headers. */
-		n = hdr - resp->h_tbl->tbl;
 		if (!(hdr->flags & TFW_STR_HBH_HDR))
 			h = hdr;
-		else if (n < TFW_HTTP_HDR_RAW)
+		else if (hdr - resp->h_tbl->tbl < TFW_HTTP_HDR_RAW)
 			h = &empty;
 		else
 			continue;

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -601,7 +601,8 @@ static int
 tfw_http_set_hdr_connection(TfwHttpMsg *hm, int conn_flg)
 {
 	if (((hm->flags & __TFW_HTTP_CONN_MASK) == conn_flg)
-	    && (!TFW_STR_EMPTY(&hm->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION])))
+	    && (!TFW_STR_EMPTY(&hm->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION]))
+	    && !(hm->flags & TFW_HTTP_CONN_EXTRA))
 		return 0;
 
 	switch (conn_flg) {

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -617,7 +617,7 @@ tfw_http_set_hdr_connection(TfwHttpMsg *hm, int conn_flg)
 	}
 }
 
-/*
+/**
  * Add/Replace/Remove Keep-Alive header field to/from HTTP message.
  */
 static int
@@ -630,7 +630,7 @@ tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, int conn_flg)
 
 	switch (conn_flg) {
 	case TFW_HTTP_CONN_CLOSE:
-		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive", TFW_HTTP_HDR_RAW);
+		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive", TFW_HTTP_HDR_KEEP_ALIVE);
 		if (unlikely(r && r != -ENOENT)) {
 			TFW_WARN("Cannot delete Keep-Alive header (%d)\n", r);
 			return r;

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -736,6 +736,10 @@ tfw_http_adjust_req(TfwHttpReq *req)
 	if (r)
 		return r;
 
+	r = tfw_http_msg_del_hbh_hdrs(hm);
+	if (r < 0)
+		return r;
+
 	return tfw_http_set_hdr_connection(hm, TFW_HTTP_CONN_KA);
 }
 
@@ -751,6 +755,10 @@ tfw_http_adjust_resp(TfwHttpResp *resp, TfwHttpReq *req)
 	__init_resp_ss_flags(resp, req);
 
 	r = tfw_http_sess_resp_process(resp, req);
+	if (r < 0)
+		return r;
+
+	r = tfw_http_msg_del_hbh_hdrs(hm);
 	if (r < 0)
 		return r;
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -145,6 +145,7 @@ typedef struct {
  * If the new header is hop-by-hop (must not be forwarded and cached by Tempesta)
  * it must be listed in __hbh_parser_init_req()/__hbh_parser_init_resp() for
  * unconditionally hop-by-hop header or in __parse_connection() otherwize.
+ * If the header is end-to-end it must be listed in __hbh_parser_add_data().
  *
  * Note: don't forget to update __http_msg_hdr_val() upon adding a new header.
  *

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -197,7 +197,8 @@ typedef struct {
  * adjusting as well as saves cache storage.
  *
  * Headers unconditionaly treated as hop-by-hop must be listed in
- * __hbh_parser_init() function and must be members of Special headers
+ * __hbh_parser_init_req()/__hbh_parser_init_resp() functions and must be
+ * members of Special headers.
  * group.
  *
  * @spec	- bit array for special headers. Hop-by-hop special header is

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -198,6 +198,7 @@ typedef enum {
 
 	TFW_HTTP_HDR_CONNECTION = TFW_HTTP_HDR_NONSINGULAR,
 	TFW_HTTP_HDR_X_FORWARDED_FOR,
+	TFW_HTTP_HDR_KEEP_ALIVE,
 	TFW_HTTP_HDR_TRANSFER_ENCODING,
 
 	/* Start of list of generic (raw) headers. */
@@ -263,6 +264,7 @@ typedef struct {
  * @content_length	- the value of Content-Length header field;
  * @conn		- connection which the message was received on;
  * @jtstamp		- time the message has been received, in jiffies;
+ * @keep_alive		- keep-alive timeout
  * @crlf		- pointer to CRLF between headers and body;
  * @body		- pointer to the body of a message;
  *
@@ -278,6 +280,7 @@ typedef struct {
 	unsigned int	flags;						\
 	unsigned long	content_length;					\
 	unsigned long	jtstamp;					\
+	unsigned int	keep_alive;					\
 	TfwConnection	*conn;						\
 	void (*destructor)(void *msg);					\
 	TfwStr		crlf;						\
@@ -340,7 +343,6 @@ typedef struct {
 	TFW_HTTP_MSG_COMMON;
 	TfwStr			s_line;
 	unsigned short		status;
-	unsigned int		keep_alive;
 	time_t			date;
 } TfwHttpResp;
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -137,46 +137,13 @@ typedef struct {
 } TfwCacheControl;
 
 /**
- * We use goto/switch-driven automaton, so compiler typically generates binary
- * search code over jump labels, so it gives log(N) lookup complexity where
- * N is number of states. However, DFA for full HTTP processing can be quite
- * large and log(N) becomes expensive and hard to code.
- *
- * So we use states space splitting to avoid states explosion.
- * @_i_st is used to save current state and go to interior sub-automaton
- * (e.g. process OWS using @state while current state is saved in @_i_st
- * or using @_i_st parse value of a header described.
- *
- * @to_go	- remaining number of bytes to process in the data chunk;
- *		  (limited by single packet size and never exceeds 64KB)
- * @state	- current parser state;
- * @_i_st	- helping (interior) state;
- * @to_read	- remaining number of bytes to read;
- * @_acc	- integer accumulator for parsing chunked integers;
- * @_date	- accumulator for a date in date related headers;
- * @_hdr_tag	- stores header id which must be closed on generic EoL handling
- *		  (see RGEN_EOL());
- * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
- * @hdr		- currently parsed header.
- */
-typedef struct {
-	unsigned short	to_go;
-	int		state;
-	int		_i_st;
-	int		to_read;
-	unsigned long	_acc;
-	time_t		_date;
-	unsigned int	_hdr_tag;
-	TfwStr		_tmp_chunk;
-	TfwStr		hdr;
-} TfwHttpParser;
-
-/**
  * Http headers table.
  *
  * Singular headers (in terms of RFC 7230 3.2.2) go first to protect header
  * repetition attacks. See __hdr_is_singular() and don't forget to
  * update the static headers array when add a new singular header here.
+ * If new header can be hop-by-hop header update of __parse_connection() is
+ * also needed.
  *
  * Note: don't forget to update __http_msg_hdr_val() upon adding a new header.
  *
@@ -218,12 +185,70 @@ typedef struct {
 					 + sizeof(TfwStr) * (s))
 #define TFW_HHTBL_SZ(o)			TFW_HHTBL_EXACTSZ(__HHTBL_SZ(o))
 
+/**
+ * Non-cacheable hop-by-hop headers in terms of RFC 7230.
+ *
+ * We don't store the headers in cache and create them from scratch if needed.
+ * Adding a header is faster then modify it, so this speeds up headers
+ * adjusting as well as saves cache storage.
+ *
+ * Headers unconditionaly treated as hop-by-hop must be listed in
+ * __hbh_parser_init() function and must be members of Special headers
+ * group.
+ *
+ * @spec	- bit array for special headers. Hop-by-hop special header is
+ *		  stored as (0x1 << tfw_http_hdr_t[hid]);
+ * @raw		- table of raw headers names, parsed form connection field;
+ */
+typedef struct {
+	unsigned int	spec;
+	TfwHttpHdrTbl	*raw;
+} TfwHttpHbhHdrs;
+
+/**
+ * We use goto/switch-driven automaton, so compiler typically generates binary
+ * search code over jump labels, so it gives log(N) lookup complexity where
+ * N is number of states. However, DFA for full HTTP processing can be quite
+ * large and log(N) becomes expensive and hard to code.
+ *
+ * So we use states space splitting to avoid states explosion.
+ * @_i_st is used to save current state and go to interior sub-automaton
+ * (e.g. process OWS using @state while current state is saved in @_i_st
+ * or using @_i_st parse value of a header described.
+ *
+ * @to_go	- remaining number of bytes to process in the data chunk;
+ *		  (limited by single packet size and never exceeds 64KB)
+ * @state	- current parser state;
+ * @_i_st	- helping (interior) state;
+ * @to_read	- remaining number of bytes to read;
+ * @_hdr_tag	- stores header id which must be closed on generic EoL handling
+ *		  (see RGEN_EOL());
+ * @_acc	- integer accumulator for parsing chunked integers;
+ * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
+ * @hdr		- currently parsed header.
+ * @hbh_parser	- list of special and raw headers names to be treated as
+ *		  hop-by-hop
+ */
+typedef struct {
+	unsigned short	to_go;
+	int		state;
+	int		_i_st;
+	int		to_read;
+	unsigned long	_acc;
+	time_t		_date;
+	unsigned int	_hdr_tag;
+	TfwStr		_tmp_chunk;
+	TfwStr		hdr;
+	TfwHttpHbhHdrs	hbh_parser;
+} TfwHttpParser;
+
 /* Common flags for requests and responses. */
 #define TFW_HTTP_CONN_CLOSE		0x000001
 #define TFW_HTTP_CONN_KA		0x000002
 #define __TFW_HTTP_CONN_MASK		(TFW_HTTP_CONN_CLOSE | TFW_HTTP_CONN_KA)
-#define TFW_HTTP_CHUNKED		0x000004
-#define TFW_HTTP_MSG_SENT		0x000008
+#define TFW_HTTP_CONN_EXTRA		0x000004
+#define TFW_HTTP_CHUNKED		0x000008
+#define TFW_HTTP_MSG_SENT		0x000010
 
 /* Request flags */
 #define TFW_HTTP_HAS_STICKY		0x000100

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -202,7 +202,7 @@ typedef struct {
  */
 typedef struct {
 	unsigned int	spec;
-	TfwHttpHdrTbl	*raw;
+	TfwStr		raw[TFW_HTTP_HDR_NUM];
 } TfwHttpHbhHdrs;
 
 /**

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -810,6 +810,39 @@ tfw_http_msg_free(TfwHttpMsg *m)
 EXPORT_SYMBOL(tfw_http_msg_free);
 
 /**
+ * Add spec header indexes to list of hop-by-hop headers.
+ */
+static inline void
+__hbh_parser_init_req(TfwHttpReq *req)
+{
+	TfwHttpHbhHdrs *hbh_hdrs = &req->parser.hbh_parser;
+
+	BUG_ON(hbh_hdrs->spec);
+	/* Connection is hop-by-hop header by RFC 7230 6.1 */
+	hbh_hdrs->spec = 0x1 << TFW_HTTP_HDR_CONNECTION;
+}
+
+/**
+ * Same as @__hbh_parser_init_req for response.
+ */
+static inline void
+__hbh_parser_init_resp(TfwHttpResp *resp)
+{
+	TfwHttpHbhHdrs *hbh_hdrs = &resp->parser.hbh_parser;
+
+	BUG_ON(hbh_hdrs->spec);
+	/*
+	 * Connection is hop-by-hop header by RFC 7230 6.1
+	 *
+	 * Server header isn't defined as hop-by-hop by the RFC, but we
+	 * don't show protected server to world.
+	 */
+	hbh_hdrs->spec = (0x1 << TFW_HTTP_HDR_CONNECTION) |
+			 (0x1 << TFW_HTTP_HDR_SERVER);
+
+}
+
+/**
  * Allocate a new HTTP message.
  * Given the total message length as @data_len, it allocates an appropriate
  * number of SKBs and page fragments to hold the payload, and sets them up
@@ -841,6 +874,10 @@ tfw_http_msg_alloc(int type)
 	INIT_LIST_HEAD(&hm->msg.msg_list);
 
 	hm->parser.to_read = -1; /* unknown body size */
+	if (type & Conn_Clnt)
+		__hbh_parser_init_req((TfwHttpReq *)hm);
+	else
+		__hbh_parser_init_resp((TfwHttpResp *)hm);
 
 	if (type & Conn_Clnt)
 		hm->destructor = tfw_http_req_destruct;

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -324,22 +324,22 @@ __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str, void *data,
 }
 
 int
-__tfw_http_msg_grow_hdr_tbl(TfwHttpHdrTbl **ht, TfwPool * pool)
+tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm)
 {
-	TfwHttpHdrTbl *new_ht = *ht;
-	size_t order = new_ht->size / TFW_HTTP_HDR_NUM, new_order = order << 1;
+	TfwHttpHdrTbl *ht = hm->h_tbl;
+	size_t order = ht->size / TFW_HTTP_HDR_NUM, new_order = order << 1;
 
-	new_ht = tfw_pool_realloc(pool, new_ht, TFW_HHTBL_SZ(order),
+	ht = tfw_pool_realloc(hm->pool, ht, TFW_HHTBL_SZ(order),
 			      TFW_HHTBL_SZ(new_order));
-	if (!new_ht)
+	if (!ht)
 		return -ENOMEM;
-	new_ht->size = __HHTBL_SZ(new_order);
-	new_ht->off = (*ht)->off;
-	memset(new_ht->tbl + __HHTBL_SZ(order), 0,
+	ht->size = __HHTBL_SZ(new_order);
+	ht->off = hm->h_tbl->off;
+	memset(ht->tbl + __HHTBL_SZ(order), 0,
 	       __HHTBL_SZ(order) * sizeof(TfwStr));
-	*ht = new_ht;
+	hm->h_tbl = ht;
 
-	TFW_DBG3("grow http headers table to %d items\n", new_ht->size);
+	TFW_DBG3("grow http headers table to %d items\n", ht->size);
 
 	return 0;
 }

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -576,6 +576,27 @@ tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 }
 
 /**
+ * Remove hop-by-hop headers in the message
+ */
+int
+tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm)
+{
+	TfwHttpHdrTbl *ht = hm->h_tbl;
+	unsigned int hid = ht->off;
+	int r = 0;
+
+	do {
+		hid--;
+		if (ht->tbl[hid].flags & TFW_STR_HBH_HDR)
+			if ((r = __hdr_del(hm, hid)))
+				return r;
+	} while (hid != 0);
+
+	return 0;
+}
+
+
+/**
  * Add a header, probably duplicated, without any checking of current headers.
  */
 int

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -166,11 +166,13 @@ __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 		/* There is no sense to compare against all duplicates. */
 		if (h->flags & TFW_STR_DUPLICATE)
 			h = TFW_STR_CHUNK(h, 0);
-		if (tfw_stricmpspn(hdr, h, ':'))
-			continue;
+		if (!tfw_stricmpspn(hdr, h, ':'))
+			break;
+	}
+
+	if (id <  ht->off) {
 		if (__hdr_is_singular(hdr))
 			hm->flags |= TFW_HTTP_FIELD_DUPENTRY;
-		break;
 	}
 
 	return id;

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -39,6 +39,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 		[TFW_HTTP_HDR_CONTENT_TYPE] = SLEN("Content-Type:"),
 		[TFW_HTTP_HDR_CONNECTION] = SLEN("Connection:"),
 		[TFW_HTTP_HDR_X_FORWARDED_FOR] = SLEN("X-Forwarded-For:"),
+		[TFW_HTTP_HDR_KEEP_ALIVE] = SLEN("Keep-Alive:"),
 		[TFW_HTTP_HDR_USER_AGENT] = SLEN("User-Agent:"),
 		[TFW_HTTP_HDR_SERVER]	= SLEN("Server:"),
 		[TFW_HTTP_HDR_COOKIE]	= SLEN("Cookie:"),

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -155,10 +155,10 @@ __hdr_is_singular(const TfwStr *hdr)
  * an HTTP message. Duplicate of a singular header fields is a bug worth
  * blocking the whole HTTP message.
  */
-static int
+static unsigned int
 __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 {
-	int id;
+	unsigned int id;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 
 	for (id = TFW_HTTP_HDR_RAW; id < ht->off; ++id) {
@@ -200,7 +200,7 @@ tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start)
  * HTTP message headers list.
  */
 int
-tfw_http_msg_hdr_close(TfwHttpMsg *hm, int id)
+tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 {
 	TfwStr *h;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
@@ -344,7 +344,7 @@ tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm)
  * Add new header @hdr to the message @hm just before CRLF.
  */
 static int
-__hdr_add(TfwHttpMsg *hm, const TfwStr *hdr, int hid)
+__hdr_add(TfwHttpMsg *hm, const TfwStr *hdr, unsigned int hid)
 {
 	int r;
 	TfwStr it = {};
@@ -406,7 +406,7 @@ __hdr_expand(TfwHttpMsg *hm, TfwStr *orig_hdr, const TfwStr *hdr, bool append)
  * Delete header with identifier @hid from skb data and header table.
  */
 static int
-__hdr_del(TfwHttpMsg *hm, int hid)
+__hdr_del(TfwHttpMsg *hm, unsigned int hid)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *dup, *end, *hdr = &ht->tbl[hid];
@@ -443,7 +443,7 @@ __hdr_del(TfwHttpMsg *hm, int hid)
  */
 static int
 __hdr_sub(TfwHttpMsg *hm, char *name, size_t n_len, char *val, size_t v_len,
-	  int hid)
+	  unsigned int hid)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *dst, *tmp, *end, *orig_hdr = &ht->tbl[hid];
@@ -509,7 +509,7 @@ cleanup:
  */
 int
 tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
-		      char *val, size_t v_len, int hid, bool append)
+		      char *val, size_t v_len, unsigned int hid, bool append)
 {
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 	TfwStr *orig_hdr;
@@ -578,7 +578,7 @@ tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 int
 tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr)
 {
-	int hid;
+	unsigned int hid;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 
 	hid = ht->off;

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -40,6 +40,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 		[TFW_HTTP_HDR_CONNECTION] = SLEN("Connection:"),
 		[TFW_HTTP_HDR_X_FORWARDED_FOR] = SLEN("X-Forwarded-For:"),
 		[TFW_HTTP_HDR_KEEP_ALIVE] = SLEN("Keep-Alive:"),
+		[TFW_HTTP_HDR_TRANSFER_ENCODING] = SLEN("Transfer-Encoding:"),
 		[TFW_HTTP_HDR_USER_AGENT] = SLEN("User-Agent:"),
 		[TFW_HTTP_HDR_SERVER]	= SLEN("Server:"),
 		[TFW_HTTP_HDR_COOKIE]	= SLEN("Cookie:"),

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -74,6 +74,7 @@ int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 	tfw_http_msg_hdr_xfrm(hm, name, sizeof(name) - 1, NULL, 0, hid, 0)
 
 int tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm);
+void tfw_http_msg_mark_hbh_hdr(TfwHttpMsg *hm, TfwStr *hdr);
 
 TfwHttpMsg *tfw_http_msg_create(TfwHttpMsg *hm, TfwMsgIter *it, int type,
 				size_t data_len);
@@ -83,7 +84,14 @@ int tfw_http_msg_add_data(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,
 
 void tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start);
 int tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id);
-int tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm);
+
+int __tfw_http_msg_grow_hdr_tbl(TfwHttpHdrTbl **ht, TfwPool * pool);
+
+static inline int
+tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm)
+{
+	return __tfw_http_msg_grow_hdr_tbl(&hm->h_tbl, hm->pool);
+}
 
 TfwHttpMsg *tfw_http_msg_alloc(int type);
 void tfw_http_msg_free(TfwHttpMsg *m);

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -65,7 +65,7 @@ int __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str, void *data,
 
 int tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr);
 int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
-			  char *val, size_t v_len, int hid, bool append);
+			  char *val, size_t v_len, unsigned int hid, bool append);
 
 #define TFW_HTTP_MSG_HDR_XFRM(hm, name, val, hid, append)		\
 	tfw_http_msg_hdr_xfrm(hm, name, sizeof(name) - 1, val,		\
@@ -80,7 +80,7 @@ int tfw_http_msg_add_data(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,
 			  const TfwStr *data);
 
 void tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start);
-int tfw_http_msg_hdr_close(TfwHttpMsg *hm, int id);
+int tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id);
 int tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm);
 
 TfwHttpMsg *tfw_http_msg_alloc(int type);

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -73,6 +73,8 @@ int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 #define TFW_HTTP_MSG_HDR_DEL(hm, name, hid)				\
 	tfw_http_msg_hdr_xfrm(hm, name, sizeof(name) - 1, NULL, 0, hid, 0)
 
+int tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm);
+
 TfwHttpMsg *tfw_http_msg_create(TfwHttpMsg *hm, TfwMsgIter *it, int type,
 				size_t data_len);
 int tfw_http_msg_write(TfwMsgIter *it, TfwHttpMsg *hm, const TfwStr *data);

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -63,6 +63,7 @@ int __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str, void *data,
 	__tfw_http_msg_add_str_data(hm, str, data, len,			\
 				    ss_skb_peek_tail(&hm->msg.skb_list))
 
+unsigned int tfw_http_msg_hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr);
 int tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr);
 int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 			  char *val, size_t v_len, unsigned int hid, bool append);
@@ -74,7 +75,6 @@ int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 	tfw_http_msg_hdr_xfrm(hm, name, sizeof(name) - 1, NULL, 0, hid, 0)
 
 int tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm);
-void tfw_http_msg_mark_hbh_hdr(TfwHttpMsg *hm, TfwStr *hdr);
 
 TfwHttpMsg *tfw_http_msg_create(TfwHttpMsg *hm, TfwMsgIter *it, int type,
 				size_t data_len);

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -85,13 +85,7 @@ int tfw_http_msg_add_data(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,
 void tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start);
 int tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id);
 
-int __tfw_http_msg_grow_hdr_tbl(TfwHttpHdrTbl **ht, TfwPool * pool);
-
-static inline int
-tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm)
-{
-	return __tfw_http_msg_grow_hdr_tbl(&hm->h_tbl, hm->pool);
-}
+int tfw_http_msg_grow_hdr_tbl(TfwHttpMsg *hm);
 
 TfwHttpMsg *tfw_http_msg_alloc(int type);
 void tfw_http_msg_free(TfwHttpMsg *m);

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -477,6 +477,8 @@ static inline void
 __hbh_parser_init_req(TfwHttpReq *req)
 {
 	TfwHttpHbhHdrs *hbh_hdrs = &req->parser.hbh_parser;
+
+	BUG_ON(hbh_hdrs->spec);
 	/* Connection is hop-by-hop header by RFC 7230 6.1 */
 	hbh_hdrs->spec = 0x1 << TFW_HTTP_HDR_CONNECTION;
 }
@@ -488,6 +490,8 @@ static inline void
 __hbh_parser_init_resp(TfwHttpResp *resp)
 {
 	TfwHttpHbhHdrs *hbh_hdrs = &resp->parser.hbh_parser;
+
+	BUG_ON(hbh_hdrs->spec);
 	/*
 	 * Connection is hop-by-hop header by RFC 7230 6.1
 	 *
@@ -1348,7 +1352,7 @@ done:
 /* Main (parent) HTTP request processing states. */
 enum {
 	Req_0,
-	Req_CRLF,
+	Req_0_CRLF,
 	/* Request line. */
 	Req_Method,
 	Req_MethG,
@@ -2103,9 +2107,9 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 		/* fall through */
 	}
 
-	__FSM_STATE(Req_CRLF) {
+	__FSM_STATE(Req_0_CRLF) {
 		if (unlikely(IS_CRLF(c)))
-			__FSM_MOVE_nofixup(Req_0);
+			__FSM_MOVE_nofixup(Req_0_CRLF);
 		/* fall through */
 	}
 
@@ -2821,7 +2825,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 /* Main (parent) HTTP response processing states. */
 enum {
 	Resp_0,
-	Resp_CRLF,
+	Resp_0_CRLF,
 	Resp_HttpVer,
 	Resp_HttpVerT1,
 	Resp_HttpVerT2,
@@ -3560,9 +3564,9 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 		/* fall through */
 	}
 
-	__FSM_STATE(Resp_CRLF) {
+	__FSM_STATE(Resp_0_CRLF) {
 		if (unlikely(IS_CRLF(c)))
-			__FSM_MOVE_nofixup(Resp_0);
+			__FSM_MOVE_nofixup(Resp_0_CRLF);
 		/* fall through */
 	}
 

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -493,7 +493,7 @@ __hbh_parser_init(TfwHttpHbhHdrs *hbh_hdrs, bool req)
 		msg->parser.hdr.flags |= TFW_STR_HBH_HDR;
 
 /**
- * Mark raaw header @hdr as hop-by-hop if its name was listed in Connection
+ * Mark raw header @hdr as hop-by-hop if its name was listed in Connection
  * header
  */
 static void
@@ -531,7 +531,7 @@ __hbh_parser_alloc_table(TfwHttpMsg *hm)
 }
 
 /**
- * Add header name listed in Connection header to rable of raw headers.
+ * Add header name listed in Connection header to table of raw headers.
  * If @last is true then (@data, @len) represnts last chunk of header name and
  * chunk with ':' will be added to the end. Otherwize last header in table stays
  * open to add more data.
@@ -546,6 +546,7 @@ __hbb_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 	TfwStr *hdr, *append;
 	int r;
 	TfwHttpHdrTbl *ht = hm->parser.hbh_parser.raw;
+
 	if (!ht) {
 		if ((r = __hbh_parser_alloc_table(hm)))
 			return r;

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -2332,7 +2332,8 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 			__FSM_MOVE(Req_HdrH);
 		case 'k':
 			if (likely(__data_available(p, 11)
-				   && C4_INT_LCM(p + 1, 'e', 'e', 'p', '-')
+				   && C4_INT_LCM(p, 'k', 'e', 'e', 'p')
+				   && *(p + 4) == '-'
 				   && C4_INT_LCM(p + 5, 'a', 'l', 'i', 'v')
 				   && tolower(*(p + 9)) == 'e'
 				   && *(p + 10) == ':'))
@@ -3621,7 +3622,8 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 			__FSM_MOVE(Resp_HdrE);
 		case 'k':
 			if (likely(__data_available(p, 11)
-				   && C4_INT_LCM(p + 1, 'e', 'e', 'p', '-')
+				   && C4_INT_LCM(p, 'k', 'e', 'e', 'p')
+				   && *(p + 4) == '-'
 				   && C4_INT_LCM(p + 5, 'a', 'l', 'i', 'v')
 				   && TFW_LC(*(p + 9)) == 'e'
 				   && *(p + 10) == ':'))

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -177,6 +177,8 @@ size_t tfw_ultoa(unsigned long ai, char *buf, unsigned int len);
 #define TFW_STR_NAME		0x04
 /* Some value starts at the string chunk. */
 #define TFW_STR_VALUE		0x08
+/* The string represents hop-by-hop header, not end-to-end one */
+#define TFW_STR_HBH_HDR		0x10
 
 /*
  * @ptr		- pointer to string data or array of nested strings;

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -1081,28 +1081,33 @@ TEST(http_parser, req_hop_by_hop)
 	}
 
 	/* Connection header lists end-to-end spec headers */
-	FOR_REQ(REQ_HBH_START
-		"Connection: Host, Content-Length, Content-Type, Connection,"
-		"X-Forwarded-For, Transfer-Encoding, User-Agent, Server,"
-		" Cookie\r\n"
-		REQ_HBH_END)
-	{
-		ht = req->h_tbl;
-		/* Common (raw) headers: 17 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
-
-		for(id = 0; id < ht->off; ++id) {
-			field = &ht->tbl[id];
-			switch (id) {
-			case TFW_HTTP_HDR_CONNECTION:
-				EXPECT_TRUE(field->flags & TFW_STR_HBH_HDR);
-				break;
-			default:
-				EXPECT_FALSE(field->flags & TFW_STR_HBH_HDR);
-				break;
-			}
-		}
-	}
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: Host\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: Content-Length\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: Content-Type\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: Connection\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: X-Forwarded-For\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: Transfer-Encoding\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: User-Agent\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: Server\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: Cookie\r\n"
+			 REQ_HBH_END);
 
 	/* Connection header lists end-to-end raw headers */
 	EXPECT_BLOCK_REQ(REQ_HBH_START
@@ -1231,29 +1236,33 @@ TEST(http_parser, resp_hop_by_hop)
 	}
 
 	/* Connection header lists end-to-end spec headers */
-	FOR_RESP(RESP_HBH_START
-		 "Connection: Host, Content-Length, Content-Type, Connection,"
-		 "X-Forwarded-For, Transfer-Encoding, User-Agent, Server,"
-		 " Cookie\r\n"
-		 RESP_HBH_END)
-	{
-		ht = resp->h_tbl;
-		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
-
-		for(id = 0; id < ht->off; ++id) {
-			field = &ht->tbl[id];
-			switch (id) {
-			case TFW_HTTP_HDR_SERVER:
-			case TFW_HTTP_HDR_CONNECTION:
-				EXPECT_TRUE(field->flags & TFW_STR_HBH_HDR);
-				break;
-			default:
-				EXPECT_FALSE(field->flags & TFW_STR_HBH_HDR);
-				break;
-			}
-		}
-	}
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: Host\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: Content-Length\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: Content-Type\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: Connection\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: X-Forwarded-For\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: Transfer-Encoding\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: User-Agent\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: Server\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: Cookie\r\n"
+			  RESP_HBH_END);
 
 	/* Connection header lists end-to-end raw headers */
 	EXPECT_BLOCK_RESP(RESP_HBH_START

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -166,6 +166,37 @@ do {								\
 	while (TRY_PARSE_EXPECT_BLOCK(str, FUZZ_RESP));		\
 } while (0)
 
+TEST(http_parser, leading_eol)
+{
+	FOR_REQ("GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n");
+	FOR_REQ("\r\nGET / HTTP/1.1\r\nHost: foo.com\r\n\r\n");
+	FOR_REQ("\nGET / HTTP/1.1\r\nHost: foo.com\r\n\r\n");
+	FOR_REQ("\n\n\nGET / HTTP/1.1\r\nHost: foo.com\r\n\r\n");
+
+	FOR_RESP("HTTP/1.1 200 OK\r\n"
+		 "Content-Length: 10\r\n"
+		"\r\n"
+		"0123456789");
+
+	FOR_RESP("\n"
+		 "HTTP/1.1 200 OK\r\n"
+		 "Content-Length: 10\r\n"
+		"\r\n"
+		"0123456789");
+
+	FOR_RESP("\r\n"
+		 "HTTP/1.1 200 OK\r\n"
+		 "Content-Length: 10\r\n"
+		"\r\n"
+		"0123456789");
+
+	FOR_RESP("\n\n\n"
+		 "HTTP/1.1 200 OK\r\n"
+		 "Content-Length: 10\r\n"
+		"\r\n"
+		"0123456789");
+}
+
 TEST(http_parser, parses_req_method)
 {
 	FOR_REQ("GET / HTTP/1.1\r\n\r\n") {
@@ -1321,6 +1352,7 @@ end:
 
 TEST_SUITE(http_parser)
 {
+	TEST_RUN(http_parser, leading_eol);
 	TEST_RUN(http_parser, parses_req_method);
 	TEST_RUN(http_parser, parses_req_uri);
 	TEST_RUN(http_parser, mangled_messages);

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -1084,6 +1084,12 @@ TEST(http_parser, req_hop_by_hop)
 			 "Connection: pragma\r\n"
 			 REQ_HBH_END);
 
+	/* Too lot of connection tokens */
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: t1, t2, t3, t4, t5, t6, t7, t8, t9, t10,"
+			 "t11, t12, t13, t14, t15, t16, t17\r\n"
+			 REQ_HBH_END);
+
 #undef REQ_HBH_START
 #undef REQ_HBH_END
 }
@@ -1236,6 +1242,12 @@ TEST(http_parser, resp_hop_by_hop)
 			  RESP_HBH_END);
 	EXPECT_BLOCK_RESP(RESP_HBH_START
 			  "Connection: pragma\r\n"
+			  RESP_HBH_END);
+
+	/* Too lot of connection tokens */
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: t1, t2, t3, t4, t5, t6, t7, t8, t9, t10,"
+			  "t11, t12, t13, t14, t15, t16, t17\r\n"
 			  RESP_HBH_END);
 
 #undef RESP_HBH_START

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -428,7 +428,7 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
 	const char *s_cc  = "Cache-Control: max-age=1, no-store, min-fresh=30";
-	const char *s_te  = "Transfer-Encoding: compress, gzip, chunked";
+	const char *s_te  = "compress, gzip, chunked";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_pragma =  "Pragma: no-cache, fooo ";
 	const char *s_auth =  "Authorization: "
@@ -552,7 +552,7 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 	const char *s_dummy4 = "Dummy4: 4";
 	const char *s_cc = "Cache-Control: "
 			   "max-age=5, private, no-cache, ext=foo";
-	const char *s_te = "Transfer-Encoding: compress, gzip, chunked";
+	const char *s_te = "compress, gzip, chunked";
 	const char *s_exp = "Expires: Tue, 31 Jan 2012 15:02:53 GMT";
 	const char *s_ka = "timeout=600, max=65526";
 	/* Trailing spaces are stored within header strings. */
@@ -607,17 +607,16 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 
 		/*
 		 * Common (raw) headers: 10 dummies, Cache-Control,
-		 * Expires, Keep-Alive, Transfer-Encoding, Age, Date.
+		 * Expires, Age, Date.
 		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 15);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 14);
 
 		h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
 		h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
 		h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
 		h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
-		h_ka = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
-		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
-		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
+		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
+		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
 
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_connection, s_connection,
 					    strlen(s_connection), 0));
@@ -984,7 +983,6 @@ TEST(http_parser, req_hop_by_hop)
 	"Dummy9: 9\r\n"							\
 	"Cache-Control: max-age=1, no-store, min-fresh=30\r\n"		\
 	"Pragma: no-cache, fooo \r\n"					\
-	"Transfer-Encoding: compress, deflate, gzip\r\n"		\
 	"Cookie: session=42; theme=dark\r\n"				\
 	"Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\t \n"	\
 	"\r\n"								\
@@ -994,8 +992,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 18 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
+		/* Common (raw) headers: 17 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -1009,8 +1007,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 18 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
+		/* Common (raw) headers: 17 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -1032,8 +1030,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
+		/* Common (raw) headers: 17 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -1082,7 +1080,6 @@ TEST(http_parser, resp_hop_by_hop)
 	"Dummy9: 9\r\n"							\
 	"Expires: Tue, 31 Jan 2012 15:02:53 GMT\r\n"			\
 	"Keep-Alive: timeout=600, max=65526\r\n"			\
-	"Transfer-Encoding: compress, deflate, gzip\r\n"		\
 	"Server: Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"		\
 		" mod_fcgid/2.3.9\r\n"					\
 	"Age: 12  \n"							\
@@ -1095,8 +1092,8 @@ TEST(http_parser, resp_hop_by_hop)
 		 RESP_HBH_END)
 	{
 		ht = resp->h_tbl;
-		/* Common (raw) headers: 17 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
+		/* Common (raw) headers: 16 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -1117,8 +1114,8 @@ TEST(http_parser, resp_hop_by_hop)
 		 RESP_HBH_END)
 	{
 		ht = resp->h_tbl;
-		/* Common (raw) headers: 17 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
+		/* Common (raw) headers: 16 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -1142,7 +1139,7 @@ TEST(http_parser, resp_hop_by_hop)
 	{
 		ht = resp->h_tbl;
 		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -539,8 +539,8 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 TEST(http_parser, fills_hdr_tbl_for_resp)
 {
 	TfwHttpHdrTbl *ht;
-	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_age, *h_date, *h_exp, *h_ka;
-	TfwStr h_connection, h_conttype, h_srv, h_te;
+	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_age, *h_date, *h_exp;
+	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka;
 
 	/* Expected values for special headers. */
 	const char *s_connection = "Keep-Alive";
@@ -554,7 +554,7 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 			   "max-age=5, private, no-cache, ext=foo";
 	const char *s_te = "Transfer-Encoding: compress, gzip, chunked";
 	const char *s_exp = "Expires: Tue, 31 Jan 2012 15:02:53 GMT";
-	const char *s_ka = "Keep-Alive: timeout=600, max=65526";
+	const char *s_ka = "timeout=600, max=65526";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_age = "Age: 12  ";
 	const char *s_date = "Date: Sun, 9 Sep 2001 01:46:40 GMT\t";
@@ -602,6 +602,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					TFW_HTTP_HDR_SERVER, &h_srv);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_TRANSFER_ENCODING],
 					TFW_HTTP_HDR_TRANSFER_ENCODING, &h_te);
+		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_KEEP_ALIVE],
+					TFW_HTTP_HDR_KEEP_ALIVE, &h_ka);
 
 		/*
 		 * Common (raw) headers: 10 dummies, Cache-Control,
@@ -625,6 +627,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					    strlen(s_srv), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(&h_te, s_te,
 					    strlen(s_te), 0));
+		EXPECT_TRUE(tfw_str_eq_cstr(&h_ka, s_ka,
+					    strlen(s_ka), 0));
 
 		EXPECT_TRUE(tfw_str_eq_cstr(h_dummy4, s_dummy4,
 					    strlen(s_dummy4), 0));
@@ -634,8 +638,6 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					    strlen(s_dummy9), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_exp, s_exp,
 					    strlen(s_exp), 0));
-		EXPECT_TRUE(tfw_str_eq_cstr(h_ka, s_ka,
-					    strlen(s_ka), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_age, s_age,
 					    strlen(s_age), 0));
 		EXPECT_TRUE(tfw_str_eq_cstr(h_date, s_date,

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -1049,6 +1049,41 @@ TEST(http_parser, req_hop_by_hop)
 		}
 	}
 
+	/* Connection header lists end-to-end spec headers */
+	FOR_REQ(REQ_HBH_START
+		"Connection: Host, Content-Length, Content-Type, Connection,"
+		"X-Forwarded-For, Transfer-Encoding, User-Agent, Server,"
+		" Cookie\r\n"
+		REQ_HBH_END)
+	{
+		ht = req->h_tbl;
+		/* Common (raw) headers: 17 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
+
+		for(id = 0; id < ht->off; ++id) {
+			field = &ht->tbl[id];
+			switch (id) {
+			case TFW_HTTP_HDR_CONNECTION:
+				EXPECT_TRUE(field->flags & TFW_STR_HBH_HDR);
+				break;
+			default:
+				EXPECT_FALSE(field->flags & TFW_STR_HBH_HDR);
+				break;
+			}
+		}
+	}
+
+	/* Connection header lists end-to-end raw headers */
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: authorization\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: cache-control\r\n"
+			 REQ_HBH_END);
+	EXPECT_BLOCK_REQ(REQ_HBH_START
+			 "Connection: pragma\r\n"
+			 REQ_HBH_END);
+
 #undef REQ_HBH_START
 #undef REQ_HBH_END
 }
@@ -1157,6 +1192,51 @@ TEST(http_parser, resp_hop_by_hop)
 			}
 		}
 	}
+
+	/* Connection header lists end-to-end spec headers */
+	FOR_RESP(RESP_HBH_START
+		 "Connection: Host, Content-Length, Content-Type, Connection,"
+		 "X-Forwarded-For, Transfer-Encoding, User-Agent, Server,"
+		 " Cookie\r\n"
+		 RESP_HBH_END)
+	{
+		ht = resp->h_tbl;
+		/* Common (raw) headers: 16 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+
+		for(id = 0; id < ht->off; ++id) {
+			field = &ht->tbl[id];
+			switch (id) {
+			case TFW_HTTP_HDR_SERVER:
+			case TFW_HTTP_HDR_CONNECTION:
+				EXPECT_TRUE(field->flags & TFW_STR_HBH_HDR);
+				break;
+			default:
+				EXPECT_FALSE(field->flags & TFW_STR_HBH_HDR);
+				break;
+			}
+		}
+	}
+
+	/* Connection header lists end-to-end raw headers */
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: age\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: authorization\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: cache-control\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: date\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: expires\r\n"
+			  RESP_HBH_END);
+	EXPECT_BLOCK_RESP(RESP_HBH_START
+			  "Connection: pragma\r\n"
+			  RESP_HBH_END);
 
 #undef RESP_HBH_START
 #undef RESP_HBH_END

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -128,7 +128,7 @@ module_exit(ttls_exit);
 
 MODULE_AUTHOR("Tempesta Technologies");
 MODULE_VERSION("2.3.0");
-MODULE_LICENSE("GPL");
+MODULE_LICENSE("GPL v2");
 
 /*
  * ------------------------------------------------------------------------


### PR DESCRIPTION
Fix issue #409 

- Parse Connection header during parsing HTTP message;
- Store raw headers listed in Connection header in temporary array allocated in message's pool: every raw header is marked as hop-by-hop if it's name present in that array. When connection header parsed in the first time, parser checks already parsed raw headers and mark them as hop-by-hop headers if needed. If Connection header does not contain any raw headers names no extra allocations or string comparison happen;
- Special headers have their own marking procedure which does not involve string comparisons. Some of the special headers are always hop-by-hop (Connection, we also mark Server in responses as hop-by-hop) and using generic comparison like for Raw headers will ruin performance;
- Unit tests for responses and requests with hop-by-hop marking checks; 
- little optimisation of __hdr_lookup(): reduce string comparisons.

*TBD:* 
When response contains `Connection: keep-alive`, `Keep-alive` header will be marked as hop-by-hop header and will not be saved in cache (that was the requirement in #409 ). RFC 7230 6.1 also say:
```
 A proxy or gateway MUST parse a received Connection header field before
   a message is forwarded and, for each connection-option in this field,
   remove any header field(s) from the message with the same name as the
   connection-option, and then remove the Connection header field itself
   (or replace it with the intermediary's own connection options for the
   forwarded message).
```
Currently we have no realised way to set default `Keep-Alive` header (not found in issues but here is corresponding TODO: https://github.com/tempesta-tech/tempesta/blob/master/tempesta_fw/http.c#L639 ). So question is: delete `Keep-Alive` header in forwarded messages or not? But messages served from cache will have no such header. Currently i remove it from both forwarded messages: response and request, disabling that is one-line patch. 