### PR TITLE
Make it possible to use make with -jN option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ endif
 ifndef AVX2
 	$(warning WARNING: NO AVX2 SUPPORT, YOU WILL BE SLOW)
 endif
-	make -C tempesta_db
-	make -C $(KERNEL) M=$(PWD) modules
+	$(MAKE) -C tempesta_db
+	$(MAKE) -C $(KERNEL) M=$(PWD) modules
 
 test: build
 	./scripts/tempesta.sh --load
@@ -67,7 +67,7 @@ test: build
 	./scripts/tempesta.sh --unload
 
 clean:
-	make -C $(KERNEL) M=$(PWD) clean
-	make -C tempesta_db clean
+	$(MAKE) -C $(KERNEL) M=$(PWD) clean
+	$(MAKE) -C tempesta_db clean
 	find . \( -name \*~ -o -name \*.orig -o -name \*.symvers \) \
 		-exec rm -f {} \;

--- a/tempesta_db/Makefile
+++ b/tempesta_db/Makefile
@@ -21,13 +21,13 @@ all: libtdb tdbq
 
 .PHONY: libtdb
 libtdb:
-	make -C libtdb
+	$(MAKE) -C libtdb
 
 .PHONY: tdbq
 tdbq:
-	make -C tdbq
+	$(MAKE) -C tdbq
 
 .PHONY: clean
 clean:
-	make -C libtdb clean
-	make -C tdbq clean
+	$(MAKE) -C libtdb clean
+	$(MAKE) -C tdbq clean

--- a/tempesta_fw/stress/Makefile
+++ b/tempesta_fw/stress/Makefile
@@ -26,8 +26,8 @@ obj-m = th_stress_sys.o
 th_stress_sys-objs = sys.o
 
 all:
-	make -C ../../linux-$(KVERSION) M=$(PWD) modules
+	$(MAKE) -C ../../linux-$(KVERSION) M=$(PWD) modules
 
 clean:
-	make -C ../../linux-$(KVERSION) M=$(PWD) clean
+	$(MAKE) -C ../../linux-$(KVERSION) M=$(PWD) clean
 

--- a/tempesta_fw/t/sync_sockets/Makefile
+++ b/tempesta_fw/t/sync_sockets/Makefile
@@ -47,13 +47,13 @@ server : server.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 kernel : FORCE
-	make -C /lib/modules/$(KVERSION)/build M=$(PWD)/kernel modules
+	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD)/kernel modules
 
 %.o : %.cc $(HEADERS)
 	$(CXX) $(CXXFLAGS) -c $< -o $@ $(DEFINES)
 
 clean : FORCE
 	rm -f *.o $(TARGETS)
-	make -C /lib/modules/$(KVERSION)/build M=$(PWD)/kernel clean
+	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD)/kernel clean
 
 FORCE :

--- a/tempesta_fw/t/sync_sockets/kernel/Makefile
+++ b/tempesta_fw/t/sync_sockets/kernel/Makefile
@@ -11,7 +11,7 @@ ss_kclient-objs = \
 	../../../addr.o
 
 all:
-	make -C /lib/modules/$(KVERSION)/build M=$(PWD) modules 
+	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) modules
 
 clean:
-	make -C /lib/modules/$(KVERSION)/build M=$(PWD) clean
+	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) clean


### PR DESCRIPTION
This speeds up compile time by allowing to use -jN option with the
make. I have the following timings:

  $ time make
    real 0m54.787s

  $ time make -j$(cat /proc/cpuinfo | grep processor | wc -l)
    real 0m28.370s