### PR TITLE
Fix BUG_ON() to account for responses to HEAD requests. (#674)

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1424,7 +1424,8 @@ tfw_http_resp_process(TfwConnection *conn, struct sk_buff *skb,
 			 * The response is fully parsed,
 			 * fall through and process it.
 			 */
-			BUG_ON(!(hmresp->flags & TFW_HTTP_CHUNKED)
+			BUG_ON(!(hmresp->flags
+				 & (TFW_HTTP_CHUNKED | TFW_HTTP_VOID_BODY))
 			       && (hmresp->content_length != hmresp->body.len));
 		}
 


### PR DESCRIPTION
Responses to HEAD requests have the full header with real value
in 'Content-Length:' header field, but no actual body.