### PR TITLE
Update return codes on message parsing errors.

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2242,7 +2242,7 @@ tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 		case TFW_BLOCK:
 			TFW_DBG2("Block invalid HTTP request\n");
 			TFW_INC_STAT_BH(clnt.msgs_parserr);
-			tfw_client_drop(req, 403, "failed to parse request");
+			tfw_client_drop(req, 400, "failed to parse request");
 			return TFW_BLOCK;
 		case TFW_POSTPONE:
 			r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_REQ_CHUNK,
@@ -2833,7 +2833,7 @@ bad_msg:
 					     "response blocked:"
 					     " filtered out");
 		else
-			tfw_srv_client_drop(bad_req, 500,
+			tfw_srv_client_drop(bad_req, 502,
 					    "response dropped:"
 					    " processing error");
 	}


### PR DESCRIPTION
502 status code indicates that gateway or proxy received an
invalid response from an inbound server. See RFC 7231 Section 6.6.3.

400 status code indicates a client error (e.g., malformed request
syntax, invalid request message framing, or deceptive request routing).
See RFC 7231 Section 6.5.1.

Note, that frang module can block responses and requests, but such
blocks shouldn't be confused for parsing errors. If request was
filtered out by frang, the 403 status code must be returned. If
response was filtered out, then the same 502 status code must be
returned.

Although the patch closes issue described in #900, more work (as fixing up content-length header) is required in #900.