### PR TITLE
Fix #782: release a server connection resources on server disconnect

### DIFF
--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -414,6 +414,8 @@ tfw_sock_srv_disconnect(TfwConn *conn)
 	if (atomic_read(&conn->refcnt) != TFW_CONN_DEATHCNT)
 		ret = ss_close_sync(sk, true);
 
+	tfw_connection_release(conn);
+
 	return ret;
 }
 


### PR DESCRIPTION
there is a chance that the server connection resources wont't be released
on server disconnect and tempesta shutdown threafter so we have to explicitly
call the tfw_connection_release()

On tempesta shutdown a backend server connection state
is set to the TFW_CONN_DEATHCNT value and thus we won't
release the connection resources in tfw_sock_srv_disconnect()
and directly close the socket causing the BUG() in case
tfw_sock_srv_connect_try_later() is still trying to reconnect.

Signed-off-by: Denis Kirjanov <dk@tempesta-tech.com>