### PR TITLE
Resistance to misbehaving upstream server

### DIFF
--- a/tempesta_fw/cache.h
+++ b/tempesta_fw/cache.h
@@ -23,6 +23,7 @@
 
 #include "http.h"
 
+bool tfw_cache_msg_cacheable(TfwHttpReq *req);
 int tfw_cache_process(TfwHttpReq *req, TfwHttpResp *resp,
 		      tfw_http_cache_cb_t action);
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -187,7 +187,13 @@ tfw_http_prep_302(TfwHttpMsg *resp, TfwHttpReq *req, TfwStr *cookie)
 static inline void
 __init_req_ss_flags(TfwHttpReq *req)
 {
-	((TfwMsg *)req)->ss_flags |= SS_F_KEEP_SKB;
+	/*
+	 * We need skb data only for calculating cache key by the request
+	 * fields. In all other cases we can just pass skb data to network
+	 * layer.
+	 */
+	if (tfw_cache_msg_cacheable(req))
+		((TfwMsg *)req)->ss_flags |= SS_F_KEEP_SKB;
 }
 
 static inline void
@@ -265,7 +271,7 @@ tfw_http_send_200(TfwHttpReq *req)
  * HTTP 403 response: Access is forbidden.
  */
 int
-tfw_http_send_403(TfwHttpReq *req)
+tfw_http_send_403(TfwHttpReq *req, const char *reason)
 {
 	TfwStr rh = {
 		.ptr = (TfwStr []){
@@ -278,7 +284,7 @@ tfw_http_send_403(TfwHttpReq *req)
 		.flags = 4 << TFW_STR_CN_SHIFT
 	};
 
-	TFW_DBG("Send HTTP 404 response to the client\n");
+	TFW_DBG("Send HTTP 404 response: %s\n", reason);
 
 	return tfw_http_send_resp(req, &rh, __TFW_STR_CH(&rh, 1));
 }
@@ -289,7 +295,7 @@ tfw_http_send_403(TfwHttpReq *req)
  * HTTP 404 response: Tempesta is unable to find the requested data.
  */
 int
-tfw_http_send_404(TfwHttpReq *req)
+tfw_http_send_404(TfwHttpReq *req, const char *reason)
 {
 	TfwStr rh = {
 		.ptr = (TfwStr []){
@@ -302,7 +308,7 @@ tfw_http_send_404(TfwHttpReq *req)
 		.flags = 4 << TFW_STR_CN_SHIFT
 	};
 
-	TFW_DBG("Send HTTP 404 response to the client\n");
+	TFW_DBG("Send HTTP 404 response: %s\n", reason);
 
 	return tfw_http_send_resp(req, &rh, __TFW_STR_CH(&rh, 1));
 }
@@ -314,7 +320,7 @@ tfw_http_send_404(TfwHttpReq *req)
  * the request to a server.
  */
 static int
-tfw_http_send_500(TfwHttpReq *req)
+tfw_http_send_500(TfwHttpReq *req, const char *reason)
 {
 	TfwStr rh = {
 		.ptr = (TfwStr []){
@@ -327,7 +333,7 @@ tfw_http_send_500(TfwHttpReq *req)
 		.flags = 4 << TFW_STR_CN_SHIFT
 	};
 
-	TFW_DBG("Send HTTP 500 response to the client\n");
+	TFW_DBG("Send HTTP 500 response: %s\n", reason);
 
 	return tfw_http_send_resp(req, &rh, __TFW_STR_CH(&rh, 1));
 }
@@ -339,7 +345,7 @@ tfw_http_send_500(TfwHttpReq *req)
  * the designated server.
  */
 int
-tfw_http_send_502(TfwHttpReq *req)
+tfw_http_send_502(TfwHttpReq *req, const char *reason)
 {
 	TfwStr rh = {
 		.ptr = (TfwStr []){
@@ -352,7 +358,7 @@ tfw_http_send_502(TfwHttpReq *req)
 		.flags = 4 << TFW_STR_CN_SHIFT
 	};
 
-	TFW_DBG("Send HTTP 502 response to the client\n");
+	TFW_DBG("Send HTTP 502 response: %s\n", reason);
 
 	return tfw_http_send_resp(req, &rh, __TFW_STR_CH(&rh, 1));
 }
@@ -364,7 +370,7 @@ tfw_http_send_502(TfwHttpReq *req)
  * the designated server.
  */
 int
-tfw_http_send_504(TfwHttpReq *req)
+tfw_http_send_504(TfwHttpReq *req, const char *reason)
 {
 	TfwStr rh = {
 		.ptr = (TfwStr []){
@@ -377,7 +383,7 @@ tfw_http_send_504(TfwHttpReq *req)
 		.flags = 4 << TFW_STR_CN_SHIFT
 	};
 
-	TFW_DBG("Send HTTP 504 response to the client\n");
+	TFW_DBG("Send HTTP 504 response: %s\n", reason);
 
 	return tfw_http_send_resp(req, &rh, __TFW_STR_CH(&rh, 1));
 }
@@ -493,7 +499,8 @@ tfw_http_conn_release(TfwConnection *conn)
 		BUG_ON(((TfwHttpMsg *)msg)->conn
 			&& (((TfwHttpMsg *)msg)->conn == conn));
 		list_del(&msg->msg_list);
-		tfw_http_send_502((TfwHttpReq *)msg);
+		tfw_http_send_502((TfwHttpReq *)msg,
+				  "peer connection released");
 		tfw_http_conn_msg_free((TfwHttpMsg *)msg);
 		TFW_INC_STAT_BH(clnt.msgs_otherr);
 	}
@@ -512,9 +519,8 @@ static void
 tfw_http_conn_drop(TfwConnection *conn)
 {
 	if (conn->msg && (TFW_CONN_TYPE(conn) & Conn_Srv)) {
-		if (tfw_http_parse_terminate((TfwHttpMsg *)conn->msg)) {
+		if (tfw_http_parse_terminate((TfwHttpMsg *)conn->msg))
 			tfw_http_resp_terminate((TfwHttpMsg *)conn->msg);
-		}
 	}
 	tfw_http_conn_msg_free((TfwHttpMsg *)conn->msg);
 }
@@ -760,7 +766,11 @@ tfw_http_adjust_resp(TfwHttpResp *resp, TfwHttpReq *req)
 	if (resp->flags & TFW_HTTP_RESP_STALE) {
 #define S_WARN_110 "Warning: 110 - Response is stale"
 		/* TODO: ajust for #215 */
-		TfwStr wh = {.ptr = S_WARN_110, .len = SLEN(S_WARN_110),.eolen = 2};
+		TfwStr wh = {
+			.ptr	= S_WARN_110,
+			.len	= SLEN(S_WARN_110),
+			.eolen	= 2
+		};
 		r = tfw_http_msg_hdr_add(hm, &wh);
 		if (r)
 			return r;
@@ -797,7 +807,7 @@ resp_out:
 	tfw_http_conn_msg_free((TfwHttpMsg *)req);
 	return;
 resp_err:
-	tfw_http_send_500(req);
+	tfw_http_send_500(req, "cannot send response from cache");
 	TFW_INC_STAT_BH(clnt.msgs_otherr);
 	goto resp_out;
 }
@@ -877,16 +887,19 @@ tfw_http_req_cache_cb(TfwHttpReq *req, TfwHttpResp *resp)
 		spin_unlock(&srv_conn->msg_qlock);
 		goto send_500;
 	}
+	mb();
+	req->flags |= TFW_HTTP_MSG_SENT;
+
 	TFW_INC_STAT_BH(clnt.msgs_forwarded);
 	goto conn_put;
 
 send_502:
-	tfw_http_send_502(req);
+	tfw_http_send_502(req, "request proxy error");
 	tfw_http_conn_msg_free((TfwHttpMsg *)req);
 	TFW_INC_STAT_BH(clnt.msgs_otherr);
 	return;
 send_500:
-	tfw_http_send_500(req);
+	tfw_http_send_500(req, "request proxy error");
 	tfw_http_conn_msg_free((TfwHttpMsg *)req);
 	TFW_INC_STAT_BH(clnt.msgs_otherr);
 conn_put:
@@ -898,7 +911,8 @@ tfw_http_req_set_context(TfwHttpReq *req)
 {
 	req->vhost = tfw_vhost_match(&req->uri_path);
 	req->location = tfw_location_match(req->vhost, &req->uri_path);
-	return (!req->vhost);
+
+	return !req->vhost;
 }
 
 /**
@@ -956,6 +970,7 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 		case TFW_BLOCK:
 			TFW_DBG2("Block invalid HTTP request\n");
 			TFW_INC_STAT_BH(clnt.msgs_parserr);
+			tfw_http_conn_msg_free((TfwHttpMsg *)req);
 			return TFW_BLOCK;
 		case TFW_POSTPONE:
 			r = tfw_gfsm_move(&conn->state,
@@ -963,6 +978,7 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 			TFW_DBG3("TFW_HTTP_FSM_REQ_CHUNK return code %d\n", r);
 			if (r == TFW_BLOCK) {
 				TFW_INC_STAT_BH(clnt.msgs_filtout);
+				tfw_http_conn_msg_free((TfwHttpMsg *)req);
 				return TFW_BLOCK;
 			}
 			/*
@@ -987,6 +1003,7 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 		/* Don't accept any following requests from the peer. */
 		if (r == TFW_BLOCK) {
 			TFW_INC_STAT_BH(clnt.msgs_filtout);
+			tfw_http_conn_msg_free((TfwHttpMsg *)req);
 			return TFW_BLOCK;
 		}
 
@@ -998,8 +1015,10 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 		req->jtstamp = jiffies;
 
 		/* Assign the right Vhost for this request. */
-		if (tfw_http_req_set_context(req))
+		if (tfw_http_req_set_context(req)) {
+			tfw_http_conn_msg_free((TfwHttpMsg *)req);
 			return TFW_BLOCK;
+		}
 
 		/*
 		 * In HTTP 0.9 the server always closes the connection
@@ -1035,7 +1054,7 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 		 * So, save the needed request flag for later use as it
 		 * may not be accessible later through @req->flags.
 		 */
-		req_conn_close = (req->flags & TFW_HTTP_CONN_CLOSE);
+		req_conn_close = req->flags & TFW_HTTP_CONN_CLOSE;
 
 		if (!req_conn_close && (data_off < skb_len)) {
 			/*
@@ -1055,6 +1074,7 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 				TFW_WARN("Not enough memory to create"
 					 " a request sibling\n");
 				TFW_INC_STAT_BH(clnt.msgs_otherr);
+				tfw_http_conn_msg_free((TfwHttpMsg *)req);
 				return TFW_BLOCK;
 			}
 		}
@@ -1076,7 +1096,7 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 		 */
 		if (tfw_cache_process(req, NULL, tfw_http_req_cache_cb))
 		{
-			tfw_http_send_500(req);
+			tfw_http_send_500(req, "request cache error");
 			tfw_http_conn_msg_free((TfwHttpMsg *)req);
 			TFW_INC_STAT_BH(clnt.msgs_otherr);
 			return TFW_PASS;
@@ -1144,7 +1164,7 @@ out:
 	tfw_http_conn_msg_free((TfwHttpMsg *)req);
 	return;
 err:
-	tfw_http_send_500(req);
+	tfw_http_send_500(req, "response proxy error");
 	TFW_INC_STAT_BH(serv.msgs_otherr);
 	goto out;
 }
@@ -1153,28 +1173,32 @@ err:
  * Request messages that were forwarded to a backend server are added
  * to and kept in @msg_queue of the connection @conn for that server.
  * If a paired request is not found, then the response is deleted.
+ *
+ * If thre isn't paired client request, then it seems upsream server is
+ * misbehaving, so the caller has to drop the server connection.
  */
 static TfwHttpReq *
 tfw_http_popreq(TfwHttpMsg *hmresp)
 {
-	TfwMsg *msg;
+	TfwHttpReq *req;
 	TfwConnection *conn = hmresp->conn;
 
 	spin_lock(&conn->msg_qlock);
-	if (unlikely(list_empty(&conn->msg_queue))) {
+
+	req = list_first_entry_or_null(&conn->msg_queue, TfwHttpReq,
+				       msg.msg_list);
+	if (unlikely(!req || !(req->flags & TFW_HTTP_MSG_SENT))) {
 		spin_unlock(&conn->msg_qlock);
-		/* @conn->msg will get NULLed in the process. */
-		TFW_WARN("Paired request missing\n");
-		TFW_WARN("Possible HTTP Response Splitting attack.\n");
-		tfw_http_conn_msg_free(hmresp);
+		TFW_WARN("Paired request missing,"
+			 " HTTP Response Splitting attack?\n");
 		TFW_INC_STAT_BH(serv.msgs_otherr);
 		return NULL;
 	}
-	msg = list_first_entry(&conn->msg_queue, TfwMsg, msg_list);
-	list_del(&msg->msg_list);
+	list_del(&req->msg.msg_list);
+
 	spin_unlock(&conn->msg_qlock);
 
-	return (TfwHttpReq *)msg;
+	return req;
 }
 
 /*
@@ -1211,10 +1235,11 @@ error:
 	req = tfw_http_popreq(hmresp);
 	if (unlikely(!req)) {
 		TFW_INC_STAT_BH(serv.msgs_filtout);
+		tfw_http_conn_msg_free(hmresp);
 		return TFW_STOP;
 	}
 
-	tfw_http_send_502(req);
+	tfw_http_send_502(req, "response filtered");
 	tfw_http_conn_msg_free(hmresp);
 	tfw_http_conn_msg_free((TfwHttpMsg *)req);
 	TFW_INC_STAT_BH(serv.msgs_filtout);
@@ -1248,8 +1273,11 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 	 * deleted, and an error is returned.
 	 */
 	req = tfw_http_popreq(hmresp);
-	if (unlikely(!req))
+	if (unlikely(!req)) {
+		tfw_http_conn_msg_free(hmresp);
 		return -ENOENT;
+	}
+
 	/*
 	 * Complete HTTP message has been collected and processed
 	 * with success. Mark the message as complete in @conn as
@@ -1260,7 +1288,7 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 	if (tfw_cache_process(req, (TfwHttpResp *)hmresp,
 			      tfw_http_resp_cache_cb))
 	{
-		tfw_http_send_500(req);
+		tfw_http_send_500(req, "response cache error");
 		tfw_http_conn_msg_free(hmresp);
 		tfw_http_conn_msg_free((TfwHttpMsg *)req);
 		TFW_INC_STAT_BH(serv.msgs_otherr);
@@ -1303,6 +1331,8 @@ tfw_http_resp_process(TfwConnection *conn, struct sk_buff *skb,
 	int r = TFW_BLOCK;
 	unsigned int data_off = off;
 	unsigned int skb_len = skb->len;
+	TfwHttpReq *bad_req;
+	TfwHttpMsg *hmresp;
 
 	BUG_ON(!conn->msg);
 	BUG_ON(data_off >= skb_len);
@@ -1315,8 +1345,10 @@ tfw_http_resp_process(TfwConnection *conn, struct sk_buff *skb,
 	 */
 	while (data_off < skb_len) {
 		TfwHttpMsg *hmsib = NULL;
-		TfwHttpMsg *hmresp = (TfwHttpMsg *)conn->msg;
-		TfwHttpParser *parser = &hmresp->parser;
+		TfwHttpParser *parser;
+
+		hmresp = (TfwHttpMsg *)conn->msg;
+		parser = &hmresp->parser;
 
 		/*
 		 * Process/parse data in the SKB.
@@ -1354,14 +1386,14 @@ tfw_http_resp_process(TfwConnection *conn, struct sk_buff *skb,
 			 */
 			TFW_DBG2("Block invalid HTTP response\n");
 			TFW_INC_STAT_BH(serv.msgs_parserr);
-			return TFW_BLOCK;
+			goto bad_msg;
 		case TFW_POSTPONE:
 			r = tfw_gfsm_move(&conn->state,
 					  TFW_HTTP_FSM_RESP_CHUNK, skb, off);
 			TFW_DBG3("TFW_HTTP_FSM_RESP_CHUNK return code %d\n", r);
 			if (r == TFW_BLOCK) {
 				TFW_INC_STAT_BH(serv.msgs_filtout);
-				return TFW_BLOCK;
+				goto bad_msg;
 			}
 			/*
 			 * TFW_POSTPONE status means that parsing succeeded
@@ -1432,6 +1464,12 @@ next_resp:
 	}
 
 	return r;
+bad_msg:
+	bad_req = tfw_http_popreq(hmresp);
+	if (bad_req)
+		tfw_http_conn_msg_free((TfwHttpMsg *)bad_req);
+	tfw_http_conn_msg_free(hmresp);
+	return r;
 }
 
 /**
@@ -1448,7 +1486,7 @@ tfw_http_msg_process(void *conn, struct sk_buff *skb, unsigned int off)
 			__kfree_skb(skb);
 			return -ENOMEM;
 		}
-		TFW_DBG("Link new msg %p with connection %p\n", c->msg, c);
+		TFW_DBG2("Link new msg %p with connection %p\n", c->msg, c);
 	}
 
 	TFW_DBG2("Add skb %p to message %p\n", skb, c->msg);

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -234,6 +234,7 @@ typedef struct {
 #define TFW_HTTP_HAS_HDR_DATE		0x020000	/* Has Date: header */
 /* It is stale, but pass with a warning */
 #define TFW_HTTP_RESP_STALE		0x040000
+#define TFW_HTTP_MSG_SENT		0x080000
 
 /**
  * HTTP session descriptor.
@@ -391,10 +392,10 @@ void tfw_http_req_destruct(void *msg);
  */
 int tfw_http_send_200(TfwHttpReq *req);
 int tfw_http_prep_302(TfwHttpMsg *resp, TfwHttpReq *req, TfwStr *cookie);
-int tfw_http_send_403(TfwHttpReq *req);
-int tfw_http_send_404(TfwHttpReq *req);
-int tfw_http_send_502(TfwHttpReq *req);
-int tfw_http_send_504(TfwHttpReq *req);
+int tfw_http_send_403(TfwHttpReq *req, const char *reason);
+int tfw_http_send_404(TfwHttpReq *req, const char *reason);
+int tfw_http_send_502(TfwHttpReq *req, const char *reason);
+int tfw_http_send_504(TfwHttpReq *req, const char *reason);
 
 /*
  * Functions to create SKBs with data stream.

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -222,6 +222,7 @@ typedef struct {
 #define TFW_HTTP_CONN_KA		0x000002
 #define __TFW_HTTP_CONN_MASK		(TFW_HTTP_CONN_CLOSE | TFW_HTTP_CONN_KA)
 #define TFW_HTTP_CHUNKED		0x000004
+#define TFW_HTTP_MSG_SENT		0x000008
 
 /* Request flags */
 #define TFW_HTTP_HAS_STICKY		0x000100
@@ -234,7 +235,6 @@ typedef struct {
 #define TFW_HTTP_HAS_HDR_DATE		0x020000	/* Has Date: header */
 /* It is stale, but pass with a warning */
 #define TFW_HTTP_RESP_STALE		0x040000
-#define TFW_HTTP_MSG_SENT		0x080000
 
 /**
  * HTTP session descriptor.

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -118,7 +118,7 @@ tfw_sched_http_sched_grp(TfwMsg *msg)
 
 	sg = rule->main_sg;
 	BUG_ON(!sg);
-	TFW_DBG("sched_http: use server group: '%s'\n", sg->name);
+	TFW_DBG2("sched_http: use server group: '%s'\n", sg->name);
 
 	conn = sg->sched->sched_srv(msg, sg);
 
@@ -130,7 +130,7 @@ tfw_sched_http_sched_grp(TfwMsg *msg)
 	}
 
 	if (unlikely(!conn))
-		TFW_WARN("sched_http: Unable to select server from group"
+		TFW_DBG2("sched_http: Unable to select server from group"
 			 " '%s'\n", sg->name);
 
 	return conn;

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -266,7 +266,7 @@ TEST(http_sticky, sending_502)
 	StickyVal sv = { .ts = 1 };
 
 	EXPECT_EQ(__sticky_calc(mock.req, &sv), 0);
-	EXPECT_EQ(tfw_http_send_502(mock.req), 0);
+	EXPECT_EQ(tfw_http_send_502(mock.req, __func__), 0);
 
 	/* HTTP 502 response have no Set-Cookie header */
 	EXPECT_TRUE(mock.tfw_connection_send_was_called);


### PR DESCRIPTION
Workaround for #651: introduce TFW_HTTP_MSG_SENT flag such that unsent requests aren't paired with inavalid responses; drop connections if unpaired responses
detected.

Fix tfw_connection_unlink_to_sk(): do the actions in reverse order as they are
done in tfw_connection_link_to_sk().

Fix multiple memory leaks in error paths in HTTP request/response processing
(HTTP messages weren't freed).

Partial #658: print warning on parser failures, print reasons for error HTTP
responses.

Optimizations: don't copy request skbs if no caching introduced; don't put
work for known dead socket to work queue (races arepossible, but
we just do the extra work in worst case)

Many cleanups.