### PR TITLE
Live reconfiguration

### DIFF
--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -185,6 +185,23 @@
 #   server_queue_size 1000;
 #
 
+#
+# TAG: grace_shutdown_time
+#
+# Defines the timeout in seconds for graceful server removing during
+# reconfiguration.
+#
+# Syntax:
+#   grace_shutdown_time 5;
+#
+# If a server is deleted from the configuration, but is still alive, then
+# let all current sessions and requests to finish, but do not schedule new
+# sessions/requests to the server.
+#
+# Default:
+#   grace_shutdown_time 0;
+#
+
 # TAG: srv_group
 #
 # Groups multiple backend servers into a single unit of load balancing.

--- a/pkg/debian/tempesta-fw.service
+++ b/pkg/debian/tempesta-fw.service
@@ -14,7 +14,7 @@ Environment=TFW_CFG_PATH=/etc/tempesta_fw.conf
 RemainAfterExit=yes
 ExecStart=/lib/tempesta/scripts/tempesta.sh --start
 ExecStop=/lib/tempesta/scripts/tempesta.sh --stop
-ExecReload=/lib/tempesta/scripts/tempesta.sh --restart
+ExecReload=/lib/tempesta/scripts/tempesta.sh --reload
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -35,7 +35,7 @@ tfw_mod=tempesta_fw
 tfw_sched_mod=tfw_sched_$sched
 frang_mod="tfw_frang"
 declare frang_enable=
-declare -r LONG_OPTS="help,load,unload,start,stop,restart"
+declare -r LONG_OPTS="help,load,unload,start,stop,restart,reload"
 
 declare devs=$(ip addr show up | awk '/^[0-9]+/ { sub(/:/, "", $2); print $2}')
 
@@ -53,6 +53,7 @@ usage()
 	echo -e "  --start     Load modules and start."
 	echo -e "  --stop      Stop and unload modules."
 	echo -e "  --restart   Restart.\n"
+	echo -e "  --reload    Live reconfiguration.\n"
 }
 
 error()
@@ -179,6 +180,17 @@ stop()
 	echo "done"
 }
 
+reload()
+{
+	echo "Running live reconfiguration of Tempesta..."
+	sysctl -w net.tempesta.state=start >/dev/null
+	if [ $? -ne 0 ]; then
+		error "cannot reconfigure Tempesta FW"
+	else
+		echo "done"
+	fi
+}
+
 args=$(getopt -o "d:f" -a -l "$LONG_OPTS" -- "$@")
 eval set -- "${args}"
 while :; do
@@ -204,6 +216,10 @@ while :; do
 		--restart)
 			stop
 			start
+			exit
+			;;
+		--reload)
+			reload
 			exit
 			;;
 		# Ignore any options after action.

--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -3,7 +3,7 @@
 # Tempesta FW service script.
 #
 # Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-# Copyright (C) 2015-2016 Tempesta Technologies, Inc.
+# Copyright (C) 2015-2017 Tempesta Technologies, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1061,7 +1061,7 @@ tfw_apm_del_srv(TfwServer *srv)
 #define TFW_APM_MIN_TMINTRVL	5	/* Minimum time interval (secs). */
 
 static int
-tfw_apm_cfgfin(void)
+tfw_apm_cfgend(void)
 {
 	unsigned int jtmwindow;
 
@@ -1159,7 +1159,7 @@ static TfwCfgSpec tfw_apm_specs[] = {
 
 TfwMod tfw_apm_mod = {
 	.name	= "apm",
-	.cfgfin	= tfw_apm_cfgfin,
+	.cfgend	= tfw_apm_cfgend,
 	.specs	= tfw_apm_specs,
 };
 

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1054,11 +1054,9 @@ tfw_apm_del_srv(TfwServer *srv)
 
 #define TFW_APM_MIN_TMWSCALE	1	/* Minimum time window scale. */
 #define TFW_APM_MAX_TMWSCALE	50	/* Maximum time window scale. */
-#define TFW_APM_DEF_TMWSCALE	5	/* Default time window scale. */
 
 #define TFW_APM_MIN_TMWINDOW	60	/* Minimum time window (secs). */
 #define TFW_APM_MAX_TMWINDOW	3600	/* Maximum time window (secs). */
-#define TFW_APM_DEF_TMWINDOW	300	/* Default time window (secs). */
 
 #define TFW_APM_MIN_TMINTRVL	5	/* Minimum time interval (secs). */
 
@@ -1066,11 +1064,6 @@ static int
 tfw_apm_start(void)
 {
 	unsigned int jtmwindow;
-
-	if (!tfw_apm_jtmwindow)
-		tfw_apm_jtmwindow = TFW_APM_DEF_TMWINDOW;
-	if (!tfw_apm_tmwscale)
-		tfw_apm_tmwscale = TFW_APM_DEF_TMWSCALE;
 
 	if ((tfw_apm_jtmwindow < TFW_APM_MIN_TMWINDOW)
 	    || (tfw_apm_jtmwindow > TFW_APM_MAX_TMWINDOW))
@@ -1152,7 +1145,7 @@ tfw_cfgop_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 static TfwCfgSpec tfw_apm_specs[] = {
 	{
 		.name = "apm_stats",
-		.deflt = NULL,
+		.deflt = "window=300 scale=5",
 		.handler = tfw_cfgop_apm_stats,
 		.cleanup  = tfw_cfgop_cleanup_apm,
 		.allow_none = true,

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -940,7 +940,7 @@ tfw_apm_rbent_init(TfwApmRBEnt *rbent, unsigned long jtmistamp)
  * Note that due to specifics of Tempesta start up process this code
  * is executed in SoftIRQ context (so that sleeping is not allowed).
  */
-void *
+static void *
 tfw_apm_create(void)
 {
 	TfwApmData *data;

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1065,6 +1065,9 @@ tfw_apm_start(void)
 {
 	unsigned int jtmwindow;
 
+	if (tfw_runstate_is_reconfig())
+		return 0;
+
 	if ((tfw_apm_jtmwindow < TFW_APM_MIN_TMWINDOW)
 	    || (tfw_apm_jtmwindow > TFW_APM_MAX_TMWINDOW))
 	{

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1110,13 +1110,13 @@ tfw_apm_start(void)
  * and the APM timers are deleted.
  */
 static void
-tfw_apm_cfg_cleanup(TfwCfgSpec *cs)
+tfw_cfgop_cleanup_apm(TfwCfgSpec *cs)
 {
-	tfw_apm_jtmwindow = tfw_apm_jtmintrvl = tfw_apm_tmwscale = 0;
+	tfw_apm_jtmwindow = tfw_apm_tmwscale = 0;
 }
 
 static int
-tfw_handle_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
+tfw_cfgop_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int i, r;
 	const char *key, *val;
@@ -1131,6 +1131,7 @@ tfw_handle_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 			    cs->name);
 		return 0;
 	}
+
 	TFW_CFG_ENTRY_FOR_EACH_ATTR(ce, i, key, val) {
 		if (!strcasecmp(key, "window")) {
 			if ((r = tfw_cfg_parse_int(val, &tfw_apm_jtmwindow)))
@@ -1150,11 +1151,12 @@ tfw_handle_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 static TfwCfgSpec tfw_apm_specs[] = {
 	{
-		"apm_stats", NULL,
-		tfw_handle_apm_stats,
+		.name = "apm_stats",
+		.deflt = NULL,
+		.handler = tfw_cfgop_apm_stats,
+		.cleanup  = tfw_cfgop_cleanup_apm,
 		.allow_none = true,
 		.allow_repeat = false,
-		.cleanup  = tfw_apm_cfg_cleanup,
 	},
 	{ 0 }
 };

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1061,7 +1061,7 @@ tfw_apm_del_srv(TfwServer *srv)
 #define TFW_APM_MIN_TMINTRVL	5	/* Minimum time interval (secs). */
 
 static int
-tfw_apm_start(void)
+tfw_apm_cfgfin(void)
 {
 	unsigned int jtmwindow;
 
@@ -1159,7 +1159,7 @@ static TfwCfgSpec tfw_apm_specs[] = {
 
 TfwMod tfw_apm_mod = {
 	.name	= "apm",
-	.start	= tfw_apm_start,
+	.cfgfin	= tfw_apm_cfgfin,
 	.specs	= tfw_apm_specs,
 };
 

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1063,7 +1063,7 @@ tfw_apm_del_srv(TfwServer *srv)
 #define TFW_APM_MIN_TMINTRVL	5	/* Minimum time interval (secs). */
 
 static int
-tfw_apm_cfg_start(void)
+tfw_apm_start(void)
 {
 	unsigned int jtmwindow;
 
@@ -1148,7 +1148,7 @@ tfw_handle_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	return 0;
 }
 
-static TfwCfgSpec tfw_apm_cfg_specs[] = {
+static TfwCfgSpec tfw_apm_specs[] = {
 	{
 		"apm_stats", NULL,
 		tfw_handle_apm_stats,
@@ -1156,11 +1156,24 @@ static TfwCfgSpec tfw_apm_cfg_specs[] = {
 		.allow_repeat = false,
 		.cleanup  = tfw_apm_cfg_cleanup,
 	},
-	{}
+	{ 0 }
 };
 
-TfwCfgMod tfw_apm_cfg_mod = {
-	.name  = "apm",
-	.start = tfw_apm_cfg_start,
-	.specs = tfw_apm_cfg_specs,
+TfwMod tfw_apm_mod = {
+	.name	= "apm",
+	.start	= tfw_apm_start,
+	.specs	= tfw_apm_specs,
 };
+
+int
+tfw_apm_init(void)
+{
+	tfw_mod_register(&tfw_apm_mod);
+	return 0;
+}
+
+void
+tfw_apm_exit(void)
+{
+	tfw_mod_unregister(&tfw_apm_mod);
+}

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1849,7 +1849,7 @@ tfw_cache_cfg_method(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	return 0;
 }
 
-static TfwCfgSpec tfw_cache_cfg_specs[] = {
+static TfwCfgSpec tfw_cache_specs[] = {
 	{
 		"cache",
 		"2",
@@ -1885,12 +1885,25 @@ static TfwCfgSpec tfw_cache_cfg_specs[] = {
 			.len_range = { 1, PATH_MAX },
 		}
 	},
-	{}
+	{ 0 }
 };
 
-TfwCfgMod tfw_cache_cfg_mod = {
+TfwMod tfw_cache_mod = {
 	.name 	= "cache",
 	.start	= tfw_cache_start,
 	.stop	= tfw_cache_stop,
-	.specs	= tfw_cache_cfg_specs,
+	.specs	= tfw_cache_specs,
 };
+
+int
+tfw_cache_init(void)
+{
+	tfw_mod_register(&tfw_cache_mod);
+	return 0;
+}
+
+void
+tfw_cache_exit(void)
+{
+	tfw_mod_unregister(&tfw_cache_mod);
+}

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1741,6 +1741,8 @@ tfw_cache_start(void)
 	int i, r = 1;
 	TfwVhost *vhost = tfw_vhost_get_default();
 
+	if (tfw_runstate_is_reconfig())
+		return 0;
 	if (!(cache_cfg.cache || vhost->cache_purge))
 		return 0;
 
@@ -1780,6 +1782,8 @@ tfw_cache_stop(void)
 {
 	int i;
 
+	if (tfw_runstate_is_reconfig())
+		return;
 	if (!cache_cfg.cache)
 		return;
 

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1818,7 +1818,7 @@ static const TfwCfgEnum cache_http_methods_enum[] = {
 };
 
 static int
-tfw_cache_cfg_method(TfwCfgSpec *cs, TfwCfgEntry *ce)
+tfw_cfgop_cache_methods(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	unsigned int i, method;
 	const char *val;
@@ -1851,37 +1851,37 @@ tfw_cache_cfg_method(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 static TfwCfgSpec tfw_cache_specs[] = {
 	{
-		"cache",
-		"2",
-		tfw_cfg_set_int,
-		&cache_cfg.cache,
-		&(TfwCfgSpecInt) {
+		.name = "cache",
+		.deflt = "2",
+		.handler = tfw_cfg_set_int,
+		.dest = &cache_cfg.cache,
+		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, 2 },
-		}
+		},
 	},
 	{
-		"cache_methods",
-		"GET",
-		tfw_cache_cfg_method,
+		.name = "cache_methods",
+		.deflt = "GET",
+		.handler = tfw_cfgop_cache_methods,
 		.allow_none = true,
 		.allow_repeat = false,
 	},
 	{
-		"cache_size",
-		"268435456",
-		tfw_cfg_set_int,
-		&cache_cfg.db_size,
-		&(TfwCfgSpecInt) {
+		.name = "cache_size",
+		.deflt = "268435456",
+		.handler = tfw_cfg_set_int,
+		.dest = &cache_cfg.db_size,
+		.spec_ext = &(TfwCfgSpecInt) {
 			.multiple_of = PAGE_SIZE,
 			.range = { PAGE_SIZE, (1 << 30) },
 		}
 	},
 	{
-		"cache_db",
-		"/opt/tempesta/db/cache.tdb",
-		tfw_cfg_set_str,
-		&cache_cfg.db_path,
-		&(TfwCfgSpecStr) {
+		.name = "cache_db",
+		.deflt = "/opt/tempesta/db/cache.tdb",
+		.handler = tfw_cfg_set_str,
+		.dest = &cache_cfg.db_path,
+		.spec_ext = &(TfwCfgSpecStr) {
 			.len_range = { 1, PATH_MAX },
 		}
 	},

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -61,8 +61,6 @@
  * TODO:
  *  - "include" directives.
  *  - Handling large sets of data, possibly via TDB.
- *  - Re-loading some parts of the configuration on the fly without stopping the
- *    whole system.
  *  - Improve efficiency: too many memory allocations and data copying.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -1504,6 +1504,7 @@ tfw_cfg_migrate_state(TfwCfgSpec *cs)
 			spec->__called_ever = true;
 		if (spec->handler == &tfw_cfg_handle_children)
 			tfw_cfg_migrate_state(spec->dest);
+		spec->__called_cfg = false;
 	}
 }
 

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -759,8 +759,10 @@ spec_handle_entry(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry)
 {
 	int r;
 
-	if (tfw_runstate_is_reconfig() && !spec->allow_reconfig)
+	if (tfw_runstate_is_reconfig() && !spec->allow_reconfig) {
+		TFW_DBG2("skip spec '%s': reconfig not allowed\n", spec->name);
 		return 0;
+	}
 	if (!spec->allow_repeat && spec->__called_now) {
 		TFW_ERR_NL("duplicate entry: '%s', only one such entry is"
 			   " allowed.\n", parsed_entry->name);

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -1144,14 +1144,13 @@ tfw_cfg_handle_children(TfwCfgSpec *cs, TfwCfgEntry *e)
 		matching_spec = spec_find(nested_specs, ps->e.name);
 		if (!matching_spec) {
 			TFW_ERR("don't know how to handle: %s\n", ps->e.name);
-			entry_reset(&ps->e);
 			return -EINVAL;
 		}
 
 		ret = spec_handle_entry(matching_spec, &ps->e);
-		entry_reset(&ps->e);
 		if (ret)
 			return ret;
+		entry_reset(&ps->e);
 	}
 
 	/*

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -315,6 +315,22 @@ tfw_cfg_is_dflt_value(TfwCfgEntry *cfg_entry)
 	return cfg_entry->dflt_value;
 }
 
+/*
+ * Tempesta strives to support live reconfiguration. New configuration
+ * is loaded, processed and set while Tempesta is running. Ultimately,
+ * directives in configuration file are translated into internal data
+ * stractures in Tempesta. Internal data structures for data that may
+ * be reconfigured need to have a configuration flags member that will
+ * indicate one of several major actions noted below. Implementation
+ * of each action is specific to configuration entry.
+ */
+#define TFW_CFG_F_ADD		0x0001	/* Add an entry */
+#define TFW_CFG_F_DEL		0x0002	/* Delete an entry */
+#define TFW_CFG_F_MOD		0x0004	/* Modify an entry */
+#define TFW_CFG_F_KEEP		0x0008	/* Keep an entry */
+#define TFW_CFG_M_ACTION	\
+	(TFW_CFG_F_ADD | TFW_CFG_F_DEL | TFW_CFG_F_MOD | TFW_CFG_F_KEEP)
+
 /* Generic TfwCfgSpec->handler functions. */
 int tfw_cfg_set_bool(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_int(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);

--- a/tempesta_fw/classifier/frang.c
+++ b/tempesta_fw/classifier/frang.c
@@ -895,7 +895,7 @@ static const TfwCfgEnum frang_http_methods_enum[] = {
 };
 
 static int
-frang_set_methods_mask(TfwCfgSpec *cs, TfwCfgEntry *ce)
+frang_cfgop_http_methods(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int i, r, method_id;
 	const char *method_str;
@@ -923,13 +923,13 @@ frang_set_methods_mask(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static void
-frang_clear_methods_mask(TfwCfgSpec *cs)
+frang_cfgop_cleanup_http_methods(TfwCfgSpec *cs)
 {
 	frang_cfg.http_methods_mask = 0;
 }
 
 static int
-frang_set_ct_vals(TfwCfgSpec *cs, TfwCfgEntry *ce)
+frang_cfgop_http_ct_vals(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	void *mem;
 	const char *in_str;
@@ -986,7 +986,7 @@ frang_set_ct_vals(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static void
-frang_free_ct_vals(TfwCfgSpec *cs)
+frang_cfgop_cleanup_http_ct_vals(TfwCfgSpec *cs)
 {
 	kfree(frang_cfg.http_ct_vals);
 	frang_cfg.http_ct_vals = NULL;
@@ -1003,107 +1003,125 @@ frang_start(void)
 	return 0;
 }
 
-static TfwCfgSpec frang_specs_section[] = {
+static TfwCfgSpec frang_limits_specs[] = {
 	{
-		"ip_block", "off",
-		tfw_cfg_set_bool,
-		&frang_cfg.ip_block,
+		.name = "ip_block",
+		.deflt = "off",
+		.handler = tfw_cfg_set_bool,
+		.dest = &frang_cfg.ip_block,
 	},
 	{
-		"request_rate", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.req_rate,
+		.name = "request_rate",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.req_rate,
 	},
 	{
-		"request_burst", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.req_burst,
+		.name = "request_burst",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.req_burst,
 	},
 	{
-		"connection_rate", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.conn_rate,
+		.name = "connection_rate",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.conn_rate,
 	},
 	{
-		"connection_burst", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.conn_burst,
+		.name = "connection_burst",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.conn_burst,
 	},
 	{
-		"concurrent_connections", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.conn_max,
+		.name = "concurrent_connections",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.conn_max,
 	},
 	{
-		"client_header_timeout", "0",
-		tfw_cfg_set_int,
-		(unsigned int *)&frang_cfg.clnt_hdr_timeout,
+		.name = "client_header_timeout",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = (unsigned int *)&frang_cfg.clnt_hdr_timeout,
 	},
 	{
-		"client_body_timeout", "0",
-		tfw_cfg_set_int,
-		(unsigned int *)&frang_cfg.clnt_body_timeout,
+		.name = "client_body_timeout",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = (unsigned int *)&frang_cfg.clnt_body_timeout,
 	},
 	{
-		"http_uri_len", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.http_uri_len,
+		.name = "http_uri_len",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.http_uri_len,
 	},
 	{
-		"http_field_len", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.http_field_len,
+		.name = "http_field_len",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.http_field_len,
 	},
 	{
-		"http_body_len", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.http_body_len,
+		.name = "http_body_len",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.http_body_len,
 	},
 	{
-		"http_header_cnt", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.http_hdr_cnt,
+		.name = "http_header_cnt",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.http_hdr_cnt,
 	},
 	{
-		"http_header_chunk_cnt", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.http_hchunk_cnt,
+		.name = "http_header_chunk_cnt",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.http_hchunk_cnt,
 	},
 	{
-		"http_body_chunk_cnt", "0",
-		tfw_cfg_set_int,
-		&frang_cfg.http_bchunk_cnt,
+		.name = "http_body_chunk_cnt",
+		.deflt = "0",
+		.handler = tfw_cfg_set_int,
+		.dest = &frang_cfg.http_bchunk_cnt,
 	},
 	{
-		"http_host_required", "true",
-		tfw_cfg_set_bool,
-		&frang_cfg.http_host_required,
+		.name = "http_host_required",
+		.deflt = "true",
+		.handler = tfw_cfg_set_bool,
+		.dest = &frang_cfg.http_host_required,
 	},
 	{
-		"http_ct_required", "false",
-		tfw_cfg_set_bool,
-		&frang_cfg.http_ct_required,
+		.name = "http_ct_required",
+		.deflt = "false",
+		.handler = tfw_cfg_set_bool,
+		.dest = &frang_cfg.http_ct_required,
 	},
 	{
-		"http_methods", "",
-		frang_set_methods_mask,
-		.cleanup = frang_clear_methods_mask,
+		.name = "http_methods",
+		.deflt = "",
+		.handler = frang_cfgop_http_methods,
+		.cleanup = frang_cfgop_cleanup_http_methods,
 	},
 	{
-		"http_ct_vals", NULL,
-		frang_set_ct_vals,
+		.name = "http_ct_vals",
+		.deflt = NULL,
+		.handler = frang_cfgop_http_ct_vals,
 		.allow_none = 1,
-		.cleanup = frang_free_ct_vals,
+		.cleanup = frang_cfgop_cleanup_http_ct_vals,
 	},
 	{ 0 }
 };
 
-static TfwCfgSpec frang_specs_toplevel[] = {
+static TfwCfgSpec frang_specs[] = {
 	{
 		.name = "frang_limits",
 		.handler = tfw_cfg_handle_children,
-		.dest = &frang_specs_section,
-		.cleanup = tfw_cfg_cleanup_children
+		.cleanup = tfw_cfg_cleanup_children,
+		.dest = frang_limits_specs,
 	},
 	{ 0 }
 };
@@ -1111,7 +1129,7 @@ static TfwCfgSpec frang_specs_toplevel[] = {
 static TfwMod frang_mod = {
 	.name	= "frang",
 	.start	= frang_start,
-	.specs	= frang_specs_toplevel
+	.specs	= frang_specs,
 };
 
 static int __init

--- a/tempesta_fw/classifier/frang.c
+++ b/tempesta_fw/classifier/frang.c
@@ -1003,7 +1003,7 @@ frang_start(void)
 	return 0;
 }
 
-static TfwCfgSpec frang_cfg_section_specs[] = {
+static TfwCfgSpec frang_specs_section[] = {
 	{
 		"ip_block", "off",
 		tfw_cfg_set_bool,
@@ -1095,23 +1095,23 @@ static TfwCfgSpec frang_cfg_section_specs[] = {
 		.allow_none = 1,
 		.cleanup = frang_free_ct_vals,
 	},
-	{}
+	{ 0 }
 };
 
-static TfwCfgSpec frang_cfg_toplevel_specs[] = {
+static TfwCfgSpec frang_specs_toplevel[] = {
 	{
 		.name = "frang_limits",
 		.handler = tfw_cfg_handle_children,
-		.dest = &frang_cfg_section_specs,
+		.dest = &frang_specs_section,
 		.cleanup = tfw_cfg_cleanup_children
 	},
-	{}
+	{ 0 }
 };
 
-static TfwCfgMod frang_cfg_mod = {
-	.name = "frang",
-	.start = frang_start,
-	.specs = frang_cfg_toplevel_specs
+static TfwMod frang_mod = {
+	.name	= "frang",
+	.start	= frang_start,
+	.specs	= frang_specs_toplevel
 };
 
 static int __init
@@ -1121,12 +1121,7 @@ frang_init(void)
 
 	BUILD_BUG_ON((sizeof(FrangAcc) > sizeof(TfwClassifierPrvt)));
 
-	r = tfw_cfg_mod_register(&frang_cfg_mod);
-	if (r) {
-		TFW_ERR("frang: can't register as a configuration module\n");
-		return -EINVAL;
-	}
-
+	tfw_mod_register(&frang_mod);
 	tfw_classifier_register(&frang_class_ops);
 
 	r = tfw_gfsm_register_fsm(TFW_FSM_FRANG, frang_http_req_handler);
@@ -1159,7 +1154,7 @@ err_hook:
 	tfw_gfsm_unregister_fsm(TFW_FSM_FRANG);
 err_fsm:
 	tfw_classifier_unregister();
-	tfw_cfg_mod_unregister(&frang_cfg_mod);
+	tfw_mod_unregister(&frang_mod);
 	return r;
 }
 
@@ -1171,7 +1166,7 @@ frang_exit(void)
 	tfw_gfsm_unregister_hook(TFW_FSM_HTTP, prio0, TFW_HTTP_FSM_REQ_MSG);
 	tfw_gfsm_unregister_fsm(TFW_FSM_FRANG);
 	tfw_classifier_unregister();
-	tfw_cfg_mod_unregister(&frang_cfg_mod);
+	tfw_mod_unregister(&frang_mod);
 }
 
 module_init(frang_init);

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -179,11 +179,14 @@ enum {
 	TFW_CONN_B_RESEND = 0,	/* Need to re-send requests. */
 	TFW_CONN_B_QFORWD,	/* Need to forward requests in the queue. */
 	TFW_CONN_B_HASNIP,	/* Has non-idempotent requests. */
+
+	TFW_CONN_B_DEL		/* Remove connection */
 };
 
 #define TFW_CONN_F_RESEND	(1 << TFW_CONN_B_RESEND)
 #define TFW_CONN_F_QFORWD	(1 << TFW_CONN_B_QFORWD)
 #define TFW_CONN_F_HASNIP	(1 << TFW_CONN_B_HASNIP)
+
 
 /**
  * TLS hardened connection.

--- a/tempesta_fw/filter.c
+++ b/tempesta_fw/filter.c
@@ -298,7 +298,7 @@ tfw_filter_stop(void)
 	tdb_close(ip_filter_db);
 }
 
-static TfwCfgSpec tfw_filter_cfg_specs[] = {
+static TfwCfgSpec tfw_filter_specs[] = {
 	{
 		"filter_tbl_size",
 		"16777216",
@@ -318,12 +318,25 @@ static TfwCfgSpec tfw_filter_cfg_specs[] = {
 			.len_range = { 1, PATH_MAX },
 		}
 	},
-	{}
+	{ 0 }
 };
 
-TfwCfgMod tfw_filter_cfg_mod = {
+TfwMod tfw_filter_mod = {
 	.name 	= "filter",
 	.start	= tfw_filter_start,
 	.stop	= tfw_filter_stop,
-	.specs	= tfw_filter_cfg_specs,
+	.specs	= tfw_filter_specs,
 };
+
+int
+tfw_filter_init(void)
+{
+	tfw_mod_register(&tfw_filter_mod);
+	return 0;
+}
+
+void
+tfw_filter_exit(void)
+{
+	tfw_mod_unregister(&tfw_filter_mod);
+}

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1391,7 +1391,14 @@ tfw_http_conn_release(TfwConn *conn)
 	BUG_ON(!(TFW_CONN_TYPE(srv_conn) & Conn_Srv));
 
 	if (likely(ss_active())) {
+		/*
+		 * Server is removed from configuration and won't be available
+		 * any more, reschedule it's forward queue.
+		 */
+		if (unlikely(test_bit(TFW_CONN_B_DEL, &srv_conn->flags)))
+			tfw_http_conn_repair(conn);
 		__tfw_srv_conn_clear_restricted(srv_conn);
+
 		return;
 	}
 

--- a/tempesta_fw/http_match.h
+++ b/tempesta_fw/http_match.h
@@ -149,6 +149,19 @@ TfwHttpMatchRule *tfw_http_match_rule_new(TfwHttpMatchList *, size_t arg_len);
 	_c;								\
 })
 
+#define tfw_http_match_for_each(mlst, container, member, func) 		\
+({									\
+	int r = 0;							\
+	TfwHttpMatchRule *rule;					 	\
+	if (mlst)							\
+		list_for_each_entry(rule, &mlst->list, list) {		\
+			r = func(container_of(rule, container, member));\
+			if (r)						\
+				break;					\
+		}							\
+	r;								\
+})
+
 void tfw_http_match_rule_init(TfwHttpMatchRule *rule, tfw_http_match_fld_t field,
 	tfw_http_match_op_t op, tfw_http_match_arg_t type, const char *arg);
 

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -776,6 +776,8 @@ tfw_cfgop_sess_lifetime(TfwCfgSpec *cs, TfwCfgEntry *ce)
 static int
 tfw_http_sess_start(void)
 {
+	if (tfw_runstate_is_reconfig())
+		return 0;
 	tfw_cfg_sticky.enabled = !TFW_STR_EMPTY(&tfw_cfg_sticky.name);
 
 	return 0;
@@ -784,6 +786,8 @@ tfw_http_sess_start(void)
 static void
 tfw_http_sess_stop(void)
 {
+	if (tfw_runstate_is_reconfig())
+		return;
 	tfw_cfg_sticky.enabled = 0;
 }
 

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -661,7 +661,7 @@ __try_conn(TfwMsg *msg, TfwSrvConn *srv_conn)
 	 * server group, see comment for TfwStickyConn.
 	 */
 	srv = (TfwServer *)srv_conn->peer;
-	return (srv->sg) ? srv->sg->sched->sched_srv_conn(msg, srv) : NULL;
+	return srv->sg->sched->sched_srv_conn(msg, srv);
 }
 
 /**

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -747,13 +747,13 @@ tfw_http_sess_get_srv_conn(TfwMsg *msg)
 				tfw_http_sess_set_expired(sess);
 				goto err;
 			}
-			TFW_ERR("sticky sched: pinned server %s in group %s"
-				"is down\n",
+			TFW_ERR("sticky sched: pinned server %s in group '%s'"
+				" is down\n",
 				addr_str, srv->sg->name);
 			goto err;
 		}
-		TFW_WARN("sticky sched: pinned server %s in group %s"
-			 "is down, try find other server\n",
+		TFW_WARN("sticky sched: pinned server %s in group '%s'"
+			 " is down, try find other server\n",
 			 addr_str, srv->sg->name);
 	}
 

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -34,7 +34,7 @@
  *
  * 2. Session pinning is switched to 'disable'. Keep using pinned server until
  * session is expired. (Alternative: unpin sesion from a server and use generic
- * scheduling algorythm.)
+ * scheduling algorithm.)
  *
  * 3. A new server is added to main/backup group. New sessions will be
  * eventually pinned to the server.

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -23,18 +23,43 @@
 #include "http.h"
 
 /**
- * Connection, servicing HTTP session.
+ * HTTP session pinning.
+ *
+ * An HTTP session may be pinned to a server from main or backup group
+ * according to a match rules defined in HTTP scheduler. But when live
+ * reconfiguration happens, the next situations may appear:
+ *
+ * 1. Session pinning is switched to 'enable'. Nothing special, use general
+ * scheduling routine to obtain target server and pin the session to it.
+ *
+ * 2. Session pinning is switched to 'disable'. Keep using pinned server until
+ * session is expired. (Alternative: unpin sesion from a server and use generic
+ * scheduling algorythm.)
+ *
+ * 3. A new server is added to main/backup group. New sessions will be
+ * eventually pinned to the server.
+ *
+ * 4. A server is removed from main/backup group. Re-pin sessions of that
+ * server to others using generic scheduling routine if allowed. Otherwise
+ * mark the session as expired, since the pinned server instance will never
+ * go up.
+ *
+ * 5. Main and backup group is removed from new configuration. Same as p. 4.
+ *
+ * 6. Main and backup group are no more interchangeable; according to the new
+ * HTTP match rules sessions must be pinned to complitely other server groups.
+ * This cases cannot be deduced during live reconfiguration, manual session
+ * removing is required. End user should avoid such configurations.
  *
  * @srv_conn	- last used connection;
- * @main_sg	- primary server group to schedule connection on failovering;
- * @backup_sg	- backup server group;
  * @lock	- protects whole @TfwStickyConn;
+ * @flags	- sticky flags: TFW_SRV_STICKY_FLAGS
+ *
  */
 typedef struct {
 	TfwSrvConn		*srv_conn;
-	TfwSrvGroup		*main_sg;
-	TfwSrvGroup		*backup_sg;
 	rwlock_t		lock;
+	unsigned int		flags;
 } TfwStickyConn;
 
 /**
@@ -63,20 +88,6 @@ void tfw_http_sess_put(TfwHttpSess *sess);
 /* Sticky sessions scheduling routines. */
 TfwSrvConn *tfw_http_sess_get_srv_conn(TfwMsg *msg);
 
-static inline void
-tfw_http_sess_save_sg(TfwHttpReq *req, TfwSrvGroup *main_sg,
-		      TfwSrvGroup *backup_sg)
-{
-	if (req->sess && (main_sg->flags & TFW_SRV_STICKY)) {
-		TfwStickyConn *st_conn = &req->sess->st_conn;
-
-		/*
-		 * @st_conn->lock is already acquired for writing, if called
-		 * during  @tfw_http_sess_get_srv_conn() routine.
-		 */
-		st_conn->main_sg = main_sg;
-		st_conn->backup_sg = backup_sg;
-	}
-}
+void tfw_http_sess_use_sticky_sess(bool use);
 
 #endif /* __TFW_HTTP_SESS_H__ */

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -53,13 +53,10 @@
  *
  * @srv_conn	- last used connection;
  * @lock	- protects whole @TfwStickyConn;
- * @flags	- sticky flags: TFW_SRV_STICKY_FLAGS
- *
  */
 typedef struct {
 	TfwSrvConn		*srv_conn;
 	rwlock_t		lock;
-	unsigned int		flags;
 } TfwStickyConn;
 
 /**

--- a/tempesta_fw/main.c
+++ b/tempesta_fw/main.c
@@ -28,6 +28,7 @@
 #include "log.h"
 #include "str.h"
 #include "sync_socket.h"
+#include "server.h"
 
 MODULE_AUTHOR(TFW_AUTHOR);
 MODULE_DESCRIPTION(TFW_NAME);
@@ -119,6 +120,7 @@ tfw_cleanup(struct list_head *mod_list)
 	 */
 	ss_synchronize();
 	tfw_cfg_cleanup(mod_list);
+	tfw_sg_wait_release();
 }
 
 static inline void

--- a/tempesta_fw/main.c
+++ b/tempesta_fw/main.c
@@ -290,6 +290,7 @@ tfw_init(void)
 		return -1;
 	}
 
+	/* The order of initialization is highly important. */
 	DO_INIT(pool);
 	DO_INIT(cfg);
 	DO_INIT(apm);

--- a/tempesta_fw/main.c
+++ b/tempesta_fw/main.c
@@ -167,17 +167,17 @@ tfw_mods_start(struct list_head *mod_list)
 }
 
 static int
-tfw_mods_cfgfin(struct list_head *mod_list)
+tfw_mods_cfgend(struct list_head *mod_list)
 {
 	int ret;
 	TfwMod *mod;
 
 	TFW_DBG2("Completing the configuration processing...\n");
 	MOD_FOR_EACH(mod, mod_list) {
-		if (!mod->cfgfin)
+		if (!mod->cfgend)
 			continue;
-		TFW_DBG2("mod_cfgfin(): %s\n", mod->name);
-		if ((ret = mod->cfgfin())) {
+		TFW_DBG2("mod_cfgend(): %s\n", mod->name);
+		if ((ret = mod->cfgend())) {
 			TFW_ERR("Unable to complete the configuration "
 				"of module '%s': %d\n", mod->name, ret);
 			return ret;
@@ -196,7 +196,7 @@ tfw_start(struct list_head *mod_list)
 	ss_start();
 	if ((ret = tfw_cfg_parse(mod_list)))
 		goto cleanup;
-	if ((ret = tfw_mods_cfgfin(mod_list)))
+	if ((ret = tfw_mods_cfgend(mod_list)))
 		goto stop_mods;
 	if ((ret = tfw_mods_start(mod_list)))
 		goto stop_mods;

--- a/tempesta_fw/main.c
+++ b/tempesta_fw/main.c
@@ -161,7 +161,7 @@ tfw_mods_cfgstart(struct list_head *mod_list)
 			return ret;
 		}
 	}
-	TFW_LOG("Prepearing fot the configuration processing.\n");
+	TFW_LOG("Prepearing for the configuration processing.\n");
 
 	return 0;
 }

--- a/tempesta_fw/main.c
+++ b/tempesta_fw/main.c
@@ -41,31 +41,137 @@ size_t  exit_hooks_n;
 DEFINE_MUTEX(tfw_sysctl_mtx);
 static bool tfw_started = false;
 
+/*
+ * The global list of all registered modules
+ * (consists of TfwMod{} objects).
+ */
+static LIST_HEAD(tfw_mods);
+static DEFINE_RWLOCK(tfw_mods_lock);
+
+/**
+ * Add @mod to the global list of registered modules.
+ *
+ * After the registration the module will start receiving
+ * start/stop/setup/cleanup events and configuration updates.
+ */
+void
+tfw_mod_register(TfwMod *mod)
+{
+	BUG_ON(!mod || !mod->name);
+	TFW_DBG2("%s: %s\n", __func__, mod->name);
+
+	write_lock(&tfw_mods_lock);
+	INIT_LIST_HEAD(&mod->list);
+	list_add_tail(&mod->list, &tfw_mods);
+	write_unlock(&tfw_mods_lock);
+}
+EXPORT_SYMBOL(tfw_mod_register);
+
+/**
+ * Remove the @mod from the global list.
+ */
+void
+tfw_mod_unregister(TfwMod *mod)
+{
+	BUG_ON(!mod || !mod->name);
+	TFW_DBG2("%s: %s\n", __func__, mod->name);
+
+	write_lock(&tfw_mods_lock);
+	list_del(&mod->list);
+	write_unlock(&tfw_mods_lock);
+}
+EXPORT_SYMBOL(tfw_mod_unregister);
+
+TfwMod *
+tfw_mod_find(const char *name)
+{
+	TfwMod *mod;
+
+	read_lock(&tfw_mods_lock);
+	list_for_each_entry(mod, &tfw_mods, list) {
+		if (!name || !strcasecmp(name, mod->name)) {
+			read_unlock(&tfw_mods_lock);
+			return mod;
+		}
+	}
+	read_unlock(&tfw_mods_lock);
+
+	return NULL;
+}
+
+static void
+tfw_stop(struct list_head *mod_list)
+{
+	TfwMod *mod;
+
+	ss_stop();
+
+	TFW_LOG("Stopping all modules...\n");
+	MOD_FOR_EACH_REVERSE(mod, mod_list)
+		if (mod->stop)
+			mod->stop();
+
+	/*
+	 * Wait until all network activity is stopped
+	 * before data in modules can be cleaned up safely.
+	 */
+	ss_synchronize();
+
+	tfw_cfg_stop(mod_list);
+}
+
+static int
+tfw_start_mods(struct list_head *mod_list)
+{
+	int ret;
+	TfwMod *mod;
+
+	TFW_DBG2("starting modules...\n");
+	MOD_FOR_EACH(mod, mod_list) {
+		if (!mod->start)
+			continue;
+		TFW_DBG2("mod_start(): %s\n", mod->name);
+		if ((ret = mod->start())) {
+			TFW_ERR("Unable to start module '%s': %d\n",
+				mod->name, ret);
+			tfw_stop(mod_list);
+			return ret;
+		}
+	}
+
+	TFW_LOG("modules are started\n");
+	return 0;
+}
+
+static int
+tfw_start(struct list_head *mod_list)
+{
+	int ret;
+
+	ss_start();
+	if ((ret = tfw_cfg_start(mod_list)))
+		return ret;
+	return tfw_start_mods(mod_list);
+}
+
 /**
  * Process command received from sysctl as string (either "start" or "stop").
  * Do corresponding actions, but only if the state is changed.
  */
 static int
-handle_state_change(const char *old_state, const char *new_state)
+tfw_ctlfn_state_change(const char *old_state, const char *new_state)
 {
 	TFW_DBG2("got state via sysctl: %s\n", new_state);
-
-	if (!strcasecmp(old_state, new_state)) {
-		TFW_DBG2("the state '%s' isn't changed, nothing to do\n",
-			 new_state);
-		return 0;
-	}
 
 	if (!strcasecmp("start", new_state)) {
 		int r;
 
 		if (READ_ONCE(tfw_started)) {
-			TFW_WARN("Trying to start running system\n");
+			TFW_WARN("Trying to start a running system\n");
 			return -EINVAL;
 		}
 
-		ss_start();
-		if (!(r = tfw_cfg_start()))
+		if (!(r = tfw_start(&tfw_mods)))
 			WRITE_ONCE(tfw_started, true);
 
 		return r;
@@ -73,12 +179,11 @@ handle_state_change(const char *old_state, const char *new_state)
 
 	if (!strcasecmp("stop", new_state)) {
 		if (!READ_ONCE(tfw_started)) {
-			TFW_WARN("Trying to stop inactive system\n");
+			TFW_WARN("Trying to stop an inactive system\n");
 			return -EINVAL;
 		}
 
-		ss_stop();
-		tfw_cfg_stop();
+		tfw_stop(&tfw_mods);
 		WRITE_ONCE(tfw_started, false);
 
 		return 0;
@@ -94,8 +199,8 @@ handle_state_change(const char *old_state, const char *new_state)
  * Syctl handler for tempesta.state read/write operations.
  */
 static int
-handle_sysctl_state_io(struct ctl_table *ctl, int is_write,
-		       void __user *user_buf, size_t *lenp, loff_t *ppos)
+tfw_ctlfn_state_io(struct ctl_table *ctl, int is_write,
+		   void __user *user_buf, size_t *lenp, loff_t *ppos)
 {
 	int r = 0;
 
@@ -115,7 +220,7 @@ handle_sysctl_state_io(struct ctl_table *ctl, int is_write,
 		new_state = strim(new_state_buf);
 		old_state = ctl->data;
 
-		r = handle_state_change(old_state, new_state);
+		r = tfw_ctlfn_state_change(old_state, new_state);
 		if (r)
 			goto out;
 	}
@@ -134,9 +239,9 @@ static struct ctl_table tfw_sysctl_tbl[] = {
 		.data		= tfw_sysctl_state_buf,
 		.maxlen		= sizeof(tfw_sysctl_state_buf) - 1,
 		.mode		= 0644,
-		.proc_handler	= handle_sysctl_state_io,
+		.proc_handler	= tfw_ctlfn_state_io,
 	},
-	{}
+	{ 0 }
 };
 
 #define DO_INIT(mod)						\
@@ -152,14 +257,6 @@ do {								\
 		goto err;					\
 	}							\
 	exit_hooks[exit_hooks_n++] = tfw_##mod##_exit;		\
-} while (0)
-
-#define DO_CFG_REG(mod)						\
-do {								\
-	extern TfwCfgMod tfw_##mod##_cfg_mod;			\
-	r = tfw_cfg_mod_register(&tfw_##mod##_cfg_mod);		\
-	if (r)							\
-		goto err;					\
 } while (0)
 
 static void
@@ -195,10 +292,12 @@ tfw_init(void)
 
 	DO_INIT(pool);
 	DO_INIT(cfg);
-	DO_INIT(procfs);
+	DO_INIT(apm);
 	DO_INIT(vhost);
 
 	DO_INIT(classifier);
+	DO_INIT(filter);
+	DO_INIT(cache);
 
 	/* Register TLS before HTTP, so HTTP FSM can register TLS hooks. */
 	DO_INIT(tls);
@@ -210,16 +309,7 @@ tfw_init(void)
 	DO_INIT(client);
 	DO_INIT(sock_srv);
 	DO_INIT(sock_clnt);
-
-	DO_CFG_REG(apm);
-	DO_CFG_REG(tls);
-	DO_CFG_REG(vhost);
-	DO_CFG_REG(filter);
-	DO_CFG_REG(cache);
-	DO_CFG_REG(http_sess);
-	DO_CFG_REG(sock_srv);
-	DO_CFG_REG(sock_clnt);
-	DO_CFG_REG(procfs);
+	DO_INIT(procfs);
 
 	return 0;
 err:

--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -273,6 +273,8 @@ tfw_procfs_start(void)
 		.psz = ARRAY_SIZE(tfw_pstats_ith)
 	};
 
+	if (tfw_runstate_is_reconfig())
+		return 0;
 	if (!tfw_procfs_tempesta)
 		return -ENOENT;
 	if (tfw_apm_pstats_verify(&pstats))
@@ -291,6 +293,8 @@ tfw_procfs_start(void)
 static void
 tfw_procfs_stop(void)
 {
+	if (tfw_runstate_is_reconfig())
+		return;
 	remove_proc_subtree("servers", tfw_procfs_tempesta);
 }
 

--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -265,7 +265,7 @@ tfw_procfs_srv_create(TfwServer *srv)
 }
 
 static int
-tfw_procfs_cfgfin(void)
+tfw_procfs_cfgend(void)
 {
 	int ret;
 	TfwPrcntlStats pstats = {
@@ -314,7 +314,7 @@ static TfwCfgSpec tfw_procfs_specs[] = {
 
 TfwMod tfw_procfs_mod = {
         .name	= "procfs",
-        .cfgfin	= tfw_procfs_cfgfin,
+        .cfgend	= tfw_procfs_cfgend,
         .start	= tfw_procfs_start,
         .stop	= tfw_procfs_stop,
 	.specs	= tfw_procfs_specs,

--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -265,7 +265,7 @@ tfw_procfs_srv_create(TfwServer *srv)
 }
 
 static int
-tfw_procfs_cfg_start(void)
+tfw_procfs_start(void)
 {
 	int i, ret;
 	TfwPrcntlStats pstats = {
@@ -289,20 +289,20 @@ tfw_procfs_cfg_start(void)
 }
 
 static void
-tfw_procfs_cfg_stop(void)
+tfw_procfs_stop(void)
 {
 	remove_proc_subtree("servers", tfw_procfs_tempesta);
 }
 
-static TfwCfgSpec tfw_procfs_cfg_specs[] = {
-	{},
+static TfwCfgSpec tfw_procfs_specs[] = {
+	{ 0 },
 };
 
-TfwCfgMod tfw_procfs_cfg_mod = {
-        .name  = "procfs",
-        .start = tfw_procfs_cfg_start,
-        .stop  = tfw_procfs_cfg_stop,
-	.specs = tfw_procfs_cfg_specs,
+TfwMod tfw_procfs_mod = {
+        .name	= "procfs",
+        .start	= tfw_procfs_start,
+        .stop	= tfw_procfs_stop,
+	.specs	= tfw_procfs_specs,
 };
 
 /*
@@ -329,6 +329,8 @@ tfw_procfs_init(void)
 	if (!tfw_procfs_perfstat)
 		goto out_tempesta;
 
+	tfw_mod_register(&tfw_procfs_mod);
+
 	return 0;
 
 out:
@@ -341,6 +343,7 @@ out_tempesta:
 void
 tfw_procfs_exit(void)
 {
+	tfw_mod_unregister(&tfw_procfs_mod);
 	remove_proc_entry("perfstat", tfw_procfs_tempesta);
 	remove_proc_entry("tempesta", NULL);
 }

--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -277,7 +277,7 @@ tfw_procfs_cfgend(void)
 		return 0;
 	if (tfw_apm_pstats_verify(&pstats))
 		return -EINVAL;
-	if ((ret = tfw_sg_for_each_srv(true, tfw_procfs_srv_collect)) != 0)
+	if ((ret = tfw_sg_for_each_srv_reconfig(tfw_procfs_srv_collect)) != 0)
 		return ret;
 	return 0;
 }

--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -277,7 +277,7 @@ tfw_procfs_cfgend(void)
 		return 0;
 	if (tfw_apm_pstats_verify(&pstats))
 		return -EINVAL;
-	if ((ret = tfw_sg_for_each_srv(tfw_procfs_srv_collect)) != 0)
+	if ((ret = tfw_sg_for_each_srv(true, tfw_procfs_srv_collect)) != 0)
 		return ret;
 	return 0;
 }

--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -198,6 +198,8 @@ tfw_srvstats_seq_show(struct seq_file *seq, void *off)
 			rc++;
 	}
 
+	seq_printf(seq, "Total pinned sessions\t\t: %zd\n",
+			atomic64_read(&srv->sess_n));
 	seq_printf(seq, "Total schedulable connections\t: %zd\n",
 			srv->conn_n - rc);
 	seq_printf(seq, "Maximum forwarding queue size\t: %u\n",

--- a/tempesta_fw/sched.c
+++ b/tempesta_fw/sched.c
@@ -51,16 +51,17 @@ tfw_sched_get_sg_srv_conn(TfwMsg *msg, TfwSrvGroup *main_sg,
 			  TfwSrvGroup *backup_sg)
 {
 	TfwHttpReq *req = (TfwHttpReq *)msg;
-	TfwSrvConn *srv_conn;
+	TfwSrvConn *srv_conn = NULL;
 
 	BUG_ON(!main_sg);
 	TFW_DBG2("sched: use server group: '%s'\n", main_sg->name);
 
 	tfw_http_sess_save_sg(req, main_sg, backup_sg);
 
-	srv_conn = main_sg->sched->sched_sg_conn(msg, main_sg);
+	if (likely(main_sg->sched))
+		srv_conn = main_sg->sched->sched_sg_conn(msg, main_sg);
 
-	if (unlikely(!srv_conn && backup_sg)) {
+	if (unlikely(!srv_conn && backup_sg && backup_sg->sched)) {
 		TFW_DBG("sched: the main group is offline, use backup: '%s'\n",
 			backup_sg->name);
 		srv_conn = backup_sg->sched->sched_sg_conn(msg, backup_sg);

--- a/tempesta_fw/sched/tfw_sched_hash.c
+++ b/tempesta_fw/sched/tfw_sched_hash.c
@@ -332,7 +332,7 @@ tfw_sched_hash_add_grp(TfwSrvGroup *sg, void *data)
 			+ sizeof(TfwHashConn) * conn_n * 2;
 	if (!(cl = kzalloc(size, GFP_KERNEL)))
 		return -ENOMEM;
-	if (!(srv_cls = kcalloc(sg->srv_n, sizeof(TfwHashSrvConnList *),
+	if (!(srv_cls = kcalloc(sg->srv_n, sizeof(TfwHashSrvConnList),
 				GFP_KERNEL))) {
 		kfree(cl);
 		return -ENOMEM;

--- a/tempesta_fw/sched/tfw_sched_hash.c
+++ b/tempesta_fw/sched/tfw_sched_hash.c
@@ -243,7 +243,7 @@ static void
 tfw_sched_hash_del_grp(TfwSrvGroup *sg)
 {
 	TfwServer *srv;
-	TfwHashConnList *cl = sg->sched_data;
+	TfwHashConnList *cl = rcu_dereference(sg->sched_data);
 
 	list_for_each_entry(srv, &sg->srv_list, list)
 		rcu_assign_pointer(srv->sched_data, NULL);

--- a/tempesta_fw/sched/tfw_sched_hash.c
+++ b/tempesta_fw/sched/tfw_sched_hash.c
@@ -333,7 +333,8 @@ tfw_sched_hash_add_grp(TfwSrvGroup *sg, void *data)
 	if (!(cl = kzalloc(size, GFP_KERNEL)))
 		return -ENOMEM;
 	if (!(srv_cls = kcalloc(sg->srv_n, sizeof(TfwHashSrvConnList),
-				GFP_KERNEL))) {
+				GFP_KERNEL)))
+	{
 		kfree(cl);
 		return -ENOMEM;
 	}

--- a/tempesta_fw/sched/tfw_sched_hash.c
+++ b/tempesta_fw/sched/tfw_sched_hash.c
@@ -287,6 +287,10 @@ __add_conn(TfwHashConnList *cl, TfwSrvConn *conn, unsigned long hash)
 	return 0;
 }
 
+/**
+ * Fill per-server sched_data according to sched_data of the entire server
+ * group.
+ */
 static void
 __fill_srv_lists(TfwHashConnList *cl, size_t srv_n, TfwHashSrvConnList *srv_cls)
 {
@@ -335,6 +339,10 @@ tfw_sched_hash_add_grp(TfwSrvGroup *sg, void *data)
 	}
 	offset = sizeof(TfwHashConnList) + sizeof(TfwHashConn) * conn_n;
 
+	/*
+	 * The add_group() function can be called during live reconfiguration,
+	 * assign srv->sched_data after the data is fully prepared and valid.
+	 */
 	list_for_each_entry(srv, &sg->srv_list, list) {
 		TfwSrvConn *conn;
 		unsigned long srv_hash = __calc_srv_hash(srv);

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -382,7 +382,7 @@ tfw_cfgop_cleanup_rules(TfwCfgSpec *cs)
 	tfw_http_match_list_free(tfw_rules_reconfig);
 	tfw_rules_reconfig = NULL;
 
-	if (tfw_runstate_is_reconfig())
+	if (!tfw_runstate_is_reconfig())
 		tfw_cfgop_replace_active_rules(NULL);
 }
 

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -96,6 +96,34 @@ static TfwHttpMatchList __rcu *tfw_rules;
 /* Reconfig HTTP Scheduler rules. */
 static TfwHttpMatchList *tfw_rules_reconfig;
 
+/**
+ * Find connection for a message @msg in @main_sg or @backup_sg server groups.
+ */
+static TfwSrvConn *
+tfw_sched_get_sg_srv_conn(TfwMsg *msg, TfwSrvGroup *main_sg,
+			  TfwSrvGroup *backup_sg)
+{
+	TfwSrvConn *srv_conn = NULL;
+
+	BUG_ON(!main_sg);
+	TFW_DBG2("sched: use server group: '%s'\n", main_sg->name);
+
+	if (likely(main_sg->sched))
+		srv_conn = main_sg->sched->sched_sg_conn(msg, main_sg);
+
+	if (unlikely(!srv_conn && backup_sg && backup_sg->sched)) {
+		TFW_DBG("sched: the main group is offline, use backup: '%s'\n",
+			backup_sg->name);
+		srv_conn = backup_sg->sched->sched_sg_conn(msg, backup_sg);
+	}
+
+	if (unlikely(!srv_conn))
+		TFW_DBG2("sched: Unable to select server from group '%s'\n",
+			 backup_sg ? backup_sg->name : main_sg->name);
+
+	return srv_conn;
+}
+
 /*
  * Find a connection for an outgoing HTTP request.
  *

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -337,7 +337,7 @@ static TfwMod tfw_sched_http_mod;
 static TfwCfgSpec tfw_sched_http_rules_specs[];
 
 static int
-tfw_sched_http_start(void)
+tfw_sched_http_cfgfin(void)
 {
 	TfwHttpMatchRule *mrule;
 	TfwSrvGroup *sg_default;
@@ -423,7 +423,7 @@ static TfwCfgSpec tfw_sched_http_specs[] = {
 
 static TfwMod tfw_sched_http_mod = {
 	.name	= "tfw_sched_http",
-	.start	= tfw_sched_http_start,
+	.cfgfin	= tfw_sched_http_cfgfin,
 	.specs	= tfw_sched_http_specs,
 };
 

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -262,7 +262,7 @@ tfw_cfgop_match(TfwCfgSpec *cs, TfwCfgEntry *e)
 	in_arg = e->vals[3];
 	in_backup_sg = tfw_cfg_get_attr(e, "backup", NULL);
 
-	main_sg = tfw_sg_lookup(in_main_sg);
+	main_sg = tfw_sg_lookup_reconfig(in_main_sg);
 	if (!main_sg) {
 		TFW_ERR_NL("sched_http: srv_group is not found: '%s'\n",
 			   in_main_sg);
@@ -272,7 +272,7 @@ tfw_cfgop_match(TfwCfgSpec *cs, TfwCfgEntry *e)
 	if (!in_backup_sg) {
 		backup_sg = NULL;
 	} else {
-		backup_sg = tfw_sg_lookup(in_backup_sg);
+		backup_sg = tfw_sg_lookup_reconfig(in_backup_sg);
 		if (!backup_sg) {
 			TFW_ERR_NL("sched_http: backup srv_group is not found:"
 				   " '%s'\n", in_backup_sg);
@@ -401,7 +401,7 @@ tfw_sched_http_cfgend(void)
 	 * No default rule specified in the configuration, but there's no
 	 * group 'default' so we would have nowhere to point this rule to.
 	 */
-	if ((sg_default = tfw_sg_lookup("default")) == NULL)
+	if ((sg_default = tfw_sg_lookup_reconfig("default")) == NULL)
 		return 0;
 
 	/*

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -337,7 +337,7 @@ static TfwMod tfw_sched_http_mod;
 static TfwCfgSpec tfw_sched_http_rules_specs[];
 
 static int
-tfw_sched_http_cfgfin(void)
+tfw_sched_http_cfgend(void)
 {
 	TfwHttpMatchRule *mrule;
 	TfwSrvGroup *sg_default;
@@ -423,7 +423,7 @@ static TfwCfgSpec tfw_sched_http_specs[] = {
 
 static TfwMod tfw_sched_http_mod = {
 	.name	= "tfw_sched_http",
-	.cfgfin	= tfw_sched_http_cfgfin,
+	.cfgend	= tfw_sched_http_cfgend,
 	.specs	= tfw_sched_http_specs,
 };
 

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -100,8 +100,8 @@ static TfwHttpMatchList *tfw_rules_reconfig;
  * Find connection for a message @msg in @main_sg or @backup_sg server groups.
  */
 static TfwSrvConn *
-tfw_sched_get_sg_srv_conn(TfwMsg *msg, TfwSrvGroup *main_sg,
-			  TfwSrvGroup *backup_sg)
+tfw_sched_http_get_srv_conn(TfwMsg *msg, TfwSrvGroup *main_sg,
+			    TfwSrvGroup *backup_sg)
 {
 	TfwSrvConn *srv_conn = NULL;
 
@@ -150,8 +150,8 @@ tfw_sched_http_sched_grp(TfwMsg *msg)
 		goto done;
 	}
 
-	srv_conn = tfw_sched_get_sg_srv_conn(msg, rule->main_sg,
-					     rule->backup_sg);
+	srv_conn = tfw_sched_http_get_srv_conn(msg, rule->main_sg,
+					       rule->backup_sg);
 done:
 	rcu_read_unlock();
 	return srv_conn;

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -347,6 +347,8 @@ tfw_sched_http_start(void)
 	static const char cfg_text[] =
 		"sched_http_rules {\nmatch default * * *;\n}\n";
 
+	if (tfw_runstate_is_reconfig())
+		return 0;
 	/*
 	 * See if we need to add a default rule that forwards all
 	 * requests that do not match any rule to group 'default'.
@@ -386,7 +388,7 @@ tfw_sched_http_start(void)
 	cfg_spec = tfw_cfg_spec_find(sched_mod.specs, "sched_http_rules");
 	cfg_spec->allow_repeat = true;
 
-	if (tfw_cfg_parse_mods_cfg(cfg_text, &mod_list))
+	if (tfw_cfg_parse_mods(cfg_text, &mod_list))
 		return -EINVAL;
 
 	return 0;

--- a/tempesta_fw/sched/tfw_sched_ratio.c
+++ b/tempesta_fw/sched/tfw_sched_ratio.c
@@ -989,7 +989,7 @@ tfw_sched_ratio_cleanup(TfwRatio *ratio)
 static void
 tfw_sched_ratio_del_grp(TfwSrvGroup *sg)
 {
-	TfwRatio *ratio = sg->sched_data;
+	TfwRatio *ratio = rcu_dereference(sg->sched_data);
 
 	rcu_assign_pointer(sg->sched_data, NULL);
 	synchronize_rcu();

--- a/tempesta_fw/sched/tfw_sched_ratio.c
+++ b/tempesta_fw/sched/tfw_sched_ratio.c
@@ -990,8 +990,11 @@ static void
 tfw_sched_ratio_del_grp(TfwSrvGroup *sg)
 {
 	TfwRatio *ratio = rcu_dereference(sg->sched_data);
+	TfwServer *srv;
 
 	rcu_assign_pointer(sg->sched_data, NULL);
+	list_for_each_entry(srv, &sg->srv_list, list)
+		rcu_assign_pointer(srv->sched_data, NULL);
 	synchronize_rcu();
 	if (!ratio)
 		return;
@@ -1174,7 +1177,7 @@ tfw_sched_ratio_add_grp_dynamic(TfwSrvGroup *sg, void *arg)
 		mod_timer(&ratio->timer, jiffies + ratio->intvl);
 	}
 
-	return 0;
+	return ratio;
 
 cleanup:
 	tfw_sched_ratio_cleanup(ratio);

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -523,25 +523,17 @@ __tfw_sg_release_all_reconfig(void)
 
 /**
  * Wait until all server groups and server are destructed. The function is
- * called after ss_synchronize(): there is no active server connections.
- * The fuction is called after configuration cleanup: all references taken to
- * servers and groups are already released.
+ * called after ss_synchronize(): there shouldn't be any active server
+ * connections, but this is still possible. The fuction is called after
+ * configuration cleanup: all references taken to servers and groups are
+ * already released.
  */
 void
 tfw_sg_wait_release(void)
 {
 	unsigned long tend = jiffies + HZ * 5;
-	bool warn = true;
 
 	might_sleep();
-	while (time_is_after_eq_jiffies(tfw_sg_grace_shutdown_finish())) {
-		if (warn) {
-			TFW_WARN_NL("wait for servers to complete grace shutdown"
-				    "\n");
-			warn = false;
-		}
-		schedule();
-	}
 	/*
 	 * Wait until all server groups will be destroyed, otherwise a crash is
 	 * a matter of time.

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -208,7 +208,7 @@ tfw_sg_apply_reconfig(struct list_head *del_sg)
 /**
  * Clear reconfig group list.
  *
- *  This function is called when configuration processing is failed. Simply
+ * This function is called when configuration processing is failed. Simply
  * clean reconfig list, sock_srv.c is responsible to remove all groups
  * added to the list.
  */

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -340,6 +340,25 @@ __tfw_sg_for_each_srv(TfwSrvGroup *sg, int (*cb)(TfwServer *srv))
 }
 
 /**
+ * Iterate over all the acive server groups and call @cb for each server group.
+ * @cb is called under spin-lock, so can't sleep.
+ * @cb is considered as updater, so write lock is used.
+ */
+int
+tfw_sg_for_each_sg(int (*cb)(TfwSrvGroup *sg))
+{
+	int ret = 0;
+	TfwSrvGroup *sg;
+
+	write_lock(&sg_lock);
+	list_for_each_entry(sg, &sg_list, list)
+		if ((ret = cb(sg)))
+			break;
+	write_unlock(&sg_lock);
+	return ret;
+}
+
+/**
  * Iterate over all the acive server groups and call @cb for each server.
  * @cb is called under spin-lock, so can't sleep.
  * @cb is considered as updater, so write lock is used.

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -375,7 +375,7 @@ tfw_sg_stop_sched(TfwSrvGroup *sg)
 }
 
 /**
- * Iterate over all server groups of given server grop @sg and call @cb for
+ * Iterate over all servers of given server group @sg and call @cb for
  * each server.
  * @cb is called under spin-lock, so can't sleep.
  * @cb is considered as updater, so write lock is used.
@@ -395,7 +395,7 @@ __tfw_sg_for_each_srv(TfwSrvGroup *sg, int (*cb)(TfwServer *srv))
 }
 
 /**
- * Iterate over all the acive server groups and call @cb for each server group.
+ * Iterate over all the active server groups and call @cb for each server group.
  * @cb is called under spin-lock, so can't sleep.
  * @cb is considered as updater, so write lock is used.
  */

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -206,6 +206,24 @@ tfw_sg_apply_reconfig(struct list_head *del_sg)
 }
 
 /**
+ * Clear reconfig group list.
+ *
+ *  This function is called when configuration processing is failed. Simply
+ * clean reconfig list, sock_srv.c is responsible to remove all groups
+ * added to the list.
+ */
+void
+tfw_sg_drop_reconfig(void)
+{
+	TfwSrvGroup *sg, *tmp;
+
+	write_lock(&sg_lock);
+	list_for_each_entry_safe(sg, tmp, &sg_list_reconfig, list_reconfig)
+		list_del_init(&sg->list_reconfig);
+	write_unlock(&sg_lock);
+}
+
+/**
  * Remove a Server Group from the list.
  * This function is called only on configuration processing.
  */

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -288,7 +288,10 @@ void
 tfw_sg_del_srv(TfwSrvGroup *sg, TfwServer *srv)
 {
 	BUG_ON(srv->sg != sg);
-	srv->sg = NULL;
+	/*
+	 * Don't remove srv->sg reference, it's not supposed, that a server can
+	 * change it's group on the fly.
+	*/
 
 	TFW_DBG2("Remove backend server from group '%s'\n", sg->name);
 	write_lock(&sg->lock);

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -96,14 +96,14 @@ tfw_server_lookup(TfwSrvGroup *sg, TfwAddr *addr)
 {
 	TfwServer *srv;
 
-	write_lock(&sg->lock);
+	read_lock(&sg->lock);
 	list_for_each_entry(srv, &sg->srv_list, list)
 		if (tfw_addr_eq(&srv->addr, addr)) {
 			tfw_server_get(srv);
-			write_unlock(&sg->lock);
+			read_unlock(&sg->lock);
 			return srv;
 		}
-	write_unlock(&sg->lock);
+	read_unlock(&sg->lock);
 
 	return NULL;
 }
@@ -456,7 +456,7 @@ void
 tfw_sg_destroy(TfwSrvGroup *sg)
 {
 	TFW_DBG2("release group: '%s'\n", sg->name);
-	BUG_ON(!list_empty(&sg->srv_list));
+	WARN_ON(!list_empty(&sg->srv_list));
 
 	kfree(sg);
 	atomic64_dec(&act_sg_n);

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -194,7 +194,7 @@ tfw_sg_add_srv(TfwSrvGroup *sg, TfwServer *srv)
 }
 
 int
-tfw_sg_set_sched(TfwSrvGroup *sg, const char *sched_name)
+tfw_sg_set_sched(TfwSrvGroup *sg, const char *sched_name, void *arg)
 {
 	TfwScheduler *s = tfw_sched_lookup(sched_name);
 
@@ -203,7 +203,7 @@ tfw_sg_set_sched(TfwSrvGroup *sg, const char *sched_name)
 
 	sg->sched = s;
 	if (s->add_grp)
-		return s->add_grp(sg);
+		return s->add_grp(sg, arg);
 
 	return 0;
 }

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -44,7 +44,7 @@ static struct kmem_cache *srv_cache;
  * sock_srv.c
  *
  * The same server group instance may be listed in both sg_list and
- * sg_list_reconfig lists. That's why TfwSrvGroup has mambers .list and
+ * sg_list_reconfig lists. That's why TfwSrvGroup has members .list and
  * .list_reconfig.
  *
  * The list of active server groups may change only during configuration

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -127,8 +127,6 @@ typedef struct {
 #define TFW_SRV_STICKY_FLAGS		\
 	(TFW_SRV_STICKY | TFW_SRV_STICKY_FAILOVER)
 
-#define TFW_SG_F_DEL			0x8000	/* SG is to be removed. */
-
 /**
  * Requests scheduling algorithm handler.
  *
@@ -197,7 +195,8 @@ static inline bool
 tfw_srv_conn_need_resched(TfwSrvConn *srv_conn)
 {
 	TfwSrvGroup *sg = ((TfwServer *)srv_conn->peer)->sg;
-	return (ACCESS_ONCE(srv_conn->recns) >= sg->max_recns);
+	return ((ACCESS_ONCE(srv_conn->recns) >= sg->max_recns) ||
+		unlikely(test_bit(TFW_CONN_B_DEL, &srv_conn->flags)));
 }
 
 /* Server group routines. */

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -279,7 +279,6 @@ void tfw_sg_release(TfwSrvGroup *sg);
 void tfw_sg_release_all(void);
 void __tfw_sg_release_all_reconfig(void);
 void tfw_sg_wait_release(void);
-unsigned long tfw_sg_grace_shutdown_finish(void);
 
 static inline bool
 tfw_sg_live(TfwSrvGroup *sg)

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -190,12 +190,15 @@ tfw_srv_conn_need_resched(TfwSrvConn *srv_conn)
 /* Server group routines. */
 TfwSrvGroup *tfw_sg_lookup(const char *name);
 TfwSrvGroup *tfw_sg_new(const char *name, gfp_t flags);
+int tfw_sg_add(TfwSrvGroup *sg);
+void tfw_sg_del(TfwSrvGroup *sg);
 void tfw_sg_free(TfwSrvGroup *sg);
 unsigned int tfw_sg_count(void);
 
-void tfw_sg_add(TfwSrvGroup *sg, TfwServer *srv);
+void tfw_sg_add_srv(TfwSrvGroup *sg, TfwServer *srv);
 int tfw_sg_set_sched(TfwSrvGroup *sg, const char *sched);
 int tfw_sg_for_each_srv(int (*cb)(TfwServer *srv));
+void tfw_sg_release(TfwSrvGroup *sg);
 void tfw_sg_release_all(void);
 
 /* Scheduler routines. */

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -242,8 +242,7 @@ static inline bool
 tfw_srv_conn_need_resched(TfwSrvConn *srv_conn)
 {
 	TfwSrvGroup *sg = ((TfwServer *)srv_conn->peer)->sg;
-	return ((ACCESS_ONCE(srv_conn->recns) >= sg->max_recns) ||
-		unlikely(test_bit(TFW_CONN_B_DEL, &srv_conn->flags)));
+	return ((ACCESS_ONCE(srv_conn->recns) >= sg->max_recns));
 }
 
 /* Server group routines. */

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -208,6 +208,7 @@ void tfw_sg_del_srv(TfwSrvGroup *sg, TfwServer *srv);
 int tfw_sg_start_sched(TfwSrvGroup *sg, TfwScheduler *sched, void *arg);
 void tfw_sg_stop_sched(TfwSrvGroup *sg);
 int __tfw_sg_for_each_srv(TfwSrvGroup *sg, int (*cb)(TfwServer *srv));
+int tfw_sg_for_each_sg(int (*cb)(TfwSrvGroup *sg));
 int tfw_sg_for_each_srv(int (*cb)(TfwServer *srv));
 int tfw_sg_for_each_srv_reconfig(int (*cb)(TfwServer *srv));
 void tfw_sg_release(TfwSrvGroup *sg);

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -66,7 +66,9 @@ typedef struct {
  * Reverse proxy must define load balancing policy. Forward proxy must define
  * eviction policy. While both of them should define failovering policy.
  *
- * @list	- member pointer in the list of server groups;
+ * @list	- member pointer in the active server groups list;
+ * @list_reconfig - member pointer in the reconfig server groups list;
+ *		  See 'Server group management' comment in server.c;
  * @srv_list	- list of servers belonging to the group;
  * @lock	- synchronizes the group readers with updaters;
  * @sched	- requests scheduling handler;
@@ -191,10 +193,10 @@ tfw_srv_conn_need_resched(TfwSrvConn *srv_conn)
 }
 
 /* Server group routines. */
-TfwSrvGroup *__tfw_sg_lookup(const char *name, bool reconfig);
-#define	tfw_sg_lookup(name)	__tfw_sg_lookup(name, true)
+TfwSrvGroup *tfw_sg_lookup(const char *name);
+TfwSrvGroup *tfw_sg_lookup_reconfig(const char *name);
 TfwSrvGroup *tfw_sg_new(const char *name, gfp_t flags);
-int tfw_sg_add(TfwSrvGroup *sg);
+int tfw_sg_add_reconfig(TfwSrvGroup *sg);
 void tfw_sg_del(TfwSrvGroup *sg);
 void tfw_sg_free(TfwSrvGroup *sg);
 unsigned int tfw_sg_count(void);
@@ -205,10 +207,11 @@ void tfw_sg_del_srv(TfwSrvGroup *sg, TfwServer *srv);
 int tfw_sg_start_sched(TfwSrvGroup *sg, TfwScheduler *sched, void *arg);
 void tfw_sg_stop_sched(TfwSrvGroup *sg);
 int __tfw_sg_for_each_srv(TfwSrvGroup *sg, int (*cb)(TfwServer *srv));
-int tfw_sg_for_each_srv(bool reconfig, int (*cb)(TfwServer *srv));
+int tfw_sg_for_each_srv(int (*cb)(TfwServer *srv));
+int tfw_sg_for_each_srv_reconfig(int (*cb)(TfwServer *srv));
 void tfw_sg_release(TfwSrvGroup *sg);
 void tfw_sg_release_all(void);
-void tfw_sg_release_reconfig(void);
+void __tfw_sg_release_all_reconfig(void);
 
 /* Scheduler routines. */
 TfwSrvConn *tfw_sched_get_srv_conn(TfwMsg *msg);

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -148,6 +148,11 @@ typedef struct {
  * schedulers. Group schedulers can determine the target server group from
  * request's content (@sched_grp callback) and then get an outgoing
  * connection by calling @tfw_sched_get_sg_srv_conn().
+ *
+ * sched_*() methods can be called during live reconfiguration. Significant
+ * changes of a server group may ruin scheduling process, so the group must be
+ * removed from a scheduler before applying such changes. After that the group
+ * can be added to a scheduler once again.
  */
 struct tfw_scheduler_t {
 	const char		*name;

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -201,6 +201,7 @@ void tfw_sg_del(TfwSrvGroup *sg);
 void tfw_sg_free(TfwSrvGroup *sg);
 unsigned int tfw_sg_count(void);
 void tfw_sg_apply_reconfig(struct list_head *del_sg);
+void tfw_sg_drop_reconfig(void);
 
 void tfw_sg_add_srv(TfwSrvGroup *sg, TfwServer *srv);
 void tfw_sg_del_srv(TfwSrvGroup *sg, TfwServer *srv);

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -51,7 +51,7 @@ typedef struct {
 	TFW_PEER_COMMON;
 	struct list_head	list;
 	TfwSrvGroup		*sg;
-	void			*sched_data;
+	void __rcu		*sched_data;
 	void			*apmref;
 	unsigned int		weight;
 	size_t			conn_n;
@@ -82,7 +82,7 @@ struct tfw_srv_group_t {
 	struct list_head	srv_list;
 	rwlock_t		lock;
 	TfwScheduler		*sched;
-	void			*sched_data;
+	void __rcu		*sched_data;
 	size_t			srv_n;
 	unsigned int		max_qsize;
 	unsigned int		max_refwd;
@@ -147,7 +147,7 @@ typedef struct {
 struct tfw_scheduler_t {
 	const char		*name;
 	struct list_head	list;
-	int			(*add_grp)(TfwSrvGroup *sg);
+	int			(*add_grp)(TfwSrvGroup *sg, void *arg);
 	void			(*del_grp)(TfwSrvGroup *sg);
 	TfwSrvConn		*(*sched_grp)(TfwMsg *msg);
 	TfwSrvConn		*(*sched_sg_conn)(TfwMsg *msg, TfwSrvGroup *sg);
@@ -196,7 +196,7 @@ void tfw_sg_free(TfwSrvGroup *sg);
 unsigned int tfw_sg_count(void);
 
 void tfw_sg_add_srv(TfwSrvGroup *sg, TfwServer *srv);
-int tfw_sg_set_sched(TfwSrvGroup *sg, const char *sched);
+int tfw_sg_set_sched(TfwSrvGroup *sg, const char *sched, void *arg);
 int tfw_sg_for_each_srv(int (*cb)(TfwServer *srv));
 void tfw_sg_release(TfwSrvGroup *sg);
 void tfw_sg_release_all(void);

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -41,7 +41,7 @@ typedef struct tfw_scheduler_t TfwScheduler;
  * Server descriptor, a TfwPeer successor.
  *
  * @list	- member pointer in the list of servers of a server group;
- * @gs_timmer	- grace shutdown timer;
+ * @gs_timer	- grace shutdown timer;
  * @sg		- back-reference to the server group;
  * @sched_data	- private scheduler data for the server;
  * @apmref	- opaque handle for APM stats;

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -29,6 +29,7 @@
 #include "log.h"
 #include "procfs.h"
 #include "sync_socket.h"
+#include "tempesta_fw.h"
 #include "work_queue.h"
 
 typedef enum {
@@ -1493,7 +1494,12 @@ EXPORT_SYMBOL(ss_synchronize);
 void
 ss_start(void)
 {
-	/* Concurrent starts are synchronized at sysctl layer. */
+	/*
+	 * Concurrent starts are synchronized at sysctl layer.
+	 * Consecutive starts without stopping are for reconfiguration.
+	 */
+	if (tfw_runstate_is_reconfig())
+		return;
 	WRITE_ONCE(__ss_active, true);
 }
 EXPORT_SYMBOL(ss_start);
@@ -1501,6 +1507,8 @@ EXPORT_SYMBOL(ss_start);
 void
 ss_stop(void)
 {
+	if (tfw_runstate_is_reconfig())
+		return;
 	WRITE_ONCE(__ss_active, false);
 }
 EXPORT_SYMBOL(ss_stop);

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -433,7 +433,7 @@ int
 tfw_sock_check_listeners(void)
 {
 	TFW_DBG3("Call %s\n", __func__);
-	return tfw_sg_for_each_srv(true, tfw_sock_check_lst);
+	return tfw_sg_for_each_srv_reconfig(tfw_sock_check_lst);
 }
 
 /*

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -530,7 +530,7 @@ tfw_cfgop_cleanup_sock_clnt(TfwCfgSpec *cs)
 }
 
 static int
-tfw_sock_clnt_cfgfin(void)
+tfw_sock_clnt_cfgend(void)
 {
 	int r;
 
@@ -631,7 +631,7 @@ static TfwCfgSpec tfw_sock_clnt_specs[] = {
 
 TfwMod tfw_sock_clnt_mod  = {
 	.name	= "sock_clnt",
-	.cfgfin = tfw_sock_clnt_cfgfin,
+	.cfgend = tfw_sock_clnt_cfgend,
 	.start	= tfw_sock_clnt_start,
 	.stop	= tfw_sock_clnt_stop,
 	.specs	= tfw_sock_clnt_specs,

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -501,7 +501,7 @@ tfw_sock_check_listeners(void)
  */
 
 static int
-tfw_sock_clnt_cfg_handle_listen(TfwCfgSpec *cs, TfwCfgEntry *ce)
+tfw_cfgop_listen(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
 	int port;
@@ -559,7 +559,7 @@ parse_err:
 }
 
 static int
-tfw_sock_clnt_cfg_handle_keepalive(TfwCfgSpec *cs, TfwCfgEntry *ce)
+tfw_cfgop_keepalive_timeout(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
 
@@ -586,32 +586,34 @@ tfw_sock_clnt_cfg_handle_keepalive(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static void
-tfw_sock_clnt_cfg_cleanup_listen(TfwCfgSpec *cs)
+tfw_cfgop_cleanup_sock_clnt(TfwCfgSpec *cs)
 {
 	tfw_listen_sock_del_all();
 }
+
+static TfwCfgSpec tfw_sock_clnt_specs[] = {
+	{
+		.name = "listen",
+		.deflt = "80",
+		.handler = tfw_cfgop_listen,
+		.cleanup = tfw_cfgop_cleanup_sock_clnt,
+		.allow_repeat = true,
+	},
+	{
+		.name = "keepalive_timeout",
+		.deflt = "75",
+		.handler = tfw_cfgop_keepalive_timeout,
+		.cleanup = tfw_cfgop_cleanup_sock_clnt,
+		.allow_repeat = false,
+	},
+	{ 0 }
+};
 
 TfwMod tfw_sock_clnt_mod  = {
 	.name	= "sock_clnt",
 	.start	= tfw_sock_clnt_start,
 	.stop	= tfw_sock_clnt_stop,
-	.specs	= (TfwCfgSpec[]) {
-		{
-			"listen",
-			"80",
-			tfw_sock_clnt_cfg_handle_listen,
-			.allow_repeat = true,
-			.cleanup = tfw_sock_clnt_cfg_cleanup_listen
-		},
-		{
-			"keepalive_timeout",
-			"75",
-			tfw_sock_clnt_cfg_handle_keepalive,
-			.allow_repeat = false,
-			.cleanup = tfw_sock_clnt_cfg_cleanup_listen
-		},
-		{ 0 }
-	}
+	.specs	= tfw_sock_clnt_specs,
 };
 
 /*

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -433,7 +433,7 @@ int
 tfw_sock_check_listeners(void)
 {
 	TFW_DBG3("Call %s\n", __func__);
-	return tfw_sg_for_each_srv(tfw_sock_check_lst);
+	return tfw_sg_for_each_srv(true, tfw_sock_check_lst);
 }
 
 /*
@@ -533,9 +533,6 @@ static int
 tfw_sock_clnt_cfgend(void)
 {
 	int r;
-
-	if (tfw_runstate_is_reconfig())
-		return 0;
 
 	TFW_DBG("Checking backends and listeners\n");
 	if ((r = tfw_sock_check_listeners())) {

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -693,8 +693,8 @@ tfw_sock_srv_grace_shutdown_srv(TfwSrvGroup *sg, TfwServer *srv)
 		}
 		setup_timer(&srv->gs_timer, tfw_sock_srv_grace_shutdown_cb,
 			    (unsigned long)srv);
-		mod_timer(&srv->gs_timer, jiffies + tfw_cfg_grace_time * HZ);
 		tfw_sock_srv_grace_list_add(srv);
+		mod_timer(&srv->gs_timer, jiffies + tfw_cfg_grace_time * HZ);
 	}
 	tfw_server_put(srv);
 
@@ -778,7 +778,7 @@ static struct kmem_cache *tfw_sg_cfg_cache;
  * stage since the new configuration is provided by a user and may contain
  * errors.
  * - applying stage: tfw_sock_srv_start(). Errors are unrecoverable and mean
- * that only a part of changes was appied, so the resulting configuration is
+ * that only a part of changes was applied, so the resulting configuration is
  * invalid.
  *
  * On configuration parsing stage binary representation of a server group is

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -598,7 +598,7 @@ tfw_sock_srv_del_conns(TfwServer *srv)
 static void
 tfw_sock_srv_delete_all_conns(void)
 {
-	tfw_sg_for_each_srv(false, tfw_sock_srv_del_conns);
+	tfw_sg_for_each_srv(tfw_sock_srv_del_conns);
 }
 
 /*
@@ -708,7 +708,7 @@ tfw_cfgop_new_sg_cfg(const char *name)
 		kmem_cache_free(tfw_sg_cfg_cache, sg_cfg);
 		return NULL;
 	}
-	sg_cfg->orig_sg = __tfw_sg_lookup(name, false);
+	sg_cfg->orig_sg = tfw_sg_lookup(name);
 	INIT_LIST_HEAD(&sg_cfg->list);
 
 	list_add(&sg_cfg->list, &sg_cfg_list);
@@ -1155,7 +1155,7 @@ tfw_cfgop_begin_srv_group(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	/* Reuse original group if possible. */
 	sg = sg_cfg->orig_sg ? : sg_cfg->parsed_sg;
-	if (!tfw_sg_add(sg)) {
+	if (!tfw_sg_add_reconfig(sg)) {
 		TFW_ERR_NL("Can't register already registered group '%s'\n",
 			   ce->vals[0]);
 		return -EINVAL;
@@ -1536,7 +1536,7 @@ tfw_cfgop_cleanup_srv_groups(TfwCfgSpec *cs)
 	tfw_cfgop_cleanup_srv_cfgs();
 
 	if (tfw_runstate_is_reconfig()) {
-		tfw_sg_for_each_srv(true, tfw_sock_srv_del_conns);
+		tfw_sg_for_each_srv_reconfig(tfw_sock_srv_del_conns);
 
 		return;
 	}
@@ -1593,7 +1593,7 @@ tfw_sock_srv_cfgend(void)
 		return r;
 
 	sg = tfw_cfg_sg_def->orig_sg ? : tfw_cfg_sg_def->parsed_sg;
-	if (tfw_sg_add(sg)) {
+	if (tfw_sg_add_reconfig(sg)) {
 		TFW_ERR_NL("Unable to register implicit 'default' group\n");
 		return -EINVAL;
 	}
@@ -1784,7 +1784,7 @@ tfw_sock_srv_stop(void)
 	if (tfw_runstate_is_reconfig())
 		return;
 
-	tfw_sg_for_each_srv(false, tfw_sock_srv_disconnect_srv);
+	tfw_sg_for_each_srv(tfw_sock_srv_disconnect_srv);
 }
 
 static TfwCfgSpec tfw_srv_group_specs[] = {

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1317,6 +1317,8 @@ tfw_sock_srv_start(void)
 {
 	int ret;
 
+	if (tfw_runstate_is_reconfig())
+		return 0;
 	/*
 	 * The group "default" is created implicitly, and only when
 	 * a server outside of any group is found in the configuration.
@@ -1358,6 +1360,8 @@ tfw_sock_srv_start(void)
 static void
 tfw_sock_srv_stop(void)
 {
+	if (tfw_runstate_is_reconfig())
+		return;
 	tfw_sg_for_each_srv(tfw_sock_srv_disconnect_srv);
 }
 

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1630,6 +1630,7 @@ tfw_sock_srv_cfgstart(void)
 
 	tfw_cfg_sg = tfw_cfg_sg_def;
 	tfw_cfg_use_sticky_sess = false;
+	memset(&tfw_cfg_is_set, 0, sizeof(tfw_cfg_is_set));
 
 	return 0;
 }

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -635,7 +635,7 @@ static struct kmem_cache *tfw_sg_cfg_cache;
  * invalid.
  *
  * On configuration parsing stage binary representation of a server group is
- * saved into @parsed_sg, while @orig_sg poins to the existing server group
+ * saved into @parsed_sg, while @orig_sg points to the existing server group
  * with the same name if any. @orig_sg remain unchanged until applying stage.
  * @orig_sg if any or @parsed_sg otherwize is registered as server group
  * available after reconfig by tfw_sg_add_reconfig() call. This allow other

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -921,7 +921,7 @@ tfw_cfgop_begin_srv_group(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	}
 
 	if (!(tfw_cfg_sg = tfw_sg_new(ce->vals[0], GFP_KERNEL))) {
-		TFW_ERR_NL("Unable to add group: '%s'\n", ce->vals[0]);
+		TFW_ERR_NL("Unable to create a group: '%s'\n", ce->vals[0]);
 		return -EINVAL;
 	}
 
@@ -1016,8 +1016,11 @@ tfw_cfgop_setup_srv_group(void)
 		if ((ret = tfw_sock_srv_add_conns(srv)) != 0)
 			return ret;
 		list_del(&srv->list);
-		tfw_sg_add(tfw_cfg_sg, srv);
+		tfw_sg_add_srv(tfw_cfg_sg, srv);
 	}
+	/* Add the server group to the list. */
+	if ((ret = tfw_sg_add(tfw_cfg_sg)))
+		return ret;
 	/*
 	 * Set up a scheduler and add the server group to the scheduler.
 	 * Must be called only after the server group is set up with all
@@ -1280,18 +1283,30 @@ tfw_clean_srv_groups(TfwCfgSpec *cs)
 	static const typeof(tfw_cfg_is_set) cfg_is_set_empty = { 0 };
 
 	list_for_each_entry_safe(srv, tmp, &tfw_cfg_in_slst, list) {
-		list_del(&srv->list);
 		tfw_sock_srv_del_conns(srv);
 		tfw_server_destroy(srv);
 	}
 	list_for_each_entry_safe(srv, tmp, &tfw_cfg_out_slst, list) {
-		list_del(&srv->list);
 		tfw_sock_srv_del_conns(srv);
 		tfw_server_destroy(srv);
+	}
+	if (tfw_cfg_out_sg && list_empty(&tfw_cfg_out_sg->list)) {
+		list_for_each_entry(srv, &tfw_cfg_out_sg->srv_list, list)
+			tfw_sock_srv_del_conns(srv);
+		tfw_sg_release(tfw_cfg_out_sg);
+	}
+	if (tfw_cfg_sg && (tfw_cfg_sg != tfw_cfg_out_sg)
+	    && list_empty(&tfw_cfg_sg->list))
+	{
+		list_for_each_entry(srv, &tfw_cfg_sg->srv_list, list)
+			tfw_sock_srv_del_conns(srv);
+		tfw_sg_release(tfw_cfg_sg);
 	}
 
 	tfw_cfg_slstsz = tfw_cfg_out_slstsz = 0;
 	tfw_cfg_is_set = cfg_is_set_empty;
+	INIT_LIST_HEAD(&tfw_cfg_in_slst);
+	INIT_LIST_HEAD(&tfw_cfg_out_slst);
 
 	tfw_sock_srv_delete_all_conns();
 	tfw_sg_release_all();
@@ -1309,7 +1324,7 @@ tfw_sock_srv_start(void)
 	if (tfw_cfg_out_slstsz) {
 		tfw_cfg_out_sg = tfw_sg_new("default", GFP_KERNEL);
 		if (!tfw_cfg_out_sg) {
-			TFW_ERR_NL("Unable to add default server group\n");
+			TFW_ERR_NL("Unable to create default server group\n");
 			return -EINVAL;
 		}
 

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1779,17 +1779,19 @@ tfw_cfgop_update_sg_cfg(TfwCfgSrvGroup *sg_cfg)
 
 	TFW_DBG2("Update group '%s'\n", sg_cfg->orig_sg->name);
 
-	tfw_cfgop_sg_copy_opts(sg_cfg->orig_sg, sg_cfg->parsed_sg);
-
 	if (!(sg_cfg->reconf_flags &
 	      (TFW_CFG_MDF_SG_SRV | TFW_CFG_MDF_SG_SCHED)))
+	{
+		tfw_cfgop_sg_copy_opts(sg_cfg->orig_sg, sg_cfg->parsed_sg);
 		return 0;
-
+	}
 	/*
 	 * Schedulers walk over list of servers, so stop scheduler before
-	 * updating server list.
+	 * updating server list. Schedulers may use sg.flags, don't update
+	 * server group flags before scheduler is stopped.
 	 */
 	tfw_sg_stop_sched(sg_cfg->orig_sg);
+	tfw_cfgop_sg_copy_opts(sg_cfg->orig_sg, sg_cfg->parsed_sg);
 
 	if (sg_cfg->reconf_flags & TFW_CFG_MDF_SG_SRV)
 		if ((r = tfw_cfgop_update_sg_srv_list(sg_cfg)))

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1417,11 +1417,11 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 	{ 0 }
 };
 
-TfwCfgMod tfw_sock_srv_cfg_mod = {
-	.name  = "sock_srv",
-	.start = tfw_sock_srv_start,
-	.stop  = tfw_sock_srv_stop,
-	.specs = (TfwCfgSpec[] ) {
+TfwMod tfw_sock_srv_mod = {
+	.name	= "sock_srv",
+	.start	= tfw_sock_srv_start,
+	.stop	= tfw_sock_srv_stop,
+	.specs	= (TfwCfgSpec[]) {
 		{
 			"server", NULL,
 			tfw_cfgop_out_server,
@@ -1517,13 +1517,20 @@ tfw_sock_srv_init(void)
 {
 	BUILD_BUG_ON(_TFW_PSTATS_IDX_COUNT > TFW_SG_M_PSTATS_IDX);
 	BUG_ON(tfw_srv_conn_cache);
+
 	tfw_srv_conn_cache = kmem_cache_create("tfw_srv_conn_cache",
 					       sizeof(TfwSrvConn), 0, 0, NULL);
-	return !tfw_srv_conn_cache ? -ENOMEM : 0;
+	if (!tfw_srv_conn_cache)
+		return -ENOMEM;
+
+	tfw_mod_register(&tfw_sock_srv_mod);
+
+	return 0;
 }
 
 void
 tfw_sock_srv_exit(void)
 {
+	tfw_mod_unregister(&tfw_sock_srv_mod);
 	kmem_cache_destroy(tfw_srv_conn_cache);
 }

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1277,7 +1277,7 @@ tfw_cfgop_out_sched(TfwCfgSpec *cs, TfwCfgEntry *ce)
  * Clean everything produced during parsing "server" and "srv_group" entries.
  */
 static void
-tfw_clean_srv_groups(TfwCfgSpec *cs)
+tfw_cfgop_cleanup_srv_groups(TfwCfgSpec *cs)
 {
 	TfwServer *srv, *tmp;
 	static const typeof(tfw_cfg_is_set) cfg_is_set_empty = { 0 };
@@ -1363,71 +1363,172 @@ tfw_sock_srv_stop(void)
 
 static TfwCfgSpec tfw_srv_group_specs[] = {
 	{
-		"server", NULL,
-		tfw_cfgop_in_server,
+		.name = "server",
+		.deflt = NULL,
+		.handler = tfw_cfgop_in_server,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.allow_repeat = true,
-		.cleanup = tfw_clean_srv_groups
 	},
 	{
-		"sched", "ratio static",
-		tfw_cfgop_in_sched,
+		.name = "sched",
+		.deflt = "ratio static",
+		.handler = tfw_cfgop_in_sched,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.allow_none = true,
 		.allow_repeat = false,
-		.cleanup = tfw_clean_srv_groups,
 	},
 	{
-		"server_queue_size", "1000",
-		tfw_cfgop_in_queue_size,
-		.allow_none = true,
-		.allow_repeat = false,
-		.cleanup = tfw_clean_srv_groups,
+		.name = "server_queue_size",
+		.deflt = "1000",
+		.handler = tfw_cfgop_in_queue_size,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
-	},
-	{
-		"server_forward_timeout", "60",
-		tfw_cfgop_in_fwd_timeout,
 		.allow_none = true,
 		.allow_repeat = false,
-		.cleanup = tfw_clean_srv_groups,
+	},
+	{
+		.name = "server_forward_timeout",
+		.deflt = "60",
+		.handler = tfw_cfgop_in_fwd_timeout,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
-	},
-	{
-		"server_forward_retries", "5",
-		tfw_cfgop_in_fwd_retries,
 		.allow_none = true,
 		.allow_repeat = false,
-		.cleanup = tfw_clean_srv_groups,
+	},
+	{
+		.name = "server_forward_retries",
+		.deflt = "5",
+		.handler = tfw_cfgop_in_fwd_retries,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
-	},
-	{
-		"server_retry_nonidempotent", TFW_CFG_DFLT_VAL,
-		tfw_cfgop_in_retry_nip,
 		.allow_none = true,
 		.allow_repeat = false,
-		.cleanup = tfw_clean_srv_groups,
 	},
 	{
-		"server_connect_retries", "10",
-		tfw_cfgop_in_conn_retries,
+		.name = "server_retry_nonidempotent",
+		.deflt = TFW_CFG_DFLT_VAL,
+		.handler = tfw_cfgop_in_retry_nip,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.allow_none = true,
 		.allow_repeat = false,
-		.cleanup = tfw_clean_srv_groups,
+	},
+	{
+		.name = "server_connect_retries",
+		.deflt = "10",
+		.handler = tfw_cfgop_in_conn_retries,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
-	},
-	{
-		"sticky_sessions", TFW_CFG_DFLT_VAL,
-		tfw_cfgop_in_sticky_sess,
 		.allow_none = true,
 		.allow_repeat = false,
-		.cleanup = tfw_clean_srv_groups,
+	},
+	{
+		.name = "sticky_sessions",
+		.deflt = TFW_CFG_DFLT_VAL,
+		.handler = tfw_cfgop_in_sticky_sess,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.allow_none = true,
+		.allow_repeat = false,
+	},
+	{ 0 }
+};
+
+static TfwCfgSpec tfw_sock_srv_specs[] = {
+	{
+		.name = "server",
+		.deflt = NULL,
+		.handler = tfw_cfgop_out_server,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.allow_none = true,
+		.allow_repeat = true,
+	},
+	{
+		.name = "sched",
+		.deflt = "ratio static",
+		.handler = tfw_cfgop_out_sched,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.allow_none = true,
+		.allow_repeat = false,
+	},
+	{
+		.name = "server_queue_size",
+		.deflt = "1000",
+		.handler = tfw_cfgop_out_queue_size,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.spec_ext = &(TfwCfgSpecInt) {
+			.range = { 0, INT_MAX },
+		},
+		.allow_none = true,
+		.allow_repeat = false,
+	},
+	{
+		.name = "server_forward_timeout",
+		.deflt = "60",
+		.handler = tfw_cfgop_out_fwd_timeout,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.spec_ext = &(TfwCfgSpecInt) {
+			.range = { 0, INT_MAX },
+		},
+		.allow_none = true,
+		.allow_repeat = false,
+	},
+	{
+		.name = "server_forward_retries",
+		.deflt = "5",
+		.handler = tfw_cfgop_out_fwd_retries,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.spec_ext = &(TfwCfgSpecInt) {
+			.range = { 0, INT_MAX },
+		},
+		.allow_none = true,
+		.allow_repeat = false,
+	},
+	{
+		.name = "server_retry_non_idempotent",
+		.deflt = TFW_CFG_DFLT_VAL,
+		.handler = tfw_cfgop_out_retry_nip,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.allow_none = true,
+		.allow_repeat = false,
+	},
+	{
+		.name = "server_connect_retries",
+		.deflt = "10",
+		.handler = tfw_cfgop_out_conn_retries,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.spec_ext = &(TfwCfgSpecInt) {
+			.range = { 0, INT_MAX },
+		},
+		.allow_none = true,
+		.allow_repeat = false,
+	},
+	{
+		.name = "sticky_sessions",
+		.deflt = TFW_CFG_DFLT_VAL,
+		.handler = tfw_cfgop_out_sticky_sess,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.allow_none = true,
+		.allow_repeat = false,
+	},
+	{
+		.name = "srv_group",
+		.deflt = NULL,
+		.handler = tfw_cfg_handle_children,
+		.cleanup = tfw_cfgop_cleanup_srv_groups,
+		.dest = tfw_srv_group_specs,
+		.spec_ext = &(TfwCfgSpecChild ) {
+			.begin_hook = tfw_cfgop_begin_srv_group,
+			.finish_hook = tfw_cfgop_finish_srv_group
+		},
+		.allow_none = true,
+		.allow_repeat = true,
 	},
 	{ 0 }
 };
@@ -1436,89 +1537,7 @@ TfwMod tfw_sock_srv_mod = {
 	.name	= "sock_srv",
 	.start	= tfw_sock_srv_start,
 	.stop	= tfw_sock_srv_stop,
-	.specs	= (TfwCfgSpec[]) {
-		{
-			"server", NULL,
-			tfw_cfgop_out_server,
-			.allow_none = true,
-			.allow_repeat = true,
-			.cleanup = tfw_clean_srv_groups,
-		},
-		{
-			"sched", "ratio static",
-			tfw_cfgop_out_sched,
-			.allow_none = true,
-			.allow_repeat = false,
-			.cleanup = tfw_clean_srv_groups,
-		},
-		{
-			"server_queue_size", "1000",
-			tfw_cfgop_out_queue_size,
-			.allow_none = true,
-			.allow_repeat = false,
-			.cleanup = tfw_clean_srv_groups,
-			.spec_ext = &(TfwCfgSpecInt) {
-				.range = { 0, INT_MAX },
-			},
-		},
-		{
-			"server_forward_timeout", "60",
-			tfw_cfgop_out_fwd_timeout,
-			.allow_none = true,
-			.allow_repeat = false,
-			.cleanup = tfw_clean_srv_groups,
-			.spec_ext = &(TfwCfgSpecInt) {
-				.range = { 0, INT_MAX },
-			},
-		},
-		{
-			"server_forward_retries", "5",
-			tfw_cfgop_out_fwd_retries,
-			.allow_none = true,
-			.allow_repeat = false,
-			.cleanup = tfw_clean_srv_groups,
-			.spec_ext = &(TfwCfgSpecInt) {
-				.range = { 0, INT_MAX },
-			},
-		},
-		{
-			"server_retry_non_idempotent", TFW_CFG_DFLT_VAL,
-			tfw_cfgop_out_retry_nip,
-			.allow_none = true,
-			.allow_repeat = false,
-			.cleanup = tfw_clean_srv_groups,
-		},
-		{
-			"server_connect_retries", "10",
-			tfw_cfgop_out_conn_retries,
-			.allow_none = true,
-			.allow_repeat = false,
-			.cleanup = tfw_clean_srv_groups,
-			.spec_ext = &(TfwCfgSpecInt) {
-				.range = { 0, INT_MAX },
-			},
-		},
-		{
-			"sticky_sessions", TFW_CFG_DFLT_VAL,
-			tfw_cfgop_out_sticky_sess,
-			.allow_none = true,
-			.allow_repeat = false,
-			.cleanup = tfw_clean_srv_groups,
-		},
-		{
-			"srv_group", NULL,
-			tfw_cfg_handle_children,
-			tfw_srv_group_specs,
-			&(TfwCfgSpecChild ) {
-				.begin_hook = tfw_cfgop_begin_srv_group,
-				.finish_hook = tfw_cfgop_finish_srv_group
-			},
-			.allow_none = true,
-			.allow_repeat = true,
-			.cleanup = tfw_clean_srv_groups,
-		},
-		{ 0 }
-	}
+	.specs	= tfw_sock_srv_specs,
 };
 
 /*

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1313,7 +1313,7 @@ tfw_cfgop_cleanup_srv_groups(TfwCfgSpec *cs)
 }
 
 static int
-tfw_sock_srv_cfgfin(void)
+tfw_sock_srv_cfgend(void)
 {
 	int ret;
 
@@ -1544,7 +1544,7 @@ static TfwCfgSpec tfw_sock_srv_specs[] = {
 
 TfwMod tfw_sock_srv_mod = {
 	.name	= "sock_srv",
-	.cfgfin = tfw_sock_srv_cfgfin,
+	.cfgend = tfw_sock_srv_cfgend,
 	.start	= tfw_sock_srv_start,
 	.stop	= tfw_sock_srv_stop,
 	.specs	= tfw_sock_srv_specs,

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1653,6 +1653,9 @@ tfw_sock_srv_cfgend(void)
 	if ((r = tfw_cfgop_setup_srv_group(tfw_cfg_sg_def)))
 		return r;
 
+	/* 'default' group was added explicitly in begin_srv_group(). */
+	if (tfw_sg_lookup_reconfig(TFW_CFG_IMPL_DFT_SG))
+		return 0;
 	sg = tfw_cfg_sg_def->orig_sg ? : tfw_cfg_sg_def->parsed_sg;
 	if (tfw_sg_add_reconfig(sg)) {
 		TFW_ERR_NL("Unable to register implicit 'default' group\n");

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1313,7 +1313,7 @@ tfw_cfgop_cleanup_srv_groups(TfwCfgSpec *cs)
 }
 
 static int
-tfw_sock_srv_start(void)
+tfw_sock_srv_cfgfin(void)
 {
 	int ret;
 
@@ -1346,14 +1346,19 @@ tfw_sock_srv_start(void)
 		if ((ret = tfw_cfgop_setup_srv_group()))
 			return ret;
 	}
-	/*
-	 * This must be executed only after the complete configuration
-	 * has been processed as it depends on configuration directives
-	 * that can be located anywhere in the configuration file.
-	 */
+
+	return 0;
+}
+
+static int
+tfw_sock_srv_start(void)
+{
+	int ret;
+
+	if (tfw_runstate_is_reconfig())
+		return 0;
 	if ((ret = tfw_sg_for_each_srv(tfw_apm_add_srv)) != 0)
 		return ret;
-
 	return tfw_sg_for_each_srv(tfw_sock_srv_connect_srv);
 }
 
@@ -1539,6 +1544,7 @@ static TfwCfgSpec tfw_sock_srv_specs[] = {
 
 TfwMod tfw_sock_srv_mod = {
 	.name	= "sock_srv",
+	.cfgfin = tfw_sock_srv_cfgfin,
 	.start	= tfw_sock_srv_start,
 	.stop	= tfw_sock_srv_stop,
 	.specs	= tfw_sock_srv_specs,

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -2014,12 +2014,12 @@ tfw_sock_srv_stop(void)
 	tfw_sg_release_all();
 }
 
+/* Group specs are cleaned up by tfw_sock_srv_specs["srv_group"].cleanup(). */
 static TfwCfgSpec tfw_srv_group_specs[] = {
 	{
 		.name = "server",
 		.deflt = NULL,
 		.handler = tfw_cfgop_in_server,
-		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.allow_repeat = true,
 		.allow_reconfig = true,
 	},
@@ -2027,7 +2027,6 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 		.name = "sched",
 		.deflt = "ratio static",
 		.handler = tfw_cfgop_in_sched,
-		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.allow_none = true,
 		.allow_repeat = false,
 		.allow_reconfig = true,
@@ -2036,7 +2035,6 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 		.name = "server_queue_size",
 		.deflt = "1000",
 		.handler = tfw_cfgop_in_queue_size,
-		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
@@ -2048,7 +2046,6 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 		.name = "server_forward_timeout",
 		.deflt = "60",
 		.handler = tfw_cfgop_in_fwd_timeout,
-		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
@@ -2060,7 +2057,6 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 		.name = "server_forward_retries",
 		.deflt = "5",
 		.handler = tfw_cfgop_in_fwd_retries,
-		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
@@ -2072,7 +2068,6 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 		.name = "server_retry_nonidempotent",
 		.deflt = TFW_CFG_DFLT_VAL,
 		.handler = tfw_cfgop_in_retry_nip,
-		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.allow_none = true,
 		.allow_repeat = false,
 		.allow_reconfig = true,
@@ -2081,7 +2076,6 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 		.name = "server_connect_retries",
 		.deflt = "10",
 		.handler = tfw_cfgop_in_conn_retries,
-		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
@@ -2093,7 +2087,6 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 		.name = "sticky_sessions",
 		.deflt = TFW_CFG_DFLT_VAL,
 		.handler = tfw_cfgop_in_sticky_sess,
-		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.allow_none = true,
 		.allow_repeat = false,
 		.allow_reconfig = true,

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -75,8 +75,6 @@ ss_skb_queue_tail(SsSkbList *list, struct sk_buff *skb)
 {
 	SsSkbCb *scb = TFW_SKB_CB(skb);
 
-	/* The skb shouldn't be in any other queue. */
-	BUG_ON(skb->next || skb->prev);
 	BUG_ON(scb->next || scb->prev);
 
 	scb->prev = list->last;

--- a/tempesta_fw/t/functional/cache/test_conditional.py
+++ b/tempesta_fw/t/functional/cache/test_conditional.py
@@ -1,7 +1,7 @@
 """Functional tests of caching different methods."""
 
 from __future__ import print_function
-from helpers import tf_cfg, deproxy
+from helpers import tf_cfg, deproxy, chains
 from testers import functional
 
 __author__ = 'Tempesta Technologies, Inc.'
@@ -35,10 +35,10 @@ class TestConditional(functional.FunctionalTest):
         uri = '/page.html'
         # Tests uses castom ETag and Last-Modified, so remove predefined
         remove_hdrs = ['ETag', 'Last-Modified']
-        chains = [proxy_chain(method='GET', uri=uri),
-                  cache_chain(method='GET', uri=uri)]
-        for resp in [chains[0].response, chains[0].server_response,
-                     chains[1].response]:
+        test_chains = [chains.proxy(method='GET', uri=uri),
+                       chains.cache(method='GET', uri=uri)]
+        for resp in [test_chains[0].response, test_chains[0].server_response,
+                     test_chains[1].response]:
             for hdr in remove_hdrs:
                 del resp.headers[hdr]
             if etag:
@@ -46,7 +46,7 @@ class TestConditional(functional.FunctionalTest):
             if last_modified:
                 resp.headers['Last-Modified'] = last_modified
             resp.update()
-        return chains
+        return test_chains
 
     def chains_200(self, cond_hdr, etag=None, last_modified=None):
         chains = self.chains(etag, last_modified)
@@ -148,14 +148,3 @@ class TestConditional(functional.FunctionalTest):
         cond_hdr = ('If-Modified-Since', before_lm)
         chains = self.chains_200(cond_hdr, etag, lm)
         self.generic_test_routine(self.config, chains)
-
-
-
-def cache_chain(method, uri):
-    chain = functional.base_message_chain(uri=uri, method=method)
-    chain.no_forward()
-    return chain
-
-def proxy_chain(method, uri):
-    chain = functional.base_message_chain(uri=uri, method=method)
-    return chain

--- a/tempesta_fw/t/functional/helpers/control.py
+++ b/tempesta_fw/t/functional/helpers/control.py
@@ -245,7 +245,8 @@ class Tempesta(object):
     def __init__(self):
         self.node = remote.tempesta
         self.workdir = self.node.workdir
-        self.config_name = os.path.join(self.workdir, tf_cfg.cfg.get('Tempesta', 'config'))
+        self.config_name = os.path.join(self.workdir,
+                                        tf_cfg.cfg.get('Tempesta', 'config'))
         self.config = tempesta.Config()
         self.stats = tempesta.Stats()
         self.host = tf_cfg.cfg.get('Tempesta', 'hostname')
@@ -257,7 +258,8 @@ class Tempesta(object):
         self.node.copy_file(self.config_name, self.config.get_config())
         cmd = '%s/scripts/tempesta.sh --start' % self.workdir
         env = { 'TFW_CFG_PATH': self.config_name }
-        self.node.run_cmd(cmd, timeout=30, env=env, err_msg=(self.err_msg % 'start'))
+        self.node.run_cmd(cmd, timeout=30, env=env,
+                          err_msg=(self.err_msg % 'start'))
 
     def stop(self):
         """ Stop and unload all TempestaFW modules. """
@@ -265,6 +267,15 @@ class Tempesta(object):
         cmd = '%s/scripts/tempesta.sh --stop' % self.workdir
         self.node.run_cmd(cmd, timeout=30, err_msg=(self.err_msg % 'stop'))
         self.node.remove_file(self.config_name)
+
+    def reload(self):
+        """Live reconfiguration"""
+        tf_cfg.dbg(3, '\tReconfiguring TempestaFW on %s' % self.host)
+        self.node.copy_file(self.config_name, self.config.get_config())
+        cmd = '%s/scripts/tempesta.sh --reload' % self.workdir
+        env = { 'TFW_CFG_PATH': self.config_name }
+        self.node.run_cmd(cmd, timeout=30, env=env,
+                          err_msg=(self.err_msg % 'reload'))
 
     def get_stats(self):
         cmd = 'cat /proc/tempesta/perfstat'

--- a/tempesta_fw/t/functional/helpers/deproxy.py
+++ b/tempesta_fw/t/functional/helpers/deproxy.py
@@ -501,7 +501,7 @@ class Client(asyncore.dispatcher):
         return self.tester.is_srvs_ready() and (len(self.request_buffer) > 0)
 
     def handle_write(self):
-        tf_cfg.dbg(4, '\tDeproxy: Client: Send request to server.')
+        tf_cfg.dbg(4, '\tDeproxy: Client: Send request to Tempesta.')
         tf_cfg.dbg(5, self.request_buffer)
         sent = self.send(self.request_buffer)
         self.request_buffer = self.request_buffer[sent:]

--- a/tempesta_fw/t/functional/helpers/tempesta.py
+++ b/tempesta_fw/t/functional/helpers/tempesta.py
@@ -139,6 +139,7 @@ class ServerGroup(object):
 
     def __init__(self, name='default', sched='ratio'):
         self.name = name
+        self.implicit = (name == 'default')
         self.sched = sched
         self.servers = []
         # Server group options, inserted after servers.
@@ -153,7 +154,7 @@ class ServerGroup(object):
 
     def get_config(self):
         sg = ''
-        if self.name == 'default':
+        if (self.name == 'default') and self.implicit:
             sg = '\n'.join(['sched %s;' % self.sched] + self.servers
                            + [self.options])
         else:
@@ -168,9 +169,14 @@ class Config(object):
         self.server_groups = []
         self.defconfig = ''
 
-    def add_sg(self, new_sg):
+    def find_sg(self, sg_name):
         for sg in self.server_groups:
-            error.assertTrue(sg.name != new_sg.name)
+            if sg.name == sg_name:
+                return sg
+        return None
+
+    def add_sg(self, new_sg):
+        error.assertTrue(self.find_sg(new_sg.name) is None)
         self.server_groups.append(new_sg)
 
     def get_config(self):

--- a/tempesta_fw/t/functional/reconf/__init__.py
+++ b/tempesta_fw/t/functional/reconf/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ['reconf_stress', 'test_stress_sched_hash']
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tempesta_fw/t/functional/reconf/__init__.py
+++ b/tempesta_fw/t/functional/reconf/__init__.py
@@ -1,3 +1,4 @@
-__all__ = ['reconf_stress', 'test_stress_sched_hash']
+__all__ = ['reconf_stress', 'test_stress_sched_hash', 'test_stress_sched_http',
+           'test_stress_sched_ratio', 'test_stress_sticky', 'test_stress_grace']
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tempesta_fw/t/functional/reconf/reconf_stress.py
+++ b/tempesta_fw/t/functional/reconf/reconf_stress.py
@@ -1,0 +1,116 @@
+"""
+Live reconfiguration stress test primitive.
+"""
+
+from threading import Thread
+from time import sleep
+from helpers import tempesta, control, tf_cfg
+from testers import stress
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+
+class LiveReconfStress(stress.StressTest):
+
+    defconfig = ''
+    sg_name = 'default'
+
+    def create_servers(self):
+        port = tempesta.upstream_port_start_from()
+        rm_srv_n = tempesta.servers_in_group() / 3
+        add_srn_n = rm_srv_n
+        const_srv_n = tempesta.servers_in_group() - rm_srv_n - add_srn_n
+
+        self.rm_srvs = []
+        self.add_srvs = []
+        self.const_srvs = []
+        self.servers = []
+
+        for _ in range(rm_srv_n):
+            server = control.Nginx(listen_port=port)
+            self.rm_srvs.append(server)
+            port += 1
+        for _ in range(const_srv_n):
+            server = control.Nginx(listen_port=port)
+            self.const_srvs.append(server)
+            port += 1
+        for _ in range(add_srn_n):
+            server = control.Nginx(listen_port=port)
+            self.add_srvs.append(server)
+            port += 1
+
+        # united array to start and stop all servers at once
+        self.servers = self.rm_srvs + self.const_srvs + self.add_srvs
+
+    def add_sg(self, config, sg_name, servers):
+        sg = tempesta.ServerGroup(sg_name)
+        for s in servers:
+            sg.add_server(s.ip, s.config.port, s.conns_n)
+        config.add_sg(sg)
+
+    def make_config(self, sg_name, servers, defconfig=None):
+        """Create new configuration for TempestaFW."""
+        config = tempesta.Config()
+        if defconfig is None:
+            defconfig = self.defconfig
+        config.set_defconfig(defconfig)
+        self.add_sg(config, sg_name, servers)
+        return config
+
+    def reconfig(self):
+        sleep(int(tf_cfg.cfg.get('General', 'Duration')) / 2)
+        self.reconfigure_func()
+        self.tempesta.reload()
+
+    def assert_clients(self):
+        """ Check benchmark result: 502 errors may happen but only for short
+        period of time (during reconfig)."""
+        duration = int(tf_cfg.cfg.get('General', 'Duration'))
+        for c in self.clients:
+            req, err = c.results()
+            # Tempesta must be reconfigured in less that 1sec. Errors must not
+            # happen after reconfig has finished.
+            max_err = req / duration
+            self.assertTrue((err < max_err), msg='HTTP client detected errors')
+
+    def stress_reconfig_generic(self, configure_func, reconfigure_func):
+        """Generic test routinr for reconfig.
+        """
+        self.reconfigure_func = reconfigure_func
+        control.servers_start(self.servers)
+        configure_func()
+        self.tempesta.start()
+
+        r_thread = Thread(target=self.reconfig)
+        r_thread.start()
+
+        control.clients_run_parallel(self.clients)
+        self.show_performance()
+        self.tempesta.get_stats()
+
+        r_thread.join()
+        self.assert_clients()
+
+    def configure_srvs_start(self):
+        srvs = self.const_srvs + self.rm_srvs
+        config = self.make_config(self.sg_name, srvs)
+        self.tempesta.config = config
+
+    def configure_srvs_add(self):
+        srvs = self.const_srvs + self.rm_srvs + self.add_srvs
+        config = self.make_config(self.sg_name, srvs)
+        self.tempesta.config = config
+
+    def configure_srvs_del(self):
+        srvs = self.const_srvs
+        config = self.make_config(self.sg_name, srvs)
+        self.tempesta.config = config
+
+    def configure_srvs_del_add(self):
+        srvs = self.const_srvs + self.add_srvs
+        config = self.make_config(self.sg_name, srvs)
+        self.tempesta.config = config
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tempesta_fw/t/functional/reconf/test_stress_sched_hash.py
+++ b/tempesta_fw/t/functional/reconf/test_stress_sched_hash.py
@@ -1,0 +1,66 @@
+"""
+Live reconfiguration stress test for hash scheduler.
+"""
+
+from helpers import tempesta
+from . import reconf_stress
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+
+class SchedHashImplDefaultSg(reconf_stress.LiveReconfStress):
+
+    sg_name = 'default'
+
+    def set_hash_sched(self):
+        for sg in self.tempesta.config.server_groups:
+            sg.sched = 'hash'
+
+    def configure_srvs_start(self):
+        reconf_stress.LiveReconfStress.configure_srvs_start(self)
+        self.set_hash_sched()
+
+    def configure_srvs_add(self):
+        reconf_stress.LiveReconfStress.configure_srvs_add(self)
+        self.set_hash_sched()
+
+    def configure_srvs_del(self):
+        reconf_stress.LiveReconfStress.configure_srvs_del(self)
+        self.set_hash_sched()
+
+    def configure_srvs_del_add(self):
+        reconf_stress.LiveReconfStress.configure_srvs_del_add(self)
+        self.set_hash_sched()
+
+    def test_hash_add_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_add)
+
+    def test_hash_del_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_del)
+
+    def test_hash_del_add_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_del_add)
+
+
+class SchedHashExplDefaultSg(SchedHashImplDefaultSg):
+
+    def set_hash_sched(self):
+        for sg in self.tempesta.config.server_groups:
+            sg.sched = 'hash'
+            sg.implicit = False
+
+class SchedHashCustomSg(SchedHashImplDefaultSg):
+
+    sg_name = 'custom'
+    defconfig = (
+        'sched_http_rules {\n'
+        '  match custom * * *;\n'
+        '}\n'
+        '\n')
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tempesta_fw/t/functional/reconf/test_stress_sched_http.py
+++ b/tempesta_fw/t/functional/reconf/test_stress_sched_http.py
@@ -1,0 +1,39 @@
+"""
+Live reconfiguration stress test for http scheduler.
+"""
+
+from helpers import tempesta
+from . import reconf_stress
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+
+class SchedHttp(reconf_stress.LiveReconfStress):
+
+    orig_sg = 'origin'
+    alt_sg = 'alternate'
+
+    def configure_http_sched(self, active_group):
+        defconfig = (
+        'sched_http_rules {\n'
+        '  match %s * * *;\n'
+        '}\n'
+        '\n' % active_group)
+        config = self.make_config(self.orig_sg, self.const_srvs, defconfig)
+        self.add_sg(config, self.alt_sg, self.add_srvs)
+        self.tempesta.config = config
+
+    def configure_start(self):
+        self.configure_http_sched(self.orig_sg)
+
+    def configure_reconfig(self):
+        self.configure_http_sched(self.alt_sg)
+
+    def test_hash_add_srvs(self):
+        self.stress_reconfig_generic(self.configure_start,
+                                     self.configure_reconfig)
+
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tempesta_fw/t/functional/reconf/test_stress_sched_ratio.py
+++ b/tempesta_fw/t/functional/reconf/test_stress_sched_ratio.py
@@ -1,0 +1,96 @@
+"""
+Live reconfiguration stress test for ratio scheduler.
+"""
+
+from helpers import tempesta
+from . import reconf_stress
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+# Ratio Static tests
+
+class SchedRatioStaticImplDefaultSg(reconf_stress.LiveReconfStress):
+
+    sg_name = 'default'
+    sched = 'ratio static'
+
+    def set_ratio_sched(self):
+        for sg in self.tempesta.config.server_groups:
+            sg.sched = self.sched
+
+    def configure_srvs_start(self):
+        reconf_stress.LiveReconfStress.configure_srvs_start(self)
+        self.set_ratio_sched()
+
+    def configure_srvs_add(self):
+        reconf_stress.LiveReconfStress.configure_srvs_add(self)
+        self.set_ratio_sched()
+
+    def configure_srvs_del(self):
+        reconf_stress.LiveReconfStress.configure_srvs_del(self)
+        self.set_ratio_sched()
+
+    def configure_srvs_del_add(self):
+        reconf_stress.LiveReconfStress.configure_srvs_del_add(self)
+        self.set_ratio_sched()
+
+    def test_ratio_add_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_add)
+
+    def test_ratio_del_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_del)
+
+    def test_ratio_del_add_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_del_add)
+
+
+class SchedRatioStaticExplDefaultSg(SchedRatioStaticImplDefaultSg):
+
+    def set_ratio_sched(self):
+        for sg in self.tempesta.config.server_groups:
+            sg.sched = self.sched
+            sg.implicit = False
+
+class SchedRatioStaticCustomSg(SchedRatioStaticImplDefaultSg):
+
+    sg_name = 'custom'
+    defconfig = (
+        'sched_http_rules {\n'
+        '  match custom * * *;\n'
+        '}\n'
+        '\n')
+
+# Ratio Dynamic tests
+
+class SchedRatioDynamicImplDefaultSg(SchedRatioStaticImplDefaultSg):
+
+    sched = 'ratio dynamic'
+
+class SchedRatioDynamicExplDefaultSg(SchedRatioStaticExplDefaultSg):
+
+    sched = 'ratio dynamic'
+
+class SchedRatioDynamicCustomSg(SchedRatioStaticCustomSg):
+
+    sched = 'ratio dynamic'
+
+# Ratio Predict tests
+
+class SchedRatioPredictImplDefaultSg(SchedRatioStaticImplDefaultSg):
+
+    sched = 'ratio predict'
+
+class SchedRatioPredictExplDefaultSg(SchedRatioStaticExplDefaultSg):
+
+    sched = 'ratio predict'
+
+class SchedRatioPredictCustomSg(SchedRatioStaticCustomSg):
+
+    sched = 'ratio predict'
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tempesta_fw/t/functional/reconf/test_stress_sticky.py
+++ b/tempesta_fw/t/functional/reconf/test_stress_sticky.py
@@ -1,0 +1,64 @@
+"""
+Live reconfiguration stress test for ratio scheduler.
+"""
+
+from helpers import control, tf_cfg
+from . import reconf_stress
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+class SchedSticky(reconf_stress.LiveReconfStress):
+
+    sg_name = 'default'
+    sched = 'ratio static'
+    defconfig = (
+        'cache 0;\n'
+        'sticky enforce;\n'
+        'sticky_secret "f00)9eR59*_/22";\n'
+        '\n')
+    clients_num = min(int(tf_cfg.cfg.get('General', 'concurrent_connections')),
+                      1000)
+
+    def create_clients(self):
+        # See test_sticky_sess_stress
+        self.wrk = control.Wrk(threads=self.clients_num)
+        self.wrk.connections = self.wrk.threads
+        self.wrk.set_script("cookie-many-clients")
+        self.clients = [self.wrk]
+
+    def set_ratio_sched(self):
+        for sg in self.tempesta.config.server_groups:
+            sg.sched = self.sched
+            sg.options = 'sticky_sessions;'
+
+    def configure_srvs_start(self):
+        reconf_stress.LiveReconfStress.configure_srvs_start(self)
+        self.set_ratio_sched()
+
+    def configure_srvs_add(self):
+        reconf_stress.LiveReconfStress.configure_srvs_add(self)
+        self.set_ratio_sched()
+
+    def configure_srvs_del(self):
+        reconf_stress.LiveReconfStress.configure_srvs_del(self)
+        self.set_ratio_sched()
+
+    def configure_srvs_del_add(self):
+        reconf_stress.LiveReconfStress.configure_srvs_del_add(self)
+        self.set_ratio_sched()
+
+    def test_ratio_add_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_add)
+
+    def test_ratio_del_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_del)
+
+    def test_ratio_del_add_srvs(self):
+        self.stress_reconfig_generic(self.configure_srvs_start,
+                                     self.configure_srvs_del_add)
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -28,6 +28,8 @@
 #define tfw_srv_conn_release test_srv_conn_release
 #undef tfw_sock_srv_mod
 #define tfw_sock_srv_mod test_sock_srv_mod
+#undef tfw_sg_grace_shutdown_finish
+#define tfw_sg_grace_shutdown_finish test_sg_grace_shutdown_finish
 #include "sock_srv.c"
 
 #include "server.h"

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -73,6 +73,8 @@ test_start_sg(TfwSrvGroup *sg, const char *sched_name, unsigned int flags)
 	kernel_fpu_end();
 
 	sg->flags = flags;
+	r = tfw_sg_add(sg);
+	BUG_ON(r);
 	/* Adjust servers weights for ratio scheduler. */
 	if (!strcmp(sched_name, "ratio"))
 		tfw_cfg_sg_ratio_adjust(&sg->srv_list);
@@ -106,7 +108,7 @@ test_create_srv(const char *in_addr, TfwSrvGroup *sg)
 	srv = tfw_server_create(&addr);
 	BUG_ON(!srv);
 
-	tfw_sg_add(sg, srv);
+	tfw_sg_add_srv(sg, srv);
 
 	return srv;
 }
@@ -153,6 +155,188 @@ test_conn_release_all(TfwSrvGroup *sg)
 			tfw_srv_conn_free((TfwSrvConn *)conn);
 		}
 	}
+}
+
+/**
+ * Unit test. Message cannot be scheduled to empty server group.
+ */
+void
+test_sched_sg_empty_sg(struct TestSchedHelper *sched_helper)
+{
+	size_t i;
+	TfwSrvGroup *sg;
+
+	BUG_ON(!sched_helper);
+	BUG_ON(!sched_helper->sched);
+	BUG_ON(!sched_helper->conn_types);
+	BUG_ON(!sched_helper->get_sched_arg);
+	BUG_ON(!sched_helper->free_sched_arg);
+
+	sg = test_create_sg("test");
+	test_start_sg(sg, sched_helper->sched, sched_helper->flags);
+
+	for (i = 0; i < sched_helper->conn_types; ++i) {
+		TfwMsg *msg = sched_helper->get_sched_arg(i);
+		TfwSrvConn *srv_conn = sg->sched->sched_sg_conn(msg, sg);
+
+		EXPECT_NULL(srv_conn);
+		sched_helper->free_sched_arg(msg);
+	}
+
+	test_sg_release_all();
+}
+
+/**
+ * Unit test. Message cannot be scheduled to server group if server in that
+ * group have no live connections.
+ */
+void
+test_sched_sg_one_srv_zero_conn(struct TestSchedHelper *sched_helper)
+{
+	size_t i;
+	TfwSrvGroup *sg;
+
+	BUG_ON(!sched_helper);
+	BUG_ON(!sched_helper->sched);
+	BUG_ON(!sched_helper->conn_types);
+	BUG_ON(!sched_helper->get_sched_arg);
+	BUG_ON(!sched_helper->free_sched_arg);
+
+	sg = test_create_sg("test");
+	test_create_srv("127.0.0.1", sg);
+	test_start_sg(sg, sched_helper->sched, sched_helper->flags);
+
+	for (i = 0; i < sched_helper->conn_types; ++i) {
+		TfwMsg *msg = sched_helper->get_sched_arg(i);
+		TfwSrvConn *srv_conn = sg->sched->sched_sg_conn(msg, sg);
+
+		EXPECT_NULL(srv_conn);
+		sched_helper->free_sched_arg(msg);
+	}
+
+	test_sg_release_all();
+}
+
+/**
+ * Unit test. Message cannot be scheduled to server group if servers in that
+ * group have no live connections. Server group contain as much servers as
+ * possible.
+ */
+void
+test_sched_sg_max_srv_zero_conn(struct TestSchedHelper *sched_helper)
+{
+	size_t i, j;
+	TfwSrvGroup *sg;
+
+	BUG_ON(!sched_helper);
+	BUG_ON(!sched_helper->sched);
+	BUG_ON(!sched_helper->conn_types);
+	BUG_ON(!sched_helper->get_sched_arg);
+	BUG_ON(!sched_helper->free_sched_arg);
+
+	sg = test_create_sg("test");
+
+	for (j = 0; j < TFW_TEST_SG_MAX_SRV_N; ++j)
+		test_create_srv("127.0.0.1", sg);
+	test_start_sg(sg, sched_helper->sched, sched_helper->flags);
+
+	for (i = 0; i < sched_helper->conn_types; ++i) {
+		TfwMsg *msg = sched_helper->get_sched_arg(i);
+
+		for (j = 0; j < sg->srv_n; ++j) {
+			TfwSrvConn *srv_conn =
+				sg->sched->sched_sg_conn(msg, sg);
+
+			EXPECT_NULL(srv_conn);
+			/*
+			 * Don't let the kernel watchdog decide
+			 * that we're stuck in a locked context.
+			 */
+			kernel_fpu_end();
+			schedule();
+			kernel_fpu_begin();
+		}
+		sched_helper->free_sched_arg(msg);
+	}
+
+	test_sg_release_all();
+}
+
+/**
+ * Unit test. Message cannot be scheduled to server if it has no live
+ * connections.
+ */
+void
+test_sched_srv_one_srv_zero_conn(struct TestSchedHelper *sched_helper)
+{
+	size_t i;
+	TfwSrvGroup *sg;
+	TfwServer *srv;
+
+	BUG_ON(!sched_helper);
+	BUG_ON(!sched_helper->sched);
+	BUG_ON(!sched_helper->conn_types);
+	BUG_ON(!sched_helper->get_sched_arg);
+	BUG_ON(!sched_helper->free_sched_arg);
+
+	sg = test_create_sg("test");
+	srv = test_create_srv("127.0.0.1", sg);
+	test_start_sg(sg, sched_helper->sched, sched_helper->flags);
+
+	for (i = 0; i < sched_helper->conn_types; ++i) {
+		TfwMsg *msg = sched_helper->get_sched_arg(i);
+		TfwSrvConn *srv_conn = sg->sched->sched_srv_conn(msg, srv);
+
+		EXPECT_NULL(srv_conn);
+		sched_helper->free_sched_arg(msg);
+	}
+
+	test_sg_release_all();
+}
+
+/**
+ * Unit test. Message cannot be scheduled to any server of server group if
+ * there is no no live connections across all server.
+ */
+void
+test_sched_srv_max_srv_zero_conn(struct TestSchedHelper *sched_helper)
+{
+	size_t i, j;
+	TfwSrvGroup *sg;
+
+	BUG_ON(!sched_helper);
+	BUG_ON(!sched_helper->sched);
+	BUG_ON(!sched_helper->conn_types);
+	BUG_ON(!sched_helper->get_sched_arg);
+	BUG_ON(!sched_helper->free_sched_arg);
+
+	sg = test_create_sg("test");
+
+	for (j = 0; j < TFW_TEST_SG_MAX_SRV_N; ++j)
+		test_create_srv("127.0.0.1", sg);
+	test_start_sg(sg, sched_helper->sched, sched_helper->flags);
+
+	for (i = 0; i < sched_helper->conn_types; ++i) {
+		TfwMsg *msg = sched_helper->get_sched_arg(i);
+		TfwServer *srv;
+
+		list_for_each_entry(srv, &sg->srv_list, list) {
+			TfwSrvConn *srv_conn =
+				sg->sched->sched_srv_conn(msg, srv);
+
+			EXPECT_NULL(srv_conn);
+			/*
+			 * Don't let the kernel watchdog decide
+			 * that we're stuck in a locked context.
+			 */
+			kernel_fpu_end();
+			schedule();
+			kernel_fpu_begin();
+		}
+		sched_helper->free_sched_arg(msg);
+	}
+
+	test_sg_release_all();
 }
 
 /**

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -76,7 +76,7 @@ test_start_sg(TfwSrvGroup *sg, const char *sched_name, unsigned int flags)
 	kernel_fpu_end();
 
 	sg->flags = flags;
-	r = tfw_sg_add(sg);
+	r = tfw_sg_add_reconfig(sg);
 	BUG_ON(r);
 	/* Adjust servers weights for ratio scheduler. */
 	if (!strcmp(sched_name, "ratio"))
@@ -96,7 +96,7 @@ test_sg_release_all(void)
 	kernel_fpu_end();
 
 	tfw_sg_release_all();
-	tfw_sg_release_reconfig();
+	__tfw_sg_release_all_reconfig();
 
 	kernel_fpu_begin();
 }

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -26,8 +26,8 @@
 #define tfw_sock_srv_exit test_sock_srv_exit
 #undef tfw_srv_conn_release
 #define tfw_srv_conn_release test_srv_conn_release
-#undef tfw_sock_srv_cfg_mod
-#define tfw_sock_srv_cfg_mod test_sock_srv_cfg_mod
+#undef tfw_sock_srv_mod
+#define tfw_sock_srv_mod test_sock_srv_mod
 #include "sock_srv.c"
 
 #include "server.h"

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -28,8 +28,6 @@
 #define tfw_srv_conn_release test_srv_conn_release
 #undef tfw_sock_srv_mod
 #define tfw_sock_srv_mod test_sock_srv_mod
-#undef tfw_sg_grace_shutdown_finish
-#define tfw_sg_grace_shutdown_finish test_sg_grace_shutdown_finish
 #include "sock_srv.c"
 
 #include "server.h"

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -71,6 +71,7 @@ void
 test_start_sg(TfwSrvGroup *sg, const char *sched_name, unsigned int flags)
 {
 	int r;
+	TfwScheduler *sched;
 
 	kernel_fpu_end();
 
@@ -80,7 +81,10 @@ test_start_sg(TfwSrvGroup *sg, const char *sched_name, unsigned int flags)
 	/* Adjust servers weights for ratio scheduler. */
 	if (!strcmp(sched_name, "ratio"))
 		tfw_cfg_sg_ratio_adjust(&sg->srv_list);
-	r = tfw_sg_set_sched(sg, sched_name, NULL);
+
+	sched = tfw_sched_lookup(sched_name);
+	BUG_ON(!sched);
+	r = tfw_sg_start_sched(sg, sched, NULL);
 	BUG_ON(r);
 
 	kernel_fpu_begin();
@@ -92,6 +96,7 @@ test_sg_release_all(void)
 	kernel_fpu_end();
 
 	tfw_sg_release_all();
+	tfw_sg_release_reconfig();
 
 	kernel_fpu_begin();
 }

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -40,11 +40,11 @@ test_spec_cleanup(TfwCfgSpec specs[])
 	TfwCfgSpec *spec;
 
 	TFW_CFG_FOR_EACH_SPEC(spec, specs) {
-		if (spec->call_counter && spec->cleanup) {
+		if (spec->__called_ever && spec->cleanup) {
 			TFW_DBG2("spec cleanup: '%s'\n", spec->name);
 			spec->cleanup(spec);
 		}
-		spec->call_counter = 0;
+		spec->__called_ever = false;
 	}
 }
 

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -80,7 +80,7 @@ test_start_sg(TfwSrvGroup *sg, const char *sched_name, unsigned int flags)
 	/* Adjust servers weights for ratio scheduler. */
 	if (!strcmp(sched_name, "ratio"))
 		tfw_cfg_sg_ratio_adjust(&sg->srv_list);
-	r = tfw_sg_set_sched(sg, sched_name);
+	r = tfw_sg_set_sched(sg, sched_name, NULL);
 	BUG_ON(r);
 
 	kernel_fpu_begin();

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -40,10 +40,12 @@ test_spec_cleanup(TfwCfgSpec specs[])
 	TfwCfgSpec *spec;
 
 	TFW_CFG_FOR_EACH_SPEC(spec, specs) {
-		if (spec->__called_ever && spec->cleanup) {
-			TFW_DBG2("spec cleanup: '%s'\n", spec->name);
+		bool called = spec->__called_cfg | spec->__called_ever;
+		if (called && spec->cleanup) {
+			TFW_DBG2("%s: '%s'\n", __func__, spec->name);
 			spec->cleanup(spec);
 		}
+		spec->__called_cfg = false;
 		spec->__called_ever = false;
 	}
 }

--- a/tempesta_fw/t/unit/test_cfg.c
+++ b/tempesta_fw/t/unit/test_cfg.c
@@ -1015,7 +1015,8 @@ TEST(tfw_cfg_handle_children, propagates_cleanup_to_nested_specs)
 			&call_ctr,
 			&cleanup_ctr,
 			.cleanup = cleanup_incr_ctr,
-			.allow_repeat = true
+			.allow_repeat = true,
+			.allow_none = true
 		},
 		{ 0 }
 	};

--- a/tempesta_fw/t/unit/test_cfg.c
+++ b/tempesta_fw/t/unit/test_cfg.c
@@ -61,7 +61,7 @@ do_parse_cfg(const char *cfg_text, TfwCfgSpec specs[])
 	test_dummy_mod.specs = specs;
 	list_add(&test_dummy_mod.list, &test_tfw_mods);
 
-	if ((ret = tfw_cfg_parse(cfg_text, &test_tfw_mods)))
+	if ((ret = tfw_cfg_parse_mods(cfg_text, &test_tfw_mods)))
 		return ret;
 
 	return tfw_start_mods(&test_tfw_mods);

--- a/tempesta_fw/t/unit/test_cfg.c
+++ b/tempesta_fw/t/unit/test_cfg.c
@@ -63,8 +63,9 @@ do_parse_cfg(const char *cfg_text, TfwCfgSpec specs[])
 
 	if ((ret = tfw_cfg_parse_mods(cfg_text, &test_tfw_mods)))
 		return ret;
-
-	return tfw_start_mods(&test_tfw_mods);
+	if ((ret = tfw_mods_cfgfin(&test_tfw_mods)))
+		return ret;
+	return tfw_mods_start(&test_tfw_mods);
 }
 
 static void

--- a/tempesta_fw/t/unit/test_cfg.c
+++ b/tempesta_fw/t/unit/test_cfg.c
@@ -63,7 +63,7 @@ do_parse_cfg(const char *cfg_text, TfwCfgSpec specs[])
 
 	if ((ret = tfw_cfg_parse_mods(cfg_text, &test_tfw_mods)))
 		return ret;
-	if ((ret = tfw_mods_cfgfin(&test_tfw_mods)))
+	if ((ret = tfw_mods_cfgend(&test_tfw_mods)))
 		return ret;
 	return tfw_mods_start(&test_tfw_mods);
 }

--- a/tempesta_fw/t/unit/test_cfg.c
+++ b/tempesta_fw/t/unit/test_cfg.c
@@ -28,6 +28,14 @@
 #define EXPORT_SYMBOL(func)
 #endif
 #include "cfg.c"
+
+#undef module_init
+#undef module_exit
+#define module_init(fn)
+#define module_exit(fn)
+#define tfw_init(arg)	__maybe_unused __tfw_init(arg)
+#include "../../main.c"
+
 /*
  * ------------------------------------------------------------------------
  *	Generic helpers common for all tests.
@@ -38,26 +46,32 @@
  * The internal functions are imported to simplify testing.
  * We don't want to inject a real Tempesta FW module via public API because
  * our specs may interfere with already existing modules.
- * Instead, we create a dummy TfwCfgMod and pass it to them as if it was real.
+ * Instead, we create a dummy TfwMod{} and pass it to them as if it was real.
  */
 
-TfwCfgMod test_dummy_mod = { .name = "test_dummy_mod" };
+static LIST_HEAD(test_tfw_mods);
+TfwMod test_dummy_mod = { .name = "test_dummy_mod" };
 
 static int
 do_parse_cfg(const char *cfg_text, TfwCfgSpec specs[])
 {
-	BUG_ON(!list_empty(&tfw_cfg_mods));
-	test_dummy_mod.specs = specs;
-	list_add(&test_dummy_mod.list, &tfw_cfg_mods);
+	int ret;
 
-	return tfw_cfg_start_mods(cfg_text);
+	BUG_ON(!list_empty(&test_tfw_mods));
+	test_dummy_mod.specs = specs;
+	list_add(&test_dummy_mod.list, &test_tfw_mods);
+
+	if ((ret = tfw_cfg_parse(cfg_text, &test_tfw_mods)))
+		return ret;
+
+	return tfw_start_mods(&test_tfw_mods);
 }
 
 static void
 do_cleanup_cfg(void)
 {
-	BUG_ON(list_empty(&tfw_cfg_mods));
-	tfw_cfg_stop();
+	BUG_ON(list_empty(&test_tfw_mods));
+	tfw_stop(&test_tfw_mods);
 	list_del(&test_dummy_mod.list);
 }
 

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -571,8 +571,8 @@ TEST_SUITE(http_sticky)
 
 	/* emulate configuration file */
 	ce_sticky.val_n = 0; /* remove "enforce" parameter */
-	tfw_http_sticky_cfg(&tfw_http_sess_cfg_mod.specs[0], &ce_sticky);
-	tfw_http_sticky_secret_cfg(&tfw_http_sess_cfg_mod.specs[1], &ce_secret);
+	tfw_http_sticky_cfg(&tfw_http_sess_mod.specs[0], &ce_sticky);
+	tfw_http_sticky_secret_cfg(&tfw_http_sess_mod.specs[1], &ce_secret);
 
 	tfw_cfg_sess_start();
 
@@ -590,7 +590,7 @@ TEST_SUITE(http_sticky)
 
 	/* test "enforce" mode */
 	ce_sticky.val_n = 1; /* return "enforce" parameter */
-	tfw_http_sticky_cfg(&tfw_http_sess_cfg_mod.specs[0], &ce_sticky);
+	tfw_http_sticky_cfg(&tfw_http_sess_mod.specs[0], &ce_sticky);
 
 	TEST_RUN(http_sticky, req_no_cookie_enforce);
 	TEST_RUN(http_sticky, req_have_cookie_enforce);

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -571,10 +571,10 @@ TEST_SUITE(http_sticky)
 
 	/* emulate configuration file */
 	ce_sticky.val_n = 0; /* remove "enforce" parameter */
-	tfw_http_sticky_cfg(&tfw_http_sess_mod.specs[0], &ce_sticky);
-	tfw_http_sticky_secret_cfg(&tfw_http_sess_mod.specs[1], &ce_secret);
+	tfw_cfgop_sticky(&tfw_http_sess_mod.specs[0], &ce_sticky);
+	tfw_cfgop_sticky_secret(&tfw_http_sess_mod.specs[1], &ce_secret);
 
-	tfw_cfg_sess_start();
+	tfw_http_sess_start();
 
 	kernel_fpu_begin();
 
@@ -590,14 +590,14 @@ TEST_SUITE(http_sticky)
 
 	/* test "enforce" mode */
 	ce_sticky.val_n = 1; /* return "enforce" parameter */
-	tfw_http_sticky_cfg(&tfw_http_sess_mod.specs[0], &ce_sticky);
+	tfw_cfgop_sticky(&tfw_http_sess_mod.specs[0], &ce_sticky);
 
 	TEST_RUN(http_sticky, req_no_cookie_enforce);
 	TEST_RUN(http_sticky, req_have_cookie_enforce);
 
 	kernel_fpu_end();
 
-	tfw_cfg_sess_stop();
+	tfw_http_sess_stop();
 	tfw_http_sess_exit();
 
 	kernel_fpu_begin();

--- a/tempesta_fw/t/unit/test_sched_hash.c
+++ b/tempesta_fw/t/unit/test_sched_hash.c
@@ -28,8 +28,6 @@
 #define tfw_srv_conn_release test_hash_srv_conn_release
 #undef tfw_sock_srv_mod
 #define tfw_sock_srv_mod test_hash_sock_srv_mod
-#undef tfw_sg_grace_shutdown_finish
-#define tfw_sg_grace_shutdown_finish test_hash_sg_grace_shutdown_finish
 
 #include "sock_srv.c"
 

--- a/tempesta_fw/t/unit/test_sched_hash.c
+++ b/tempesta_fw/t/unit/test_sched_hash.c
@@ -28,6 +28,8 @@
 #define tfw_srv_conn_release test_hash_srv_conn_release
 #undef tfw_sock_srv_mod
 #define tfw_sock_srv_mod test_hash_sock_srv_mod
+#undef tfw_sg_grace_shutdown_finish
+#define tfw_sg_grace_shutdown_finish test_hash_sg_grace_shutdown_finish
 
 #include "sock_srv.c"
 

--- a/tempesta_fw/t/unit/test_sched_hash.c
+++ b/tempesta_fw/t/unit/test_sched_hash.c
@@ -26,8 +26,8 @@
 #define tfw_sock_srv_exit test_hash_sock_srv_exit
 #undef tfw_srv_conn_release
 #define tfw_srv_conn_release test_hash_srv_conn_release
-#undef tfw_sock_srv_cfg_mod
-#define tfw_sock_srv_cfg_mod test_hash_sock_srv_cfg_mod
+#undef tfw_sock_srv_mod
+#define tfw_sock_srv_mod test_hash_sock_srv_mod
 
 #include "sock_srv.c"
 

--- a/tempesta_fw/t/unit/test_sched_http.c
+++ b/tempesta_fw/t/unit/test_sched_http.c
@@ -61,6 +61,12 @@ parse_cfg(const char *cfg_text)
 	list_add(&sched_mod.list, &mod_list);
 
 	r = tfw_cfg_parse_mods(cfg_text, &mod_list);
+	/*
+	 * Only 'tfw_sched_http' is used, start it directly to make HTTP
+	 * scheduler working. cfgend() is not used since implicit default
+	 * match rule is undesirable in the tests.
+	 */
+	r &= tfw_sched_http_start();
 
 	kernel_fpu_begin();
 

--- a/tempesta_fw/t/unit/test_sched_http.c
+++ b/tempesta_fw/t/unit/test_sched_http.c
@@ -27,8 +27,6 @@
 #define tfw_srv_conn_release test_http_srv_conn_release
 #undef tfw_sock_srv_mod
 #define tfw_sock_srv_mod test_http_sock_srv_mod
-#undef tfw_sg_grace_shutdown_finish
-#define tfw_sg_grace_shutdown_finish test_http_sg_grace_shutdown_finish
 
 #include "sock_srv.c"
 

--- a/tempesta_fw/t/unit/test_sched_http.c
+++ b/tempesta_fw/t/unit/test_sched_http.c
@@ -27,6 +27,8 @@
 #define tfw_srv_conn_release test_http_srv_conn_release
 #undef tfw_sock_srv_mod
 #define tfw_sock_srv_mod test_http_sock_srv_mod
+#undef tfw_sg_grace_shutdown_finish
+#define tfw_sg_grace_shutdown_finish test_http_sg_grace_shutdown_finish
 
 #include "sock_srv.c"
 

--- a/tempesta_fw/t/unit/test_sched_http.c
+++ b/tempesta_fw/t/unit/test_sched_http.c
@@ -25,8 +25,8 @@
 #define tfw_sock_srv_exit test_http_sock_srv_exit
 #undef tfw_srv_conn_release
 #define tfw_srv_conn_release test_http_srv_conn_release
-#undef tfw_sock_srv_cfg_mod
-#define tfw_sock_srv_cfg_mod test_http_sock_srv_cfg_mod
+#undef tfw_sock_srv_mod
+#define tfw_sock_srv_mod test_http_sock_srv_mod
 
 #include "sock_srv.c"
 
@@ -49,16 +49,16 @@ static int
 parse_cfg(const char *cfg_text)
 {
 	struct list_head mod_list;
-	TfwCfgMod cfg_mod;
+	TfwMod sched_mod;
 	int r;
 
 	kernel_fpu_end();
 
-	cfg_mod = *tfw_cfg_mod_find("tfw_sched_http");
+	sched_mod = *tfw_mod_find("tfw_sched_http");
 	
-	INIT_LIST_HEAD(&cfg_mod.list);
+	INIT_LIST_HEAD(&sched_mod.list);
 	INIT_LIST_HEAD(&mod_list);
-	list_add(&cfg_mod.list, &mod_list);
+	list_add(&sched_mod.list, &mod_list);
 
 	r = tfw_cfg_parse_mods_cfg(cfg_text, &mod_list);
 
@@ -70,11 +70,10 @@ parse_cfg(const char *cfg_text)
 static void
 cleanup_cfg(void)
 {
-	TfwCfgMod cfg_mod;
+	TfwMod sched_mod;
 
-
-	cfg_mod = *tfw_cfg_mod_find("tfw_sched_http");
-	test_spec_cleanup(cfg_mod.specs);
+	sched_mod = *tfw_mod_find("tfw_sched_http");
+	test_spec_cleanup(sched_mod.specs);
 }
 
 static void

--- a/tempesta_fw/t/unit/test_sched_http.c
+++ b/tempesta_fw/t/unit/test_sched_http.c
@@ -60,7 +60,7 @@ parse_cfg(const char *cfg_text)
 	INIT_LIST_HEAD(&mod_list);
 	list_add(&sched_mod.list, &mod_list);
 
-	r = tfw_cfg_parse_mods_cfg(cfg_text, &mod_list);
+	r = tfw_cfg_parse_mods(cfg_text, &mod_list);
 
 	kernel_fpu_begin();
 

--- a/tempesta_fw/t/unit/test_sched_http.c
+++ b/tempesta_fw/t/unit/test_sched_http.c
@@ -78,8 +78,12 @@ cleanup_cfg(void)
 {
 	TfwMod sched_mod;
 
+	kernel_fpu_end();
+
 	sched_mod = *tfw_mod_find("tfw_sched_http");
 	test_spec_cleanup(sched_mod.specs);
+
+	kernel_fpu_begin();
 }
 
 static void

--- a/tempesta_fw/t/unit/test_sched_ratio.c
+++ b/tempesta_fw/t/unit/test_sched_ratio.c
@@ -28,8 +28,6 @@
 #define tfw_srv_conn_release test_ratio_srv_conn_release
 #undef tfw_sock_srv_mod
 #define tfw_sock_srv_mod test_ratio_sock_srv_mod
-#undef tfw_sg_grace_shutdown_finish
-#define tfw_sg_grace_shutdown_finish test_rato_sg_grace_shutdown_finish
 
 #include "sock_srv.c"
 

--- a/tempesta_fw/t/unit/test_sched_ratio.c
+++ b/tempesta_fw/t/unit/test_sched_ratio.c
@@ -28,6 +28,8 @@
 #define tfw_srv_conn_release test_ratio_srv_conn_release
 #undef tfw_sock_srv_mod
 #define tfw_sock_srv_mod test_ratio_sock_srv_mod
+#undef tfw_sg_grace_shutdown_finish
+#define tfw_sg_grace_shutdown_finish test_rato_sg_grace_shutdown_finish
 
 #include "sock_srv.c"
 

--- a/tempesta_fw/t/unit/test_sched_ratio.c
+++ b/tempesta_fw/t/unit/test_sched_ratio.c
@@ -26,8 +26,8 @@
 #define tfw_sock_srv_exit test_ratio_sock_srv_exit
 #undef tfw_srv_conn_release
 #define tfw_srv_conn_release test_ratio_srv_conn_release
-#undef tfw_sock_srv_cfg_mod
-#define tfw_sock_srv_cfg_mod test_ratio_srv_cfg_mod
+#undef tfw_sock_srv_mod
+#define tfw_sock_srv_mod test_ratio_sock_srv_mod
 
 #include "sock_srv.c"
 

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -32,7 +32,7 @@
 
 #define TFW_AUTHOR		"Tempesta Technologies, Inc"
 #define TFW_NAME		"Tempesta FW"
-#define TFW_VERSION		"0.5.0-pre7"
+#define TFW_VERSION		"0.5.0-pre8"
 
 #define DEF_MAX_PORTS		8
 

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -36,4 +36,54 @@
 
 #define DEF_MAX_PORTS		8
 
+/**
+ * Internally, Tempesta FW code is split into modules. These are not
+ * necessarily kernel modules, but rather loosely coupled pieces of code.
+ * Parsed configuration data and start/stop events need to be delivered
+ * to the modules. The parser should not depend on all possible modules,
+ * so a late binding approach is utilized here.
+ *
+ * Each module defines a TfwMod{} structure and calls tfw_mod_register().
+ * A list of registered modules is maintained. Events and configuration
+ * data are pushed to modules via callbacks.
+ *
+ * @name is a unique text identifier of the module. Just like C language
+ * identifiers, it must consist of alphanumeric characters and start with
+ * a letter and so on.
+ *
+ * @specs is the specification for the configuration parser. It lists
+ * all possible configuration sections and directives for the module and
+ * describes how to handle them. @specs must be an array of TfwCfgSpec{}
+ * structures which is terminated by a null (zero'ed) element.
+ *
+ * @start and @stop callbacks are invoked when corresponding events are
+ * received via sysctl. The @start is called after the configuration is
+ * parsed and all @specs are handled by modules.
+ */
+/**
+ * @list	- member in the list of modules;
+ * @name	- module name, [A-Za-z0-9_], starts with a letter;
+ * @start	- called to start a module after all configuration is parsed;
+ * @stop	- called to stop module when Tempesta is stopped;
+ * @specs	- array of configuration directives specifications for a module,
+ *		  terminated by a null element;
+ */
+typedef struct {
+	struct list_head	list;
+	const char		*name;
+	int			(*start)(void);
+	void			(*stop)(void);
+	TfwCfgSpec		*specs;
+} TfwMod;
+
+#define MOD_FOR_EACH(pos, head)		\
+	list_for_each_entry(pos, head, list)
+
+#define MOD_FOR_EACH_REVERSE(pos, head)	\
+	list_for_each_entry_reverse(pos, head, list)
+
+void tfw_mod_register(TfwMod *mod);
+void tfw_mod_unregister(TfwMod *mod);
+TfwMod *tfw_mod_find(const char *name);
+
 #endif /* __TEMPESTA_FW_H__ */

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -63,10 +63,10 @@
 /**
  * @list	- member in the list of modules;
  * @name	- module name, [A-Za-z0-9_], starts with a letter;
- * @start	- called to start a module after all configuration is parsed;
- * @stop	- called to stop module when Tempesta is stopped;
- * @specs	- array of configuration directives specifications for a module,
- *		  terminated by a null element;
+ * @start	- called to start a module after configuration is parsed;
+ * @stop	- called to stop a module when Tempesta is stopped;
+ * @specs	- array of configuration directives specifications
+ *		  for a module, terminated by a null element;
  */
 typedef struct {
 	struct list_head	list;

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -63,7 +63,8 @@
 /**
  * @list	- member in the list of modules;
  * @name	- module name, [A-Za-z0-9_], starts with a letter;
- * @start	- called to start a module after configuration is parsed;
+ * @cfgfin	- called after configuration is parsed;
+ * @start	- called to start a module;
  * @stop	- called to stop a module when Tempesta is stopped;
  * @specs	- array of configuration directives specifications
  *		  for a module, terminated by a null element;
@@ -71,6 +72,7 @@
 typedef struct {
 	struct list_head	list;
 	const char		*name;
+	int			(*cfgfin)(void);
 	int			(*start)(void);
 	void			(*stop)(void);
 	TfwCfgSpec		*specs;

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -63,8 +63,9 @@
 /**
  * @list	- member in the list of modules;
  * @name	- module name, [A-Za-z0-9_], starts with a letter;
+ * @cfgstart	- called before configuration is parsed;
  * @cfgend	- called after configuration is parsed;
- * @start	- called to start a module;
+ * @start	- called to start or reconfig a module;
  * @stop	- called to stop a module when Tempesta is stopped;
  * @specs	- array of configuration directives specifications
  *		  for a module, terminated by a null element;
@@ -72,6 +73,7 @@
 typedef struct {
 	struct list_head	list;
 	const char		*name;
+	int			(*cfgstart)(void);
 	int			(*cfgend)(void);
 	int			(*start)(void);
 	void			(*stop)(void);

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -63,7 +63,7 @@
 /**
  * @list	- member in the list of modules;
  * @name	- module name, [A-Za-z0-9_], starts with a letter;
- * @cfgfin	- called after configuration is parsed;
+ * @cfgend	- called after configuration is parsed;
  * @start	- called to start a module;
  * @stop	- called to stop a module when Tempesta is stopped;
  * @specs	- array of configuration directives specifications
@@ -72,7 +72,7 @@
 typedef struct {
 	struct list_head	list;
 	const char		*name;
-	int			(*cfgfin)(void);
+	int			(*cfgend)(void);
 	int			(*start)(void);
 	void			(*stop)(void);
 	TfwCfgSpec		*specs;

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -86,4 +86,6 @@ void tfw_mod_register(TfwMod *mod);
 void tfw_mod_unregister(TfwMod *mod);
 TfwMod *tfw_mod_find(const char *name);
 
+bool tfw_runstate_is_reconfig(void);
+
 #endif /* __TEMPESTA_FW_H__ */

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -438,7 +438,7 @@ tfw_tls_stop(void)
  * Handle 'ssl_certificate <path>' config entry.
  */
 static int
-tfw_tls_cfg_handle_crt(TfwCfgSpec *cs, TfwCfgEntry *ce)
+tfw_cfgop_ssl_certificate(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
 	void *crt_data;
@@ -482,7 +482,7 @@ tfw_tls_cfg_handle_crt(TfwCfgSpec *cs, TfwCfgEntry *ce)
  * Handle 'ssl_certificate_key <path>' config entry.
  */
 static int
-tfw_tls_cfg_handle_crt_key(TfwCfgSpec *cs, TfwCfgEntry *ce)
+tfw_cfgop_ssl_certificate_key(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
 	void *key_data;
@@ -524,14 +524,16 @@ tfw_tls_cfg_handle_crt_key(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 static TfwCfgSpec tfw_tls_specs[] = {
 	{
-		"ssl_certificate", NULL,
-		tfw_tls_cfg_handle_crt,
+		.name = "ssl_certificate",
+		.deflt = NULL,
+		.handler = tfw_cfgop_ssl_certificate,
 		.allow_none = true,
 		.allow_repeat = false,
 	},
 	{
-		"ssl_certificate_key", NULL,
-		tfw_tls_cfg_handle_crt_key,
+		.name = "ssl_certificate_key",
+		.deflt = NULL,
+		.handler = tfw_cfgop_ssl_certificate_key,
 		.allow_none = true,
 		.allow_repeat = false,
 	},

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -411,6 +411,9 @@ tfw_tls_start(void)
 {
 	int r;
 
+	if (tfw_runstate_is_reconfig())
+		return 0;
+
 	if ((tfw_tls.crt.version && !tfw_tls.key.pk_ctx) ||
 	    (!tfw_tls.crt.version && tfw_tls.key.pk_ctx)) {
 		TFW_ERR("TLS: SSL certificate/key pair is incomplete\n");
@@ -430,6 +433,8 @@ tfw_tls_start(void)
 static void
 tfw_tls_stop(void)
 {
+	if (tfw_runstate_is_reconfig())
+		return;
 	mbedtls_x509_crt_free(&tfw_tls.crt);
 	mbedtls_pk_free(&tfw_tls.key);
 }

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -407,7 +407,7 @@ tfw_tls_do_cleanup(void)
  */
 
 static int
-tfw_tls_cfg_start(void)
+tfw_tls_start(void)
 {
 	int r;
 
@@ -428,7 +428,7 @@ tfw_tls_cfg_start(void)
 }
 
 static void
-tfw_tls_cfg_stop(void)
+tfw_tls_stop(void)
 {
 	mbedtls_x509_crt_free(&tfw_tls.crt);
 	mbedtls_pk_free(&tfw_tls.key);
@@ -522,7 +522,7 @@ tfw_tls_cfg_handle_crt_key(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	return 0;
 }
 
-static TfwCfgSpec tfw_tls_cfg_specs[] = {
+static TfwCfgSpec tfw_tls_specs[] = {
 	{
 		"ssl_certificate", NULL,
 		tfw_tls_cfg_handle_crt,
@@ -535,14 +535,14 @@ static TfwCfgSpec tfw_tls_cfg_specs[] = {
 		.allow_none = true,
 		.allow_repeat = false,
 	},
-	{}
+	{ 0 }
 };
 
-TfwCfgMod tfw_tls_cfg_mod = {
+TfwMod tfw_tls_mod = {
 	.name	= "tls",
-	.start	= tfw_tls_cfg_start,
-	.stop	= tfw_tls_cfg_stop,
-	.specs	= tfw_tls_cfg_specs,
+	.start	= tfw_tls_start,
+	.stop	= tfw_tls_stop,
+	.specs	= tfw_tls_specs,
 };
 
 /*
@@ -567,6 +567,7 @@ tfw_tls_init(void)
 	}
 
 	tfw_connection_hooks_register(&tls_conn_hooks, TFW_FSM_TLS);
+	tfw_mod_register(&tfw_tls_mod);
 
 	return 0;
 }
@@ -574,6 +575,7 @@ tfw_tls_init(void)
 void
 tfw_tls_exit(void)
 {
+	tfw_mod_unregister(&tfw_tls_mod);
 	tfw_connection_hooks_unregister(TFW_FSM_TLS);
 	tfw_gfsm_unregister_fsm(TFW_FSM_TLS);
 	tfw_tls_do_cleanup();

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -953,7 +953,7 @@ tfw_cfgop_cleanup_hdrvia(TfwCfgSpec *cs)
 }
 
 static int
-tfw_vhost_cfgfin(void)
+tfw_vhost_cfgend(void)
 {
 	BUILD_BUG_ON(sizeof(tfw_nipdef_dflt[0]->method) * 8 - 1
 		     < _TFW_HTTP_METH_COUNT);
@@ -1076,7 +1076,7 @@ static TfwCfgSpec tfw_vhost_specs[] = {
 
 TfwMod tfw_vhost_mod = {
 	.name	= "vhost",
-	.cfgfin	= tfw_vhost_cfgfin,
+	.cfgend	= tfw_vhost_cfgend,
 	.stop	= tfw_vhost_stop,
 	.specs	= tfw_vhost_specs,
 };

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -953,7 +953,7 @@ tfw_cfgop_cleanup_hdrvia(TfwCfgSpec *cs)
 }
 
 static int
-tfw_vhost_start(void)
+tfw_vhost_cfgfin(void)
 {
 	BUILD_BUG_ON(sizeof(tfw_nipdef_dflt[0]->method) * 8 - 1
 		     < _TFW_HTTP_METH_COUNT);
@@ -1076,7 +1076,7 @@ static TfwCfgSpec tfw_vhost_specs[] = {
 
 TfwMod tfw_vhost_mod = {
 	.name	= "vhost",
-	.start	= tfw_vhost_start,
+	.cfgfin	= tfw_vhost_cfgfin,
 	.stop	= tfw_vhost_stop,
 	.specs	= tfw_vhost_specs,
 };

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -952,7 +952,7 @@ tfw_cleanup_hdrvia(TfwCfgSpec *cs)
 }
 
 static int
-tfw_vhost_cfg_start(void)
+tfw_vhost_start(void)
 {
 	BUILD_BUG_ON(sizeof(tfw_nipdef_dflt[0]->method) * 8 - 1
 		     < _TFW_HTTP_METH_COUNT);
@@ -970,7 +970,7 @@ tfw_vhost_cfg_start(void)
 }
 
 static void
-tfw_vhost_cfg_stop(void)
+tfw_vhost_stop(void)
 {
 	__tfw_cleanup_hdrvia();
 	__tfw_cleanup_locache();
@@ -1001,7 +1001,7 @@ static TfwCfgSpec tfw_location_specs[] = {
 	{ 0 }
 };
 
-static TfwCfgSpec tfw_vhost_cfg_specs[] = {
+static TfwCfgSpec tfw_vhost_specs[] = {
 	{
 		"hdr_via", NULL,
 		tfw_handle_hdr_via,
@@ -1059,16 +1059,17 @@ static TfwCfgSpec tfw_vhost_cfg_specs[] = {
 	{ 0 },
 };
 
-TfwCfgMod tfw_vhost_cfg_mod = {
+TfwMod tfw_vhost_mod = {
 	.name	= "vhost",
-	.start	= tfw_vhost_cfg_start,
-	.stop	= tfw_vhost_cfg_stop,
-	.specs	= tfw_vhost_cfg_specs,
+	.start	= tfw_vhost_start,
+	.stop	= tfw_vhost_stop,
+	.specs	= tfw_vhost_specs,
 };
 
 int
 tfw_vhost_init(void)
 {
+	tfw_mod_register(&tfw_vhost_mod);
 	return 0;
 }
 
@@ -1076,6 +1077,8 @@ void
 tfw_vhost_exit(void)
 {
 	size_t i;
+
+	tfw_mod_unregister(&tfw_vhost_mod);
 
 	for (i = 0; i < tfw_location_sz; ++i)
 		if (tfw_location[i].capo)

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -962,6 +962,9 @@ tfw_vhost_start(void)
 	BUILD_BUG_ON(sizeof(tfw_location_dflt.op) * 8 - 1
 		     < _TFW_HTTP_MATCH_O_COUNT);
 
+	if (tfw_runstate_is_reconfig())
+		return 0;
+
 	if (tfw_vhost_dflt.cache_purge && !tfw_vhost_dflt.cache_purge_acl)
 		TFW_WARN("cache_purge directive works only in combination"
 			 " with cache_purge_acl directive.\n");
@@ -973,6 +976,8 @@ tfw_vhost_start(void)
 static void
 tfw_vhost_stop(void)
 {
+	if (tfw_runstate_is_reconfig())
+		return;
 	tfw_vhost_dflt.loc_sz = 0;
 }
 


### PR DESCRIPTION
Live reconfiguration, only core features are supported in reconfiguration:
- Adding and removing server groups
- adding and removing servers in server groups
- adding more connections to each server (removing of connection are not supported)
- adding and removing http match rules
- changing any server group options
- changing scheduler assigned to a server group

Known limitations/issues:
- can't reduce number of server connections

To start live reconfiguration simply run `./scripts/tempesta.sh --reload` or write sysctl variable `sysctl -w net.tempesta.state=start` while Tempesta FW is running. 