### PR TITLE
Fix __read_mostly section collision

### DIFF
--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -515,7 +515,7 @@ typedef struct {
  * [1ms, 349ms] should be sufficient for almost any installation,
  * including cross atlantic.
  */
-static const TfwPcntCtl __read_mostly tfw_rngctl_init[TFW_STATS_RANGES] = {
+static const TfwPcntCtl tfw_rngctl_init[TFW_STATS_RANGES] = {
 	{{0, 1, 16}},
 	{{1, 17, 47}},
 	{{2, 48, 108}},

--- a/tempesta_fw/apm.h
+++ b/tempesta_fw/apm.h
@@ -49,7 +49,7 @@ enum {
 	_TFW_PSTATS_IDX_COUNT
 };
 
-static const unsigned int __read_mostly tfw_pstats_ith[] = {
+static const unsigned int tfw_pstats_ith[] = {
 	[TFW_PSTATS_IDX_MIN ... TFW_PSTATS_IDX_AVG] = 0,
 	[TFW_PSTATS_IDX_P50] = 50,
 	[TFW_PSTATS_IDX_P75] = 75,

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -73,10 +73,10 @@ tfw_http_prep_date_from(char *buf, time_t date)
 	struct tm tm;
 	char *ptr = buf;
 
-	static char *wday[] __read_mostly =
+	static const char * const wday[] =
 		{ "Sun, ", "Mon, ", "Tue, ",
 		  "Wed, ", "Thu, ", "Fri, ", "Sat, " };
-	static char *month[] __read_mostly =
+	static const char * const month[] =
 		{ " Jan ", " Feb ", " Mar ", " Apr ", " May ", " Jun ",
 		  " Jul ", " Aug ", " Sep ", " Oct ", " Nov ", " Dec " };
 
@@ -1497,7 +1497,7 @@ static int
 tfw_http_add_hdr_via(TfwHttpMsg *hm)
 {
 	int r;
-	static const char const * __read_mostly s_http_version[] = {
+	static const char * const s_http_version[] = {
 		[0 ... _TFW_HTTP_VER_COUNT] = NULL,
 		[TFW_HTTP_VER_09] = "0.9 ",
 		[TFW_HTTP_VER_10] = "1.0 ",
@@ -1505,7 +1505,7 @@ tfw_http_add_hdr_via(TfwHttpMsg *hm)
 		[TFW_HTTP_VER_20] = "2.0 ",
 	};
 	TfwVhost *vhost = tfw_vhost_get_default();
-	TfwStr rh = {
+	const TfwStr rh = {
 #define S_VIA	"Via: "
 		.ptr = (TfwStr []) {
 			{ .ptr = S_VIA, .len = SLEN(S_VIA) },
@@ -1853,7 +1853,7 @@ static void
 tfw_http_req_mark_nip(TfwHttpReq *req)
 {
 	/* See RFC 7231 4.2.1 */
-	static const unsigned int __read_mostly safe_methods =
+	static const unsigned int safe_methods =
 		(1 << TFW_HTTP_METH_GET) | (1 << TFW_HTTP_METH_HEAD)
 		| (1 << TFW_HTTP_METH_OPTIONS) | (1 << TFW_HTTP_METH_PROPFIND)
 		| (1 << TFW_HTTP_METH_TRACE);

--- a/tempesta_fw/http_match.c
+++ b/tempesta_fw/http_match.c
@@ -335,8 +335,7 @@ match_wildcard(const TfwHttpReq *req, const TfwHttpMatchRule *rule)
 
 typedef bool (*match_fn)(const TfwHttpReq *, const TfwHttpMatchRule *);
 
-static const match_fn
-__read_mostly match_fn_tbl[_TFW_HTTP_MATCH_F_COUNT] = {
+static const match_fn match_fn_tbl[_TFW_HTTP_MATCH_F_COUNT] = {
 	[TFW_HTTP_MATCH_F_WILDCARD]	= match_wildcard,
 	[TFW_HTTP_MATCH_F_HDR_CONN]	= match_hdr,
 	[TFW_HTTP_MATCH_F_HDR_HOST]	= match_hdr,

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -120,7 +120,7 @@ static bool
 __hdr_is_singular(const TfwStr *hdr)
 {
 	int i, fc;
-	static const TfwStr hdr_singular[] __read_mostly = {
+	static const TfwStr hdr_singular[] = {
 #define TfwStr_string(v) { (v), NULL, sizeof(v) - 1, 0 }
 		TfwStr_string("authorization:"),
 		TfwStr_string("from:"),
@@ -612,7 +612,7 @@ tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm)
  * Add a header, probably duplicated, without any checking of current headers.
  */
 int
-tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr)
+tfw_http_msg_hdr_add(TfwHttpMsg *hm, const TfwStr *hdr)
 {
 	unsigned int hid;
 	TfwHttpHdrTbl *ht = hm->h_tbl;

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -64,7 +64,7 @@ int __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str, void *data,
 				    ss_skb_peek_tail(&hm->msg.skb_list))
 
 unsigned int tfw_http_msg_hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr);
-int tfw_http_msg_hdr_add(TfwHttpMsg *hm, TfwStr *hdr);
+int tfw_http_msg_hdr_add(TfwHttpMsg *hm, const TfwStr *hdr);
 int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 			  char *val, size_t v_len, unsigned int hid, bool append);
 

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -590,7 +590,7 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 	TfwStr *hdr, *append;
 	TfwHttpHbhHdrs *hbh = &hm->parser.hbh_parser;
 	unsigned long i;
-	static const TfwStr block[] __read_mostly = {
+	static const TfwStr block[] = {
 #define TfwStr_string(v) { (v), NULL, sizeof(v) - 1, 0 }
 		/* End-to-end spec headers */
 		TfwStr_string("host:"),

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -148,7 +148,7 @@ static TfwScheduler tfw_sched_http = {
  */
 
 /* e.g.: match group ENUM eq "pattern"; */
-static const TfwCfgEnum __read_mostly tfw_sched_http_cfg_field_enum[] = {
+static const TfwCfgEnum tfw_sched_http_cfg_field_enum[] = {
 	{ "*",		TFW_HTTP_MATCH_F_WILDCARD },
 	{ "uri",	TFW_HTTP_MATCH_F_URI },
 	{ "host",	TFW_HTTP_MATCH_F_HOST },
@@ -159,7 +159,7 @@ static const TfwCfgEnum __read_mostly tfw_sched_http_cfg_field_enum[] = {
 };
 
 /* e.g.: match group uri ENUM "pattern"; */
-static const TfwCfgEnum __read_mostly tfw_sched_http_cfg_op_enum[] = {
+static const TfwCfgEnum tfw_sched_http_cfg_op_enum[] = {
 	{ "*",		TFW_HTTP_MATCH_O_WILDCARD },
 	{ "eq",		TFW_HTTP_MATCH_O_EQ },
 	{ "prefix",	TFW_HTTP_MATCH_O_PREFIX },
@@ -169,7 +169,7 @@ static const TfwCfgEnum __read_mostly tfw_sched_http_cfg_op_enum[] = {
 };
 
 static const tfw_http_match_arg_t
-__read_mostly tfw_sched_http_cfg_arg_tbl[_TFW_HTTP_MATCH_F_COUNT] = {
+tfw_sched_http_cfg_arg_tbl[_TFW_HTTP_MATCH_F_COUNT] = {
 	[TFW_HTTP_MATCH_F_WILDCARD]	= TFW_HTTP_MATCH_A_WILDCARD,
 	[TFW_HTTP_MATCH_F_HDR_CONN]	= TFW_HTTP_MATCH_A_STR,
 	[TFW_HTTP_MATCH_F_HDR_HOST]	= TFW_HTTP_MATCH_A_STR,
@@ -343,7 +343,7 @@ tfw_sched_http_start(void)
 	struct list_head mod_list;
 	TfwCfgMod cfg_mod;
 	TfwCfgSpec *cfg_spec;
-	static const char __read_mostly cfg_text[] =
+	static const char cfg_text[] =
 		"sched_http_rules {\nmatch default * * *;\n}\n";
 
 	/*

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -584,7 +584,7 @@ EXPORT_SYMBOL(tfw_str_to_cstr);
 
 #ifdef DEBUG
 void
-tfw_str_dprint(TfwStr *str, const char *msg)
+tfw_str_dprint(const TfwStr *str, const char *msg)
 {
 	TfwStr *dup, *dup_end, *c, *chunk_end;
 

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -351,7 +351,7 @@ int tfw_strcat(TfwPool *pool, TfwStr *dst, TfwStr *src);
 
 int tfw_stricmpspn(const TfwStr *s1, const TfwStr *s2, int stop);
 bool tfw_str_eq_cstr(const TfwStr *str, const char *cstr, int cstr_len,
-                     tfw_str_eq_flags_t flags);
+		     tfw_str_eq_flags_t flags);
 bool tfw_str_eq_cstr_pos(const TfwStr *str, const char *pos, const char *cstr,
 			 int cstr_len, tfw_str_eq_flags_t flags);
 bool tfw_str_eq_cstr_off(const TfwStr *str, ssize_t offset, const char *cstr,
@@ -360,7 +360,7 @@ bool tfw_str_eq_cstr_off(const TfwStr *str, ssize_t offset, const char *cstr,
 size_t tfw_str_to_cstr(const TfwStr *str, char *out_buf, int buf_size);
 
 #ifdef DEBUG
-void tfw_str_dprint(TfwStr *str, const char *msg);
+void tfw_str_dprint(const TfwStr *str, const char *msg);
 #else
 #define tfw_str_dprint(str, msg)
 #endif

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -24,7 +24,7 @@
 #include "str.h"
 
 /* Mappings for match operators. */
-static TfwCfgEnum const __read_mostly tfw_match_enum[] = {
+static const TfwCfgEnum tfw_match_enum[] = {
 	{ "*",		TFW_HTTP_MATCH_O_WILDCARD },
 	{ "eq",		TFW_HTTP_MATCH_O_EQ },
 	{ "prefix",	TFW_HTTP_MATCH_O_PREFIX },
@@ -33,7 +33,7 @@ static TfwCfgEnum const __read_mostly tfw_match_enum[] = {
 };
 
 /* Mappings for HTTP request methods. */
-static TfwCfgEnum const __read_mostly tfw_method_enum[] = {
+static const TfwCfgEnum tfw_method_enum[] = {
 	{ "*",		UINT_MAX },
 	{ "COPY",	1 << TFW_HTTP_METH_COPY },
 	{ "DELETE",	1 << TFW_HTTP_METH_DELETE },
@@ -118,7 +118,7 @@ static TfwAddr		tfw_capuacl[TFW_CAPUACL_ARRAY_SZ];
  * Note that @loc_dflt in the default vhost serves as global
  * default caching policy.
  */
-static char const __read_mostly s_hdr_via_dflt[] =
+static const char s_hdr_via_dflt[] =
 	"tempesta_fw" " (" TFW_NAME " " TFW_VERSION ")";
 
 static TfwVhost		tfw_vhost_dflt = {
@@ -187,7 +187,7 @@ __tfw_match_prefix(tfw_match_t op, const char *cstr, size_t len, TfwStr *arg)
 
 typedef bool (*__tfw_match_fn)(tfw_match_t, const char *, size_t, TfwStr *);
 
-static __tfw_match_fn const __read_mostly __tfw_match_fn_tbl[] = {
+static const __tfw_match_fn __tfw_match_fn_tbl[] = {
 	[0 ... _TFW_HTTP_MATCH_O_COUNT] = NULL,
 	[TFW_HTTP_MATCH_O_WILDCARD]	= __tfw_match_wildcard,
 	[TFW_HTTP_MATCH_O_EQ]		= __tfw_match_eq,


### PR DESCRIPTION
const __read_mostly is not legal and causes section type conflicts.
That's because the read.mostly section is not read only.

GCC 7 raises build error on this line.