### PR TITLE
Fix possible but unlikely  TfwSrvConn.qsize overflow

### DIFF
--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -200,10 +200,10 @@ tfw_srvstats_seq_show(struct seq_file *seq, void *off)
 
 	seq_printf(seq, "Total schedulable connections\t: %zd\n",
 			srv->conn_n - rc);
-	seq_printf(seq, "Maximum forwarding queue size\t: %d\n",
+	seq_printf(seq, "Maximum forwarding queue size\t: %u\n",
 			srv->sg->max_qsize);
 	for (i = 0; i < srv->conn_n; ++i)
-		seq_printf(seq, "\tConnection %03zd queue size\t: %d\n",
+		seq_printf(seq, "\tConnection %03zd queue size\t: %u\n",
 				i, qsize[i]);
 
 	return 0;

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -160,6 +160,13 @@ void tfw_server_destroy(TfwServer *srv);
 
 void tfw_srv_conn_release(TfwSrvConn *srv_conn);
 
+/*
+ * TODO: The function is racy: we can push into @srv_conn more requests than
+ * allowed for the server group if @srv_conn is on hold due to non-idempotent
+ * request forwarding. srv_conn->qsize is incremented during push, so values
+ * close to UINT_MAX can be vulnerable to integer overflow.
+ *
+ */
 static inline bool
 tfw_srv_conn_queue_full(TfwSrvConn *srv_conn)
 {

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -945,7 +945,7 @@ tfw_cfgop_setup_srv_group(void)
 	BUG_ON(!tfw_cfg_sg);
 	BUG_ON(!tfw_cfg_sched);
 
-	tfw_cfg_sg->max_qsize = tfw_cfg_queue_size ? : UINT_MAX;
+	tfw_cfg_sg->max_qsize = tfw_cfg_queue_size ? : INT_MAX;
 	tfw_cfg_sg->max_jqage = tfw_cfg_fwd_timeout
 			      ? msecs_to_jiffies(tfw_cfg_fwd_timeout * 1000)
 			      : ULONG_MAX;

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -945,6 +945,7 @@ tfw_cfgop_setup_srv_group(void)
 	BUG_ON(!tfw_cfg_sg);
 	BUG_ON(!tfw_cfg_sched);
 
+	/* Limit maximum value to prevent race in tfw_srv_conn_queue_full(). */
 	tfw_cfg_sg->max_qsize = tfw_cfg_queue_size ? : INT_MAX;
 	tfw_cfg_sg->max_jqage = tfw_cfg_fwd_timeout
 			      ? msecs_to_jiffies(tfw_cfg_fwd_timeout * 1000)


### PR DESCRIPTION
The overflow is very unlikely but still may happen.

`server_queue_size 0;` in TempestaFW configuration means "unlimited queue size" and sets
`TfwSrvGroup.max_qsize` to `UINT_MAX`. New requests can be pushed into `TfwSrvConn.fwd_queue`
until queue size is smaller than `max_qsize`. Queue size may overflow the maximum allowed size, but
overflowing  `UINT_MAX` cause unsigned integer overflow, so queue size will have wrong value.

Could happen if `server_queue_size` is set to `0` and size of fwd_queue has reached `UINT_MAX`.
The issue is very unlikely, almost impossible.