### PR TITLE
Fix the potential deadlock case in tfw_apm_stats(). (#664)

### DIFF
--- a/tempesta_fw/apm.h
+++ b/tempesta_fw/apm.h
@@ -52,6 +52,7 @@ void *tfw_apm_create(void);
 void tfw_apm_destroy(void *data);
 void tfw_apm_update(void *data, unsigned long jtstamp, unsigned long jrtime);
 int tfw_apm_stats(void *data, TfwPrcntlStats *pstats);
+int tfw_apm_stats_bh(void *data, TfwPrcntlStats *pstats);
 int tfw_apm_prcntl_verify(TfwPrcntl *prcntl, unsigned int prcntlsz);
 
 #endif /* __TFW_APM_H__ */

--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -162,7 +162,7 @@ tfw_srvstats_seq_show(struct seq_file *seq, void *off)
 
 	memcpy(prcntl, tfw_procfs_prcntl, sizeof(prcntl));
 
-	tfw_apm_stats(srv->apm, &pstats);
+	tfw_apm_stats_bh(srv->apm, &pstats);
 
 	SPRNE("Minimal response time\t\t", pstats.min);
 	SPRNE("Average response time\t\t", pstats.avg);


### PR DESCRIPTION
Use _BH locks in user context, and regular locks in kernel context.