### PR TITLE
Fix #838, fix #842: make GFSM get more data on L4-L7

### DIFF
--- a/tempesta_fw/classifier/frang.c
+++ b/tempesta_fw/classifier/frang.c
@@ -558,7 +558,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 static unsigned int
 frang_resp_quantum(void)
 {
-	return jiffies / HZ * FRANG_FREQ / frang_cfg.http_resp_code_block->tf;
+	return jiffies * FRANG_FREQ / (frang_cfg.http_resp_code_block->tf * HZ);
 }
 
 static int

--- a/tempesta_fw/classifier/frang.c
+++ b/tempesta_fw/classifier/frang.c
@@ -24,7 +24,7 @@
  * Or, that singular header fields may not be duplicated in an HTTP header.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -57,7 +57,7 @@
 
 MODULE_AUTHOR(TFW_AUTHOR);
 MODULE_DESCRIPTION("Tempesta static limiting classifier");
-MODULE_VERSION("0.2.0");
+MODULE_VERSION("0.3.0");
 MODULE_LICENSE("GPL");
 
 /* We account users with FRANG_FREQ frequency per second. */
@@ -78,14 +78,13 @@ typedef struct {
  *   responses longer than 68 years;
  */
 typedef struct {
-	long		cnt;
+	unsigned int	cnt;
 	unsigned int	ts;
 } __attribute__((packed)) FrangRespCodeStat;
 
 #define FRANG_HTTP_CODE_MIN 100
 #define FRANG_HTTP_CODE_MAX 599
 #define FRANG_HTTP_CODE_BIT_NUM(code) ((code) - FRANG_HTTP_CODE_MIN)
-#define FRANG_RESP_TIME_PERIOD (1 << (sizeof(int) * 8 - 1))
 
 /**
  * Response code block setting
@@ -174,6 +173,17 @@ do {									\
 #define frang_limmsg(lim_name, curr_val, lim, addr)			\
 	frang_msg(lim_name " exceeded", (addr), ": %ld (lim=%ld)\n",	\
 		  (long)curr_val, (long)lim)
+
+#ifdef DEBUG
+#define frang_dbg(fmt_msg, addr, ...)					\
+do {									\
+	char abuf[TFW_ADDR_STR_BUF_SIZE] = {0};				\
+	tfw_addr_fmt_v6(&(addr)->v6.sin6_addr, 0, abuf);		\
+	TFW_DBG("frang: " fmt_msg, abuf, ##__VA_ARGS__);		\
+} while (0)
+#else
+#define frang_dbg(...)
+#endif
 
 static int
 frang_conn_limit(FrangAcc *ra, struct sock *unused)
@@ -541,18 +551,21 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 	return ret;
 }
 
+/**
+ * Monotonically increasing time quantums. The configured time frame is devided
+ * by FRANG_FREQ slots to get the quantums granularity.
+ */
 static unsigned int
 frang_resp_quantum(void)
 {
-	return ((jiffies / HZ) % FRANG_RESP_TIME_PERIOD) * FRANG_FREQ
-		/ frang_cfg.http_resp_code_block->tf;
+	return jiffies / HZ * FRANG_FREQ / frang_cfg.http_resp_code_block->tf;
 }
 
 static int
 frang_bad_resp_limit(FrangAcc *ra)
 {
 	FrangRespCodeStat *stat = ra->resp_code_stat;
-	long cnt = 0;
+	unsigned long cnt = 0;
 	const unsigned int ts = frang_resp_quantum();
 	int i = 0;
 
@@ -682,15 +695,18 @@ do {									\
 } while (0)
 
 static int
-frang_http_req_process(FrangAcc *ra, TfwConn *conn, struct sk_buff *skb,
-		       unsigned int off)
+frang_http_req_process(FrangAcc *ra, TfwConn *conn, const TfwFsmData *data)
 {
 	int r = TFW_PASS;
-	TfwHttpReq *req = container_of(conn->msg, TfwHttpReq, msg);
+	TfwHttpReq *req = (TfwHttpReq *)data->req;
+	struct sk_buff *skb = data->skb;
 	struct sk_buff *head_skb = ss_skb_peek(&req->msg.skb_list);
 	__FRANG_FSM_INIT();
 
 	BUG_ON(!ra);
+	BUG_ON(req != container_of(conn->msg, TfwHttpReq, msg));
+	frang_dbg("check request for client %s, acc=%p\n",
+		  &FRANG_ACC2CLI(ra)->addr, ra);
 
 	spin_lock(&ra->lock);
 
@@ -915,7 +931,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, struct sk_buff *skb,
 
 	/* All limits are verified for current request. */
 	__FRANG_FSM_STATE(Frang_Req_Done) {
-		tfw_gfsm_move(&conn->state, TFW_FRANG_REQ_FSM_DONE, skb, off);
+		tfw_gfsm_move(&conn->state, TFW_FRANG_REQ_FSM_DONE, data);
 		__FRANG_FSM_EXIT();
 	}
 
@@ -928,13 +944,13 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, struct sk_buff *skb,
 }
 
 static int
-frang_http_req_handler(void *obj, struct sk_buff *skb, unsigned int off)
+frang_http_req_handler(void *obj, const TfwFsmData *data)
 {
 	int r;
 	TfwConn *conn = (TfwConn *)obj;
 	FrangAcc *ra = conn->sk->sk_security;
 
-	r = frang_http_req_process(ra, conn, skb, off);
+	r = frang_http_req_process(ra, conn, data);
 	if (r == TFW_BLOCK && frang_cfg.ip_block)
 		tfw_filter_block_ip(&FRANG_ACC2CLI(ra)->addr.v6.sin6_addr);
 
@@ -954,15 +970,17 @@ frang_resp_code_range(const int n)
  * for collecting purposes only.
  */
 static int
-frang_resp_handler(void *obj, struct sk_buff *skb, unsigned int off)
+frang_resp_handler(void *obj, const TfwFsmData *data)
 {
-	TfwHttpReq *req = (TfwHttpReq *)obj;
-	TfwHttpResp *resp = (TfwHttpResp *)req->resp;
+	TfwHttpReq *req = (TfwHttpReq *)data->req;
+	TfwHttpResp *resp = (TfwHttpResp *)data->resp;
 	FrangAcc *ra = (FrangAcc *)req->conn->sk->sk_security;
 	FrangRespCodeStat *stat = ra->resp_code_stat;
 	const FrangHttpRespCodeBlock *conf = frang_cfg.http_resp_code_block;
-	unsigned int ts;
-	int i;
+	unsigned int ts, i;
+
+	frang_dbg("client %s check response %d, acc=%p\n",
+		  &FRANG_ACC2CLI(ra)->addr, resp->status, ra);
 
 	if (!frang_resp_code_range(resp->status)
 	    || !test_bit(FRANG_HTTP_CODE_BIT_NUM(resp->status), conf->codes))
@@ -974,9 +992,10 @@ frang_resp_handler(void *obj, struct sk_buff *skb, unsigned int off)
 	i = ts % FRANG_FREQ;
 	if (ts != stat[i].ts) {
 		stat[i].ts = ts;
-		stat[i].cnt = 0;
+		stat[i].cnt = 1;
+	} else {
+		++stat[i].cnt;
 	}
-	++stat[i].cnt;
 
 	spin_unlock(&ra->lock);
 
@@ -1186,6 +1205,7 @@ frang_set_rsp_code_block(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (frang_parse_ushort(ce->vals[ce->val_n - 2], &cb->limit)
 	    || frang_parse_ushort(ce->vals[ce->val_n - 1], &cb->tf))
 		return -EINVAL;
+
 	return frang_register_fsm_resp();
 }
 
@@ -1372,6 +1392,7 @@ frang_init(void)
 				       TFW_FRANG_REQ_FSM_INIT);
 	if (prio0 < 0) {
 		TFW_ERR("frang: can't register gfsm msg hook\n");
+		r = prio0;
 		goto err_hook;
 	}
 	prio1 = tfw_gfsm_register_hook(TFW_FSM_HTTP,
@@ -1380,6 +1401,7 @@ frang_init(void)
 				       TFW_FRANG_REQ_FSM_INIT);
 	if (prio1 < 0) {
 		TFW_ERR("frang: can't register gfsm chunk hook\n");
+		r = prio1;
 		goto err_hook2;
 	}
 

--- a/tempesta_fw/client.c
+++ b/tempesta_fw/client.c
@@ -4,7 +4,7 @@
  * Clients handling.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -73,6 +73,7 @@ tfw_client_put(TfwClient *cli)
 
 	spin_unlock(cli->hb_lock);
 
+	TFW_DBG("free client: cli=%p\n", cli);
 	kmem_cache_free(cli_cache, cli);
 	TFW_DEC_STAT_BH(clnt.online);
 }
@@ -86,10 +87,10 @@ EXPORT_SYMBOL(tfw_client_put);
  * The returned TfwClient reference must be released via tfw_client_put()
  * when the @sk is closed.
  *
- * TODO #100: evict connections and/or clients and drop their accouning.
- * For now a client is freed immediately when the last its connection is closed,
- * probably we should evict clients after some timeout to keep their classifier
- * statistic for following sessions...
+ * TODO #488 (#100): evict connections and/or clients and drop their accounting.
+ * For now a client is freed immediately when the last of its connections is
+ * closed, probably we should evict clients after some timeout to keep their
+ * classifier statistic for following sessions...
  */
 TfwClient *
 tfw_client_obtain(struct sock *sk, void (*init)(TfwClient *))

--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -4,7 +4,7 @@
  * Generic connection management.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -103,8 +103,12 @@ int
 tfw_connection_recv(void *cdata, struct sk_buff *skb, unsigned int off)
 {
 	TfwConn *conn = cdata;
+	TfwFsmData fsm_data = {
+		.skb = skb,
+		.off = off,
+	};
 
-	return tfw_gfsm_dispatch(&conn->state, conn, skb, off);
+	return tfw_gfsm_dispatch(&conn->state, conn, &fsm_data);
 }
 
 void

--- a/tempesta_fw/gfsm.c
+++ b/tempesta_fw/gfsm.c
@@ -21,7 +21,7 @@
  * slice sharing among processes, GFSM cares about processing hot (in sence of
  * CPU caches) data by all subroutines, who, and only who, are interested in
  * the data. I.e. when a packet arrives, all subroutines interested in
- * processing the packet are called immediatelly while the packet data resides
+ * processing the packet are called immediately while the packet data resides
  * in CPU caches. A data is considered interesting for a subroutine if the
  * subroutine subscribed (hooked) for the states of other FSM or a network
  * packet reception (tfw_gfsm_dispatch()).
@@ -59,7 +59,7 @@
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
  * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
- * This program is free software; you cana redistribute it and/or modify it
+ * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License,
  * or (at your option) any later version.
@@ -160,12 +160,12 @@ tfw_gfsm_switch(TfwGState *st, int state, int prio)
 /**
  * TODO #77 (User-kernel space transport): user-space processing is an
  * asynchronous operation which can be called at different states of different
- * FSMs, so GFSM must introdufe SLEAL logic:
+ * FSMs, so GFSM must introduce STEAL logic:
  *   1. an FSM (responsible for user-space message mapping) can return
  *      TFW_STEAL;
  *   2. getting the return code from gfsm_move() current FSM must finish
  *      the message processing logic and return with stored current state;
- *   3. when a user-space program finish GFSM must unwing the call stack and
+ *   3. when a user-space program finish GFSM must unwind the call stack and
  *      call the original FSM at the same state, so it can finish the message
  *      processing.
  */

--- a/tempesta_fw/gfsm.h
+++ b/tempesta_fw/gfsm.h
@@ -133,7 +133,7 @@ enum {
 /**
  * An input data for a subroutine (FSM) to process.
  *
- * Typically an FSM works solely on L4 or L7, however, in futuer, there could be
+ * Typically an FSM works solely on L4 or L7, however, in future, there could be
  * quite complex FSMs which need access to input data on all layers, e.g.
  * loadable user custom modules. Usually L4 data is provided to FSMs for
  * protocol handlers while L7 is for application layer FSMs, e.g. Frang security

--- a/tempesta_fw/gfsm.h
+++ b/tempesta_fw/gfsm.h
@@ -2,15 +2,12 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License,
  * or (at your option) any later version.
- *
- * Since all protocol FSMs should be able to jump between states of different
- * FSMs, all the FSM states are defined here.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
@@ -24,6 +21,7 @@
 #ifndef __TFW_GFSM_H__
 #define __TFW_GFSM_H__
 
+#include "msg.h"
 #include "sync_socket.h"
 
 /*
@@ -35,6 +33,9 @@
  *
  * Maximum number of different states for each FSM = (1 << 5 = 32).
  * States 0 and 31 are reserved as initial and accepting for automaton.
+ *
+ * TODO #102 (TL) many FSMs (user programs) can be registered and run
+ * simultaneously. See concept.tl for the discussion.
  */
 #define TFW_GFSM_STATE_BITS	5
 #define TFW_GFSM_STATE_N	(1 << TFW_GFSM_STATE_BITS)
@@ -83,7 +84,7 @@ enum {
 	TFW_FSM_HTTP,
 	TFW_FSM_HTTPS,
 
-	/* Request connection limiting classifier */
+	/* Security rules enforcement. */
 	TFW_FSM_FRANG_REQ,
 	TFW_FSM_FRANG_RESP,
 
@@ -130,16 +131,50 @@ enum {
 };
 
 /**
- * Generic FSM state representation for all running FSMs.
+ * An input data for a subroutine (FSM) to process.
  *
- * @curr	- index of current FSM in @states;
- * @obj		- an object processed by FSMs (derived from SsProto);
- * @states	- all FSM states;
+ * Typically an FSM works solely on L4 or L7, however, in futuer, there could be
+ * quite complex FSMs which need access to input data on all layers, e.g.
+ * loadable user custom modules. Usually L4 data is provided to FSMs for
+ * protocol handlers while L7 is for application layer FSMs, e.g. Frang security
+ * limits enforcing module. HTTP FSM processes L4 data and creates L7 data
+ * for further processing by other FSMs. So for futher extensions we handle all
+ * layers data in the structure instead of using a union to keep one layer data
+ * at a time.
+ *
+ * GFSM resides at the top of classes hirarchy, so use generic message classes.
+ *
+ * @skb		- currently processed skb by the TCP/IP stack;
+ * @off		- data offset within the @skb;
+ * @req		- a request associated with current state of an FSM;
+ * @resp	- a response associated with the state;
  */
 typedef struct {
-	/* The two belows should be on the same cache line. */
+	/* L4 (TCP) members. */
+	struct sk_buff	*skb;
+	unsigned int	off;
+
+	/* L7 members. */
+	TfwMsg		*req;
+	TfwMsg		*resp;
+} TfwFsmData;
+
+/**
+ * Generic FSM state representation for all running FSMs.
+ * The first two members should be on the same cache line.
+ *
+ * The GFSM describes only states for a subroutines, which can be hookable
+ * by subroutines (i.e. yield states). The states are a subset of all the
+ * states of an object @obj associated with the subroutine.
+ *
+ * @curr	- index of current FSM in @states;
+ * @obj		- an object associated with the FSM,
+ *		  e.g. a connection descriptor;
+ * @states	- all FSM states, i.e. the FSM states set;
+ */
+typedef struct {
 	char		curr;
-	void		*obj; /* object which state we track */
+	void		*obj;
 	unsigned short	states[TFW_GFSM_FSM_NUM];
 } TfwGState;
 
@@ -147,14 +182,11 @@ typedef struct {
 				 & ((TFW_GFSM_FSM_MASK << TFW_GFSM_FSM_SHIFT) \
 				    | TFW_GFSM_STATE_MASK))
 
-typedef int (*tfw_gfsm_handler_t)(void *obj, struct sk_buff *skb,
-				  unsigned int off);
+typedef int (*tfw_gfsm_handler_t)(void *obj, const TfwFsmData *data);
 
 void tfw_gfsm_state_init(TfwGState *st, void *obj, int st0);
-int tfw_gfsm_dispatch(TfwGState *st, void *obj, struct sk_buff *skb,
-		      unsigned int off);
-int tfw_gfsm_move(TfwGState *st, unsigned short state, struct sk_buff *skb,
-		  unsigned int off);
+int tfw_gfsm_dispatch(TfwGState *st, void *obj, const TfwFsmData *data);
+int tfw_gfsm_move(TfwGState *st, unsigned short state, const TfwFsmData *data);
 
 int tfw_gfsm_register_hook(int fsm_id, int prio, int state,
 			   unsigned short hndl_fsm_id, int st0);

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -2179,11 +2179,14 @@ tfw_srv_client_block(TfwHttpReq *req, int status, const char *msg)
  * TODO enter the function depending on current GFSM state.
  */
 static int
-tfw_http_req_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
+tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 {
 	int r = TFW_BLOCK;
+	struct sk_buff *skb = data->skb;
+	unsigned int off = data->off;
 	unsigned int data_off = off;
 	unsigned int skb_len = skb->len;
+	TfwFsmData data_up;
 
 	BUG_ON(!conn->msg);
 	BUG_ON(data_off >= skb_len);
@@ -2221,6 +2224,16 @@ tfw_http_req_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
 			 skb_len - off, data_off - off, req->msg.len,
 			 req->version, r);
 
+		/*
+		 * We have to keep @data the same to pass it as is to FSMs
+		 * registered with lower priorities after us, but we must
+		 * feed the new data version to FSMs registered on our states.
+		 */
+		data_up.skb = skb;
+		data_up.off = off;
+		data_up.req = (TfwMsg *)req;
+		data_up.resp = NULL;
+
 		switch (r) {
 		default:
 			TFW_ERR("Unrecognized HTTP request "
@@ -2232,8 +2245,8 @@ tfw_http_req_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
 			tfw_client_drop(req, 403, "failed to parse request");
 			return TFW_BLOCK;
 		case TFW_POSTPONE:
-			r = tfw_gfsm_move(&conn->state,
-					  TFW_HTTP_FSM_REQ_CHUNK, skb, off);
+			r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_REQ_CHUNK,
+					  &data_up);
 			TFW_DBG3("TFW_HTTP_FSM_REQ_CHUNK return code %d\n", r);
 			if (r == TFW_BLOCK) {
 				TFW_INC_STAT_BH(clnt.msgs_filtout);
@@ -2258,8 +2271,7 @@ tfw_http_req_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
 			       && (req->content_length != req->body.len));
 		}
 
-		r = tfw_gfsm_move(&conn->state,
-				  TFW_HTTP_FSM_REQ_MSG, skb, off);
+		r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_REQ_MSG, &data_up);
 		TFW_DBG3("TFW_HTTP_FSM_REQ_MSG return code %d\n", r);
 		/* Don't accept any following requests from the peer. */
 		if (r == TFW_BLOCK) {
@@ -2510,21 +2522,21 @@ tfw_http_popreq(TfwHttpMsg *hmresp)
  * in case of an error.
  */
 static int
-tfw_http_resp_gfsm(TfwHttpMsg *hmresp, struct sk_buff *skb, unsigned int off)
+tfw_http_resp_gfsm(TfwHttpMsg *hmresp, const TfwFsmData *data)
 {
 	int r;
 	TfwHttpReq *req;
 
 	BUG_ON(!hmresp->conn);
 
-	r = tfw_gfsm_move(&hmresp->conn->state, TFW_HTTP_FSM_RESP_MSG, skb, off);
+	r = tfw_gfsm_move(&hmresp->conn->state, TFW_HTTP_FSM_RESP_MSG, data);
 	TFW_DBG3("TFW_HTTP_FSM_RESP_MSG return code %d\n", r);
 	if (r == TFW_BLOCK)
 		goto error;
 	/* Proceed with the next GSFM processing */
 
-	r = tfw_gfsm_move(&hmresp->conn->state,
-			  TFW_HTTP_FSM_LOCAL_RESP_FILTER, skb, off);
+	r = tfw_gfsm_move(&hmresp->conn->state, TFW_HTTP_FSM_LOCAL_RESP_FILTER,
+			  data);
 	TFW_DBG3("TFW_HTTP_FSM_LOCAL_RESP_FILTER return code %d\n", r);
 	if (r == TFW_PASS)
 		return TFW_PASS;
@@ -2556,9 +2568,7 @@ static int
 tfw_http_resp_cache(TfwHttpMsg *hmresp)
 {
 	TfwHttpReq *req;
-	TfwGState *state;
-	TfwHttpMsg *prev_resp;
-	void *prev_state_obj;
+	TfwFsmData data;
 	time_t timestamp = tfw_current_timestamp();
 
 	/*
@@ -2588,20 +2598,14 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 	}
 
 	/*
-	 * This hook isn't in tfw_http_resp_fwd() because it isn't needed
-	 * to count responses from a cache.
-	 * FSM needs TfwHttpReq to record data. It needs TfwHttpResp as well.
-	 * It will be added to the request later in tfw_http_resp_fwd(), but it's
-	 * needed now. Save previous (NULL) value for the sake of safety
+	 * This hook isn't in tfw_http_resp_fwd() because responses from the
+	 * cache shouldn't be accounted.
 	 */
-	state = &hmresp->conn->state;
-	prev_state_obj = state->obj;
-	state->obj = req;
-	prev_resp = req->resp;
-	req->resp = hmresp;
-	tfw_gfsm_move(state, TFW_HTTP_FSM_RESP_MSG_FWD, NULL, 0);
-	state->obj = prev_state_obj;
-	req->resp = prev_resp;
+	data.skb = NULL;
+	data.off = 0;
+	data.req = (TfwMsg *)req;
+	data.resp = (TfwMsg *)hmresp;
+	tfw_gfsm_move(&hmresp->conn->state, TFW_HTTP_FSM_RESP_MSG_FWD, &data);
 
 	/*
 	 * Complete HTTP message has been collected and processed
@@ -2628,9 +2632,7 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 static void
 tfw_http_resp_terminate(TfwHttpMsg *hm)
 {
-	struct sk_buff *skb = ss_skb_peek_tail(&hm->msg.skb_list);
-
-	BUG_ON(!skb);
+	TfwFsmData data;
 
 	/*
 	 * Note that in this case we don't have data to process.
@@ -2639,7 +2641,13 @@ tfw_http_resp_terminate(TfwHttpMsg *hm)
 	 * sent to the client. The full skb->len is used as the
 	 * offset to mark this case in the post-processing phase.
 	 */
-	if (tfw_http_resp_gfsm(hm, skb, skb->len) != TFW_PASS)
+	data.skb = ss_skb_peek_tail(&hm->msg.skb_list);
+	BUG_ON(!data.skb);
+	data.off = data.skb->len;
+	data.req = NULL;
+	data.resp = (TfwMsg *)hm;
+
+	if (tfw_http_resp_gfsm(hm, &data) != TFW_PASS)
 		return;
 	tfw_http_resp_cache(hm);
 }
@@ -2649,13 +2657,16 @@ tfw_http_resp_terminate(TfwHttpMsg *hm)
  * TODO enter the function depending on current GFSM state.
  */
 static int
-tfw_http_resp_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
+tfw_http_resp_process(TfwConn *conn, const TfwFsmData *data)
 {
 	int r = TFW_BLOCK;
+	struct sk_buff *skb = data->skb;
+	unsigned int off = data->off;
 	unsigned int data_off = off;
 	unsigned int skb_len = skb->len;
 	TfwHttpReq *bad_req;
 	TfwHttpMsg *hmresp;
+	TfwFsmData data_up;
 	bool filtout = false;
 
 	BUG_ON(!conn->msg);
@@ -2694,6 +2705,16 @@ tfw_http_resp_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
 			 skb_len - off, data_off - off, hmresp->msg.len,
 			 hmresp->version, r);
 
+		/*
+		 * We have to keep @data the same to pass it as is to FSMs
+		 * registered with lower priorities after us, but we must
+		 * feed the new data version to FSMs registered on our states.
+		 */
+		data_up.skb = skb;
+		data_up.off = off;
+		data_up.req = NULL;
+		data_up.resp = (TfwMsg *)hmresp;
+
 		switch (r) {
 		default:
 			TFW_ERR("Unrecognized HTTP response "
@@ -2712,8 +2733,8 @@ tfw_http_resp_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
 			TFW_INC_STAT_BH(serv.msgs_parserr);
 			goto bad_msg;
 		case TFW_POSTPONE:
-			r = tfw_gfsm_move(&conn->state,
-					  TFW_HTTP_FSM_RESP_CHUNK, skb, off);
+			r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_RESP_CHUNK,
+					  &data_up);
 			TFW_DBG3("TFW_HTTP_FSM_RESP_CHUNK return code %d\n", r);
 			if (r == TFW_BLOCK) {
 				TFW_INC_STAT_BH(serv.msgs_filtout);
@@ -2743,7 +2764,7 @@ tfw_http_resp_process(TfwConn *conn, struct sk_buff *skb, unsigned int off)
 		 * Drop server connection in case of serious error or security
 		 * event.
 		 */
-		r = tfw_http_resp_gfsm(hmresp, skb, off);
+		r = tfw_http_resp_gfsm(hmresp, &data_up);
 		if (unlikely(r < TFW_PASS))
 			return TFW_BLOCK;
 
@@ -2824,25 +2845,25 @@ bad_msg:
  * @return status (application logic decision) of the message processing.
  */
 int
-tfw_http_msg_process(void *conn, struct sk_buff *skb, unsigned int off)
+tfw_http_msg_process(void *conn, const TfwFsmData *data)
 {
 	TfwConn *c = (TfwConn *)conn;
 
 	if (unlikely(!c->msg)) {
 		c->msg = tfw_http_conn_msg_alloc(c);
 		if (!c->msg) {
-			__kfree_skb(skb);
+			__kfree_skb(data->skb);
 			return -ENOMEM;
 		}
 		TFW_DBG2("Link new msg %p with connection %p\n", c->msg, c);
 	}
 
-	TFW_DBG2("Add skb %p to message %p\n", skb, c->msg);
-	ss_skb_queue_tail(&c->msg->skb_list, skb);
+	TFW_DBG2("Add skb %p to message %p\n", data->skb, c->msg);
+	ss_skb_queue_tail(&c->msg->skb_list, data->skb);
 
 	return (TFW_CONN_TYPE(c) & Conn_Clnt)
-		? tfw_http_req_process(c, skb, off)
-		: tfw_http_resp_process(c, skb, off);
+		? tfw_http_req_process(c, data)
+		: tfw_http_resp_process(c, data);
 }
 
 /**
@@ -3241,6 +3262,7 @@ int __init
 tfw_http_init(void)
 {
 	int r;
+
 	/* Make sure @req->httperr doesn't take too much space. */
 	BUILD_BUG_ON(FIELD_SIZEOF(TfwHttpMsg, httperr)
 		     > FIELD_SIZEOF(TfwHttpMsg, parser));
@@ -3251,13 +3273,16 @@ tfw_http_init(void)
 
 	tfw_connection_hooks_register(&http_conn_hooks, TFW_FSM_HTTP);
 
-	/* Must be last call - we can't unregister the hook. */
 	ghprio = tfw_gfsm_register_hook(TFW_FSM_TLS,
 					TFW_GFSM_HOOK_PRIORITY_ANY,
 					TFW_TLS_FSM_DATA_READY,
 					TFW_FSM_HTTP, TFW_HTTP_FSM_INIT);
-	if (ghprio < 0)
+	if (ghprio < 0) {
+		tfw_connection_hooks_unregister(TFW_FSM_HTTP);
+		tfw_gfsm_unregister_fsm(TFW_FSM_HTTP);
 		return ghprio;
+	}
+
 	tfw_mod_register(&tfw_http_mod);
 
 	return 0;

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -529,7 +529,7 @@ int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
 bool tfw_http_parse_terminate(TfwHttpMsg *hm);
 
 /* External HTTP functions. */
-int tfw_http_msg_process(void *conn, struct sk_buff *skb, unsigned int off);
+int tfw_http_msg_process(void *conn, const TfwFsmData *data);
 unsigned long tfw_http_req_key_calc(TfwHttpReq *req);
 void tfw_http_req_destruct(void *msg);
 void tfw_http_resp_fwd(TfwHttpReq *req, TfwHttpResp *resp);

--- a/tempesta_fw/msg.h
+++ b/tempesta_fw/msg.h
@@ -4,7 +4,7 @@
  * Generic protocol message.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -24,8 +24,6 @@
 #define __TFW_MSG_H__
 
 #include <linux/skbuff.h>
-
-#include "gfsm.h"
 
 #include "sync_socket.h"
 

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -7,7 +7,7 @@
  * on top on native Linux socket buffers. The helpers provide common and
  * convenient wrappers for skb processing.
  *
- * Copyright (C) 2015-2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -401,8 +401,8 @@ __split_linear_data(struct sk_buff *skb, char *pspt, int len, TfwStr *it)
 	int tail_len = (char *)skb_tail_pointer(skb) - pspt;
 	int tail_off = pspt - (char *)page_address(page);
 
-	TFW_DBG("[%d]: %s: skb [%p] pspt [%p] len [%d] tail_len [%d]\n",
-		smp_processor_id(), __func__, skb, pspt, len, tail_len);
+	TFW_DBG3("[%d]: %s: skb [%p] pspt [%p] len [%d] tail_len [%d]\n",
+		 smp_processor_id(), __func__, skb, pspt, len, tail_len);
 	BUG_ON(!skb->head_frag);
 	BUG_ON(tail_len <= 0);
 	BUG_ON(!(alloc | tail_len));
@@ -505,9 +505,9 @@ __split_pgfrag_add(struct sk_buff *skb, int i, int off, int len, TfwStr *it)
 	struct sk_buff *skb_dst, *skb_new;
 	skb_frag_t *frag_dst, *frag = &skb_shinfo(skb)->frags[i];
 
-	TFW_DBG("[%d]: %s: skb [%p] i [%d] off [%d] len [%d] fragsize [%d]\n",
-		smp_processor_id(), __func__,
-		skb, i, off, len, skb_frag_size(frag));
+	TFW_DBG3("[%d]: %s: skb [%p] i [%d] off [%d] len [%d] fragsize [%d]\n",
+		 smp_processor_id(), __func__,
+		 skb, i, off, len, skb_frag_size(frag));
 
 	/*
 	 * Make a fragment that can hold @len bytes. If @off is
@@ -589,9 +589,9 @@ __split_pgfrag_del(struct sk_buff *skb, int i, int off, int len, TfwStr *it)
 	skb_frag_t *frag = &skb_shinfo(skb)->frags[i];
 	struct skb_shared_info *si = skb_shinfo(skb);
 
-	TFW_DBG("[%d]: %s: skb [%p] i [%d] off [%d] len [%d] fragsize [%d]\n",
-		smp_processor_id(), __func__,
-		skb, i, off, len, skb_frag_size(frag));
+	TFW_DBG3("[%d]: %s: skb [%p] i [%d] off [%d] len [%d] fragsize [%d]\n",
+		 smp_processor_id(), __func__,
+		 skb, i, off, len, skb_frag_size(frag));
 
 	if (unlikely(off + len > skb_frag_size(frag))) {
 		TFW_WARN("Attempt to delete too much\n");
@@ -697,12 +697,12 @@ __skb_fragment(struct sk_buff *skb, char *pspt, int len, TfwStr *it)
 	unsigned int d_size;
 	struct skb_shared_info *si = skb_shinfo(skb);
 
-	TFW_DBG("[%d]: %s: in: len [%d] pspt [%p], skb [%p]: head [%p]"
-		" data [%p] tail [%p] end [%p] len [%u] data_len [%u]"
-		" truesize [%u] nr_frags [%u]\n",
-		smp_processor_id(), __func__, len, pspt, skb, skb->head,
-		skb->data, skb_tail_pointer(skb), skb_end_pointer(skb),
-		skb->len, skb->data_len, skb->truesize, si->nr_frags);
+	TFW_DBG3("[%d]: %s: in: len [%d] pspt [%p], skb [%p]: head [%p]"
+		 " data [%p] tail [%p] end [%p] len [%u] data_len [%u]"
+		 " truesize [%u] nr_frags [%u]\n",
+		 smp_processor_id(), __func__, len, pspt, skb, skb->head,
+		 skb->data, skb_tail_pointer(skb), skb_end_pointer(skb),
+		 skb->len, skb->data_len, skb->truesize, si->nr_frags);
 	BUG_ON(!len);
 
 	/*
@@ -775,12 +775,12 @@ append:
 	__it_next_data(skb, i + 1, it);
 
 done:
-	TFW_DBG("[%d]: %s: out: res [%p], skb [%p]: head [%p] data [%p]"
-		" tail [%p] end [%p] len [%u] data_len [%u]"
-		" truesize [%u] nr_frags [%u]\n",
-		smp_processor_id(), __func__, it->ptr, skb, skb->head,
-		skb->data, skb_tail_pointer(skb), skb_end_pointer(skb),
-		skb->len, skb->data_len, skb->truesize, si->nr_frags);
+	TFW_DBG3("[%d]: %s: out: res [%p], skb [%p]: head [%p] data [%p]"
+		 " tail [%p] end [%p] len [%u] data_len [%u]"
+		 " truesize [%u] nr_frags [%u]\n",
+		 smp_processor_id(), __func__, it->ptr, skb, skb->head,
+		 skb->data, skb_tail_pointer(skb), skb_end_pointer(skb),
+		 skb->len, skb->data_len, skb->truesize, si->nr_frags);
 
 	if (ret < 0)
 		return ret;

--- a/tempesta_fw/stress/sys.c
+++ b/tempesta_fw/stress/sys.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * TODO Stress/overload module for the local system (issue #100).
+ * TODO Stress/overload module for the local system (issue #488).
  *
  * Copyright (C) 2012-2013 NatSys Lab. (info@natsys-lab.com).
  * Copyright (C) 2015 Tempesta Technologies, Inc.

--- a/tempesta_fw/t/functional/README.md
+++ b/tempesta_fw/t/functional/README.md
@@ -83,8 +83,8 @@ That can be done using `ssh-copy-id`.
 
 ### Configuration
 
-Testing framework is configured via `tests_config.ini' file. Example
-configuration is described in `tests_config.ini.sample' file.
+Testing framework is configured via `tests_config.ini` file. Example
+configuration is described in `tests_config.ini.sample` file.
 You can also create default tests configuration by calling:
 
 ```sh


### PR DESCRIPTION
1. GFSM #838: use TfwFsmData as L4-L7 data descriptor for GFSM - pass skb and
   off as well as request and response, probably NULL, to each call.
2. GFSM #842: actually hooks are unregisterable for a while;
3. Frang: use explicit uint type conversion instead of FRANG_RESP_TIME_PERIOD
4. Frang: no need to keep per-quantum counter in 64-bit integer;
5. Adjust levels of debug messages on SS layer according to log.h comment;
6. Small cleanups all around.