### PR TITLE
Allow unlimited (mostly) servers and connections

### DIFF
--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -25,9 +25,13 @@
 #include "connection.h"
 #include "peer.h"
 
-#define TFW_SRV_MAX_CONN	32	/* TfwSrvConn{} per TfwServer{} */
-#define TFW_SG_MAX_SRV		32	/* TfwServer{} per TfwSrvGroup{} */
-#define TFW_SG_MAX_CONN		(TFW_SG_MAX_SRV * TFW_SRV_MAX_CONN)
+/* Default number of connections between Tempesta and a backend server. */
+#define TFW_SRV_DEF_CONN_N	32
+#define TFW_SRV_MAX_CONN_N	USHRT_MAX
+/* Default number of servers in server group. */
+#define TFW_SG_DEF_SRV_N	32
+#define TFW_SG_MAX_SRV_N	USHRT_MAX
+
 
 typedef struct tfw_srv_group_t TfwSrvGroup;
 typedef struct tfw_scheduler_t TfwScheduler;

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -219,11 +219,11 @@ test_sched_sg_max_srv_zero_conn(struct TestSchedHelper *sched_helper)
 
 	sg = test_create_sg("test", sched_helper->sched);
 
-	for (j = 0; j < TFW_SG_MAX_SRV; ++j)
+	for (j = 0; j < TFW_TEST_SG_SRV_N; ++j)
 		test_create_srv("127.0.0.1", sg);
 
 	for (i = 0; i < sched_helper->conn_types; ++i) {
-		for (j = 0; j < TFW_SG_MAX_SRV; ++j) {
+		for (j = 0; j < TFW_TEST_SG_SRV_N; ++j) {
 			TfwMsg *msg = sched_helper->get_sched_arg(i);
 			TfwSrvConn *srv_conn =
 					sg->sched->sched_sg_conn(msg, sg);
@@ -286,7 +286,7 @@ test_sched_srv_max_srv_zero_conn(struct TestSchedHelper *sched_helper)
 
 	sg = test_create_sg("test", sched_helper->sched);
 
-	for (j = 0; j < TFW_SG_MAX_SRV; ++j)
+	for (j = 0; j < TFW_TEST_SG_SRV_N; ++j)
 		test_create_srv("127.0.0.1", sg);
 
 	for (i = 0; i < sched_helper->conn_types; ++i) {
@@ -322,11 +322,11 @@ test_sched_srv_offline_srv(struct TestSchedHelper *sched_helper)
 	BUG_ON(!sched_helper->conn_types);
 	BUG_ON(!sched_helper->get_sched_arg);
 	BUG_ON(!sched_helper->free_sched_arg);
-	BUG_ON(offline_num >= TFW_SG_MAX_SRV);
+	BUG_ON(offline_num >= TFW_TEST_SG_SRV_N);
 
 	sg = test_create_sg("test", sched_helper->sched);
 
-	for (i = 0; i < TFW_SG_MAX_SRV; ++i) {
+	for (i = 0; i < TFW_TEST_SG_SRV_N; ++i) {
 		TfwServer *srv = test_create_srv("127.0.0.1", sg);
 		TfwSrvConn *srv_conn = test_create_conn((TfwPeer *)srv);
 		sg->sched->add_conn(sg, srv, srv_conn);

--- a/tempesta_fw/t/unit/sched_helper.h
+++ b/tempesta_fw/t/unit/sched_helper.h
@@ -26,6 +26,11 @@
 #include "cfg.h"
 #include "connection.h"
 
+/* Force schedulers to reallocate. */
+#define TFW_TEST_SG_SRV_N (TFW_SG_DEF_SRV_N * 3)
+#define TFW_TEST_SRV_CONN_N (TFW_SRV_DEF_CONN_N * 3)
+#define TFW_TEST_SG_CONN_N (TFW_TEST_SG_SRV_N * TFW_TEST_SRV_CONN_N)
+
 int tfw_server_init(void);
 int tfw_sched_rr_init(void);
 void sched_helper_init(void);

--- a/tempesta_fw/t/unit/test_sched_hash.c
+++ b/tempesta_fw/t/unit/test_sched_hash.c
@@ -99,7 +99,7 @@ TEST(tfw_sched_hash, sched_sg_one_srv_max_conn)
 	TfwSrvGroup *sg = test_create_sg("test", sched_helper_hash.sched);
 	TfwServer *srv = test_create_srv("127.0.0.1", sg);
 
-	for (i = 0; i < TFW_SRV_MAX_CONN; ++i) {
+	for (i = 0; i < TFW_TEST_SRV_CONN_N; ++i) {
 		TfwSrvConn *srv_conn = test_create_conn((TfwPeer *)srv);
 		sg->sched->add_conn(sg, srv, srv_conn);
 	}
@@ -108,11 +108,13 @@ TEST(tfw_sched_hash, sched_sg_one_srv_max_conn)
 	for (i = 0; i < sched_helper_hash.conn_types; ++i) {
 		TfwSrvConn *exp_conn = NULL;
 
-		for (j = 0; j < TFW_SRV_MAX_CONN; ++j) {
+		for (j = 0; j < TFW_TEST_SRV_CONN_N; ++j) {
 			TfwMsg *msg = sched_helper_hash.get_sched_arg(i);
 			TfwSrvConn *srv_conn =
 					sg->sched->sched_sg_conn(msg, sg);
 			EXPECT_NOT_NULL(srv_conn);
+			if (!srv_conn)
+				goto err;
 
 			if (!exp_conn)
 				exp_conn = srv_conn;
@@ -123,7 +125,7 @@ TEST(tfw_sched_hash, sched_sg_one_srv_max_conn)
 			sched_helper_hash.free_sched_arg(msg);
 		}
 	}
-
+err:
 	test_conn_release_all(sg);
 	test_sg_release_all();
 }
@@ -139,10 +141,10 @@ TEST(tfw_sched_hash, sched_sg_max_srv_max_conn)
 
 	TfwSrvGroup *sg = test_create_sg("test", sched_helper_hash.sched);
 
-	for (i = 0; i < TFW_SG_MAX_SRV; ++i) {
+	for (i = 0; i < TFW_TEST_SG_SRV_N; ++i) {
 		TfwServer *srv = test_create_srv("127.0.0.1", sg);
 
-		for (j = 0; j < TFW_SRV_MAX_CONN; ++j) {
+		for (j = 0; j < TFW_TEST_SRV_CONN_N; ++j) {
 			TfwSrvConn *srv_conn = test_create_conn((TfwPeer *)srv);
 			sg->sched->add_conn(sg, srv, srv_conn);
 		}
@@ -152,11 +154,13 @@ TEST(tfw_sched_hash, sched_sg_max_srv_max_conn)
 	for (i = 0; i < sched_helper_hash.conn_types; ++i) {
 		TfwSrvConn *exp_conn = NULL;
 
-		for (j = 0; j < TFW_SG_MAX_SRV * TFW_SRV_MAX_CONN; ++j) {
+		for (j = 0; j < TFW_TEST_SG_CONN_N; ++j) {
 			TfwMsg *msg = sched_helper_hash.get_sched_arg(i);
 			TfwSrvConn *srv_conn =
 					sg->sched->sched_sg_conn(msg, sg);
 			EXPECT_NOT_NULL(srv_conn);
+			if (!srv_conn)
+				goto err;
 
 			if (!exp_conn)
 				exp_conn = srv_conn;
@@ -167,7 +171,7 @@ TEST(tfw_sched_hash, sched_sg_max_srv_max_conn)
 			sched_helper_hash.free_sched_arg(msg);
 		}
 	}
-
+err:
 	test_conn_release_all(sg);
 	test_sg_release_all();
 }
@@ -184,7 +188,7 @@ TEST(tfw_sched_hash, sched_srv_one_srv_max_conn)
 	TfwSrvGroup *sg = test_create_sg("test", sched_helper_hash.sched);
 	TfwServer *srv = test_create_srv("127.0.0.1", sg);
 
-	for (i = 0; i < TFW_SRV_MAX_CONN; ++i) {
+	for (i = 0; i < TFW_TEST_SRV_CONN_N; ++i) {
 		TfwSrvConn *srv_conn = test_create_conn((TfwPeer *)srv);
 		sg->sched->add_conn(sg, srv, srv_conn);
 	}
@@ -193,12 +197,14 @@ TEST(tfw_sched_hash, sched_srv_one_srv_max_conn)
 	for (i = 0; i < sched_helper_hash.conn_types; ++i) {
 		TfwSrvConn *exp_conn = NULL;
 
-		for (j = 0; j < TFW_SRV_MAX_CONN; ++j) {
+		for (j = 0; j < TFW_TEST_SRV_CONN_N; ++j) {
 			TfwMsg *msg = sched_helper_hash.get_sched_arg(i);
 			TfwSrvConn *srv_conn =
 					sg->sched->sched_srv_conn(msg, srv);
 
 			EXPECT_NOT_NULL(srv_conn);
+			if (!srv_conn)
+				goto err;
 			EXPECT_EQ((TfwServer *)srv_conn->peer, srv);
 
 			if (!exp_conn)
@@ -210,7 +216,7 @@ TEST(tfw_sched_hash, sched_srv_one_srv_max_conn)
 			sched_helper_hash.free_sched_arg(msg);
 		}
 	}
-
+err:
 	test_conn_release_all(sg);
 	test_sg_release_all();
 }
@@ -226,10 +232,10 @@ TEST(tfw_sched_hash, sched_srv_max_srv_max_conn)
 
 	TfwSrvGroup *sg = test_create_sg("test", sched_helper_hash.sched);
 
-	for (i = 0; i < TFW_SG_MAX_SRV; ++i) {
+	for (i = 0; i < TFW_TEST_SG_SRV_N; ++i) {
 		TfwServer *srv = test_create_srv("127.0.0.1", sg);
 
-		for (j = 0; j < TFW_SRV_MAX_CONN; ++j) {
+		for (j = 0; j < TFW_TEST_SRV_CONN_N; ++j) {
 			TfwSrvConn *srv_conn =
 					test_create_conn((TfwPeer *)srv);
 			sg->sched->add_conn(sg, srv, srv_conn);
@@ -243,12 +249,14 @@ TEST(tfw_sched_hash, sched_srv_max_srv_max_conn)
 		list_for_each_entry(srv, &sg->srv_list, list) {
 			TfwSrvConn *exp_conn = NULL;
 
-			for (j = 0; j < TFW_SG_MAX_SRV * TFW_SRV_MAX_CONN; ++j) {
+			for (j = 0; j < TFW_TEST_SG_CONN_N; ++j) {
 				TfwMsg *msg = sched_helper_hash.get_sched_arg(i);
 				TfwSrvConn *srv_conn =
 					sg->sched->sched_srv_conn(msg, srv);
 
 				EXPECT_NOT_NULL(srv_conn);
+				if (!srv_conn)
+					goto err;
 				EXPECT_EQ((TfwServer *)srv_conn->peer, srv);
 
 				if (!exp_conn)
@@ -261,7 +269,7 @@ TEST(tfw_sched_hash, sched_srv_max_srv_max_conn)
 			}
 		}
 	}
-
+err:
 	test_conn_release_all(sg);
 	test_sg_release_all();
 }


### PR DESCRIPTION
* Number of servers in server group is limited to USHRT_MAX
* Number of connections for server  is limited to USHRT_MAX

Branch requires changes from ik-sticky-ng, so diff here is for that branch