### PR TITLE
Fix SIMD call from non FPU-safe context

### DIFF
--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -341,7 +341,7 @@ tfw_sg_put(TfwSrvGroup *sg)
 static inline bool
 tfw_sg_name_match(TfwSrvGroup *sg, const char *name, unsigned int len)
 {
-	return len == sg->nlen && !tfw_stricmp(sg->name, name, len);
+	return len == sg->nlen && !strncasecmp(sg->name, name, len);
 }
 
 /* Scheduler routines. */


### PR DESCRIPTION
Replace `tfw_cstricmp()` by `strncasecmp()` as `tfw_sg_name_match()` is called from process context