### PR TITLE
Cleanup: Remove dead code: tfw_str_del_chunk()

### DIFF
--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -97,29 +97,6 @@ tfw_ultoa(unsigned long ai, char *buf, unsigned int len)
 }
 EXPORT_SYMBOL(tfw_ultoa);
 
-void
-tfw_str_del_chunk(TfwStr *str, int id)
-{
-	unsigned int cn = TFW_STR_CHUNKN(str);
-
-	if (unlikely(TFW_STR_PLAIN(str)))
-		return;
-	BUG_ON(TFW_STR_DUP(str));
-	BUG_ON(id >= cn);
-
-	if (TFW_STR_CHUNKN(str) == 2) {
-		/* Just fall back to plain string. */
-		*str = *((TfwStr *)str->ptr + (id ^ 1));
-		return;
-	}
-
-	str->len -= TFW_STR_CHUNK(str, id)->len;
-	TFW_STR_CHUNKN_SUB(str, 1);
-	/* Move all chunks after @id. */
-	memmove((TfwStr *)str->ptr + id, (TfwStr *)str->ptr + id + 1,
-		(cn - id - 1) * sizeof(TfwStr));
-}
-
 /**
  * Grow @str for @n new chunks.
  * New branches of the string tree are created on 2nd level only,

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -336,8 +336,6 @@ tfw_str_fixup_eol(TfwStr *str, int eolen)
 		*(short *)(str->ptr + str->len) = 0x0a0d; /* CRLF, '\r\n' */
 }
 
-void tfw_str_del_chunk(TfwStr *str, int id);
-
 TfwStr *tfw_str_add_compound(TfwPool *pool, TfwStr *str);
 TfwStr *tfw_str_add_duplicate(TfwPool *pool, TfwStr *str);
 


### PR DESCRIPTION
The function is unused since the commit 08a10df55e37 when the original
__field_finish() was removed from http_parser.c, and the parser was
fixed to not create unnecessary empty chunks at the end of a current
chunk of processed data.

There was no need in this function since September 2015, so I believe
it's safe to remove it.