### PR TITLE
[Tests] Fix server connections failovering functional tests

### DIFF
--- a/tempesta_fw/t/functional/helpers/deproxy.py
+++ b/tempesta_fw/t/functional/helpers/deproxy.py
@@ -608,14 +608,14 @@ class Server(asyncore.dispatcher, stateful.Stateful):
         self.stop_procedures = [self.__stop_server]
 
     def run_start(self):
-        tf_cfg.dbg(4, '\tDeproxy: Server: Start on %s:%d.' % (self.ip, self.port))
+        tf_cfg.dbg(3, '\tDeproxy: Server: Start on %s:%d.' % (self.ip, self.port))
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
         self.set_reuse_addr()
         self.bind((self.ip, self.port))
         self.listen(socket.SOMAXCONN)
 
     def __stop_server(self):
-        tf_cfg.dbg(4, '\tDeproxy: Server: Stop on %s:%d.' % (self.ip,
+        tf_cfg.dbg(3, '\tDeproxy: Server: Stop on %s:%d.' % (self.ip,
                                                              self.port))
         self.close()
         connections = [conn for conn in self.connections]
@@ -691,10 +691,10 @@ class Deproxy(stateful.Stateful):
         self.stop_procedures = [self.__stop_deproxy]
 
     def __stop_deproxy(self):
-        tf_cfg.dbg(3, 'Stopping deproxy tester')
+        tf_cfg.dbg(3, '\tStopping deproxy tester')
 
     def run_start(self):
-        pass
+        tf_cfg.dbg(3, '\tStarting deproxy tester')
 
     def register_tester(self):
         self.client.set_tester(self)

--- a/tempesta_fw/t/functional/helpers/deproxy.py
+++ b/tempesta_fw/t/functional/helpers/deproxy.py
@@ -12,7 +12,7 @@ from . import error, tf_cfg, tempesta, stateful
 
 
 __author__ = 'Tempesta Technologies, Inc.'
-__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017-2018 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
 #-------------------------------------------------------------------------------

--- a/tempesta_fw/t/functional/regression/test_srv_failovering.py
+++ b/tempesta_fw/t/functional/regression/test_srv_failovering.py
@@ -10,7 +10,7 @@ from helpers import deproxy, tempesta
 from testers import functional
 
 __author__ = 'Tempesta Technologies, Inc.'
-__copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017-2018 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
 class FailoveringTest(functional.FunctionalTest):

--- a/tempesta_fw/t/functional/regression/test_srv_failovering.py
+++ b/tempesta_fw/t/functional/regression/test_srv_failovering.py
@@ -38,7 +38,7 @@ class FailoveringTest(functional.FunctionalTest):
         self.tempesta.start()
         self.create_client()
         self.client.start()
-        chains = [deproxy.MessageChain.empty()]
+        # Message chains are not needed for the tester.
         self.create_tester()
         self.tester.start()
 

--- a/tempesta_fw/t/functional/regression/test_srv_failovering.py
+++ b/tempesta_fw/t/functional/regression/test_srv_failovering.py
@@ -31,12 +31,16 @@ class FailoveringTest(functional.FunctionalTest):
         self.tempesta.config.set_defconfig('')
 
         self.create_servers()
+        for server in self.servers:
+            server.start()
         self.configure_tempesta()
 
         self.tempesta.start()
         self.create_client()
+        self.client.start()
         chains = [deproxy.MessageChain.empty()]
         self.create_tester()
+        self.tester.start()
 
     def test_on_close(self):
         self.init()


### PR DESCRIPTION
The `regression.test_srv_failovering` doesn't use `generic_test_routine()` to start test, and starting of stateful classes was missed in last tests updates. Issue was reported in #936 