### PR TITLE
Fix errors in configuration

### DIFF
--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1064,12 +1064,13 @@ tfw_handle_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	const char *key, *val;
 
 	if (ce->val_n) {
-		TFW_ERR("%s: Arguments must be a key=value pair.\n", cs->name);
+		TFW_ERR_NL("%s: Arguments must be a key=value pair.\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	if (!ce->attr_n) {
-		TFW_WARN("%s: arguments missing, using default values.\n",
-			 cs->name);
+		TFW_WARN_NL("%s: arguments missing, using default values.\n",
+			    cs->name);
 		return 0;
 	}
 	TFW_CFG_ENTRY_FOR_EACH_ATTR(ce, i, key, val) {
@@ -1080,8 +1081,8 @@ tfw_handle_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 			if ((r = tfw_cfg_parse_int(val, &tfw_apm_tmwscale)))
 				return r;
 		} else {
-			TFW_ERR("%s: unsupported argument: '%s=%s'.\n",
-				cs->name, key, val);
+			TFW_ERR_NL("%s: unsupported argument: '%s=%s'.\n",
+				   cs->name, key, val);
 			return -EINVAL;
 		}
 	}

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1409,18 +1409,18 @@ tfw_cache_cfg_method(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		} else if (!strcasecmp(val, "POST")) {
 			method = TFW_HTTP_METH_POST;
 		} else {
-			TFW_ERR("%s: unsupported method: '%s'\n",
-				cs->name, val);
+			TFW_ERR_NL("%s: unsupported method: '%s'\n",
+				   cs->name, val);
 			return -EINVAL;
 		}
 		if (__cache_method_nc_test(method)) {
-			TFW_ERR("%s: non-cacheable method: '%s'\n",
-				cs->name, val);
+			TFW_ERR_NL("%s: non-cacheable method: '%s'\n",
+				   cs->name, val);
 			return -EINVAL;
 		}
 		if (__cache_method_test(method)) {
-			TFW_WARN("%s: duplicate method: '%s'\n",
-				 cs->name, val);
+			TFW_WARN_NL("%s: duplicate method: '%s'\n",
+				    cs->name, val);
 			continue;
 		}
 		__cache_method_add(method);

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -238,7 +238,7 @@ entry_add_val(TfwCfgEntry *e, const char *val_src, size_t val_len)
 		return -EINVAL;
 
 	if (e->val_n == ARRAY_SIZE(e->vals)) {
-		TFW_ERR("maximum number of values per entry reached\n");
+		TFW_ERR_NL("maximum number of values per entry reached\n");
 		return -ENOBUFS;
 	}
 
@@ -268,7 +268,7 @@ entry_add_attr(TfwCfgEntry *e, const char *key_src, size_t key_len,
 		return -EINVAL;
 
 	if (e->attr_n == ARRAY_SIZE(e->attrs)) {
-		TFW_ERR("maximum number of attributes per entry reached\n");
+		TFW_ERR_NL("maximum number of attributes per entry reached\n");
 		return -ENOBUFS;
 	}
 
@@ -761,8 +761,8 @@ spec_handle_entry(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry)
 	int r;
 
 	if (!spec->allow_repeat && spec->call_counter) {
-		TFW_ERR("duplicate entry: '%s', only one such entry is allowed."
-			"\n", parsed_entry->name);
+		TFW_ERR_NL("duplicate entry: '%s', only one such entry is"
+			   " allowed.\n", parsed_entry->name);
 		return -EINVAL;
 	}
 
@@ -857,11 +857,11 @@ spec_finish_handling(TfwCfgSpec specs[])
 	return 0;
 
 err_no_entry:
-	TFW_ERR("the required entry is not found: '%s'\n", spec->name);
+	TFW_ERR_NL("the required entry is not found: '%s'\n", spec->name);
 	return -EINVAL;
 
 err_dflt_val:
-	TFW_ERR("Error handling default value for: '%s'\n", spec->name);
+	TFW_ERR_NL("Error handling default value for: '%s'\n", spec->name);
 	return r;
 }
 
@@ -977,8 +977,8 @@ int
 tfw_cfg_check_val_n(const TfwCfgEntry *e, int val_n)
 {
 	if (e->val_n != val_n) {
-		TFW_ERR("invalid number of values; expected: %d, got: %zu\n",
-			val_n, e->val_n);
+		TFW_ERR_NL("invalid number of values; expected: %d, got: %zu\n",
+			   val_n, e->val_n);
 		return -EINVAL;
 	}
 	return 0;
@@ -1000,13 +1000,13 @@ tfw_cfg_check_single_val(const TfwCfgEntry *e)
 	int r = -EINVAL;
 
 	if (e->val_n == 0)
-		TFW_ERR("no value specified\n");
+		TFW_ERR_NL("no value specified\n");
 	else if (e->val_n > 1)
-		TFW_ERR("more than one value specified\n");
+		TFW_ERR_NL("more than one value specified\n");
 	else if (e->attr_n)
-		TFW_ERR("unexpected attributes\n");
+		TFW_ERR_NL("unexpected attributes\n");
 	else if (e->have_children)
-		TFW_ERR("unexpected children entries\n");
+		TFW_ERR_NL("unexpected children entries\n");
 	else
 		r = 0;
 
@@ -1112,7 +1112,7 @@ tfw_cfg_handle_children(TfwCfgSpec *cs, TfwCfgEntry *e)
 	}
 
 	if (!e->have_children) {
-		TFW_ERR("the entry has no nested children entries\n");
+		TFW_ERR_NL("the entry has no nested children entries\n");
 		return -EINVAL;
 	}
 
@@ -1222,7 +1222,7 @@ tfw_cfg_set_bool(TfwCfgSpec *cs, TfwCfgEntry *e)
 
 	BUG_ON(is_true && is_false);
 	if (!is_true && !is_false) {
-		TFW_ERR("invalid boolean value: '%s'\n", in_str);
+		TFW_ERR_NL("invalid boolean value: '%s'\n", in_str);
 		return -EINVAL;
 	}
 
@@ -1327,14 +1327,15 @@ tfw_cfg_set_str(TfwCfgSpec *cs, TfwCfgEntry *e)
 		min = cse->len_range.min;
 		max = cse->len_range.max;
 		if (min != max && (len < min || len > max)) {
-			TFW_ERR("the string length (%d) is out of valid range "
-				" (%d, %d): '%s'\n", len, min, max, str);
+			TFW_ERR_NL("the string length (%d) is out of valid "
+				   "range (%d, %d): '%s'\n", len, min, max,
+				   str);
 			return -EINVAL;
 		}
 
 		cset = cse->cset;
 		if (cset && !is_matching_to_cset(str, cset)) {
-			TFW_ERR("invalid characters found: '%s'\n", str);
+			TFW_ERR_NL("invalid characters found: '%s'\n", str);
 			return -EINVAL;
 		}
 	}
@@ -1579,7 +1580,7 @@ tfw_cfg_start(void)
 
 	TFW_LOG("Starting all modules...\n");
 	if ((r = tfw_cfg_start_mods(cfg_text_buf)))
-		TFW_ERR("failed to start modules\n");
+		TFW_ERR_NL("failed to start modules\n");
 
 	vfree(cfg_text_buf);
 

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -352,7 +352,10 @@ typedef struct {
 	/* Length of @lit (the @lit is not terminated). */
 	int lit_len;
 	int prev_lit_len;
-	int line;
+
+	/* Current line. */
+	size_t line_no;
+	const char *line;
 
 	int  err;  /* The latest error code. */
 
@@ -388,14 +391,16 @@ do {					\
 
 /* Macros specific to TFSM. */
 
-#define TFSM_MOVE(to_state)	\
-do {				\
-	ps->prev_c = ps->c;	\
-	ps->c = *(++ps->pos);	\
+#define TFSM_MOVE(to_state)		\
+do {					\
+	ps->prev_c = ps->c;		\
+	ps->c = *(++ps->pos);		\
 	TFW_DBG3("tfsm move: '%c' -> '%c'\n", ps->prev_c, ps->c); \
-	FSM_JMP(to_state);	\
-	if ( ps->prev_c == '\n'){\
-		++ps->line; }	 \
+	if (ps->prev_c == '\n') {	\
+		++ps->line_no;		\
+		ps->line = ps->pos;	\
+	}				\
+	FSM_JMP(to_state);		\
 } while (0)
 
 #define TFSM_MOVE_EXIT(token_type)	\
@@ -616,6 +621,7 @@ parse_cfg_entry(TfwCfgParserState *ps)
 		TFW_DBG3("set name: %.*s\n", ps->lit_len, ps->lit);
 
 		ps->err = entry_set_name(&ps->e, ps->lit, ps->lit_len);
+		ps->e.line_no = ps->line_no;
 		ps->e.line = ps->line;
 		FSM_COND_JMP(ps->err, PS_EXIT);
 
@@ -764,7 +770,7 @@ spec_handle_entry(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry)
 	r = spec->handler(spec, parsed_entry);
 	++spec->call_counter;
 	if (r)
-		TFW_ERR("configuration handler returned error: %d\n", r);
+		TFW_DBG("configuration handler returned error: %d\n", r);
 
 	return r;
 }
@@ -790,7 +796,7 @@ spec_handle_default(TfwCfgSpec *spec)
 	TFW_DBG2("use default entry: '%s'\n", fake_entry_buf);
 
 	memset(&ps, 0, sizeof(ps));
-	ps.in = ps.pos = fake_entry_buf;
+	ps.line = ps.in = ps.pos = fake_entry_buf;
 	parse_cfg_entry(&ps);
 	BUG_ON(!ps.e.name);
 	BUG_ON(ps.err);
@@ -1411,9 +1417,26 @@ mod_stop(TfwCfgMod *mod)
 static void
 print_parse_error(const TfwCfgParserState *ps)
 {
+	int len = 0;
+	const char *ticks = "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+			    "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^";
+	const char* eos = NULL;
 
-	TFW_ERR("configuration parsing error: str:%d;w:%s\n", ps->e.line + 1,
-		ps->e.name);
+	/*
+	 * Line is not known: mandatory option is not present, error is raised
+	 * by @spec_finish_handling() function.
+	 */
+	if (!ps->e.line) {
+		TFW_ERR_NL("configuration parsing error");
+		return;
+	}
+
+	eos = strchrnul(ps->e.line, '\n');
+	len = min(80, (int)(eos - ps->e.line));
+	TFW_ERR_NL("configuration parsing error:\n"
+		   "%4zu: %.*s\n"
+		   "      %.*s\n",
+		   ps->e.line_no + 1, len, ps->e.line, len, ticks);
 }
 
 /*
@@ -1440,7 +1463,8 @@ tfw_cfg_parse_mods_cfg(const char *cfg_text, struct list_head *mod_list)
 {
 	TfwCfgParserState ps = {
 		.in = cfg_text,
-		.pos = cfg_text
+		.pos = cfg_text,
+		.line = cfg_text
 	};
 	TfwCfgMod *mod;
 	TfwCfgSpec *matching_spec = NULL;
@@ -1466,14 +1490,13 @@ tfw_cfg_parse_mods_cfg(const char *cfg_text, struct list_head *mod_list)
 		}
 		if (!matching_spec) {
 			TFW_ERR("don't know how to handle: '%s'\n", ps.e.name);
-			entry_reset(&ps.e);
 			goto err;
 		}
 
 		r = spec_handle_entry(matching_spec, &ps.e);
-		entry_reset(&ps.e);
 		if (r)
 			goto err;
+		entry_reset(&ps.e);
 	} while (ps.t);
 
 	MOD_FOR_EACH(mod, mod_list) {
@@ -1485,6 +1508,7 @@ tfw_cfg_parse_mods_cfg(const char *cfg_text, struct list_head *mod_list)
 	return 0;
 err:
 	print_parse_error(&ps);
+	entry_reset(&ps.e);
 	return -EINVAL;
 }
 EXPORT_SYMBOL(tfw_cfg_parse_mods_cfg);
@@ -1507,7 +1531,7 @@ tfw_cfg_start_mods(const char *cfg_text)
 	TFW_DBG2("parsing configuration and pushing it to modules...\n");
 	ret = tfw_cfg_parse_mods_cfg(cfg_text, &tfw_cfg_mods);
 	if (ret) {
-		TFW_ERR("can't parse configuration data\n");
+		TFW_DBG("can't parse configuration data\n");
 		goto err_recover_cleanup;
 	}
 

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -88,18 +88,23 @@
  * and acts as an interface between the parser FSM and TfwCfgSpec->handler.
  * The parser accumulates data in the TfwCfgEntry, and when the current entry is
  * finished, the parser executes the handler and then destroys the structure.
+ *
+ * @line_no	- Current line number, used to show propper config parsing error
+ *		  to user.
+ * @line	- Pointer to start of the current line, for same purpose.
  */
 typedef struct {
 	bool have_children;
 	size_t val_n;
 	size_t attr_n;
-	int line; /* The current line */
 	const char *name;
 	const char *vals[TFW_CFG_ENTRY_VAL_MAX];
 	struct {
 		const char *key;
 		const char *val;
 	} attrs[TFW_CFG_ENTRY_ATTR_MAX];
+	size_t line_no;
+	const char *line;
 } TfwCfgEntry;
 
 /**

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -169,6 +169,22 @@ typedef struct {
  * system is stopped, or new configuration is available, or an error occurred).
  * The @cleanup callback is invoked when @handler was called at least once
  * regardless of the handler's return value.
+ *
+ * Configuration specification may have nested entries. In that case @handler
+ * must be filled with pointer to function @tfw_cfg_handle_children(),
+ * @dest - null-terminated array of nested specifications, @spec_ext -
+ * poitner to instance of @TfwCfgSpecChild struct. @cleanup function cleaning
+ * specification and all the nested entries is a mandatory in this case.
+ * Generic @tfw_cfg_cleanup_children() function calls @cleanup functions for all
+ * the nested entries and may be used here. Or user-defined function may be
+ * provided, if so it takes responsibility to clean up all the nested entries.
+ *
+ * Note: There is special case of repeatable specifications containing
+ * non-repeatable nested entries. Such entries need @call_counter values
+ * of non-repeatable child entries to be reset before using specs in the
+ * configuration parser. That breaks generic @cleanup approach based on
+ * @call_counter values, so reset will take place only if user-defined cleanup
+ * function is provided.
  */
 typedef struct TfwCfgSpec TfwCfgSpec;
 struct TfwCfgSpec {
@@ -281,6 +297,7 @@ int tfw_cfg_set_bool(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_int(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_str(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_handle_children(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
+void tfw_cfg_cleanup_children(TfwCfgSpec *cs);
 
 /* Various helpers for building custom handler functions. */
 int tfw_cfg_check_range(long value, long min, long max);

--- a/tempesta_fw/classifier/frang.c
+++ b/tempesta_fw/classifier/frang.c
@@ -1075,7 +1075,8 @@ static TfwCfgSpec frang_cfg_toplevel_specs[] = {
 	{
 		.name = "frang_limits",
 		.handler = tfw_cfg_handle_children,
-		.dest = &frang_cfg_section_specs
+		.dest = &frang_cfg_section_specs,
+		.cleanup = tfw_cfg_cleanup_children
 	},
 	{}
 };

--- a/tempesta_fw/classifier/frang.c
+++ b/tempesta_fw/classifier/frang.c
@@ -882,7 +882,7 @@ frang_set_methods_mask(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		r = tfw_cfg_map_enum(frang_http_methods_enum, method_str,
 				     &method_id);
 		if (r) {
-			TFW_ERR("frang: invalid method: '%s'\n", method_str);
+			TFW_ERR_NL("frang: invalid method: '%s'\n", method_str);
 			return -EINVAL;
 		}
 

--- a/tempesta_fw/log.h
+++ b/tempesta_fw/log.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2016 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -76,7 +76,7 @@
 #define TFW_WARN(...)	__CALLSTACK_MSG(KERN_WARNING TFW_BANNER		\
 					"Warning: " __VA_ARGS__)
 #define TFW_LOG(...)	pr_info(TFW_BANNER __VA_ARGS__)
-
+/* Non-limited printing for use only during start/stop. */
 #define TFW_ERR_NL(...)		TFW_ERR(__VA_ARGS__)
 #define TFW_WARN_NL(...)	TFW_WARN(__VA_ARGS__)
 #define TFW_LOG_NL(...)		TFW_LOG(__VA_ARGS__)
@@ -85,7 +85,7 @@
 #define TFW_ERR(...)	net_err_ratelimited(TFW_BANNER "ERROR: " __VA_ARGS__)
 #define TFW_WARN(...)	net_warn_ratelimited(TFW_BANNER "Warning: " __VA_ARGS__)
 #define TFW_LOG(...)	net_info_ratelimited(TFW_BANNER __VA_ARGS__)
-
+/* Non-limited printing for use only during start/stop. */
 #define TFW_ERR_NL(...)		pr_err(TFW_BANNER "ERROR: " __VA_ARGS__)
 #define TFW_WARN_NL(...)	pr_warn(TFW_BANNER "Warning: " __VA_ARGS__)
 #define TFW_LOG_NL(...)		pr_log(TFW_BANNER __VA_ARGS__)

--- a/tempesta_fw/log.h
+++ b/tempesta_fw/log.h
@@ -76,11 +76,19 @@
 #define TFW_WARN(...)	__CALLSTACK_MSG(KERN_WARNING TFW_BANNER		\
 					"Warning: " __VA_ARGS__)
 #define TFW_LOG(...)	pr_info(TFW_BANNER __VA_ARGS__)
+
+#define TFW_ERR_NL(...)		TFW_ERR(__VA_ARGS__)
+#define TFW_WARN_NL(...)	TFW_WARN(__VA_ARGS__)
+#define TFW_LOG_NL(...)		TFW_LOG(__VA_ARGS__)
 #else
 #include <linux/net.h>
 #define TFW_ERR(...)	net_err_ratelimited(TFW_BANNER "ERROR: " __VA_ARGS__)
 #define TFW_WARN(...)	net_warn_ratelimited(TFW_BANNER "Warning: " __VA_ARGS__)
 #define TFW_LOG(...)	net_info_ratelimited(TFW_BANNER __VA_ARGS__)
+
+#define TFW_ERR_NL(...)		pr_err(TFW_BANNER "ERROR: " __VA_ARGS__)
+#define TFW_WARN_NL(...)	pr_warn(TFW_BANNER "Warning: " __VA_ARGS__)
+#define TFW_LOG_NL(...)		pr_log(TFW_BANNER __VA_ARGS__)
 #endif
 
 /*

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -262,8 +262,8 @@ tfw_sched_http_cfg_handle_match(TfwCfgSpec *cs, TfwCfgEntry *e)
 
 	main_sg = tfw_sg_lookup(in_main_sg);
 	if (!main_sg) {
-		TFW_ERR("sched_http: srv_group is not found: '%s'\n",
-			in_main_sg);
+		TFW_ERR_NL("sched_http: srv_group is not found: '%s'\n",
+			   in_main_sg);
 		return -EINVAL;
 	}
 
@@ -272,23 +272,23 @@ tfw_sched_http_cfg_handle_match(TfwCfgSpec *cs, TfwCfgEntry *e)
 	} else {
 		backup_sg = tfw_sg_lookup(in_backup_sg);
 		if (!backup_sg) {
-			TFW_ERR("sched_http: backup srv_group is not found:"
-				" '%s'\n", in_backup_sg);
+			TFW_ERR_NL("sched_http: backup srv_group is not found:"
+				   " '%s'\n", in_backup_sg);
 			return -EINVAL;
 		}
 	}
 
 	r = tfw_cfg_map_enum(tfw_sched_http_cfg_field_enum, in_field, &field);
 	if (r) {
-		TFW_ERR("sched_http: invalid HTTP request field: '%s'\n",
-			in_field);
+		TFW_ERR_NL("sched_http: invalid HTTP request field: '%s'\n",
+			   in_field);
 		return -EINVAL;
 	}
 
 	r = tfw_cfg_map_enum(tfw_sched_http_cfg_op_enum, in_op, &op);
 	if (r) {
-		TFW_ERR("sched_http: invalid matching operator: '%s'\n",
-			in_op);
+		TFW_ERR_NL("sched_http: invalid matching operator: '%s'\n",
+			   in_op);
 		return -EINVAL;
 	}
 
@@ -298,7 +298,8 @@ tfw_sched_http_cfg_handle_match(TfwCfgSpec *cs, TfwCfgEntry *e)
 	rule = tfw_http_match_entry_new(tfw_sched_http_rules,
 					TfwSchedHttpRule, rule, arg_size);
 	if (!rule) {
-		TFW_ERR("sched_http: can't allocate memory for parsed rule\n");
+		TFW_ERR_NL("sched_http: can't allocate memory for parsed "
+			   "rule\n");
 		return -ENOMEM;
 	}
 

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -416,7 +416,8 @@ static TfwCfgMod tfw_sched_http_cfg_mod = {
 				.begin_hook = tfw_sched_http_cfg_begin_rules,
 				.finish_hook = tfw_sched_http_cfg_finish_rules
 			},
-			.allow_none = true
+			.allow_none = true,
+			.cleanup = tfw_cfg_cleanup_children
 		},
 		{}
 	}

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -545,8 +545,8 @@ tfw_sock_clnt_cfg_handle_listen(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		goto parse_err;
 
 parse_err:
-	TFW_ERR("Unable to parse 'listen' value: '%s'\n",
-		in_str ? in_str : "No value specified");
+	TFW_ERR_NL("Unable to parse 'listen' value: '%s'\n",
+		   in_str ? in_str : "No value specified");
 	return -EINVAL;
 }
 
@@ -561,16 +561,16 @@ tfw_sock_clnt_cfg_handle_keepalive(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	r = tfw_cfg_parse_int(ce->vals[0], &tfw_cli_cfg_ka_timeout);
 	if (r) {
-		TFW_ERR("Unable to parse 'keepalive_timeout' value: '%s'\n",
-			ce->vals[0]
-			? ce->vals[0]
-			: "No value specified");
+		TFW_ERR_NL("Unable to parse 'keepalive_timeout' value: '%s'\n",
+			   ce->vals[0]
+			   ? ce->vals[0]
+			   : "No value specified");
 		return -EINVAL;
 	}
 
 	if (tfw_cli_cfg_ka_timeout < 0) {
-		TFW_ERR("Unable to parse 'keepalive_timeout' value: '%s'\n",
-			"Value less the zero");
+		TFW_ERR_NL("Unable to parse 'keepalive_timeout' value: '%s'\n",
+			   "Value less the zero");
 		return -EINVAL;
 	}
 

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -596,13 +596,13 @@ tfw_cfgop_intval(TfwCfgSpec *cs, TfwCfgEntry *ce, int *intval)
 	int ret;
 
 	if (ce->attr_n) {
-		TFW_ERR("%s: Arguments may not have the \'=\' sign\n",
-			cs->name);
+		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 1) {
-		TFW_ERR("%s: Invalid number of arguments: %d\n",
-			cs->name, (int)ce->val_n);
+		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
+			   cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
 	if ((ret = tfw_cfg_parse_int(ce->vals[0], intval)))
@@ -651,7 +651,8 @@ static inline int
 tfw_cfgop_retry_nip(TfwCfgSpec *cs, TfwCfgEntry *ce, int *retry_nip)
 {
 	if (ce->attr_n || ce->val_n) {
-		TFW_ERR("%s: The option may not have arguments.\n", cs->name);
+		TFW_ERR_NL("%s: The option may not have arguments.\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	*retry_nip = 1;
@@ -710,41 +711,43 @@ tfw_cfgop_server(TfwCfgSpec *cs, TfwCfgEntry *ce,
 	const char *key, *val, *saddr;
 
 	if (ce->val_n != 1) {
-		TFW_ERR("%s: %s %s: Invalid number of arguments: %zd\n",
-			sg->name, cs->name, ce->val_n ? ce->vals[0] : "",
-			ce->val_n);
+		TFW_ERR_NL("%s: %s %s: Invalid number of arguments: %zd\n",
+			   sg->name, cs->name, ce->val_n ? ce->vals[0] : "",
+			   ce->val_n);
 		return -EINVAL;
 	}
 	if (ce->attr_n > 2) {
-		TFW_ERR("%s: %s %s: Invalid number of key=value pairs: %zd\n",
-			sg->name, cs->name, ce->vals[0], ce->attr_n);
+		TFW_ERR_NL("%s: %s %s: Invalid number of key=value pairs: %zd\n",
+			   sg->name, cs->name, ce->vals[0], ce->attr_n);
 		return -EINVAL;
 	}
 
 	saddr = ce->vals[0];
 
 	if (tfw_addr_pton(&TFW_STR_FROM(saddr), &addr)) {
-		TFW_ERR("%s: %s %s: Invalid IP address: '%s'\n",
-			sg->name, cs->name, saddr, saddr);
+		TFW_ERR_NL("%s: %s %s: Invalid IP address: '%s'\n",
+			   sg->name, cs->name, saddr, saddr);
 		return -EINVAL;
 	}
 
 	TFW_CFG_ENTRY_FOR_EACH_ATTR(ce, i, key, val) {
 		if (!strcasecmp(key, "conns_n")) {
 			if (has_conns_n) {
-				TFW_ERR("%s: %s %s: Duplicate arg: '%s=%s'\n",
-					sg->name, cs->name, saddr, key, val);
+				TFW_ERR_NL("%s: %s %s: Duplicate arg: '%s=%s'"
+					   "\n", sg->name, cs->name, saddr, key,
+					   val);
 				return -EINVAL;
 			}
 			if (tfw_cfg_parse_int(val, &conns_n)) {
-				TFW_ERR("%s: %s %s: Invalid value: '%s=%s'\n",
-					sg->name, cs->name, saddr, key, val);
+				TFW_ERR_NL("%s: %s %s: Invalid value: '%s=%s'"
+					   "\n", sg->name, cs->name, saddr, key,
+					   val);
 				return -EINVAL;
 			}
 			has_conns_n = true;
 		} else {
-			TFW_ERR("%s: %s %s: Unsupported argument: '%s=%s'\n",
-				sg->name, cs->name, saddr, key, val);
+			TFW_ERR_NL("%s: %s %s: Unsupported argument: '%s=%s'\n",
+				   sg->name, cs->name, saddr, key, val);
 			return -EINVAL;
 		}
 	}
@@ -752,15 +755,15 @@ tfw_cfgop_server(TfwCfgSpec *cs, TfwCfgEntry *ce,
 	if (!has_conns_n) {
 		conns_n = TFW_CFG_SRV_CONNS_N_DEF;
 	} else if ((conns_n < 1) || (conns_n > TFW_SRV_MAX_CONN)) {
-		TFW_ERR("%s: %s %s: Out of range of [1..%d]: 'conns_n=%d'\n",
-			sg->name, cs->name, saddr, TFW_SRV_MAX_CONN, conns_n);
+		TFW_ERR_NL("%s: %s %s: Out of range of [1..%d]: 'conns_n=%d'\n",
+			   sg->name, cs->name, saddr, TFW_SRV_MAX_CONN,
+			   conns_n);
 		return -EINVAL;
 	}
 
-
 	if (!(srv = tfw_server_create(&addr))) {
-		TFW_ERR("%s: %s %s: Error handling the server\n",
-			sg->name, cs->name, saddr);
+		TFW_ERR_NL("%s: %s %s: Error handling the server\n",
+			   sg->name, cs->name, saddr);
 		return -EINVAL;
 	}
 	tfw_sg_add(sg, srv);
@@ -832,7 +835,7 @@ tfw_cfgop_out_server(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		static const char __read_mostly s_default[] = "default";
 
 		if (!(tfw_cfg_out_sg = tfw_sg_new(s_default, GFP_KERNEL))) {
-			TFW_ERR("Unable to add default server group\n");
+			TFW_ERR_NL("Unable to add default server group\n");
 			return -EINVAL;
 		}
 	}
@@ -861,18 +864,19 @@ static int
 tfw_cfgop_begin_srv_group(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	if (ce->val_n != 1) {
-		TFW_ERR("%s %s: Invalid number of arguments: %zd\n",
-			cs->name, ce->val_n ? ce->vals[0] : "", ce->val_n);
+		TFW_ERR_NL("%s %s: Invalid number of arguments: %zd\n",
+			   cs->name, ce->val_n ? ce->vals[0] : "", ce->val_n);
 			return -EINVAL;
 	}
 	if (ce->attr_n) {
-		TFW_ERR("%s %s: Arguments may not have the \'=\' sign\n",
-			cs->name, ce->vals[0]);
+		TFW_ERR_NL("%s %s: Arguments may not have the \'=\' sign\n",
+			   cs->name, ce->vals[0]);
 		return -EINVAL;
 	}
 
 	if (!(tfw_cfg_in_sg = tfw_sg_new(ce->vals[0], GFP_KERNEL))) {
-		TFW_ERR("%s %s: Unable to add group\n", cs->name, ce->vals[0]);
+		TFW_ERR_NL("%s %s: Unable to add group\n", cs->name,
+			   ce->vals[0]);
 		return -EINVAL;
 	}
 
@@ -919,8 +923,8 @@ tfw_cfgop_finish_srv_group(TfwCfgSpec *cs)
 	sg->flags |= tfw_cfg_in_retry_nip ? TFW_SRV_RETRY_NIP : 0;
 
 	if (tfw_sg_set_sched(sg, tfw_cfg_in_sched->name)) {
-		TFW_ERR("%s %s: Unable to set scheduler: '%s'\n",
-			cs->name, sg->name, tfw_cfg_in_sched->name);
+		TFW_ERR_NL("%s %s: Unable to set scheduler: '%s'\n",
+			   cs->name, sg->name, tfw_cfg_in_sched->name);
 		return -EINVAL;
 	}
 	/* Add connections only after a scheduler is set. */
@@ -929,9 +933,9 @@ tfw_cfgop_finish_srv_group(TfwCfgSpec *cs)
 		if (tfw_sock_srv_add_conns(srv, tfw_cfg_in_nconn[i])) {
 			char as[TFW_ADDR_STR_BUF_SIZE] = { 0 };
 			tfw_addr_ntop(&srv->addr, as, sizeof(as));
-			TFW_ERR("%s %s: server '%s': "
-				"Error adding connections\n",
-				cs->name, sg->name, as);
+			TFW_ERR_NL("%s %s: server '%s': "
+				   "Error adding connections\n",
+				   cs->name, sg->name, as);
 			return -EINVAL;
 		}
 	}
@@ -948,19 +952,19 @@ tfw_cfgop_sched(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwScheduler **arg_sched)
 	TfwScheduler *sched;
 
 	if (!ce->val_n) {
-		TFW_ERR("%s: Invalid number of arguments: %zd\n",
-			cs->name, ce->val_n);
+		TFW_ERR_NL("%s: Invalid number of arguments: %zd\n",
+			   cs->name, ce->val_n);
 		return -EINVAL;
 	}
 	if (ce->attr_n) {
-		TFW_ERR("%s %s: Arguments may not have the \'=\' sign\n",
-			cs->name, ce->vals[0]);
+		TFW_ERR_NL("%s %s: Arguments may not have the \'=\' sign\n",
+			   cs->name, ce->vals[0]);
 		return -EINVAL;
 	}
 
 	if (!(sched = tfw_sched_lookup(ce->vals[0]))) {
-		TFW_ERR("%s %s: Unrecognized scheduler: '%s'\n",
-			cs->name, ce->vals[0], ce->vals[0]);
+		TFW_ERR_NL("%s %s: Unrecognized scheduler: '%s'\n",
+			   cs->name, ce->vals[0], ce->vals[0]);
 		return -EINVAL;
 	}
 
@@ -1013,8 +1017,8 @@ tfw_sock_srv_start(void)
 		sg->flags |= tfw_cfg_out_retry_nip ? TFW_SRV_RETRY_NIP : 0;
 
 		if (tfw_sg_set_sched(sg, tfw_cfg_out_sched->name)) {
-			TFW_ERR("srv_group %s: Unable to set scheduler: "
-				"'%s'\n", sg->name, tfw_cfg_out_sched->name);
+			TFW_ERR_NL("srv_group %s: Unable to set scheduler: "
+				   "'%s'\n", sg->name, tfw_cfg_out_sched->name);
 			return -EINVAL;
 		}
 		/* Add connections only after a scheduler is set. */
@@ -1023,9 +1027,9 @@ tfw_sock_srv_start(void)
 			if (tfw_sock_srv_add_conns(srv, tfw_cfg_out_nconn[i])) {
 				char as[TFW_ADDR_STR_BUF_SIZE] = { 0 };
 				tfw_addr_ntop(&srv->addr, as, sizeof(as));
-				TFW_ERR("srv_group %s: server '%s': "
-					"Error adding connections\n",
-					sg->name, as);
+				TFW_ERR_NL("srv_group %s: server '%s': "
+					   "Error adding connections\n",
+					   sg->name, as);
 				return -EINVAL;
 			}
 		}

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -864,7 +864,7 @@ tfw_cfgop_begin_srv_group(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		TFW_ERR("%s %s: Invalid number of arguments: %zd\n",
 			cs->name, ce->val_n ? ce->vals[0] : "", ce->val_n);
 			return -EINVAL;
-        }
+	}
 	if (ce->attr_n) {
 		TFW_ERR("%s %s: Arguments may not have the \'=\' sign\n",
 			cs->name, ce->vals[0]);
@@ -1163,6 +1163,7 @@ TfwCfgMod tfw_sock_srv_cfg_mod = {
 			},
 			.allow_none = true,
 			.allow_repeat = true,
+			.cleanup = tfw_clean_srv_groups,
 		},
 		{ 0 }
 	}

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -45,19 +45,6 @@ test_spec_cleanup(TfwCfgSpec specs[])
 			spec->cleanup(spec);
 		}
 		spec->call_counter = 0;
-
-		/**
-		 * When spec processing function is tfw_cfg_handle_children(),
-		 * a user-defined .cleanup function for that spec is not
-		 * allowed. Instead, an special .cleanup function is assigned
-		 * to that spec, thus overwriting the (zero) value there.
-		 * When the whole cleanup process completes, revert that spec
-		 * entry to original (zero) value. That will allow reuse of
-		 * the spec.
-		 */
-		if (spec->handler == &tfw_cfg_handle_children) {
-			spec->cleanup = NULL;
-		}
 	}
 }
 

--- a/tempesta_fw/t/unit/test_cfg.c
+++ b/tempesta_fw/t/unit/test_cfg.c
@@ -952,8 +952,10 @@ TEST(tfw_cfg_handle_children, parses_nested_entries_recursively)
 		{ 0 }
 	};
 	TfwCfgSpec root_specs[] = {
-		{ "section1", NULL, tfw_cfg_handle_children, section1_specs },
-		{ "section2", NULL, tfw_cfg_handle_children, section2_specs },
+		{ "section1", NULL, tfw_cfg_handle_children, section1_specs,
+		  .cleanup = tfw_cfg_cleanup_children },
+		{ "section2", NULL, tfw_cfg_handle_children, section2_specs,
+		  .cleanup = tfw_cfg_cleanup_children },
 		{ "incr", NULL, cb_incr_ctr, &counter3, .allow_repeat = true },
 		{ "decr", NULL, cb_decr_ctr, &counter3, .allow_repeat = true },
 		{ 0 }
@@ -1007,7 +1009,8 @@ TEST(tfw_cfg_handle_children, propagates_cleanup_to_nested_specs)
 			"section", NULL,
 			tfw_cfg_handle_children,
 			nested_specs,
-			.allow_repeat = true
+			.allow_repeat = true,
+			.cleanup = tfw_cfg_cleanup_children
 		},
 		{ 0 }
 	};

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -447,20 +447,20 @@ tfw_tls_cfg_handle_crt(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	mbedtls_x509_crt_init(&tfw_tls.crt);
 
 	if (ce->attr_n) {
-		TFW_ERR("%s: Arguments may not have the \'=\' sign\n",
-			cs->name);
+		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 1) {
-		TFW_ERR("%s: Invalid number of arguments: %d\n",
-			cs->name, (int)ce->val_n);
+		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
+			   cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
 
 	crt_data = tfw_cfg_read_file((const char *)ce->vals[0], &crt_size);
 	if (!crt_data) {
-		TFW_ERR("%s: Can't read certificate file '%s'\n",
-			ce->name, (const char *)ce->vals[0]);
+		TFW_ERR_NL("%s: Can't read certificate file '%s'\n",
+			   ce->name, (const char *)ce->vals[0]);
 		return -EINVAL;
 	}
 
@@ -470,8 +470,8 @@ tfw_tls_cfg_handle_crt(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	vfree(crt_data);
 
 	if (r) {
-		TFW_ERR("%s: Invalid certificate specified (%x)\n",
-			cs->name, -r);
+		TFW_ERR_NL("%s: Invalid certificate specified (%x)\n",
+			   cs->name, -r);
 		return -EINVAL;
 	}
 
@@ -491,20 +491,20 @@ tfw_tls_cfg_handle_crt_key(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	mbedtls_pk_init(&tfw_tls.key);
 
 	if (ce->attr_n) {
-		TFW_ERR("%s: Arguments may not have the \'=\' sign\n",
-			cs->name);
+		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 1) {
-		TFW_ERR("%s: Invalid number of arguments: %d\n",
-			cs->name, (int)ce->val_n);
+		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
+			   cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
 
 	key_data = tfw_cfg_read_file((const char *)ce->vals[0], &key_size);
 	if (!key_data) {
-		TFW_ERR("%s: Can't read certificate file '%s'\n",
-			ce->name, (const char *)ce->vals[0]);
+		TFW_ERR_NL("%s: Can't read certificate file '%s'\n",
+			   ce->name, (const char *)ce->vals[0]);
 		return -EINVAL;
 	}
 
@@ -514,8 +514,8 @@ tfw_tls_cfg_handle_crt_key(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	vfree(key_data);
 
 	if (r) {
-		TFW_ERR("%s: Invalid private key specified (%x)\n",
-			cs->name, -r);
+		TFW_ERR_NL("%s: Invalid private key specified (%x)\n",
+			   cs->name, -r);
 		return -EINVAL;
 	}
 

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -397,12 +397,12 @@ tfw_handle_nonidempotent(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	BUG_ON(!tfwcfg_this_location);
 
 	if (ce->attr_n) {
-		TFW_ERR("%s: Arguments may not have the \'=\' sign\n",
-			cs->name);
+		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 3) {
-		TFW_ERR("%s: Invalid number of arguments.\n", cs->name);
+		TFW_ERR_NL("%s: Invalid number of arguments.\n", cs->name);
 		return -EINVAL;
 	}
 
@@ -410,8 +410,8 @@ tfw_handle_nonidempotent(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	in_method = ce->vals[0];
 	ret = tfw_cfg_map_enum(tfw_method_enum, in_method, &method);
 	if (ret) {
-		TFW_ERR("Unsupported HTTP method: '%s %s'\n",
-			cs->name, in_method);
+		TFW_ERR_NL("Unsupported HTTP method: '%s %s'\n",
+			   cs->name, in_method);
 		return -EINVAL;
 	}
 
@@ -432,10 +432,10 @@ tfw_handle_nonidempotent(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	 * (URI path) that is not the last entry.
 	 */
 	if (tfw_nipdef_lookup_dup(loc, method, op, arg, len))
-		TFW_WARN("%s: Duplicate entry in location '%s': "
-			 "'%s %s %s %s'\n", cs->name,
-			 loc == &tfw_location_dflt ? "default" : loc->arg,
-			 cs->name, in_method, in_op, arg);
+		TFW_WARN_NL("%s: Duplicate entry in location '%s': "
+			    "'%s %s %s %s'\n", cs->name,
+			    loc == &tfw_location_dflt ? "default" : loc->arg,
+			    cs->name, in_method, in_op, arg);
 
 	/*
 	 * Do not add a "duplicate" entry within a location. If the
@@ -547,13 +547,13 @@ tfw_handle_capolicy(TfwCfgSpec *cs, TfwCfgEntry *ce, int cmd)
 	BUG_ON((cmd != TFW_D_CACHE_BYPASS) && (cmd != TFW_D_CACHE_FULFILL));
 
 	if (ce->attr_n) {
-		TFW_ERR("%s: Arguments may not have the \'=\' sign\n",
-			cs->name);
+		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n < 2) {
-		TFW_ERR("%s: Invalid number of arguments: %d\n",
-			cs->name, (int)ce->val_n);
+		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
+			   cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
 
@@ -562,7 +562,7 @@ tfw_handle_capolicy(TfwCfgSpec *cs, TfwCfgEntry *ce, int cmd)
 	/* Convert the match operator string to the enum value. */
 	ret = tfw_cfg_map_enum(tfw_match_enum, in_op, &op);
 	if (ret) {
-		TFW_ERR("Unknown match OP: '%s %s'\n", cs->name, in_op);
+		TFW_ERR_NL("Unknown match OP: '%s %s'\n", cs->name, in_op);
 		return -EINVAL;
 	}
 
@@ -576,8 +576,8 @@ tfw_handle_capolicy(TfwCfgSpec *cs, TfwCfgEntry *ce, int cmd)
 		/* Get the cache policy entry. */
 		capo = tfw_capolicy_lookup(cmd, op, arg, len);
 		if (capo) {
-			TFW_WARN("%s: Duplicate entry: '%s %s %s'\n",
-				 cs->name, cs->name, in_op, arg);
+			TFW_WARN_NL("%s: Duplicate entry: '%s %s %s'\n",
+				    cs->name, cs->name, in_op, arg);
 			continue;
 		}
 		capo = tfw_capolicy_new(cmd, op, arg, len);
@@ -693,13 +693,13 @@ tfw_begin_location(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	const char *in_op, *arg;
 
 	if (ce->attr_n) {
-		TFW_ERR("%s: Arguments may not have the \'=\' sign\n",
-			cs->name);
+		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 2) {
-		TFW_ERR("%s: Invalid number of arguments: %d\n",
-			cs->name, (int)ce->val_n);
+		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
+			   cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
 
@@ -711,23 +711,23 @@ tfw_begin_location(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	/* Convert the match operator string to the enum value. */
 	ret = tfw_cfg_map_enum(tfw_match_enum, in_op, &op);
 	if (ret) {
-		TFW_ERR("%s: Unknown match OP: '%s %s %s'\n",
-			cs->name, cs->name, in_op, arg);
+		TFW_ERR_NL("%s: Unknown match OP: '%s %s %s'\n",
+			   cs->name, cs->name, in_op, arg);
 		return -EINVAL;
 	}
 
 	/* Make sure the location is not a duplicate. */
 	if (tfw_location_lookup(op, arg, len)) {
-		TFW_ERR("%s: Duplicate entry: '%s %s %s'\n",
-			cs->name, cs->name, in_op, arg);
+		TFW_ERR_NL("%s: Duplicate entry: '%s %s %s'\n",
+			   cs->name, cs->name, in_op, arg);
 		return -EINVAL;
 	}
 
 	/* Add new location and set it to be the current one. */
 	tfwcfg_this_location = tfw_location_new(op, arg, len);
 	if (tfwcfg_this_location == NULL) {
-		TFW_ERR("%s: Unable to add new location: '%s %s %s'\n",
-			cs->name, cs->name, in_op, arg);
+		TFW_ERR_NL("%s: Unable to add new location: '%s %s %s'\n",
+			   cs->name, cs->name, in_op, arg);
 		return -EINVAL;
 	}
 
@@ -829,20 +829,20 @@ tfw_handle_cache_purge_acl(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		TfwAddr addr = { 0 };
 
 		if (tfw_addr_pton_cidr(val, &addr)) {
-			TFW_ERR("%s: Invalid ACL entry: '%s'\n",
-				cs->name, val);
+			TFW_ERR_NL("%s: Invalid ACL entry: '%s'\n",
+				   cs->name, val);
 			return -EINVAL;
 		}
 		/* Make sure the address is not a duplicate. */
 		if (tfw_capuacl_lookup(vhost, &addr)) {
-			TFW_ERR("%s: Duplicate IP address or prefix: '%s'\n",
-				cs->name, val);
+			TFW_ERR_NL("%s: Duplicate IP address or prefix: '%s'\n",
+				   cs->name, val);
 			return -EINVAL;
 		}
 		/* Add new ACL entry. */
 		if (vhost->capuacl_sz == TFW_CAPUACL_ARRAY_SZ) {
-			TFW_ERR("%s: Unable to add new ACL: '%s'\n",
-				cs->name, val);
+			TFW_ERR_NL("%s: Unable to add new ACL: '%s'\n",
+				   cs->name, val);
 			return -EINVAL;
 		}
 		vhost->capuacl[vhost->capuacl_sz++] = addr;
@@ -876,8 +876,8 @@ tfw_handle_cache_purge(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		if (!strcasecmp(val, "invalidate")) {
 			vhost->cache_purge_mode = TFW_D_CACHE_PURGE_INVALIDATE;
 		} else {
-			TFW_ERR("%s: unsupported argument: '%s'\n",
-				cs->name, val);
+			TFW_ERR_NL("%s: unsupported argument: '%s'\n",
+				   cs->name, val);
 			return -EINVAL;
 		}
 	}
@@ -898,13 +898,13 @@ tfw_handle_hdr_via(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	TfwVhost *vhost = &tfw_vhost_dflt;
 
 	if (ce->attr_n) {
-		TFW_ERR("%s: Arguments may not have the \'=\' sign\n",
-			cs->name);
+		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			   cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 1) {
-		TFW_ERR("%s: Invalid number of arguments: %d\n",
-			cs->name, (int)ce->val_n);
+		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
+			   cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
 

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1039,8 +1039,7 @@ static TfwCfgSpec tfw_vhost_cfg_specs[] = {
 		},
 		.allow_none = true,
 		.allow_repeat = true,
-		/* .cleanup function in a section with
-		   children causes a BUG_ON in cfg.c. */
+		.cleanup = tfw_cfg_cleanup_children
 	},
 	{ 0 },
 };


### PR DESCRIPTION
Change log:
- fix issue #698 . 
- display configuration parsing errors without rate limit.
- fix issue #65 , display error in the correct way, e.g print message:
```
[18638.202740] [tempesta] ERROR: invalid number of values; expected: 1, got: 0
[18638.204503] [tempesta] ERROR: Unable to parse 'listen' value: 'No value specified'
[18638.206276] [tempesta] ERROR: configuration parsing error:
                  5: listen; # 80;
                     ^^^^^^^^^^^^^
[18638.208295] [tempesta] ERROR: failed to start modules
```
for configuration:
```
cache 0;
listen 80;
server 127.0.0.1:8080;
# some comment here
listen; # 80;
# some comment here
# some comment here
# some comment here
# some comment here
# some comment here
``` 