### PR TITLE
Handle conditional requests

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1081,28 +1081,17 @@ __save_hdr_304_off(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *hdr, long off)
 		return true;
 	}
 
-	/* Raw headers. */
-	fc = tolower(*(unsigned char *)(TFW_STR_CHUNK(hdr, 0)->ptr));
-	for (i = 0; i < ARRAY_SIZE(tfw_cache_raw_headers_304); i++) {
-		const TfwStr *sh = &tfw_cache_raw_headers_304[i];
-		int sc = *(unsigned char *)sh->ptr;
-		if (fc > sc)
-			continue;
-		if (fc < sc)
-			break;
-		if (!tfw_stricmpspn(hdr, sh, ':')) {
-			/*
-			 * RFC 7234 4.1: Don't send Last-Modified if ETag is
-			 * present.
-			 */
-			if ((sc == 'l')
-			    && !TFW_STR_EMPTY(&resp->h_tbl->tbl[TFW_HTTP_HDR_ETAG]))
-				return false;
+	TFW_STR_IF_IN_ARRAY(hdr, tfw_cache_raw_headers_304, {
+		/*
+		 * RFC 7234 4.1: Don't send Last-Modified if ETag is
+		 * present.
+		 */
+		 if ((sc == 'l')
+		     && !TFW_STR_EMPTY(&resp->h_tbl->tbl[TFW_HTTP_HDR_ETAG]))
+			return false;
 
-			ce->hdrs_304[i + TFW_CACHE_304_SPEC_HDRS_NUM] = off;
-			return true;
-		}
-	}
+		ce->hdrs_304[i + TFW_CACHE_304_SPEC_HDRS_NUM] = off;
+	});
 
 	return false;
 }

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1099,7 +1099,7 @@ __save_hdr_304_off(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *hdr, long off)
 		return true;
 	}
 
-	TFW_STR_IF_IN_ARRAY(hdr, tfw_cache_raw_headers_304, {
+	TFW_IF_HDR_IN_ARRAY(hdr, tfw_cache_raw_headers_304, {
 		/*
 		 * RFC 7234 4.1: Don't send Last-Modified if ETag is
 		 * present.

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -43,8 +43,10 @@ int ghprio; /* GFSM hook priority. */
 
 #define S_200			"HTTP/1.1 200 OK"
 #define S_302			"HTTP/1.1 302 Found"
+#define S_304			"HTTP/1.1 304 Not Modified"
 #define S_403			"HTTP/1.1 403 Forbidden"
 #define S_404			"HTTP/1.1 404 Not Found"
+#define S_412			"HTTP/1.1 412 Precondition Failed"
 #define S_500			"HTTP/1.1 500 Internal Server Error"
 #define S_502			"HTTP/1.1 502 Bad Gateway"
 #define S_504			"HTTP/1.1 504 Gateway Timeout"
@@ -54,6 +56,7 @@ int ghprio; /* GFSM hook priority. */
 #define S_F_CONTENT_LENGTH	"Content-Length: "
 #define S_F_LOCATION		"Location: "
 #define S_F_CONNECTION		"Connection: "
+#define S_F_ETAG		"ETag: "
 
 #define S_V_DATE		"Sun, 06 Nov 1994 08:49:37 GMT"
 #define S_V_CONTENT_LENGTH	"9999"
@@ -185,6 +188,65 @@ tfw_http_prep_302(TfwHttpMsg *resp, TfwHttpReq *req, TfwStr *cookie)
 	return TFW_PASS;
 }
 
+#define S_304_PART_01	S_304 S_CRLF S_F_DATE
+#define S_304_PART_02	S_CRLF S_F_ETAG "\""
+#define S_304_FIXLEN	SLEN(S_304_PART_01 S_V_DATE)
+#define S_304_KEEP	S_CRLF S_H_CONN_KA
+#define S_304_CLOSE	S_CRLF S_H_CONN_CLOSE
+/*
+ * HTTP 304 response: Not Modified.
+ */
+int
+tfw_http_prep_304(TfwHttpMsg *resp, TfwHttpReq *req, TfwStr *etag_val)
+{
+	size_t data_len = S_304_FIXLEN;
+	int conn_flag = req->flags & __TFW_HTTP_CONN_MASK;
+	TfwMsgIter it;
+	TfwStr rh = {
+		.ptr = (TfwStr []){
+			{ .ptr = S_304_PART_01, .len = SLEN(S_304_PART_01) },
+			{ .ptr = *this_cpu_ptr(&g_buf), .len = SLEN(S_V_DATE) },
+		},
+		.len = S_304_FIXLEN,
+		.flags = 2 << TFW_STR_CN_SHIFT
+	};
+	static TfwStr part2 = {
+		.ptr = S_304_PART_02, .len = SLEN(S_304_PART_02) };
+	static TfwStr crlfcrlf = {
+		.ptr = S_CRLFCRLF, .len = SLEN(S_CRLFCRLF) };
+	static TfwStr crlf_keep = {
+		.ptr = S_304_KEEP, .len = SLEN(S_304_KEEP) };
+	static TfwStr crlf_close = {
+		.ptr = S_304_CLOSE, .len = SLEN(S_304_CLOSE) };
+	TfwStr *crlf = &crlfcrlf;
+
+	/* Set "Connection:" header field if needed. */
+	if (conn_flag == TFW_HTTP_CONN_CLOSE)
+		crlf = &crlf_close;
+	else if (conn_flag == TFW_HTTP_CONN_KA)
+		crlf = &crlf_keep;
+
+	/* Add variable part of data length to get the total */
+	data_len += crlf->len;
+	if (!TFW_STR_EMPTY(etag_val))
+		data_len += part2.len + etag_val->len;
+
+	if (tfw_http_msg_setup(resp, &it, data_len))
+		return TFW_BLOCK;
+
+	tfw_http_prep_date(__TFW_STR_CH(&rh, 1)->ptr);
+	tfw_http_msg_write(&it, resp, &rh);
+	if (!TFW_STR_EMPTY(etag_val)) {
+		tfw_http_msg_write(&it, resp, &part2);
+		tfw_http_msg_write(&it, resp, etag_val);
+	}
+	tfw_http_msg_write(&it, resp, crlf);
+
+	TFW_DBG("Send HTTP 304 response\n");
+
+	return TFW_PASS;
+}
+
 /*
  * Perform operations common to sending an error response to a client.
  * Set current date in the header of an HTTP error response, and set
@@ -295,6 +357,30 @@ tfw_http_send_404(TfwHttpReq *req, const char *reason)
 	};
 
 	TFW_DBG("Send HTTP 404 response: %s\n", reason);
+
+	return tfw_http_send_resp(req, &rh, __TFW_STR_CH(&rh, 1));
+}
+
+#define S_412_PART_01	S_412 S_CRLF S_F_DATE
+#define S_412_PART_02	S_CRLF S_F_CONTENT_LENGTH "0" S_CRLF
+/*
+ * HTTP 412 response: Preconditional headers are evaluated to false.
+ */
+int
+tfw_http_send_412(TfwHttpReq *req)
+{
+	TfwStr rh = {
+		.ptr = (TfwStr []){
+			{ .ptr = S_412_PART_01, .len = SLEN(S_412_PART_01) },
+			{ .ptr = *this_cpu_ptr(&g_buf), .len = SLEN(S_V_DATE) },
+			{ .ptr = S_412_PART_02, .len = SLEN(S_412_PART_02) },
+			{ .ptr = S_CRLF, .len = SLEN(S_CRLF) },
+		},
+		.len = SLEN(S_412_PART_01 S_V_DATE S_412_PART_02 S_CRLF),
+		.flags = 4 << TFW_STR_CN_SHIFT
+	};
+
+	TFW_DBG("Send HTTP 412 response\n");
 
 	return tfw_http_send_resp(req, &rh, __TFW_STR_CH(&rh, 1));
 }

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -83,6 +83,7 @@ enum {
 	TFW_HTTP_FSM_DONE	= TFW_GFSM_HTTP_STATE(TFW_GFSM_STATE_LAST)
 };
 
+/* TODO: When CONNECT will be added, add it to tfw_handle_validation_req() */
 typedef enum {
 	_TFW_HTTP_METH_NONE,
 	/*

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -165,8 +165,8 @@ typedef struct {
  * repetition attacks. See __hdr_is_singular() and don't forget to
  * update the static headers array when add a new singular header here.
  * If the new header is hop-by-hop (must not be forwarded and cached by Tempesta)
- * it must be listed in __hbh_parser_init_req()/__hbh_parser_init_resp() for
- * unconditionally hop-by-hop header or in __parse_connection() otherwize.
+ * it must be listed in tfw_http_init_parser_req()/tfw_http_init_parser_resp()
+ * for unconditionally hop-by-hop header or in __parse_connection() otherwize.
  * If the header is end-to-end it must be listed in __hbh_parser_add_data().
  *
  * Note: don't forget to update __http_msg_hdr_val() upon adding a new header.
@@ -222,7 +222,7 @@ typedef struct {
  * adjusting as well as saves cache storage.
  *
  * Headers unconditionaly treated as hop-by-hop must be listed in
- * __hbh_parser_init_req()/__hbh_parser_init_resp() functions and must be
+ * tfw_http_init_parser_req()/tfw_http_init_parser_resp() functions and must be
  * members of Special headers.
  * group.
  *
@@ -484,6 +484,8 @@ tfw_current_timestamp(void)
 typedef void (*tfw_http_cache_cb_t)(TfwHttpReq *, TfwHttpResp *);
 
 /* Internal (parser) HTTP functions. */
+void tfw_http_init_parser_req(TfwHttpReq *req);
+void tfw_http_init_parser_resp(TfwHttpResp *resp);
 int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
 bool tfw_http_parse_terminate(TfwHttpMsg *hm);

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -501,8 +501,10 @@ void tfw_http_resp_fwd(TfwHttpReq *req, TfwHttpResp *resp);
  */
 int tfw_http_send_200(TfwHttpReq *req);
 int tfw_http_prep_302(TfwHttpMsg *resp, TfwHttpReq *req, TfwStr *cookie);
+int tfw_http_prep_304(TfwHttpMsg *resp, TfwHttpReq *req, TfwStr *etag);
 int tfw_http_send_403(TfwHttpReq *req, const char *reason);
 int tfw_http_send_404(TfwHttpReq *req, const char *reason);
+int tfw_http_send_412(TfwHttpReq *req);
 int tfw_http_send_502(TfwHttpReq *req, const char *reason);
 int tfw_http_send_504(TfwHttpReq *req, const char *reason);
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -502,7 +502,8 @@ void tfw_http_resp_fwd(TfwHttpReq *req, TfwHttpResp *resp);
  */
 int tfw_http_send_200(TfwHttpReq *req);
 int tfw_http_prep_302(TfwHttpMsg *resp, TfwHttpReq *req, TfwStr *cookie);
-int tfw_http_prep_304(TfwHttpMsg *resp, TfwHttpReq *req, TfwStr *etag);
+int tfw_http_prep_304(TfwHttpMsg *resp, TfwHttpReq *req, void *msg_it,
+		      size_t hdrs_size);
 int tfw_http_send_403(TfwHttpReq *req, const char *reason);
 int tfw_http_send_404(TfwHttpReq *req, const char *reason);
 int tfw_http_send_412(TfwHttpReq *req);

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -261,15 +261,12 @@ typedef struct {
  * @hbh_parser	- list of special and raw headers names to be treated as
  *		  hop-by-hop
  * @_date	- currently parsed http date value;
- * @_date_hdr	- defines which exact date header is processed, see enum before
- *		__parse_http_date().
  */
 typedef struct {
 	unsigned short	to_go;
 	int		state;
 	int		_i_st;
 	int		to_read;
-	int		_date_hdr;
 	unsigned long	_acc;
 	time_t		_date;
 	unsigned int	_hdr_tag;

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -44,6 +44,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 		[TFW_HTTP_HDR_USER_AGENT] = SLEN("User-Agent:"),
 		[TFW_HTTP_HDR_SERVER]	= SLEN("Server:"),
 		[TFW_HTTP_HDR_COOKIE]	= SLEN("Cookie:"),
+		[TFW_HTTP_HDR_ETAG]	= SLEN("ETag:"),
 	};
 
 	TfwStr *c, *end;
@@ -59,6 +60,8 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 
 	if (unlikely(id == TFW_HTTP_HDR_SERVER && client))
 		nlen = SLEN("User-Agent:");
+	else if (unlikely(id == TFW_HTTP_HDR_ETAG && client))
+		nlen = SLEN("If-None-Match:");
 	else
 		nlen = hdr_lens[id];
 
@@ -124,7 +127,6 @@ __hdr_is_singular(const TfwStr *hdr)
 #define TfwStr_string(v) { (v), NULL, sizeof(v) - 1, 0 }
 		TfwStr_string("authorization:"),
 		TfwStr_string("from:"),
-		TfwStr_string("if-modified-since:"),
 		TfwStr_string("if-unmodified-since:"),
 		TfwStr_string("location:"),
 		TfwStr_string("max-forwards:"),

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -135,7 +135,7 @@ __hdr_is_singular(const TfwStr *hdr)
 #undef TfwStr_string
 	};
 
-	TFW_STR_IF_IN_ARRAY(hdr, hdr_singular, { return true; });
+	TFW_IF_HDR_IN_ARRAY(hdr, hdr_singular, { return true; });
 
 	return false;
 }

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -135,17 +135,8 @@ __hdr_is_singular(const TfwStr *hdr)
 #undef TfwStr_string
 	};
 
-	fc = tolower(*(unsigned char *)(TFW_STR_CHUNK(hdr, 0)->ptr));
-	for (i = 0; i < ARRAY_SIZE(hdr_singular); i++) {
-		const TfwStr *sh = &hdr_singular[i];
-		int sc = *(unsigned char *)sh->ptr;
-		if (fc > sc)
-			continue;
-		if (fc < sc)
-			break;
-		if (!tfw_stricmpspn(hdr, sh, ':'))
-			return true;
-	}
+	TFW_STR_IF_IN_ARRAY(hdr, hdr_singular, { return true; });
+
 	return false;
 }
 

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -28,6 +28,26 @@
 
 #define SLEN(s)			(sizeof(s) - 1)
 
+/*
+ * Do @lambda if name of header @hdr is listed in @array of header names.
+ * @array must be sorted in alphabetical order.
+ */
+#define TFW_IF_HDR_IN_ARRAY(hdr, array, lambda)				\
+	/* int fc; */							\
+	fc = tolower(*(unsigned char *)(TFW_STR_CHUNK(hdr, 0)->ptr));	\
+	for (i = 0; i < ARRAY_SIZE(array); i++) {			\
+		const TfwStr *sh = &array[i];				\
+		int sc = *(unsigned char *)sh->ptr;			\
+		if (fc > sc)						\
+			continue;					\
+		if (fc < sc)						\
+			break;						\
+		if (!tfw_stricmpspn(hdr, sh, ':')) {			\
+			lambda;						\
+			break;						\
+		}							\
+	}
+
 typedef struct {
 	unsigned int	frag;
 	struct sk_buff	*skb;

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -28,25 +28,10 @@
 
 #define SLEN(s)			(sizeof(s) - 1)
 
-/*
- * Do @lambda if name of header @hdr is listed in @array of header names.
- * @array must be sorted in alphabetical order.
- */
-#define TFW_IF_HDR_IN_ARRAY(hdr, array, lambda)				\
-	/* int fc; */							\
-	fc = tolower(*(unsigned char *)(TFW_STR_CHUNK(hdr, 0)->ptr));	\
-	for (i = 0; i < ARRAY_SIZE(array); i++) {			\
-		const TfwStr *sh = &array[i];				\
-		int sc = *(unsigned char *)sh->ptr;			\
-		if (fc > sc)						\
-			continue;					\
-		if (fc < sc)						\
-			break;						\
-		if (!tfw_stricmpspn(hdr, sh, ':')) {			\
-			lambda;						\
-			break;						\
-		}							\
-	}
+const TfwStr *__tfw_http_msg_find_hdr(const TfwStr *hdr, const TfwStr array[],
+				      size_t size);
+#define tfw_http_msg_find_hdr(hdr, array)				\
+	__tfw_http_msg_find_hdr(hdr, array, ARRAY_SIZE(array))
 
 typedef struct {
 	unsigned int	frag;

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -587,7 +587,6 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 {
 	TfwStr *hdr, *append;
 	TfwHttpHbhHdrs *hbh = &hm->parser.hbh_parser;
-	unsigned long i;
 	static const TfwStr block[] = {
 #define TfwStr_string(v) { (v), NULL, sizeof(v) - 1, 0 }
 		/* End-to-end spec and raw headers */
@@ -609,7 +608,6 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 		TfwStr_string("x-forwarded-for:"),
 #undef TfwStr_string
 	};
-	int fc;
 
 	if (hbh->off == TFW_HBH_TOKENS_MAX)
 		return CSTR_NEQ;
@@ -638,7 +636,8 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 		hdr->len += s_colon.len;
 		++hbh->off;
 
-		TFW_IF_HDR_IN_ARRAY(hdr, block, { return CSTR_NEQ; });
+		if (tfw_http_msg_find_hdr(hdr, block))
+			return CSTR_NEQ;
 		/*
 		 * Don't set TFW_STR_HBH_HDR flag if such header was already
 		 * parsed. See comment in mark_raw_hbh()

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -590,26 +590,26 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 	unsigned long i;
 	static const TfwStr block[] = {
 #define TfwStr_string(v) { (v), NULL, sizeof(v) - 1, 0 }
-		/* End-to-end spec headers */
-		TfwStr_string("host:"),
-		TfwStr_string("content-length:"),
-		TfwStr_string("content-type:"),
-		TfwStr_string("connection:"),
-		TfwStr_string("x-forwarded-for:"),
-		TfwStr_string("transfer-encoding:"),
-		TfwStr_string("user-agent:"),
-		TfwStr_string("server:"),
-		TfwStr_string("cookie:"),
-		TfwStr_string("etag:"),
-		/* End-to-end raw headers. */
+		/* End-to-end spec and raw headers */
 		TfwStr_string("age:"),
 		TfwStr_string("authorization:"),
 		TfwStr_string("cache-control:"),
+		TfwStr_string("connection:"),
+		TfwStr_string("content-length:"),
+		TfwStr_string("content-type:"),
+		TfwStr_string("cookie:"),
 		TfwStr_string("date:"),
+		TfwStr_string("etag:"),
 		TfwStr_string("expires:"),
+		TfwStr_string("host:"),
 		TfwStr_string("pragma:"),
+		TfwStr_string("server:"),
+		TfwStr_string("transfer-encoding:"),
+		TfwStr_string("user-agent:"),
+		TfwStr_string("x-forwarded-for:"),
 #undef TfwStr_string
 	};
+	int fc;
 
 	if (hbh->off == TFW_HBH_TOKENS_MAX)
 		return CSTR_NEQ;
@@ -638,11 +638,7 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 		hdr->len += s_colon.len;
 		++hbh->off;
 
-		/* Drop message if header is end-to-end */
-		for (i = 0; i < ARRAY_SIZE(block); ++i)
-			if (!tfw_stricmpspn(hdr, &block[i], ':'))
-				return CSTR_NEQ;
-
+		TFW_STR_IF_IN_ARRAY(hdr, block, { return CSTR_NEQ; });
 		/*
 		 * Don't set TFW_STR_HBH_HDR flag if such header was already
 		 * parsed. See comment in mark_raw_hbh()

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -638,7 +638,7 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 		hdr->len += s_colon.len;
 		++hbh->off;
 
-		TFW_STR_IF_IN_ARRAY(hdr, block, { return CSTR_NEQ; });
+		TFW_IF_HDR_IN_ARRAY(hdr, block, { return CSTR_NEQ; });
 		/*
 		 * Don't set TFW_STR_HBH_HDR flag if such header was already
 		 * parsed. See comment in mark_raw_hbh()

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -3225,8 +3225,8 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 			if (likely(__data_available(p, 18)
 				   && TFW_LC(*(p + 1)) == 'f'
 				   && *(p + 2) == '-'
-				   && C4_INT_LCM(p + 3, 'm', 'o', 'd', 'i')
-				   && C4_INT_LCM(p + 7, 'f', 'i', 'e', 'd')
+				   && C8_INT_LCM(p + 3, 'm', 'o', 'd', 'i',
+							'f', 'i', 'e', 'd')
 				   && *(p + 11) == '-'
 				   && C4_INT_LCM(p + 12, 's', 'i', 'n', 'c')
 				   && TFW_LC(*(p + 16)) == 'e'
@@ -4288,8 +4288,8 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 			if (likely(__data_available(p, 14)
 				   && C4_INT_LCM(p, 'l', 'a', 's', 't')
 				   && *(p + 4) == '-'
-				   && C4_INT_LCM(p + 5, 'm', 'o', 'd', 'i')
-				   && C4_INT_LCM(p + 9, 'f', 'i', 'e', 'd')
+				   && C8_INT_LCM(p + 5, 'm', 'o', 'd', 'i',
+							'f', 'i', 'e', 'd')
 				   && *(p + 13) == ':'))
 			{
 				parser->_i_st = Resp_HdrLast_ModifiedV;

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -304,9 +304,10 @@ EXPORT_SYMBOL(tfw_strcat);
  * headers until ':', so plain C is Ok for now.
  *
  * Returns:
- *   0 - strings match;
- *   1 - strings match and @stop is found;
- *  -1 - strings do not match;
+ *   0		- strings match;
+ *   INT_MAX	- strings match and @stop is found;
+ *   -1		- strings do not match, @s1 < @s2;
+ *   1		- strings do not match, @s1 > @s2;
  */
 static inline int
 __cstricmpspn(const unsigned char *s1, const unsigned char *s2, int n, int stop,
@@ -324,9 +325,9 @@ __cstricmpspn(const unsigned char *s1, const unsigned char *s2, int n, int stop,
 			c2 = TFW_LC(*s2++);
 		}
 		if (c1 != c2)
-			return -1;
+			return (c1 < c2) ? -1 : 1;
 		if (unlikely(c1 == stop))
-			return 1;
+			return INT_MAX;
 		n--;
 	}
 
@@ -369,10 +370,10 @@ __tfw_strcmpspn(const TfwStr *s1, const TfwStr *s2, int stop, int cs)
 			r = __cstricmpspn((unsigned char *)c1->ptr + off1,
 					  (unsigned char *)c2->ptr + off2,
 					  cn, stop, cs);
-			if (r > 0)
+			if (r == INT_MAX)
 				return 0;
-			if (r < 0)
-				return 1;
+			if (r)
+				return r;
 		} else {
 			r = (*cmp)((char *)c1->ptr + off1,
 				   (char *)c2->ptr + off2, cn);

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -607,7 +607,8 @@ tfw_str_next_str_val(const TfwStr *str)
 	TfwStr r_str = { 0 }, *chunk, *end;
 	bool skip = true;
 
-	if (!str || TFW_STR_DUP(str) || TFW_STR_PLAIN(str))
+	BUG_ON(TFW_STR_DUP(str));
+	if (!str || TFW_STR_PLAIN(str))
 		return r_str;
 
 	end =  (TfwStr*)str->ptr + TFW_STR_CHUNKN(str);

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -606,8 +606,8 @@ tfw_str_dprint(const TfwStr *str, const char *msg)
 		TFW_DBG("  duplicate %p, len=%lu, flags=%x eolen=%u:\n",
 			dup, dup->len, dup->flags, dup->eolen);
 		TFW_STR_FOR_EACH_CHUNK(c, dup, chunk_end)
-			TFW_DBG("   len=%lu, eolen=%u ptr=%p '%.*s'\n",
-				c->len, c->eolen, c->ptr,
+			TFW_DBG("   len=%lu, eolen=%u ptr=%p flags=%x '%.*s'\n",
+				c->len, c->eolen, c->ptr, c->flags,
 				(int)c->len, (char *)c->ptr);
 	}
 }

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -179,6 +179,8 @@ size_t tfw_ultoa(unsigned long ai, char *buf, unsigned int len);
 #define TFW_STR_VALUE		0x08
 /* The string represents hop-by-hop header, not end-to-end one */
 #define TFW_STR_HBH_HDR		0x10
+/* Weak identifier was set for Etag value. */
+#define TFW_STR_ETAG_WEAK	0x20
 
 /*
  * @ptr		- pointer to string data or array of nested strings;

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -270,6 +270,26 @@ typedef struct {
 	}								\
 	for ( ; (d) < (end); ++(d))
 
+/*
+ * Do @lambda if name of header @hdr is listed in @array. @array must be
+ * sorted in alphabetical order.
+ */
+#define TFW_STR_IF_IN_ARRAY(hdr, array, lambda)				\
+	/* int fc; */							\
+	fc = tolower(*(unsigned char *)(TFW_STR_CHUNK(hdr, 0)->ptr));	\
+	for (i = 0; i < ARRAY_SIZE(array); i++) {			\
+		const TfwStr *sh = &array[i];				\
+		int sc = *(unsigned char *)sh->ptr;			\
+		if (fc > sc)						\
+			continue;					\
+		if (fc < sc)						\
+			break;						\
+		if (!tfw_stricmpspn(hdr, sh, ':')) {			\
+			lambda;						\
+			break;						\
+		}							\
+	}
+
 /**
  * Update length of the string which points to new data ending at @curr_p.
  */

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -349,7 +349,10 @@ typedef enum {
 int tfw_strcpy(TfwStr *dst, const TfwStr *src);
 int tfw_strcat(TfwPool *pool, TfwStr *dst, TfwStr *src);
 
-int tfw_stricmpspn(const TfwStr *s1, const TfwStr *s2, int stop);
+int __tfw_strcmpspn(const TfwStr *s1, const TfwStr *s2, int stop, int cs);
+#define tfw_stricmpspn(s1, s2, stop) __tfw_strcmpspn((s1), (s2), (stop), 0)
+#define tfw_strcmpspn(s1, s2, stop) __tfw_strcmpspn((s1), (s2), (stop), 1)
+
 bool tfw_str_eq_cstr(const TfwStr *str, const char *cstr, int cstr_len,
 		     tfw_str_eq_flags_t flags);
 bool tfw_str_eq_cstr_pos(const TfwStr *str, const char *pos, const char *cstr,

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -364,6 +364,8 @@ bool tfw_str_eq_cstr_off(const TfwStr *str, ssize_t offset, const char *cstr,
 
 size_t tfw_str_to_cstr(const TfwStr *str, char *out_buf, int buf_size);
 
+TfwStr tfw_str_next_str_val(const TfwStr *str);
+
 #ifdef DEBUG
 void tfw_str_dprint(const TfwStr *str, const char *msg);
 #else

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -270,26 +270,6 @@ typedef struct {
 	}								\
 	for ( ; (d) < (end); ++(d))
 
-/*
- * Do @lambda if name of header @hdr is listed in @array. @array must be
- * sorted in alphabetical order.
- */
-#define TFW_STR_IF_IN_ARRAY(hdr, array, lambda)				\
-	/* int fc; */							\
-	fc = tolower(*(unsigned char *)(TFW_STR_CHUNK(hdr, 0)->ptr));	\
-	for (i = 0; i < ARRAY_SIZE(array); i++) {			\
-		const TfwStr *sh = &array[i];				\
-		int sc = *(unsigned char *)sh->ptr;			\
-		if (fc > sc)						\
-			continue;					\
-		if (fc < sc)						\
-			break;						\
-		if (!tfw_stricmpspn(hdr, sh, ':')) {			\
-			lambda;						\
-			break;						\
-		}							\
-	}
-
 /**
  * Update length of the string which points to new data ending at @curr_p.
  */

--- a/tempesta_fw/t/functional/cache/__init__.py
+++ b/tempesta_fw/t/functional/cache/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ['test_cache', 'test_cache_methods']
+__all__ = ['test_cache', 'test_cache_methods', 'test_purge', 'test_conditional']
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tempesta_fw/t/functional/cache/test_conditional.py
+++ b/tempesta_fw/t/functional/cache/test_conditional.py
@@ -1,0 +1,161 @@
+"""Functional tests of caching different methods."""
+
+from __future__ import print_function
+from helpers import tf_cfg, deproxy
+from testers import functional
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+# TODO: Check that all headers that must be present in 304 response are there.
+# Not implemented since some of them (at least Vary) affect cache behaviour.
+
+class TestConditional(functional.FunctionalTest):
+
+    config = ('cache 2;\n'
+              'cache_fulfill * *;\n'
+              'cache_methods GET;\n')
+
+    def make_304(self, response):
+        # Connection is added since tempesta send 'Connection: keep-alive' or
+        # 'Connection: close'
+        hdrs_304 = ['cache-control', 'content-location', 'date', 'etag',
+                    'expires', 'vary', 'connection']
+        hdrs = response.headers.keys()
+        for hdr in hdrs:
+            if not hdr in hdrs_304:
+                del response.headers[hdr]
+        response.status = '304'
+        response.body = ''
+        response.body_void = True
+        response.update()
+
+    def chains(self, etag=None, last_modified=None):
+        uri = '/page.html'
+        # Tests uses castom ETag and Last-Modified, so remove predefined
+        remove_hdrs = ['ETag', 'Last-Modified']
+        chains = [proxy_chain(method='GET', uri=uri),
+                  cache_chain(method='GET', uri=uri)]
+        for resp in [chains[0].response, chains[0].server_response,
+                     chains[1].response]:
+            for hdr in remove_hdrs:
+                del resp.headers[hdr]
+            if etag:
+                resp.headers['ETag'] = etag
+            if last_modified:
+                resp.headers['Last-Modified'] = last_modified
+            resp.update()
+        return chains
+
+    def chains_200(self, cond_hdr, etag=None, last_modified=None):
+        chains = self.chains(etag, last_modified)
+
+        hdr, val = cond_hdr
+        chains[1].request.headers[hdr] = val
+        chains[1].request.update()
+
+        return chains
+
+    def chains_304(self, cond_hdr, etag=None, last_modified=None):
+        chains = self.chains_200(cond_hdr, etag, last_modified)
+        self.make_304(chains[1].response)
+        return chains
+
+    # If-None-Match. Client has cached resource.
+
+    def test_none_match(self):
+        "Client have cached resource, send 304"
+        etag = '"asdfqwerty"'
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-None-Match', etag)
+        chains = self.chains_304(cond_hdr, etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+    def test_none_match_weak_srv(self):
+        "Same as test_none_match() but server sends weak etag"
+        etag = '"asdfqwerty"'
+        w_etag = 'W/%s' % etag
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-None-Match', etag)
+        chains = self.chains_304(cond_hdr, w_etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+    def test_none_match_weak_clnt(self):
+        "Same as test_none_match() but client sends weak etag"
+        etag = '"asdfqwerty"'
+        w_etag = 'W/%s' % etag
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-None-Match', w_etag)
+        chains = self.chains_304(cond_hdr, etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+    def test_none_match_weak_all(self):
+        "Same as test_none_match() but both server and client send weak etag"
+        etag = '"asdfqwerty"'
+        w_etag = 'W/%s' % etag
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-None-Match', w_etag)
+        chains = self.chains_304(cond_hdr, w_etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+    def test_none_match_list(self):
+        """Same as test_none_match() but client has saved copies of several
+        resources"""
+        etag = '"asdfqwerty"'
+        etag_list = '"fsdfds", %s, "sdfrgg"' % etag
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-None-Match', etag_list)
+        chains = self.chains_304(cond_hdr, etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+    def test_none_match_any(self):
+        """Same as test_none_match() but client has cached entire world
+        cached"""
+        etag = '"asdfqwerty"'
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-None-Match', '*')
+        chains = self.chains_304(cond_hdr, etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+    # If-None-Match. Client has no cached resource.
+
+    def test_none_match_nc(self):
+        "Client have no cached resource, send full response"
+        etag = '"asdfqwerty"'
+        etag_other = '"jfgfdgnjdn"'
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-None-Match', etag_other)
+        chains = self.chains_200(cond_hdr, etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+    # If-Modified-Since
+
+    def test_mod_since(self):
+        "Client have cached resource, send 304"
+        etag = '"asdfqwerty"'
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        after_lm = " Mon, 19 Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-Modified-Since', after_lm)
+        chains = self.chains_304(cond_hdr, etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+    def test_mod_since_nc(self):
+        "Client have no cached resource, send full response"
+        etag = '"asdfqwerty"'
+        lm = " Mon, 12 Dec 2016 13:59:39 GMT"
+        before_lm = " Mon, 5  Dec 2016 13:59:39 GMT"
+        cond_hdr = ('If-Modified-Since', before_lm)
+        chains = self.chains_200(cond_hdr, etag, lm)
+        self.generic_test_routine(self.config, chains)
+
+
+
+def cache_chain(method, uri):
+    chain = functional.base_message_chain(uri=uri, method=method)
+    chain.no_forward()
+    return chain
+
+def proxy_chain(method, uri):
+    chain = functional.base_message_chain(uri=uri, method=method)
+    return chain

--- a/tempesta_fw/t/unit/Makefile
+++ b/tempesta_fw/t/unit/Makefile
@@ -1,7 +1,7 @@
 #		Tempesta FW
 #
 # Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-# Copyright (C) 2015-2016 Tempesta Technologies, Inc.
+# Copyright (C) 2015-2017 Tempesta Technologies, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@ tfw_test-objs = \
 	test_cfg.o \
 	test_hash.o \
 	test_http_match.o \
+	test_http_msg.o \
 	tfw_str_helper.o \
 	test_tfw_str.o \
 	test_http_parser.o \

--- a/tempesta_fw/t/unit/test.c
+++ b/tempesta_fw/t/unit/test.c
@@ -93,6 +93,7 @@ TEST_SUITE(tfw_str);
 TEST_SUITE(http_parser);
 TEST_SUITE(http_sticky);
 TEST_SUITE(http_match);
+TEST_SUITE(http_msg);
 TEST_SUITE(hash);
 TEST_SUITE(addr);
 TEST_SUITE(sched_ratio);
@@ -117,6 +118,7 @@ test_run_all(void)
 	TEST_SUITE_RUN(tfw_str);
 	TEST_SUITE_RUN(http_parser);
 	TEST_SUITE_RUN(http_match);
+	TEST_SUITE_RUN(http_msg);
 	TEST_SUITE_RUN(http_sticky);
 	TEST_SUITE_RUN(hash);
 	TEST_SUITE_RUN(addr);

--- a/tempesta_fw/t/unit/test_http_msg.c
+++ b/tempesta_fw/t/unit/test_http_msg.c
@@ -1,0 +1,82 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2017 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+
+#include "test.h"
+#include "http_msg.h"
+
+TEST(http_msg, hdr_in_array)
+{
+	size_t i;
+#define TfwStr_string(v)	{ (v), NULL, sizeof(v) - 1, 0 }
+	static const TfwStr hdrs[] = {
+		TfwStr_string("age:"),
+		TfwStr_string("authorization:"),
+		TfwStr_string("cache-control:"),
+		TfwStr_string("connection:"),
+		TfwStr_string("content-length:"),
+		TfwStr_string("content-type:"),
+		TfwStr_string("cookie:"),
+		TfwStr_string("date:"),
+		TfwStr_string("etag:"),
+		TfwStr_string("expires:"),
+		TfwStr_string("from:"),
+		TfwStr_string("host:"),
+		TfwStr_string("if-unmodified-since:"),
+		TfwStr_string("last-modified:"),
+		TfwStr_string("location:"),
+		TfwStr_string("pragma:"),
+		TfwStr_string("proxy-authorization:"),
+		TfwStr_string("referer:"),
+		TfwStr_string("server:"),
+		TfwStr_string("transfer-encoding:"),
+		TfwStr_string("user-agent:"),
+		TfwStr_string("vary:"),
+		TfwStr_string("x-forwarded-for:"),
+	};
+	static const TfwStr o_hdrs[] = {
+		TfwStr_string("keep-alive:"),
+		TfwStr_string("max-forwards:"),
+		TfwStr_string("content-location:"),
+	};
+#undef TfwStr_string
+
+	for (i = 0; i < ARRAY_SIZE(hdrs); ++i) {
+		const TfwStr *h = &hdrs[i];
+		bool found = false;
+		int fc;
+
+		TFW_IF_HDR_IN_ARRAY(h, hdrs, { found = true; });
+		EXPECT_TRUE(found);
+	};
+	for (i = 0; i < ARRAY_SIZE(o_hdrs); ++i) {
+		const TfwStr *h = &o_hdrs[i];
+		bool found = false;
+		int fc;
+
+		TFW_IF_HDR_IN_ARRAY(h, hdrs, { found = true; });
+		EXPECT_FALSE(found);
+	};
+}
+
+TEST_SUITE(http_msg)
+{
+	TEST_RUN(http_msg, hdr_in_array);
+}

--- a/tempesta_fw/t/unit/test_http_msg.c
+++ b/tempesta_fw/t/unit/test_http_msg.c
@@ -56,24 +56,33 @@ TEST(http_msg, hdr_in_array)
 		TfwStr_string("max-forwards:"),
 		TfwStr_string("content-location:"),
 	};
+#define S_PART_01	"cache-control: no-cache"
+#define S_PART_02	"cache-control: no-store"
+	TfwStr dup_hdr = {
+		.ptr = (TfwStr []){
+			TfwStr_string(S_PART_01),
+			TfwStr_string(S_PART_01),
+		},
+		.len = SLEN(S_PART_01 S_PART_02),
+		.flags = (2 << TFW_STR_CN_SHIFT) | TFW_STR_DUPLICATE,
+	};
 #undef TfwStr_string
+#undef S_PART_01
+#undef S_PART_02
 
 	for (i = 0; i < ARRAY_SIZE(hdrs); ++i) {
 		const TfwStr *h = &hdrs[i];
-		bool found = false;
-		int fc;
 
-		TFW_IF_HDR_IN_ARRAY(h, hdrs, { found = true; });
-		EXPECT_TRUE(found);
+		EXPECT_NOT_NULL(tfw_http_msg_find_hdr(h, hdrs));
 	};
 	for (i = 0; i < ARRAY_SIZE(o_hdrs); ++i) {
 		const TfwStr *h = &o_hdrs[i];
-		bool found = false;
-		int fc;
 
-		TFW_IF_HDR_IN_ARRAY(h, hdrs, { found = true; });
-		EXPECT_FALSE(found);
+		EXPECT_NULL(tfw_http_msg_find_hdr(h, hdrs));
 	};
+
+	/* Duplicated string */
+	EXPECT_NOT_NULL(tfw_http_msg_find_hdr(&dup_hdr, hdrs));
 }
 
 TEST_SUITE(http_msg)

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -1369,7 +1369,7 @@ TEST(http_parser, if_none_match)
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
-		"If-None-Match:    \"" ETAG_1 "\", \"" ETAG_2 "\", W/\"" ETAG_3 "\"  \r\n"
+		"If-None-Match:    \"" ETAG_1 "\", W/\"" ETAG_2 "\", \"" ETAG_3 "\"  \r\n"
 		"\r\n")
 	{
 		TfwStr h_inm = req->h_tbl->tbl[TFW_HTTP_HDR_IF_NONE_MATCH];

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -1168,6 +1168,292 @@ TEST(http_parser, cookie)
 		"\r\n");
 }
 
+TEST(http_parser, etag)
+{
+#define RESP_ETAG_START							\
+	"HTTP/1.1 200 OK\r\n"						\
+	"Date: Mon, 23 May 2005 22:38:34 GMT\r\n"			\
+	"Content-Type: text/html; charset=UTF-8\r\n"			\
+	"Content-Encoding: UTF-8\r\n"					\
+	"Content-Length: 10\r\n"					\
+	"Last-Modified: Wed, 08 Jan 2003 23:11:55 GMT\r\n"		\
+	"Server: Apache/1.3.3.7 (Unix) (Red-Hat/Linux)\r\n"
+
+#define RESP_ETAG_END							\
+	"Accept-Ranges: bytes\r\n"					\
+	"Connection: close\r\n"						\
+	"\r\n"								\
+	"0123456789"
+
+#define ETAG_VALUE	"3f80f-1b6-3e1cb03b"
+#define ETAG_H		"ETag:   \""
+#define ETAG_TAIL	"\"  \r\n"
+#define ETAG		ETAG_H ETAG_VALUE ETAG_TAIL
+#define ETAG_H_WEAK	"ETag:   W/\""
+#define ETAG_WEAK	ETAG_H_WEAK ETAG_VALUE ETAG_TAIL
+
+	FOR_RESP(RESP_ETAG_START
+		 ETAG
+		 RESP_ETAG_END)
+	{
+		TfwStr h_etag, s_etag;
+		DEFINE_TFW_STR(exp_etag, ETAG_VALUE "\"");
+
+		tfw_http_msg_srvhdr_val(&resp->h_tbl->tbl[TFW_HTTP_HDR_ETAG],
+					TFW_HTTP_HDR_ETAG,
+					&h_etag);
+		s_etag = tfw_str_next_str_val(&h_etag);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				     & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
+	}
+
+	FOR_RESP(RESP_ETAG_START
+		 ETAG_WEAK
+		 RESP_ETAG_END)
+	{
+		TfwStr h_etag, s_etag;
+		DEFINE_TFW_STR(exp_etag, ETAG_VALUE "\"");
+
+		tfw_http_msg_srvhdr_val(&resp->h_tbl->tbl[TFW_HTTP_HDR_ETAG],
+					TFW_HTTP_HDR_ETAG,
+					&h_etag);
+		s_etag = tfw_str_next_str_val(&h_etag);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_TRUE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				    & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
+	}
+
+	FOR_RESP(RESP_ETAG_START
+		 "ETag: \"\" \r\n"
+		 RESP_ETAG_END)
+	{
+		TfwStr h_etag, s_etag;
+		DEFINE_TFW_STR(exp_etag, "\"");
+
+		tfw_http_msg_srvhdr_val(&resp->h_tbl->tbl[TFW_HTTP_HDR_ETAG],
+					TFW_HTTP_HDR_ETAG,
+					&h_etag);
+		s_etag = tfw_str_next_str_val(&h_etag);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				     & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
+	}
+
+	EXPECT_BLOCK_RESP(RESP_ETAG_START
+			  "ETag: \"3f80f-1b6-3e1cb03b\"\r\n"
+			  "ETag: \"3f80f-1b6-3e1cb03b\"\r\n"
+			  RESP_ETAG_END);
+
+	EXPECT_BLOCK_RESP(RESP_ETAG_START
+			  "ETag: \"3f80f-1b6-3e1cb03b\r\n"
+			  RESP_ETAG_END);
+
+	EXPECT_BLOCK_RESP(RESP_ETAG_START
+			  "ETag: 3f80f-1b6-3e1cb03b\"\r\n"
+			  RESP_ETAG_END);
+
+	EXPECT_BLOCK_RESP(RESP_ETAG_START
+			  "ETag: W/  \"3f80f-1b6-3e1cb03b\"\r\n"
+			  RESP_ETAG_END);
+
+	/* Same code is used to parse ETag header and If-None-Match header. */
+	EXPECT_BLOCK_RESP(RESP_ETAG_START
+			  "ETag: \"3f80f\", \"3e1cb03b\"\r\n"
+			  RESP_ETAG_END);
+
+	EXPECT_BLOCK_RESP(RESP_ETAG_START
+			  "ETag: *\r\n"
+			  RESP_ETAG_END);
+
+#undef RESP_ETAG_START
+#undef RESP_ETAG_END
+#undef ETAG
+#undef ETAG_WEAK
+#undef ETAG_H
+#undef ETAG_H_WEAK
+#undef ETAG_TAIL
+#undef ETAG_VALUE
+}
+
+TEST(http_parser, if_none_match)
+{
+#define ETAG_1		"3f80f-1b6-3e1cb03b"
+#define ETAG_2		"dhjkshfkjSDFDS"
+#define ETAG_3		"3f80f"
+
+	FOR_REQ("GET / HTTP/1.1\r\n"
+		"If-None-Match:    \"" ETAG_1 "\"  \r\n"
+		"\r\n")
+	{
+		TfwStr h_inm = req->h_tbl->tbl[TFW_HTTP_HDR_IF_NONE_MATCH];
+		TfwStr s_etag;
+		DEFINE_TFW_STR(exp_etag, ETAG_1 "\"");
+
+		s_etag = tfw_str_next_str_val(&h_inm);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				     & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
+
+		EXPECT_FALSE(req->cond.flags & TFW_HTTP_COND_ETAG_ANY);
+	}
+
+	FOR_REQ("GET / HTTP/1.1\r\n"
+		"If-None-Match:    \"\"  \r\n"
+		"\r\n")
+	{
+		TfwStr h_inm = req->h_tbl->tbl[TFW_HTTP_HDR_IF_NONE_MATCH];
+		TfwStr s_etag;
+		DEFINE_TFW_STR(exp_etag, "\"");
+
+		s_etag = tfw_str_next_str_val(&h_inm);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				     & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
+
+		EXPECT_FALSE(req->cond.flags & TFW_HTTP_COND_ETAG_ANY);
+	}
+
+	FOR_REQ("GET / HTTP/1.1\r\n"
+		"If-None-Match:    \"" ETAG_1 "\", \"" ETAG_2 "\"  \r\n"
+		"\r\n")
+	{
+		TfwStr h_inm = req->h_tbl->tbl[TFW_HTTP_HDR_IF_NONE_MATCH];
+		TfwStr s_etag;
+		DEFINE_TFW_STR(exp_etag_1, ETAG_1 "\"");
+		DEFINE_TFW_STR(exp_etag_2, ETAG_2 "\"");
+
+		s_etag = tfw_str_next_str_val(&h_inm);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_1, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				     & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_2, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				     & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
+
+		EXPECT_FALSE(req->cond.flags & TFW_HTTP_COND_ETAG_ANY);
+	}
+
+	FOR_REQ("GET / HTTP/1.1\r\n"
+		"If-None-Match:    \"" ETAG_1 "\", \"" ETAG_2 "\", W/\"" ETAG_3 "\"  \r\n"
+		"\r\n")
+	{
+		TfwStr h_inm = req->h_tbl->tbl[TFW_HTTP_HDR_IF_NONE_MATCH];
+		TfwStr s_etag;
+		DEFINE_TFW_STR(exp_etag_1, ETAG_1 "\"");
+		DEFINE_TFW_STR(exp_etag_2, ETAG_2 "\"");
+		DEFINE_TFW_STR(exp_etag_3, ETAG_3 "\"");
+
+		s_etag = tfw_str_next_str_val(&h_inm);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_1, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				     & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_2, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_TRUE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				    & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_3, '"'), 0);
+		if (!TFW_STR_EMPTY(&s_etag)) {
+			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
+				     & TFW_STR_ETAG_WEAK);
+		}
+
+		s_etag = tfw_str_next_str_val(&s_etag);
+		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
+
+		EXPECT_FALSE(req->cond.flags & TFW_HTTP_COND_ETAG_ANY);
+	}
+
+	FOR_REQ("GET / HTTP/1.1\r\n"
+		"If-None-Match:   *  \r\n"
+		"\r\n")
+	{
+		EXPECT_TRUE(req->cond.flags & TFW_HTTP_COND_ETAG_ANY);
+	}
+
+	/* Empty header */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: \r\n"
+			 "\r\n");
+	/* Not quoted value. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: " ETAG_1 "\r\n"
+			 "\r\n");
+	/* No closing quote. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: \"" ETAG_1 "\r\n"
+			 "\r\n");
+	/* No opening quote. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: " ETAG_1 "\"\r\n"
+			 "\r\n");
+	/* Dublicated header. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: \"" ETAG_1 "\"\r\n"
+			 "If-None-Match: \"" ETAG_1 "\"\r\n"
+			 "\r\n");
+	/* Incomplite header. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: \"" ETAG_1 "\", \r\n"
+			 "\r\n");
+	/* No delimiter. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: \"" ETAG_1 "\" \"" ETAG_2 "\" \r\n"
+			 "\r\n");
+	/* Etag list + Any etag. */
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: \"" ETAG_1 "\", * \r\n"
+			 "\r\n");
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
+			 "If-None-Match: *, \"" ETAG_1 "\" \r\n"
+			 "\r\n");
+
+#undef ETAG_1
+#undef ETAG_2
+#undef ETAG_3
+}
+
 TEST(http_parser, req_hop_by_hop)
 {
 	TfwHttpHdrTbl *ht;
@@ -1563,6 +1849,8 @@ TEST_SUITE(http_parser)
 	TEST_RUN(http_parser, folding);
 	TEST_RUN(http_parser, empty_host);
 	TEST_RUN(http_parser, chunked);
+	TEST_RUN(http_parser, etag);
+	TEST_RUN(http_parser, if_none_match);
 	TEST_RUN(http_parser, cookie);
 	TEST_RUN(http_parser, req_hop_by_hop);
 	TEST_RUN(http_parser, resp_hop_by_hop);

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -346,6 +346,7 @@ http_parse_resp_helper(void)
 {
 	/* XXX reset parser explicitly to be able to call it multiple times */
 	memset(&mock.resp->parser, 0, sizeof(mock.resp->parser));
+	tfw_http_init_parser_resp(mock.resp);
 	mock.resp->h_tbl->off = TFW_HTTP_HDR_RAW;
 	memset(mock.resp->h_tbl->tbl, 0, __HHTBL_SZ(1) * sizeof(TfwStr));
 	TFW_STR_INIT(&mock.resp->crlf);


### PR DESCRIPTION
* #529 : ETag is added to cache entry to allow handling validation and range requests
* #519 : Process Conditional (If-Modified-Since and If-None-Match) requests, respond with 304 or 412 code

More unit and functional tests to come in a couple of days.