### PR TITLE
Fix #782: release a server connection resources on tempesta

### DIFF
--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -414,6 +414,12 @@ tfw_sock_srv_disconnect(TfwConn *conn)
 	if (atomic_read(&conn->refcnt) != TFW_CONN_DEATHCNT)
 		ret = ss_close_sync(sk, true);
 
+	/* make sure the resources of a connection
+	 * closed by a backend right before the shutdown
+	 * are released
+	 */
+	tfw_connection_release(conn);
+
 	return ret;
 }
 


### PR DESCRIPTION
shutdown

there is a chance that the server connection resources wont't be released
on server disconnect and tempesta shutdown threafter so we have to explicitly
call the tfw_connection_release()

Signed-off-by: Denis Kirjanov <dk@tempesta-tech.com>