### PR TITLE
Better verbosity for tests

### DIFF
--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -145,7 +145,6 @@ setup()
 update_js_challenge_template()
 {
 	if ! grep -q "^\s*js_challenge\s" $tfw_cfg_path; then
-		echo "not found"
 		return
 	fi
 	echo "...compile html templates"

--- a/tempesta_fw/t/functional/helpers/control.py
+++ b/tempesta_fw/t/functional/helpers/control.py
@@ -152,6 +152,14 @@ class Wrk(Client):
         m = re.search(r'Requests\/sec:\s+(\d+)', stdout)
         if m:
             self.rate = int(m.group(1))
+        m = re.search(r'(Socket errors:.+)\n', stdout)
+        if m:
+            tf_cfg.dbg(0, ("WARNING! Socket errors on wrk. "
+                          "Too many concurrent connections?"))
+            err_m = re.search(r'\w+ (\d)+, \w+ (\d)+, \w+ (\d)+, \w+ (\d)+',
+                              m.group(1))
+            self.errors += (int(err_m.group(1)) + int(err_m.group(2))
+                            + int(err_m.group(3)) + int(err_m.group(4)))
         return True
 
 

--- a/tempesta_fw/t/functional/helpers/control.py
+++ b/tempesta_fw/t/functional/helpers/control.py
@@ -46,6 +46,7 @@ class Client(object):
         # List of files to be removed from remote node after client finish.
         self.cleanup_files = []
         self.requests = 0
+        self.rate = 0
         self.errors = 0
 
     def set_uri(self, uri):
@@ -61,6 +62,7 @@ class Client(object):
 
     def clear_stats(self):
         self.requests = 0
+        self.rate = 0
         self.errors = 0
 
     def cleanup(self):
@@ -89,7 +91,9 @@ class Client(object):
         return True
 
     def results(self):
-        return self.requests, self.errors
+        if (self.rate == 0):
+            self.rate = self.requests / self.duration
+        return self.requests, self.errors, self.rate
 
     def add_option_file(self, option, filename, content):
         """ Helper for using files as client options: normaly file must be
@@ -145,6 +149,9 @@ class Wrk(Client):
         m = re.search(r'Non-2xx or 3xx responses: (\d+)', stdout)
         if m:
             self.errors = int(m.group(1))
+        m = re.search(r'Requests\/sec:\s+(\d+)', stdout)
+        if m:
+            self.rate = int(m.group(1))
         return True
 
 

--- a/tempesta_fw/t/functional/helpers/control.py
+++ b/tempesta_fw/t/functional/helpers/control.py
@@ -192,6 +192,7 @@ def client_run_blocking(client):
     tf_cfg.dbg(3, '\tRunning HTTP client on %s' % remote.client.host)
     stdout, stderr = remote.client.run_cmd(client.cmd,
                                            timeout=(client.duration + 5))
+    tf_cfg.dbg(3, stdout)
     error.assertTrue(client.parse_out(stdout, stderr))
 
 def __clients_prepare(client):
@@ -202,6 +203,7 @@ def __clients_run(client):
 
 def __clients_parse_output(args):
     client, (stdout, stderr) = args
+    tf_cfg.dbg(3, stdout)
     return client.parse_out(stdout, stderr)
 
 def __clients_cleanup(client):
@@ -211,7 +213,7 @@ def clients_run_parallel(clients):
     tf_cfg.dbg(3, ('\tRunning %d HTTP clients on %s' %
                    (len(clients), remote.client.host)))
     if not clients:
-        return True
+        return
 
     pool = multiprocessing.Pool(len(clients))
     results = pool.map(__clients_prepare, clients)

--- a/tempesta_fw/t/functional/reconf/reconf_stress.py
+++ b/tempesta_fw/t/functional/reconf/reconf_stress.py
@@ -67,12 +67,11 @@ class LiveReconfStress(stress.StressTest):
     def assert_clients(self):
         """ Check benchmark result: 502 errors may happen but only for short
         period of time (during reconfig)."""
-        duration = int(tf_cfg.cfg.get('General', 'Duration'))
         for c in self.clients:
-            req, err = c.results()
+            req, err, rate = c.results()
             # Tempesta must be reconfigured in less that 1sec. Errors must not
             # happen after reconfig has finished.
-            max_err = req / duration
+            max_err = rate
             self.assertTrue((err < max_err), msg='HTTP client detected errors')
 
     def stress_reconfig_generic(self, configure_func, reconfigure_func):

--- a/tempesta_fw/t/functional/regression/test_stress_pipeline.py
+++ b/tempesta_fw/t/functional/regression/test_stress_pipeline.py
@@ -56,7 +56,7 @@ class PipelineFaultInjection(stress.StressTest):
         number of requests without responses, but there should be
         no erroneous responses. """
         for c in self.clients:
-            _, err = c.results()
+            _, err, _ = c.results()
             self.assertEqual(err, 0, msg='HTTP client detected errors')
 
     def assert_tempesta(self):

--- a/tempesta_fw/t/functional/sched/test_ratio.py
+++ b/tempesta_fw/t/functional/sched/test_ratio.py
@@ -25,6 +25,20 @@ class RatioStressTest(stress.StressTest):
     def test_ratio(self):
         self.generic_test_routine('cache 0;\n')
 
+class RatioDynamicStressTest(RatioStressTest):
+    """Use Ratio Dynamic"""
+    def configure_tempesta(self):
+        stress.StressTest.configure_tempesta(self)
+        for sg in self.tempesta.config.server_groups:
+            sg.sched = 'ratio dynamic'
+
+class RatioPredictStressTest(RatioStressTest):
+    """Use Ratio Predict"""
+    def configure_tempesta(self):
+        stress.StressTest.configure_tempesta(self)
+        for sg in self.tempesta.config.server_groups:
+            sg.sched = 'ratio predict'
+
 class RatioPerfTest(RatioStressTest):
     """Disable server connections failovering to benchmark ratio scheduler."""
 

--- a/tempesta_fw/t/functional/sched/test_ratio.py
+++ b/tempesta_fw/t/functional/sched/test_ratio.py
@@ -25,6 +25,13 @@ class RatioStressTest(stress.StressTest):
     def test_ratio(self):
         self.generic_test_routine('cache 0;\n')
 
+class RatioPerfTest(RatioStressTest):
+    """Disable server connections failovering to benchmark ratio scheduler."""
+
+    def create_servers(self):
+        self.create_servers_helper(tempesta.servers_in_group())
+        for s in self.servers:
+            s.config.set_ka(sys.maxsize)
 
 class FairLoadEqualConns(RatioStressTest):
     """ Ratio scheduler loads all the upstream servers in the fair

--- a/tempesta_fw/t/functional/testers/stress.py
+++ b/tempesta_fw/t/functional/testers/stress.py
@@ -76,15 +76,17 @@ class StressTest(unittest.TestCase):
         if tf_cfg.v_level() == 2:
             # Go to new line, don't mess up output.
             tf_cfg.dbg(2)
-        req_total = err_total = 0
+        req_total = err_total = rate_total = 0
         for c in self.clients:
-            req, err = c.results()
+            req, err, rate = c.results()
             req_total += req
             err_total += err
-            tf_cfg.dbg(3, '\tClient: errors: %d, requests: %d' % (err, req))
+            rate_total += rate
+            tf_cfg.dbg(3, ('\tClient: errors: %d, requests: %d, rate: %d'
+                           % (err, req, rate)))
         tf_cfg.dbg(
-            2, '\tClients in total: errors: %d, requests: %d' %
-            (err_total, req_total))
+            2, '\tClients in total: errors: %d, requests: %d, rate: %d' %
+            (err_total, req_total, rate_total))
 
 
     def assert_clients(self):
@@ -92,7 +94,7 @@ class StressTest(unittest.TestCase):
         cl_req_cnt = 0
         cl_conn_cnt = 0
         for c in self.clients:
-            req, err = c.results()
+            req, err, _ = c.results()
             cl_req_cnt += req
             cl_conn_cnt += c.connections * self.pipelined_req
             self.assertEqual(err, 0, msg='HTTP client detected errors')


### PR DESCRIPTION
Running tests on a new testbed configuration raises question, how effective tests are. I had been running tests for a long time before I realised that the load was extremely low and tests was ineffective.

Changes:
- Get requests rate from `wrk`  output and show it on 2-nd level of debug
- Echo full `wrk` output on debug level 3
- Warn on `wrk` socket errors
- Add basic tests for predict and dynamic ratio schedulers

At least now it's easier to look though tests results to check for performance regressions.