### PR TITLE
Fix match to list of singular headers

### DIFF
--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -133,7 +133,7 @@ __hdr_is_singular(const TfwStr *hdr)
 #undef TfwStr_string
 	};
 
-	fc = tolower(*(unsigned char *)TFW_STR_CHUNK(hdr, 0));
+	fc = tolower(*(unsigned char *)(TFW_STR_CHUNK(hdr, 0)->ptr));
 	for (i = 0; i < ARRAY_SIZE(hdr_singular); i++) {
 		const TfwStr *sh = &hdr_singular[i];
 		int sc = *(unsigned char *)sh->ptr;


### PR DESCRIPTION
`fc` in `__hdr_is_singular()` has a garbage value: it equals first byte of `TfwStr` structure, but not the first character in the string.