### PR TITLE
Fix some issues in functional tests

### DIFF
--- a/tempesta_fw/t/functional/helpers/chains.py
+++ b/tempesta_fw/t/functional/helpers/chains.py
@@ -43,6 +43,7 @@ def response_500():
         'Date: %s' % date,
         'Content-Length: 0',
         'Connection: keep-alive'
+        'Server: Tempesta FW/%s' % tempesta.version()
     ]
     response = deproxy.Response.create(status=500, headers=headers)
     return response
@@ -50,7 +51,10 @@ def response_500():
 def response_403(date=None, connection=None):
     if date is None:
         date = deproxy.HttpMessage.date_time_string()
-    headers = ['Content-Length: 0']
+    headers = [
+        'Content-Length: 0',
+        'Server: Tempesta FW/%s' % tempesta.version()
+    ]
     if connection != None:
         headers.append('Connection: %s' % connection)
 
@@ -60,7 +64,10 @@ def response_403(date=None, connection=None):
 def response_400(date=None, connection=None):
     if date is None:
         date = deproxy.HttpMessage.date_time_string()
-    headers = ['Content-Length: 0']
+    headers = [
+        'Content-Length: 0',
+        'Server: Tempesta FW/%s' % tempesta.version()
+    ]
     if connection != None:
         headers.append('Connection: %s' % connection)
 

--- a/tempesta_fw/t/functional/systemtap/resp_alloc_err.stp
+++ b/tempesta_fw/t/functional/systemtap/resp_alloc_err.stp
@@ -28,9 +28,9 @@ function tfw_pool_destroy(ptr:long) %{
 	}
 %}
 
-probe module("tempesta_fw").function("tfw_http_msg_alloc_resp_light").return
+probe module("tempesta_fw").function("__tfw_http_msg_alloc").return
 {
-	if ($return != 0) {
+	if ((@entry($type) & (0x2 << 0x8)) && !@entry($full) && ($return != 0)) {
 		tfw_pool_destroy($return->pool)
 		$return = 0
 	}

--- a/tempesta_fw/t/functional/tcp_connection/test_connection_close.py
+++ b/tempesta_fw/t/functional/tcp_connection/test_connection_close.py
@@ -61,9 +61,11 @@ class CloseClientConnectiononInvalidReq(CloseConnection):
 
     def create_chains(self):
         chain_200 = chains.base(forward=True)
-        chain_200.request.body = ''.join(['Arbitrary data ' for _ in range(300)])
-        chain_200.request.update()
-
+        # Append some garbge to message.
+        chain_200.request.msg += ''.join(['Arbitrary data ' for _ in range(300)])
+        # Body is not declared in the request, so the garbage will be treated
+        # as a new request. 400 response will be sent and client connection
+        # will be closed.
         chain_400 = deproxy.MessageChain(
             request = deproxy.Request(),
             expected_response = chains.response_400())


### PR DESCRIPTION
@vladtcvs  This is not a full solution, not all tests ar fixed. 

Test `tcp_connection.test_connection_close.CloseClientConnectiononInvalidReq` was fixed partially, recent changes in parsing response from server connection in deproxy still breaks the test: 
```
FAIL: test (tcp_connection.test_connection_close.CloseClientConnectiononInvalidReq)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/Storage/Projects/tempesta/tempesta/tempesta_fw/t/functional/tcp_connection/test_connection_close.py", line 50, in test
    self.run_sniffer()
  File "/mnt/Storage/Projects/tempesta/tempesta/tempesta_fw/t/functional/tcp_connection/test_connection_close.py", line 44, in run_sniffer
    self.generic_test_routine('cache 0;\n', self.create_chains())
  File "/mnt/Storage/Projects/tempesta/tempesta/tempesta_fw/t/functional/testers/functional.py", line 153, in generic_test_routine
    self.assertTrue(False, msg=err)
AssertionError: Garbage after response end:
'''
HTTP/1.1 400 Bad Request
Date: Wed, 28 Mar 2018 06:43:27 GMT
Content-Length: 0
Server: Tempesta FW/0.5.0

'''
```
Test `regression.test_stress_pipeline.PipelineFaultInjection` was fixed, but i'm not sure that the test really checks that it was intended. Please consult to @aleksostapenko . Also note, that the test doesn't copy `.stp` file to Tempesta node, keeping in mind upcoming splitting Tempesta code and tests framework code this should be changed.