### PR TITLE
Fix out of bounds access in add_rand_string() in fuzzer.c

### DIFF
--- a/tempesta_fw/t/fuzzer.c
+++ b/tempesta_fw/t/fuzzer.c
@@ -375,12 +375,15 @@ static void
 add_rand_string(char **p, char *end, int n, const char *seed)
 {
 	int i, len;
+	unsigned int idxval;
 
 	BUG_ON(!seed);
 
 	len = strlen(seed);
-	for (i = 0; i < n; ++i)
-		addch(p, end, seed[((i + 333) ^ seed[i % len]) % len]);
+	for (i = 0; i < n; ++i) {
+		idxval = (i + 333) ^ seed[i % len];
+		addch(p, end, seed[idxval % len]);
+	}
 }
 
 static unsigned int


### PR DESCRIPTION
The calculation uses XOR which may lead to negative values.
That leads to negative indices which cause out of bounds accesses.
The issue was reported by KASan.