### PR TITLE
Remove requests from fwd_list and put connections of requests freeing

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -617,7 +617,6 @@ err_create:
  * make a copy of requests's SKBs in SS layer.
  *
  * TODO: Making a copy of each SKB _IS BAD_. See issues #391 and #488.
- *
  */
 static inline void
 tfw_http_req_init_ss_flags(TfwSrvConn *srv_conn, TfwHttpReq *req)
@@ -766,11 +765,19 @@ __tfw_http_conn_msg_sent_prev(TfwSrvConn *srv_conn)
  * Remove @req from the server connection's forwarding queue.
  */
 static inline void
-tfw_http_req_delist(TfwSrvConn *srv_conn, TfwHttpReq *req)
+__http_req_delist(TfwSrvConn *srv_conn, TfwHttpReq *req)
 {
 	tfw_http_req_nip_delist(srv_conn, req);
 	list_del_init(&req->fwd_list);
 	srv_conn->qsize--;
+}
+
+static inline void
+tfw_http_req_delist(TfwSrvConn *srv_conn, TfwHttpReq *req)
+{
+	spin_lock(&srv_conn->fwd_qlock);
+	__http_req_delist(srv_conn, req);
+	spin_unlock(&srv_conn->fwd_qlock);
 }
 
 /*
@@ -794,7 +801,7 @@ tfw_http_req_err(TfwSrvConn *srv_conn, TfwHttpReq *req,
 		 const char *reason)
 {
 	if (srv_conn)
-		tfw_http_req_delist(srv_conn, req);
+		__http_req_delist(srv_conn, req);
 	__tfw_http_req_err(req, eq, status, reason);
 }
 
@@ -840,8 +847,7 @@ tfw_http_error_resp_switch(TfwHttpReq *req, int status, const char *reason)
 	resp_code_t code = tfw_http_enum_resp_code(status);
 	if (code == RESP_NUM) {
 		TFW_WARN("Unexpected response error code: [%d]\n", status);
-		tfw_http_send_resp(req, RESP_500);
-		return;
+		code = RESP_500;
 	}
 
 	tfw_http_send_resp(req, code);
@@ -946,14 +952,14 @@ tfw_http_req_zap_error(struct list_head *eq)
 			tfw_http_error_resp_switch(req, req->httperr.status,
 						   req->httperr.reason);
 		else
-			tfw_http_msg_free((TfwHttpMsg *)req);
+			tfw_http_conn_msg_free((TfwHttpMsg *)req);
 		TFW_INC_STAT_BH(clnt.msgs_otherr);
 	}
 }
 
 /*
- * If @req is dropped since the client fisconnected for some reason,
- * move the request to the error queue @eq for sending an error response later.
+ * If @req is dropped since the client was disconnected for some reason,
+ * just free the request w/o connection putting.
  */
 static inline bool
 tfw_http_req_evict_dropped(TfwSrvConn *srv_conn, TfwHttpReq *req)
@@ -962,7 +968,7 @@ tfw_http_req_evict_dropped(TfwSrvConn *srv_conn, TfwHttpReq *req)
 		TFW_DBG2("%s: Eviction: req=[%p] client disconnected\n",
 			 __func__, req);
 		if (srv_conn)
-			tfw_http_req_delist(srv_conn, req);
+			__http_req_delist(srv_conn, req);
 		tfw_http_msg_free((TfwHttpMsg *)req);
 		TFW_INC_STAT_BH(clnt.msgs_otherr);
 		return true;
@@ -1049,7 +1055,7 @@ tfw_http_req_fwd_send(TfwSrvConn *srv_conn, TfwServer *srv,
 		TFW_DBG2("%s: Forwarding error: conn=[%p] req=[%p]\n",
 			 __func__, srv_conn, req);
 		if (req->flags & TFW_HTTP_F_HMONITOR) {
-			tfw_http_req_delist(srv_conn, req);
+			__http_req_delist(srv_conn, req);
 			tfw_http_msg_free((TfwHttpMsg *)req);
 			TFW_WARN_ADDR("Unable to send health"
 				      " monitoring request to server",
@@ -1341,7 +1347,7 @@ tfw_http_req_resched(TfwHttpReq *req, TfwServer *srv, struct list_head *eq)
 							  srv);
 		if (!sch_conn) {
 			list_del_init(&req->fwd_list);
-			tfw_http_msg_free((TfwHttpMsg *)req);
+			tfw_http_conn_msg_free((TfwHttpMsg *)req);
 			TFW_WARN_ADDR("Unable to find connection to"
 				      " reschedule health monitoring"
 				      " request on server", &srv->addr);
@@ -1722,7 +1728,7 @@ tfw_http_conn_release(TfwConn *conn)
  * and the paired response.
  */
 static inline void
-__tfw_http_resp_pair_free(TfwHttpReq *req)
+tfw_http_resp_pair_free(TfwHttpReq *req)
 {
 	list_del_init(&req->msg.seq_list);
 	tfw_http_conn_msg_free(req->pair);
@@ -2122,7 +2128,7 @@ __tfw_http_resp_fwd(TfwCliConn *cli_conn, struct list_head *ret_queue)
 			ss_close_sync(cli_conn->sk, true);
 			return;
 		}
-		__tfw_http_resp_pair_free(req);
+		tfw_http_resp_pair_free(req);
 		TFW_INC_STAT_BH(serv.msgs_forwarded);
 	}
 }
@@ -2143,7 +2149,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 	LIST_HEAD(ret_queue);
 
 	TFW_DBG2("%s: req=[%p], resp=[%p]\n", __func__, req, resp);
-	WARN_ON(req->resp != resp);
+	WARN_ON_ONCE(req->resp != resp);
 
 	/*
 	 * If the list is empty, then it's either a bug, or the client
@@ -2163,8 +2169,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 			 "conn=[%p]\n",
 			 __func__, cli_conn);
 		ss_close_sync(cli_conn->sk, true);
-		tfw_http_conn_msg_free((TfwHttpMsg *)resp);
-		tfw_http_conn_msg_free((TfwHttpMsg *)req);
+		tfw_http_resp_pair_free(req);
 		TFW_INC_STAT_BH(serv.msgs_otherr);
 		return;
 	}
@@ -2202,6 +2207,12 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 	 * better way of doing this that is more effective. Please see
 	 * the TODO comment above and to the function tfw_http_popreq().
 	 * Also, please see the issue #687.
+	 *
+	 * TODO #687: this is the only place where req_qlock is used. Instead
+	 * of competing for the lock from different softirqs, just process
+	 * the next available response, set a flag for current softirq
+	 * processing ret_queue and make the current softire retry from
+	 * determination of req_retent.
 	 */
 	tfw_cli_conn_get(cli_conn);
 	spin_lock_bh(&cli_conn->ret_qlock);
@@ -2219,7 +2230,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 			TFW_DBG2("%s: Forwarding error: conn=[%p] resp=[%p]\n",
 				 __func__, cli_conn, req->resp);
 			BUG_ON(!req->resp);
-			__tfw_http_resp_pair_free(req);
+			tfw_http_resp_pair_free(req);
 			TFW_INC_STAT_BH(serv.msgs_otherr);
 		}
 	}
@@ -2322,9 +2333,12 @@ tfw_srv_client_block(TfwHttpReq *req, int status, const char *msg)
 static void
 tfw_http_req_cache_service(TfwHttpResp *resp)
 {
-	if (tfw_http_adjust_resp(resp)) {
-		TfwHttpReq *req = resp->req;
+	TfwHttpReq *req = resp->req;
 
+	WARN_ON_ONCE(!list_empty(&req->fwd_list));
+	WARN_ON_ONCE(!list_empty(&req->nip_list));
+
+	if (tfw_http_adjust_resp(resp)) {
 		tfw_http_conn_msg_free((TfwHttpMsg *)resp);
 		HTTP_SEND_RESP(req, 500, "response dropped: processing error");
 		TFW_INC_STAT_BH(clnt.msgs_otherr);
@@ -2332,7 +2346,6 @@ tfw_http_req_cache_service(TfwHttpResp *resp)
 	}
 	tfw_http_resp_fwd(resp);
 	TFW_INC_STAT_BH(clnt.msgs_fromcache);
-	return;
 }
 
 /**
@@ -2852,7 +2865,7 @@ tfw_http_popreq(TfwHttpMsg *hmresp)
 	spin_lock(&srv_conn->fwd_qlock);
 	if ((TfwMsg *)req == srv_conn->msg_sent)
 		srv_conn->msg_sent = NULL;
-	tfw_http_req_delist(srv_conn, req);
+	__http_req_delist(srv_conn, req);
 	tfw_http_conn_nip_adjust(srv_conn);
 	/*
 	 * Run special processing if the connection is in repair
@@ -2888,14 +2901,13 @@ tfw_http_resp_gfsm(TfwHttpMsg *hmresp, const TfwFsmData *data)
 	TFW_DBG3("TFW_HTTP_FSM_RESP_MSG return code %d\n", r);
 	if (r == TFW_BLOCK)
 		goto error;
-	/* Proceed with the next GSFM processing */
 
 	r = tfw_gfsm_move(&hmresp->conn->state, TFW_HTTP_FSM_LOCAL_RESP_FILTER,
 			  data);
 	TFW_DBG3("TFW_HTTP_FSM_LOCAL_RESP_FILTER return code %d\n", r);
 	if (r == TFW_PASS)
 		return TFW_PASS;
-	/* Proceed with the error processing */
+
 error:
 	tfw_http_popreq(hmresp);
 	tfw_http_conn_msg_free(hmresp);
@@ -3093,18 +3105,26 @@ tfw_http_resp_process(TfwConn *conn, const TfwFsmData *data)
 			return TFW_PASS;
 		case TFW_PASS:
 			/*
-			 * The response is fully parsed,
-			 * fall through and process it.
+			 * The response is fully parsed, fall through and
+			 * process it. If the response has broken length, then
+			 * block it (the server connection will be dropped).
 			 */
-			if (!(hmresp->flags
-			      & (TFW_HTTP_F_CHUNKED | TFW_HTTP_F_VOID_BODY))
+			if (!(hmresp->flags & (TFW_HTTP_F_CHUNKED
+					       | TFW_HTTP_F_VOID_BODY))
 			    && (hmresp->content_length != hmresp->body.len))
 				goto bad_msg;
 		}
 
 		/*
 		 * Verify response in context of http health monitor,
-		 * and mark server as disabled/enabled
+		 * and mark server as disabled/enabled.
+		 *
+		 * TODO (TBD) Probably we should close server connection here to
+		 * make all queued request be rescheduled to other servers.
+		 * Also it's a common practice to reset and reestablish
+		 * connections with buggy applications. Now we stop scheduling
+		 * new requests to the server and forward all, probably error
+		 * responses, for queued requests to clients.
 		 */
 		tfw_http_hm_control((TfwHttpResp *)hmresp);
 
@@ -3172,7 +3192,13 @@ next_resp:
 
 	return r;
 bad_msg:
+	/*
+	 * Send error response for the bad requests if necessary.
+	 * In any case remove the request form forward and nip queues -
+	 * we won't resend it.
+	 */
 	bad_req = hmresp->req;
+	tfw_http_req_delist((TfwSrvConn *)conn, bad_req);
 	tfw_http_conn_msg_free(hmresp);
 	if (filtout)
 		tfw_srv_client_block(bad_req, 502,
@@ -3182,7 +3208,7 @@ bad_msg:
 		tfw_srv_client_drop(bad_req, 502,
 				    "response dropped:"
 				    " processing error");
-	return r;
+	return TFW_BLOCK;
 }
 
 /**

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2211,7 +2211,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 	 * TODO #687: this is the only place where req_qlock is used. Instead
 	 * of competing for the lock from different softirqs, just process
 	 * the next available response, set a flag for current softirq
-	 * processing ret_queue and make the current softire retry from
+	 * processing ret_queue and make the current softirq retry from
 	 * determination of req_retent.
 	 */
 	tfw_cli_conn_get(cli_conn);

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -146,6 +146,9 @@ tfw_http_sticky_send_redirect(TfwHttpReq *req, StickyVal *sv)
 	TfwStr *body = tfw_cfg_js_ch ? &tfw_cfg_js_ch->body : NULL;
 	int r;
 
+	WARN_ON_ONCE(!list_empty(&req->fwd_list));
+	WARN_ON_ONCE(!list_empty(&req->nip_list));
+
 	/*
 	 * TODO: #598 rate limit requests with invalid cookie vaule.
 	 * Non-challengeable requests also must be rate limited.

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -547,7 +547,8 @@ tfw_sg_wait_release(void)
 			TFW_WARN_NL("pending for server callbacks to complete "
 				    "for 5s, %ld server groups still exist\n",
 				    atomic64_read(&act_sg_n));
-			tend = jiffies + HZ * 5;
+			__WARN();
+			return;
 		}
 	}
 }

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -734,7 +734,7 @@ ss_tcp_process_skb(struct sock *sk, struct sk_buff *skb, int *processed)
 		if (r < 0) {
 			TFW_DBG2("[%d]: Processing error: sk %p r %d\n",
 			         smp_processor_id(), sk, r);
-			goto out; /* connection dropped */
+			goto out; /* connection must be dropped */
 		}
 	}
 	if (tcp_fin) {


### PR DESCRIPTION
1. Fix #956: remove req from fwd_list on error in tfw_http_resp_process().
2. #959: print a warning and let the system crash if we can't remove a
   server grooup.
3. Add req->fwd_list and req->nip_list warnings to make sure that the req
   is removed from the list when we go to code where we don't have a pointer
   to the server connection.
4. Replace tfw_http_msg_free() by tfw_http_conn_msg_free() in couple of
   places to put connections on requests freeing to avoid memory leakage
   on connections reference counters.
5. Code leanups all around.