### PR TITLE
Fix PURGE requests

### DIFF
--- a/tempesta_db/core/htrie.c
+++ b/tempesta_db/core/htrie.c
@@ -869,6 +869,12 @@ next_bckt:
 		if (*b) {
 			read_lock_bh(&(*b)->lock);
 			r = TDB_HTRIE_BCKT_1ST_REC(*b);
+
+			if (r && tdb_live_rec(dbh, r) && r->key == key) {
+				read_unlock_bh(&_b->lock);
+				/* Unlock the bucket by tdb_rec_put(). */
+				return r;
+			}
 		}
 		read_unlock_bh(&_b->lock);
 		_b = *b;

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2558,7 +2558,7 @@ tfw_http_req_key_calc(TfwHttpReq *req)
 	if (req->hash)
 		return req->hash;
 
-	req->hash = tfw_hash_str(&req->uri_path) ^ req->method;
+	req->hash = tfw_hash_str(&req->uri_path);
 
 	tfw_http_msg_clnthdr_val(&req->h_tbl->tbl[TFW_HTTP_HDR_HOST],
 				 TFW_HTTP_HDR_HOST, &host);

--- a/tempesta_fw/t/functional/cache/test_purge.py
+++ b/tempesta_fw/t/functional/cache/test_purge.py
@@ -1,0 +1,69 @@
+"""Functional tests of caching different methods."""
+
+from __future__ import print_function
+from helpers import tf_cfg, deproxy
+from testers import functional
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+# TODO: add tests for 'cache_purge_acl'
+
+class TestPurge(functional.FunctionalTest):
+
+    config = ('cache 2;\n'
+              'cache_fulfill * *;\n'
+              'cache_methods GET HEAD;\n'
+              'cache_purge;\n'
+              'cache_purge_acl %s;\n'
+              % tf_cfg.cfg.get('Client', 'ip'))
+
+    def chains(self):
+        uri = '/page.html'
+        chains = [# All cacheable method to the resource must be cached
+                  proxy_chain(method='GET', uri=uri),
+                  proxy_chain(method='HEAD', uri=uri),
+                  cache_chain(method='GET', uri=uri),
+                  cache_chain(method='HEAD', uri=uri),
+
+                  purge_chain(uri=uri),
+                  # All cached responses was removed, expect re-caching them
+                  proxy_chain(method='GET', uri=uri),
+                  proxy_chain(method='HEAD', uri=uri),
+                  cache_chain(method='GET', uri=uri),
+                  cache_chain(method='HEAD', uri=uri)
+                  ]
+        return chains
+
+    def test_purge(self):
+        self.generic_test_routine(self.config, self.chains())
+
+
+def remove_body(response):
+    response.body = ''
+    response.body_void = True
+    response.update()
+
+def cache_chain(method, uri):
+    chain = functional.base_message_chain(uri=uri, method=method)
+    chain.no_forward()
+    if method == 'HEAD':
+        remove_body(chain.response)
+    return chain
+
+def proxy_chain(method, uri):
+    chain = functional.base_message_chain(uri=uri, method=method)
+    if method == 'HEAD':
+        remove_body(chain.response)
+        remove_body(chain.server_response)
+    return chain
+
+def purge_chain(uri):
+    chain = functional.base_message_chain(uri=uri, method='PURGE')
+    chain.no_forward()
+    headers = [
+        'Connection: keep-alive',
+        'Content-Length: 0']
+    chain.response = deproxy.Response.create(200, headers, date=True, body='')
+    return chain


### PR DESCRIPTION
Fix invalidating responses with PURGE requests, issue #787. Corresponding functional test is provided.

* Dependency to request method in request key generation is removed. This have to positives outcomes:
    * All cached responses for the same resource is added to TDB with the same key, and stored in the same collision chain. That makes much easier to process PURGE request.
    * The dependency actually broke `hash` scheduler: different methods for the same resource may be scheduled to different servers. So this is fixed.
* Fix getting the next record in collision chain in `htrie`