### PR TITLE
Initial wiki notes for schedulers

### DIFF
--- a/doc/scheduling.md
+++ b/doc/scheduling.md
@@ -1,0 +1,180 @@
+# Scheduling in TempestaFW: User Guide
+
+TempestaFW uses various schedulers to distribute load among known servers.
+
+TempestaFW implements two types of schedulers: **group** and **server** schedulers.
+**Group schedulers** are used to classify request and distribute it to corresponding
+server group. **Server schedulers** are used to distribute request to specific
+server in chosen [Server Group]().
+
+
+## Scheduling Requests among Server Groups
+
+
+### HTTP Scheduler
+
+**HTTP Scheduler** inspects headers of an HTTP request and chooses target [Server Group]()
+according to scheduling rules. Scheduling rules are defined by user in TempestaFW
+configuration and map headers patterns to server groups. By default no rules
+are defined. Syntax is:
+```
+sched_http_rules {
+	match <SRV_GROUP> <FIELD> <OP> <ARG> [backup=<BACKUP_SRV_GROUP>];
+	...
+}
+```
+`SRV_GROUP` and `BACKUP_SRV_GROUP` -- the reference to a previously defined
+server groups. `BACKUP_SRV_GROUP` is optional parameter and can be skipped, while
+main `SRV_GROUP` option is mandatory.
+
+If whole `SRV_GROUP` group is offline, request
+will be scheduled to `BACKUP_SRV_GROUP`. Backup server groups are very handy for
+[A/B testing](https://en.wikipedia.org/wiki/A/B_testing) purposes: in that case
+`SRV_GROUP` can represent unstable/test service, and `BACKUP_SRV_GROUP` -- stable
+production service; if test service is under the maintenance users will be
+forwarded to stable service.
+
+`FIELD` -- an HTTP request field, following are supported:
+* **uri** Only a part of URI is looked at that contains the path and the query
+string if any. (e.g. `/abs/path.html?query&key=val#fragment`);
+* **host** The host part from URI in HTTP request line, or the value of `Host`
+header. Host part in URI takes priority over the `Host` header value;
+* **hdr_host** The value of `Host` header;
+* **hdr_conn**  The value of `Connection` header;
+* **hdr_raw** The contents of any other HTTP header field as specified by
+`ARG`. `ARG` must include contents of an HTTP header starting with the header
+field name. The `suffix` `OP` is not supported for this `FIELD`. Processing
+of `hdr_raw` may be slow because it requires walking over all headers of an
+HTTP request.
+
+`OP` -- a string comparison operator:
+* **eq** `FIELD` is fully equal to the string specified in `ARG`;
+* **prefix** `FIELD` starts with the string specified in `ARG`;
+* **suffix** `FIELD` ends with the string specified in `ARG`;
+
+`ARG` -- an argument for the operator `OP`.
+
+Example configuration:
+```
+srv_group static { ... }
+srv_group foo_app { ... }
+srv_group foo_beta { ... }
+srv_group bar_app { ... }
+
+sched_http_rules {
+	match static   uri       prefix  "/static" ;
+	match static   uri       suffix  ".php";
+	match static   host      prefix  "static.";
+	match static   host      suffix  "tempesta-tech.com";
+	match foo_beta host      eq      "beta-foo.example.com" backup=foo_app;
+	match foo_app  host      eq      "foo.example.com";
+	match bar_app  hdr_conn  eq      "keep-alive";
+	match bar_app  hdr_host  prefix  "bar.";
+	match bar_app  hdr_host  suffix  "natsys-lab.com";
+	match bar_app  hdr_host  eq      "bar.natsys-lab.com";
+	match bar_app  hdr_raw   prefix  "X-Custom-Bar-Hdr: ";
+}
+```
+
+**HTTP Scheduler** matches request to rules in _top-down order_. If requests
+fits some rule, rule is applied and further matching is skipped. User can provide
+default match rule that matches any request. If no default rule provided and
+[default server group]() is defined, default match rule to group `default` will
+be added implicitly to the end of the list. The syntax is as follows:
+```
+match <SRV_GROUP> * * * ;
+```
+
+
+## Scheduling Requests inside Server Groups
+
+**Server Schedulers** are bound to exact server groups, see
+[Setting scheduler]() section in [Server Group]() description.
+
+User can override default server scheduler for all groups using `sched`
+configuration option:
+```
+sched <SCHED_NAME>;
+```
+
+
+### Round-Robin Scheduler
+
+**TODO:** update to Ratio and extended weights.
+
+Rotates all servers in a group in round-robin manner, parallel connections to
+the same server are also rotated in the round-robin manner, so requests are
+distributed to all the servers in a group in a fair way.
+
+Scheduler name for use in configuration file: `round-robin`.
+
+
+### Hash Scheduler
+
+Chooses server to schedule request to by hashed key value. Key is built using
+_uri_, _request method_ and _host header_ of the request. In most cases load will
+be distributed among all the servers in group, but situations when single server
+pulls all the load are also possible. Although it is quite improbable, such
+condition is quite stable: it cannot be fixed by adding/removing servers and
+restarting Tempesta FW.
+
+Hash scheduler have an advantages though. It schedules requests of same resources
+to the same servers. That can reduce load of backend servers.
+
+Scheduler name for use in configuration file: `hash`.
+
+
+## Scheduling HTTP sessions to the same server
+
+None of the schedulers is responsible for forwarding requests from the same HTTP
+session to the same server. [Sticky Sessions]() option should be used instead.
+
+
+## Effects caused to schedulers by other configuration options
+
+
+### Limitations
+
+- [HTTP Scheduler](#HTTP Scheduler) must not provide multiple backup groups to
+the same group if [Sticky Sessions]() are enabled.
+
+
+### Effects
+
+- If [Sticky Sessions]() are enabled TempestaFW does its best to reuse last used
+connection for a server. That makes round-robin schedulers to distribute HTTP
+sessions in among servers in server group, but not the requests. Situation when
+one server steals all the heavy sessions is possible. Hash scheduler is not
+expected to work good with sticky sessions, most likely that one server will
+pull most of sessions.
+
+- With [Sticky Sessions]() switching from backup group to main require closing
+all live sessions to servers in backup group.
+
+
+## Troubleshooting
+
+- TempestaFW overloads some of my servers while others in the same group are
+almost unused.
+
+Hash Server scheduler does not guarantee fair load of backend servers and
+can cause situations, when some servers pull most of the load. Round-robin
+scheduler should be used instead. Other configuration options can also affect
+schedulers behaviour, see [Effects caused to schedulers](#Effects caused to schedulers by other configuration options)
+
+- Requests are still forwarded to servers from backup group while main is
+back online.
+
+This happens only if [Sticky Sessions]() are enabled. TempestaFW will stop
+forwarding requests to backup servers as soon as all the HTTP sessions, served
+by backup servers will be closed.
+
+- Request is scheduled to a wrong server group or dropped while all the servers
+are reachable for TempestaFW.
+
+If request is scheduled to a wrong group it is most likely that there is an
+error in HTTP scheduler rules: request suit rule that is closer to the top
+of the list. Put more precise rules before more generic.
+
+Dropping of the message means that dropped request didn't match any rule.
+

--- a/doc/scheduling_devgd.md
+++ b/doc/scheduling_devgd.md
@@ -1,0 +1,80 @@
+# Scheduling in TempestaFW: Developer Guide
+
+Normally schedulers are separate modules with sources under `tempesta_fw/sched/`
+directory. Common scheduling routines and helpers implemented in `tempesta_fw/sched.c`.
+
+Both schedulers Group and Server are derived from the same `TfwScheduler` class,
+declared in `server.h`. Group schedulers must implement `sched_grp()` callback,
+where the scheduler must find target main and backup server groups for the request.
+Group scheduler must find target main and backup server groups and use
+`tfw_sched_sg_get_conn()` to schedule request to a server in one of that groups.
+
+Server schedulers must implement `sched_sg_conn()` and `sched_srv_conn()` to
+schedule request to any or to exact server in the group; `add_group()` and
+`del_group()` for binding scheduler to group; `add_conn()` for adding server's
+connection to list of known by scheduler. All the functions and `sched*()` in
+particular must be designed to work in highly concurrent environment.
+
+Schedulers register/deregister themselves
+in TempestaFW by calling `tfw_sched_register()`/`tfw_sched_unregister()` on module
+initialisation. Group schedulers are stored at the head of the list `sched_list`,
+Server schedulers - at the end of it.
+
+After new [Server group]() created, it binds itself to scheduler defined in
+Tempesta configuration by calling `add_group()`. During that call scheduler
+allocate it's private structure of server connections and theirs metadata in
+server group's member `sched_data`. When new connections for servers in the group
+is added by `add_conn()`.
+
+
+## Scheduling request
+
+Each request that cannot be served from cache must be scheduled to appropriate
+server by `tfw_sched_get_conn()` call. HTTP session for the request must be obtained
+before call. This happens in SoftIRQ during `tfw_http_req_cache_cb()`.
+
+In order to get target connection message is passed to the Group schedulers.
+Group schedulers must find target main and backup server groups and use
+`tfw_sched_sg_get_conn()` to schedule request to a server in one of that groups.
+
+If [Sticky Sessions]() are not enabled `tfw_sched_sg_get_conn()` try to schedule
+request to main server group or to backup server group if main group is offline.
+To do so callbacks `sched_sg_conn()` of schedulers registered for main and backup
+groups are called.
+
+If [Sticky Sessions]() enabled, but HTTP session for the request was not found
+situation is the same. That happens if client does not
+support cookies and [Sticky cookies are not enforced]().
+
+Situation became a little bit tricky if [Sticky Sessions]() and HTTP session
+for request was found. We must schedule request to the same servers whenever it
+is possible:
+
+- Current HTTP session was not scheduled to main server group.
+
+Schedule to any server in main group. If main group is offline, schedule to
+backup group. If the session was scheduled to backup group, last used connection
+must be reused, otherwise session must be scheduled to any server in backup
+group.
+
+There still can be a situation, when session _was_ scheduled to main server
+group. This happens when main server group is used as a backup group for some
+other group. In that case we must reuse that connection.
+
+- Current session was scheduled to main server group before.
+
+Reuse last connection. Note, that last connection may lead to server in backup
+group. That is normal situation and we have to keep scheduling to that server
+even if main server group is back online. Connection must be rescheduled to
+main server group and to backup (if main is offline) only when last used server
+offline and [user allowed us to do so]().
+
+After connection to desired server group was obtained it is saved in HTTP session.
+This logic is implemented in `tfw_sched_srv_get_sticky_conn()` in `sched.c`.
+See [Sticky Sessions Dev Guide]() for description how connections are stores for
+the HTTP session.
+
+## Scheduling non-idempotent requests
+
+**TODO**
+


### PR DESCRIPTION
Here is just initial description of schedulers for wiki.

In my opinion, wiki should contain only those things that do not changed frequently. Copying code comments is waste of paper: one day documentation will be far away from code and will be useless. 
Instead i suggest documenting in wiki the next things:
* Tempesta configuration file. User edit it, so good explanation of options is wanted. Some option can affect each other, and that can be quite complicated.
* Complicated logic of some subsystems/features. That more for developers. Some subsystems like an iceberg: api is pretty and clear, but the devil is in the detail.

That is not final document: there is a lot of references to other subsystem/modules. Just need a feedback, which sections to add, what to cover. Better to see in rich diff format.

Please don't pay a lot of attention to looks, still working on it (:
 