### PR TITLE
Fix parsing responses not allowed to have a body

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2546,9 +2546,9 @@ tfw_http_resp_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
 			 * The response is fully parsed,
 			 * fall through and process it.
 			 */
-			if(!(hmresp->flags
-			     & (TFW_HTTP_CHUNKED | TFW_HTTP_VOID_BODY))
-			   && (hmresp->content_length != hmresp->body.len))
+			if (!(hmresp->flags
+			      & (TFW_HTTP_CHUNKED | TFW_HTTP_VOID_BODY))
+			    && (hmresp->content_length != hmresp->body.len))
 				goto bad_msg;
 		}
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2546,9 +2546,10 @@ tfw_http_resp_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
 			 * The response is fully parsed,
 			 * fall through and process it.
 			 */
-			BUG_ON(!(hmresp->flags
-				 & (TFW_HTTP_CHUNKED | TFW_HTTP_VOID_BODY))
-			       && (hmresp->content_length != hmresp->body.len));
+			if(!(hmresp->flags
+			     & (TFW_HTTP_CHUNKED | TFW_HTTP_VOID_BODY))
+			   && (hmresp->content_length != hmresp->body.len))
+				goto bad_msg;
 		}
 
 		/*

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -292,7 +292,7 @@ typedef struct {
 #define TFW_HTTP_NON_IDEMP		0x000800
 
 /* Response flags */
-#define TFW_HTTP_VOID_BODY		0x010000	/* Resp to HEAD req */
+#define TFW_HTTP_VOID_BODY		0x010000	/* Resp has no body */
 #define TFW_HTTP_HAS_HDR_DATE		0x020000	/* Has Date: header */
 #define TFW_HTTP_HAS_HDR_LMODIFIED	0x040000 /* Has Last-Modified: header */
 /* It is stale, but pass with a warning */

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -1229,7 +1229,6 @@ __parse_content_length(TfwHttpMsg *msg, unsigned char *data, size_t len)
 	 */
 	if (TFW_CONN_TYPE(msg->conn) & Conn_Srv) {
 		TfwHttpResp *resp = (TfwHttpResp *)msg;
-
 		if ((msg->flags & TFW_HTTP_VOID_BODY) && (resp->status != 304))
 			return CSTR_NEQ;
 	}
@@ -4185,7 +4184,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 			/* Status code is fully parsed, move forward. */
 			resp->status = parser->_acc;
 			parser->_acc = 0;
-			/* Some responses are not allowed to have a body. */
+			/* RFC 7230 3.3.3: some responses don't have a body. */
 			/* TODO: Add (req == CONNECT && resp == 2xx) */
 			if (resp->status - 100U < 100U || resp->status == 204
 			    || resp->status == 304)


### PR DESCRIPTION
Fix #816 

* Tag all responses not allowed to have a body with VOID_BODY flag
* Block responses with Content-Length header if it is not allowed by RFC 7230 Section 3.3.2