### PR TITLE
Do not share @req->reason with @req->resp. (#696)

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -555,8 +555,9 @@ tfw_http_req_error(TfwSrvConn *srv_conn, TfwHttpReq *req,
 {
 	tfw_http_req_delist(srv_conn, req);
 	list_add_tail(&req->fwd_list, equeue);
-	req->status = status;
-	req->reason = reason;
+
+	req->httperr.status = status;
+	req->httperr.reason = reason;
 }
 
 /*
@@ -565,9 +566,9 @@ tfw_http_req_error(TfwSrvConn *srv_conn, TfwHttpReq *req,
  * fast as possible by moving failed requests to the error queue
  * that can be processed without the lock.
  *
- * Delete requests that were not forwarded due to an error. Send an
- * error response to a client. The response will be attached to the
- * request and then sent to the client in proper seq order.
+ * Process requests that were not forwarded due to an error. Send
+ * an error response to a client. The response will be attached to
+ * the request and then sent to the client in proper seq order.
  */
 static void
 tfw_http_req_zap_error(struct list_head *equeue)
@@ -579,23 +580,23 @@ tfw_http_req_zap_error(struct list_head *equeue)
 
 	list_for_each_entry_safe(req, tmp, equeue, fwd_list) {
 		list_del_init(&req->fwd_list);
-		switch(req->status) {
+		switch(req->httperr.status) {
 		case 404:
-			tfw_http_send_404(req, req->reason);
+			tfw_http_send_404(req, req->httperr.reason);
 			break;
 		case 500:
-			tfw_http_send_500(req, req->reason);
+			tfw_http_send_500(req, req->httperr.reason);
 			break;
 		case 502:
-			tfw_http_send_502(req, req->reason);
+			tfw_http_send_502(req, req->httperr.reason);
 			break;
 		case 504:
-			tfw_http_send_504(req, req->reason);
+			tfw_http_send_504(req, req->httperr.reason);
 			break;
 		default:
 			TFW_WARN("Unexpected response error code: [%d]\n",
-				 req->status);
-			tfw_http_send_500(req, req->reason);
+				 req->httperr.status);
+			tfw_http_send_500(req, req->httperr.reason);
 			break;
 		}
 		TFW_INC_STAT_BH(clnt.msgs_otherr);
@@ -2573,7 +2574,12 @@ static TfwConnHooks http_conn_hooks = {
 int __init
 tfw_http_init(void)
 {
-	int r = tfw_gfsm_register_fsm(TFW_FSM_HTTP, tfw_http_msg_process);
+	int r;
+	/* Make sure @req->httperr doesn't take too much space. */
+	BUILD_BUG_ON(sizeof(((TfwHttpMsg *)0)->httperr)
+		     > sizeof(((TfwHttpMsg *)0)->parser));
+
+	r = tfw_gfsm_register_fsm(TFW_FSM_HTTP, tfw_http_msg_process);
 	if (r)
 		return r;
 

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -819,8 +819,6 @@ tfw_http_msg_alloc_err_resp(void)
 
 	if (!(hm = (TfwHttpMsg *)tfw_pool_new(TfwHttpResp, TFW_POOL_ZERO)))
 		return NULL;
-
-	INIT_LIST_HEAD(&hm->msg.seq_list);
 	ss_skb_queue_head_init(&hm->msg.skb_list);
 
 	return hm;
@@ -885,7 +883,6 @@ tfw_http_msg_alloc(int type)
 	hm->h_tbl->off = TFW_HTTP_HDR_RAW;
 	memset(hm->h_tbl->tbl, 0, __HHTBL_SZ(1) * sizeof(TfwStr));
 
-	INIT_LIST_HEAD(&hm->msg.seq_list);
 	ss_skb_queue_head_init(&hm->msg.skb_list);
 
 	hm->parser.to_read = -1; /* unknown body size */
@@ -895,6 +892,7 @@ tfw_http_msg_alloc(int type)
 		__hbh_parser_init_resp((TfwHttpResp *)hm);
 
 	if (type & Conn_Clnt) {
+		INIT_LIST_HEAD(&hm->msg.seq_list);
 		INIT_LIST_HEAD(&((TfwHttpReq *)hm)->fwd_list);
 		INIT_LIST_HEAD(&((TfwHttpReq *)hm)->nip_list);
 		hm->destructor = tfw_http_req_destruct;


### PR DESCRIPTION
HTTP responses don't use @msg.seq_list. No need to init it.