### PR TITLE
fix #886: remove saved sessions after tests

### DIFF
--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -597,6 +597,7 @@ TEST_SUITE(http_sticky)
 
 	kernel_fpu_end();
 
+	tfw_cfgop_sticky_cleanup(&tfw_http_sess_mod.specs[0]);
 	tfw_http_sess_stop();
 	tfw_http_sess_exit();
 


### PR DESCRIPTION
I can't reproduce the issue on my side, but the sticky cleanup is certainly missed in sticky tests. Previously `tfw_http_sess_exit()` was responsible for the cleanup, not it's `tfw_cfgop_sticky_cleanup()` job. 