### PR TITLE
Fix handling of HTTPS connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,11 @@ option was given, then **HTTP** is supposed by the default.
 
 ### TLS/SSL support
 
-Tempesta allows to use TLS-encrypted HTTP connections (HTTPS). It is
-required that public certificate and private key have been configured as
+Tempesta allows the use of TLS-encrypted HTTP connections (HTTPS).
+HTTPS traffic is terminated by Tempesta. Backend servers always receive
+unecrypted traffic.
+
+It is required that public certificate and private key are configured as
 follows:
 ```
 ssl_certificate /path/to/tfw-root.crt;

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -189,7 +189,7 @@ enum {
  * TLS hardened connection.
  */
 typedef struct {
-	TfwConn		conn;
+	TfwCliConn	cli_conn;
 	TfwTlsContext	tls;
 } TfwTlsConn;
 


### PR DESCRIPTION
Recently TfwConn{} was split into TfwCliConn{} and TfwSrvConn{}.
TfwConn{} used to be what's now TfwCliConn{}. The change didn't
make it to TfwTlsConn{} which lead to a sure crash when using
HTTPS with Tempesta.