### PR TITLE
Add message streaming mode

### DIFF
--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -92,7 +92,6 @@
 # Default:
 #   None.
 
-#
 # TAG: nonidempotent
 #
 # Defines a request that is considered non-idempotent.
@@ -116,7 +115,6 @@
 #   A non-idempotent request in defined as a request that has an unsafe method.
 #
 
-#
 # TAG: server_connect_retries
 #
 # Defines the maximum number of attempts to reconnect with a server.
@@ -133,7 +131,6 @@
 #   server_connect_retries 10;
 #
 
-#
 # TAG: server_forward_retries
 #
 # Defines the maximum number of attempts to re-forward a request to a server.
@@ -145,8 +142,6 @@
 #   server_forward_retries 5;
 #
 
-
-#
 # TAG: server_forward_timeout
 #
 # Defines the maximum time frame within which a request may still be forwarded.
@@ -158,7 +153,6 @@
 # server_forward_timeout 60;
 #
 
-#
 # TAG: server_retry_nonidempotent
 #
 # Defines that non-idempotent requests should be re-forwarded.
@@ -170,7 +164,6 @@
 #   Do not re-forward non-idempotent requests.
 #
 
-#
 # TAG: server_queue_size
 #
 # Defines the size of the forwarding queue in a server connection.
@@ -185,7 +178,6 @@
 #   server_queue_size 1000;
 #
 
-#
 # TAG: grace_shutdown_time
 #
 # Defines the timeout in seconds for graceful server removing during
@@ -408,7 +400,7 @@
 #   keepalive_timeout 75;
 
 # TAG: listen
-# 
+#
 # Tempesta FW listening address.
 #
 # Syntax:
@@ -435,6 +427,24 @@
 # Default:
 #   listen 80;
 
+# TAG: client_rmem
+#
+# Receive window steering.
+#
+# Syntax:
+#   client_rmem SIZE
+#
+# Request has to be stored in Tempesta's buffers until the response is
+# forwarded to the client. The option controls how many memory is used to
+# store all requests for a single client connection. Tempesta uses
+# TCP receive window steering and doesn't allow clients push more data
+# than allowed. The value dosn't overload 'net.ipv4.tcp_rmem' limits.
+#
+# SIZE - buffer size in bytes, 32-bit integer value. '0' value means the option
+# is disabled.
+#
+# Default:
+#   client_rmem 0;
 # TAG: block_action
 #
 # Syntax:
@@ -500,7 +510,7 @@
 #   cache 2;
 
 # TAG: cache_db
-# 
+#
 # Path to a cache database used as a storage for Tempesta FW Web cache.
 #
 # Syntax:

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -427,6 +427,48 @@
 # Default:
 #   listen 80;
 
+# TAG: server_msg_buffering
+#
+# Mode of operation: buffering or streaming.
+#
+# Syntax:
+#   server_msg_buffering SIZE
+#
+# In buffering mode the whole message is assembled on Tempesta's side before
+# forwarding to client. In streaming mode a new message part is streamed
+# to client as soon it's received, full message is not stored in Tempesta's
+# memory.
+#
+# SIZE - 64-bit integer value. May have following values:
+#    0    - pure steaming mode. Only message headers are buffered;
+#    1-.. - mixed mode: only first SIZE bytes of message body is buffered;
+#   -1    - pure buffering mode. The whole message is buffered before forwarding.
+#
+# Default:
+# server_msg_buffering first 10MB of message, stream the rest:
+#   server_msg_buffering 10485760;
+
+# TAG: client_msg_buffering
+#
+# Mode of operation: buffering or streaming.
+#
+# Syntax:
+#   client_msg_buffering SIZE
+#
+# In buffering mode the whole message is assembled on Tempesta's side before
+# forwarding to backend server. In streaming mode a new message part is
+# streamed to backend server as soon it's received, full message is not stored
+# in Tempesta's memory
+#
+# SIZE - 64-bit integer value. May have following values:
+#    0    - pure steaming mode. Only message headers are buffered;
+#    1-.. - mixed mode: only first SIZE bytes of message body is buffered;
+#   -1    - pure buffering mode. The whole message is buffered before forwarding.
+#
+# Default:
+# client_msg_buffering first 1MB of message, stream the rest:
+#   client_msg_buffering 1048576;
+
 # TAG: client_rmem
 #
 # Receive window steering.
@@ -445,6 +487,7 @@
 #
 # Default:
 #   client_rmem 0;
+
 # TAG: block_action
 #
 # Syntax:

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -471,7 +471,7 @@
 
 # TAG: client_rmem
 #
-# Receive window steering.
+# Limit memory used to store all requests by single client connection.
 #
 # Syntax:
 #   client_rmem SIZE
@@ -487,6 +487,24 @@
 #
 # Default:
 #   client_rmem 0;
+
+# TAG: client_responses_rmem
+#
+# Limit memory used to store all responses for single client connection.
+#
+# Syntax:
+#   client_responses_rmem SIZE
+#
+# Responses has to be stored in Tempesta's buffers until they are forwarded
+# to the client. The option controls how many memory is used to
+# store all responses for a single client connection. Shutdown the client
+# connection if memory consumption oferflows the limit.
+#
+# SIZE - buffer size in bytes, 32-bit integer value. '0' value means the option
+# is disabled.
+#
+# Default:
+#   client_responses_rmem 0;
 
 # TAG: block_action
 #

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- * Prototype for fast precentiles calculation.
+ * Prototype for fast percentiles calculation.
  */
 #include <linux/atomic.h>
 #include <linux/kernel.h>
@@ -44,7 +44,7 @@
  * 3. Very small overall memory footprint for inexpensive handling of
  *    performance trends of many servers;
  *
- * 4. Buckets must be dynamicaly rearranged since server response times
+ * 4. Buckets must be dynamically rearranged since server response times
  *    are unknown apriori;
  *
  * 5. The adjustments of buckets must be performed in a lock-less fashion
@@ -182,7 +182,7 @@ tfw_stats_extend(TfwPcntRanges *rng, unsigned int r_time)
 	 * the upper end of the range that the data type could hold.
 	 * As the value was extended to the next order it's conceivable
 	 * that the new value exceeded the maximum for the data type.
-	 * Consirering that TfwPcntCtl{}->end is of type unsigned int,
+	 * Considering that TfwPcntCtl{}->end is of type unsigned int,
 	 * it's totally unimaginable that this situation may ever happen.
 	 */
 	BUG_ON(end >= (1UL << (FIELD_SIZEOF(TfwPcntCtl, end) * 8)));
@@ -456,7 +456,7 @@ typedef struct {
  * @rcount	- current count of health monitoring requests (in @hm->tmt);
  * @jtmstamp	- time in jiffies of last @timer call (for procfs);
  * @timer	- timer for sending health monitoring request;
- * @rearm	- flag for gracefull stopping of @timer;
+ * @rearm	- flag for graceful stopping of @timer;
  */
 typedef struct {
 	TfwApmHM		*hm;
@@ -514,7 +514,7 @@ typedef struct {
 } TfwApmRBuf;
 
 /*
- * The ring buffer contol structure.
+ * The ring buffer control structure.
  *
  * This is a supporting structure. It keeps related data that is useful
  * in making decisions on the need of recalculation of percentiles.

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1693,19 +1693,13 @@ tfw_cfgop_apm_server_failover(TfwCfgSpec *cs, TfwCfgEntry *ce)
 			   ce->vals[0]);
 		return -EINVAL;
 	}
-	if (tfw_cfg_parse_int(ce->vals[1], &limit)) {
-		TFW_ERR_NL("Unable to parse http limit value: '%s'\n",
-			   ce->vals[1]);
+	if (tfw_cfg_parse_int(ce->vals[1], &limit))
 		return -EINVAL;
-	}
 	if (tfw_cfg_check_range(limit, 1, USHRT_MAX))
 		return -EINVAL;
 
-	if (tfw_cfg_parse_int(ce->vals[2], &tframe)) {
-		TFW_ERR_NL("Unable to parse http tframe value: '%s'\n",
-			   ce->vals[2]);
+	if (tfw_cfg_parse_int(ce->vals[2], &tframe))
 		return -EINVAL;
-	}
 	if (tfw_cfg_check_range(tframe, 1, USHRT_MAX))
 		return -EINVAL;
 
@@ -1851,10 +1845,8 @@ tfw_cfgop_apm_hm_resp_crc32(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		return 0;
 	}
 
-	if (tfw_cfg_parse_uint(ce->vals[0], &crc32)) {
-		TFW_ERR_NL("Unable to parse crc32 value: '%s'\n", ce->vals[0]);
+	if (tfw_cfg_parse_uint(ce->vals[0], &crc32))
 		return -EINVAL;
-	}
 
 	tfw_hm_entry->crc32 = crc32;
 
@@ -1868,11 +1860,8 @@ tfw_cfgop_apm_hm_timeout(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	if (tfw_cfg_check_single_val(ce))
 		return -EINVAL;
-	if (tfw_cfg_parse_int(ce->vals[0], &timeout)) {
-		TFW_ERR_NL("Unable to parse http timeout value: '%s'\n",
-			   ce->vals[0]);
+	if (tfw_cfg_parse_int(ce->vals[0], &timeout))
 		return -EINVAL;
-	}
 	if (tfw_cfg_check_range(timeout, 1, USHRT_MAX))
 		return -EINVAL;
 

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -422,6 +422,19 @@ tfw_cache_employ_resp(TfwHttpResp *resp)
 #undef CC_RESP_CACHEIT
 #undef CC_RESP_DONTCACHE
 #undef CC_REQ_DONTCACHE
+	/*
+	 * TODO: caching of streamed responses.
+	 * Streamed response can be cached, but at any time the response
+	 * can be destroyed due to connection error or frang decisions.
+	 * Although incomplete cache entry might be helpful to serve ranged
+	 * responses, it's cannot be used until frang allow it.
+	 * TBD:
+	 * Size of streamed response is limited by 'server_msg_buffering'
+	 * directive to avoid memory exhaustion by single message. Same
+	 * option should be provided for cache.
+	 */
+	if (test_bit(TFW_HTTP_STREAM, resp->flags))
+		return false;
 
 	return true;
 }

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -68,7 +68,7 @@ static const TfwStr tfw_cache_raw_headers_304[] = {
 /*
  * @trec	- Database record descriptor;
  * @key_len	- length of key (URI + Host header);
- * @status_len	- length of response satus line;
+ * @status_len	- length of response status line;
  * @hdr_num	- number of headers;
  * @hdr_len	- length of whole headers data;
  * @hdr_len_304	- length of headers data used to build 304 response;
@@ -80,7 +80,7 @@ static const TfwStr tfw_cache_raw_headers_304[] = {
  * @resp_time	- the time the response was received;
  * @lifetime	- the cache entry's current lifetime;
  * @last_modified - the value of response Last-Modified: header field;
- * @key		- the cache enty key (URI + Host header);
+ * @key		- the cache entry key (URI + Host header);
  * @status	- pointer to status line  (with trailing CRLFs);
  * @hdrs	- pointer to list of HTTP headers (with trailing CRLFs);
  * @body	- pointer to response body (with a prepending CRLF);
@@ -171,7 +171,7 @@ typedef struct {
 static CaNode c_nodes[MAX_NUMNODES];
 
 /*
- * TODO the thread doesn't do anythng for now, however, kthread_stop() crashes
+ * TODO the thread doesn't do anything for now, however, kthread_stop() crashes
  * on restarts, so comment to logic out.
  */
 #if 0
@@ -205,7 +205,7 @@ static TfwStr g_crlf = { .ptr = S_CRLF, .len = SLEN(S_CRLF) };
  * The mask of non-cacheable methods per RFC 7231 4.2.3.
  * Safe methods that do not depend on a current or authoritative response
  * are defined as cacheable: GET, HEAD, and POST.
- * Note: caching of POST method responces is not supported at this time.
+ * Note: caching of POST method responses is not supported at this time.
  * Issue #506 describes, which steps must be made to support caching of POST
  * requests.
  */
@@ -345,7 +345,7 @@ tfw_cache_employ_req(TfwHttpReq *req)
 		req->cache_ctl.flags |= TFW_HTTP_CC_CFG_CACHE_BYPASS;
 		return false;
 	}
-	/* cache_fulfill - work as usual in cache mode. */
+	/* cache_fulfil - work as usual in cache mode. */
 	BUG_ON(cmd != TFW_D_CACHE_FULFILL);
 
 	if (req->cache_ctl.flags & TFW_HTTP_CC_NO_CACHE)
@@ -356,7 +356,7 @@ tfw_cache_employ_req(TfwHttpReq *req)
 		 * response is successfully validated."
 		 *
 		 * We can validate the stored response and serve request from
-		 * cache. This reduses traffic to origin server.
+		 * cache. This reduces traffic to origin server.
 		 */
 		return false;
 
@@ -782,7 +782,7 @@ tfw_cache_dbce_get(TDB *db, TdbIter *iter, TfwHttpReq *req)
 	}
 	/*
 	 * Cache may store one or more responses to the effective Request URI.
-	 * Basicaly, it is suffitient to store only the most recent response and
+	 * Basically, it is sufficient to store only the most recent response and
 	 * remove other representations from cache. (RFC 7234 4: When more than
 	 * one suitable response is stored, a cache MUST use the most recent
 	 * response) But there are still some cases when it is needed to store
@@ -845,7 +845,7 @@ tfw_cache_str_write_hdr(const TfwStr *str, char *p)
  * @return number of copied bytes (@src length).
  *
  * The function copies part of some large data of length @tot_len,
- * so it tries to minimize total number of allocations regardles
+ * so it tries to minimize total number of allocations regardless
  * how many chunks are copied.
  */
 static long
@@ -998,12 +998,12 @@ tfw_cache_copy_hdr(char **p, TdbVRec **trec, TfwStr *src, size_t *tot_len)
 /**
  * Fill @ce->etag with entity-tag value. RFC 7232 Section-2.3 doesn't limit
  * etag size, so can't just have a copy of entity-tag value somewhere in @ce,
- * insted fill @ce->etag TfwStr to correct offset in @ce->hdrs. Also set
+ * instead fill @ce->etag TfwStr to correct offset in @ce->hdrs. Also set
  * WEAK tag to the first chunk of @ce->etag if applied. This is needed for Range
  * requests.
  *
  * @h_off, @h_trec	- supposed offset and record of stored 'ETag:' header;
- * @curr_p, @curr_rec	- used to store compaund @ce->etag.
+ * @curr_p, @curr_rec	- used to store compound @ce->etag.
  */
 static int
 __set_etag(TfwCacheEntry *ce, TfwHttpResp *resp, long h_off, TdbVRec *h_trec,
@@ -1016,7 +1016,7 @@ __set_etag(TfwCacheEntry *ce, TfwHttpResp *resp, long h_off, TdbVRec *h_trec,
 
 	if (TFW_STR_EMPTY(h))
 		return 0;
-	etag_val = tfw_str_next_str_val(h); /* not emptpy after http parser. */
+	etag_val = tfw_str_next_str_val(h); /* not empty after http parser. */
 
 	/* Update supposed Etag offset to real value. */
 	/* FIXME: #803 */
@@ -1067,7 +1067,7 @@ __set_etag(TfwCacheEntry *ce, TfwHttpResp *resp, long h_off, TdbVRec *h_trec,
 		len -= c->len;
 	}
 
-	/* Compaund string was allocated in resp->pool, move to cache entry. */
+	/* Compound string was allocated in resp->pool, move to cache entry. */
 	if (!TFW_STR_PLAIN(&ce->etag)) {
 		len = sizeof(TfwStr *) * TFW_STR_CHUNKN(&ce->etag);
 		curr_p = tdb_entry_get_room(node_db(), curr_trec, curr_p, len,
@@ -1498,12 +1498,12 @@ tfw_cache_build_resp_body(TDB *db, TfwHttpResp *resp, TdbVRec *trec,
  * (copy the list of skbs is faster than scan TDB and build TfwHttpResp).
  * TLS should encrypt the data in already prepared skbs.
  *
- * Basically, skb copy/clonning involves skb creation, so it seems performance
+ * Basically, skb copy/cloning involves skb creation, so it seems performance
  * of response body creation won't change since now we just reuse TDB pages.
- * Perfromace benchmarks and profiling shows that cache_req_process_node()
+ * Performance benchmarks and profiling shows that cache_req_process_node()
  * is the bottleneck, so the problem is either in tfw_cache_dbce_get() or this
  * function, in headers compilation.
- * Also it seems cachig prebuilt responses requires introducing
+ * Also it seems caching prebuilt responses requires introducing
  * TfwCacheEntry->resp pointer to avoid additional indexing data structure.
  * However, the pointer must be zeroed on TDB shutdown and recovery.
  *
@@ -1751,7 +1751,7 @@ tfw_wq_tasklet(unsigned long data)
 
 /**
  * Cache management thread.
- * The thread loads and preprcess static Web content using inotify (TODO).
+ * The thread loads and preprocesses static Web content using inotify (TODO).
  */
 #if 0
 static int

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -1505,7 +1505,7 @@ EXPORT_SYMBOL(tfw_cfg_cleanup_children);
  *     option3;
  *     ...
  * }
- * ...and invokes the TfwCfgSpec->handler which turns out to be this fucntion.
+ * ...and invokes the TfwCfgSpec->handler which turns out to be this function.
  * Here we simply continue parsing by recursing to parse_and_handle_cfg_entry().
  *
  * Also, we cheat here: we don't create a new TfwCfgParserState, but rather

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -92,7 +92,7 @@
  * following rule:
  *                  uri != "static*" -> mark = 1;
  *
- * if parsed, will have following representaion in TfwCfgEntry{}:
+ * if parsed, will have following representation in TfwCfgEntry{}:
  *   TfwCfgEntry {
  *         .name = "rule",
  *         ...
@@ -114,7 +114,7 @@
  * rule:
  *               hdr "Referer" == "*example.com" -> mark = 7;
  *
- * will have following representaion:
+ * will have following representation:
  *   TfwCfgEntry {
  *         .name = "rule",
  *         ...
@@ -235,7 +235,7 @@ typedef struct {
  *
  * @cleanup is another callback the purpose of which is to free memory
  * allocated by @handler. It is called when the configuration is unloaded
- * (the system is stopped, or an error occured). The callback is invoked
+ * (the system is stopped, or an error occurred). The callback is invoked
  * when @handler was called at least once regardless of the handler's
  * return value.
  *
@@ -380,7 +380,7 @@ tfw_cfg_is_dflt_value(TfwCfgEntry *cfg_entry)
  * Tempesta strives to support live reconfiguration. New configuration
  * is loaded, processed and set while Tempesta is running. Ultimately,
  * directives in configuration file are translated into internal data
- * stractures in Tempesta. Internal data structures for data that may
+ * structures in Tempesta. Internal data structures for data that may
  * be reconfigured need to have a configuration flags member that will
  * indicate one of several major actions noted below. Implementation
  * of each action is specific to configuration entry.

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -404,6 +404,7 @@ enum {
 /* Generic TfwCfgSpec->handler functions. */
 int tfw_cfg_set_bool(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_int(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
+int tfw_cfg_set_long(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_str(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_handle_children(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 void tfw_cfg_cleanup_children(TfwCfgSpec *cs);
@@ -413,8 +414,10 @@ int tfw_cfg_check_range(long value, long min, long max);
 int tfw_cfg_check_multiple_of(long value, int divisor);
 int tfw_cfg_check_val_n(const TfwCfgEntry *e, int val_n);
 int tfw_cfg_check_single_val(const TfwCfgEntry *e);
+int __tfw_cfg_parse_int(const char *s, int *out_int);
 int tfw_cfg_parse_int(const char *s, int *out_int);
 int tfw_cfg_parse_uint(const char *s, unsigned int *out_uint);
+int tfw_cfg_parse_long(const char *s, long *out_long);
 int tfw_cfg_parse_intvl(const char *s, unsigned long *i0, unsigned long *i1);
 int tfw_cfg_map_enum(const TfwCfgEnum mappings[],
 		     const char *in_name, void *out_int);

--- a/tempesta_fw/client.h
+++ b/tempesta_fw/client.h
@@ -33,7 +33,7 @@
  * 			  The client is released, when the counter reaches zero:
  * 			  no connections to the server - no client for us :)
  * @class_prvt		- private client accounting data for classifier module.
- *			  Typically it's large and vastes memory in vain if
+ *			  Typically it's large and wastes memory in vain if
  *			  no any classification logic is used;
  */
 typedef struct {

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -185,22 +185,17 @@ typedef struct {
 /* Connection flags are defined by the bit number. */
 enum {
 	/* Need to re-send requests. */
-	TFW_CONN_B_RESEND = 0,
+	TFW_CONN_RESEND = 0,
 	/* Need to forward requests in the queue. */
-	TFW_CONN_B_QFORWD,
+	TFW_CONN_QFORWD,
 	/* Has non-idempotent requests. */
-	TFW_CONN_B_HASNIP,
+	TFW_CONN_HASNIP,
 
 	/* Remove connection */
-	TFW_CONN_B_DEL,
+	TFW_CONN_DEL,
 	/* Connection is in use or at least scheduled to be established. */
-	TFW_CONN_B_ACTIVE
+	TFW_CONN_ACTIVE
 };
-
-#define TFW_CONN_F_RESEND	(1 << TFW_CONN_B_RESEND)
-#define TFW_CONN_F_QFORWD	(1 << TFW_CONN_B_QFORWD)
-#define TFW_CONN_F_HASNIP	(1 << TFW_CONN_B_HASNIP)
-
 
 /**
  * TLS hardened connection.
@@ -274,7 +269,7 @@ extern TfwConnHooks *conn_hooks[TFW_CONN_MAX_PROTOS];
 static inline bool
 tfw_srv_conn_restricted(TfwSrvConn *srv_conn)
 {
-	return test_bit(TFW_CONN_B_RESEND, &srv_conn->flags);
+	return test_bit(TFW_CONN_RESEND, &srv_conn->flags);
 }
 
 /*
@@ -283,7 +278,7 @@ tfw_srv_conn_restricted(TfwSrvConn *srv_conn)
 static inline bool
 tfw_srv_conn_hasnip(TfwSrvConn *srv_conn)
 {
-	return test_bit(TFW_CONN_B_HASNIP, &srv_conn->flags);
+	return test_bit(TFW_CONN_HASNIP, &srv_conn->flags);
 }
 
 static inline bool

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -29,6 +29,8 @@
 #include "msg.h"
 #include "peer.h"
 
+#include "http_parser.h"
+
 #include "sync_socket.h"
 #include "tls.h"
 
@@ -93,6 +95,7 @@ enum {
 #define TFW_CONN_COMMON					\
 	SsProto			proto;			\
 	TfwGState		state;			\
+	TfwHttpParser		parser;			\
 	struct list_head	list;			\
 	atomic_t		refcnt;			\
 	struct timer_list	timer;			\

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -239,7 +239,7 @@ typedef struct {
 
 	/*
 	 * Called when there are no more users of a connection
-	 * and the connections's resources are finally released.
+	 * and the connection's resources are finally released.
 	 */
 	void (*conn_release)(TfwConn *conn);
 
@@ -394,7 +394,7 @@ tfw_connection_link_to_sk(TfwConn *conn, struct sock *sk)
 }
 
 /*
- * Do an oposite to what tfw_connection_link_from_sk() does.
+ * Do an opposite to what tfw_connection_link_from_sk() does.
  * Sync Sockets layer is unlinked from Tempesta, so that Tempesta
  * callbacks are not called anymore on events in the socket.
  */

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -88,6 +88,7 @@ enum {
  * @refcnt	- number of users of the connection structure instance;
  * @timer	- The keep-alive/retry timer for the connection;
  * @msg		- message that is currently being processed;
+ * @msg_sent	- message that was sent last to the connection;
  * @peer	- TfwClient or TfwServer handler;
  * @sk		- an appropriate sock handler;
  * @destructor	- called when a connection is destroyed;
@@ -100,6 +101,7 @@ enum {
 	atomic_t		refcnt;			\
 	struct timer_list	timer;			\
 	TfwMsg			*msg;			\
+	TfwMsg			*msg_sent;		\
 	TfwPeer 		*peer;			\
 	struct sock		*sk;			\
 	void			(*destructor)(void *);
@@ -143,7 +145,7 @@ typedef struct {
  * That way NO locking hierarchy is involved. Please see the code.
  */
 
-/*
+/**
  * These are specific properties that are relevant to client connections.
  *
  * @seq_queue	- queue of client's messages in the order they came;
@@ -157,7 +159,7 @@ typedef struct {
 	spinlock_t		ret_qlock;
 } TfwCliConn;
 
-/*
+/**
  * These are specific properties that are relevant to server connections.
  * See the description of special features of this structure in sock_srv.c.
  *
@@ -167,7 +169,6 @@ typedef struct {
  * @flags	- atomic flags related to server connection's state;
  * @qsize	- current number of requests in server's @fwd_queue;
  * @recns	- the number of reconnect attempts;
- * @msg_sent	- request that was sent last in a server connection;
  */
 typedef struct {
 	TFW_CONN_COMMON;
@@ -177,7 +178,6 @@ typedef struct {
 	unsigned long		flags;
 	unsigned int		qsize;
 	unsigned int		recns;
-	TfwMsg			*msg_sent;
 } TfwSrvConn;
 
 #define TFW_CONN_DEATHCNT	(INT_MIN / 2)

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -109,7 +109,7 @@ typedef struct {
 
 /*
  * Queues in client and server connections provide support for correct
- * handlng of requests and responses.
+ * handling of requests and responses.
  *
  * Incoming requests are put on client connection's @seq_queue in the
  * order they come in. When responses to these requests come, they're

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -669,11 +669,8 @@ tfw_http_req_init_ss_flags(TfwSrvConn *srv_conn, TfwHttpReq *req)
 static inline void
 tfw_http_resp_init_ss_flags(TfwHttpResp *resp)
 {
-	if (test_bit(TFW_HTTP_CONN_CLOSE, resp->req->flags)
-	    || test_bit(TFW_HTTP_SUSPECTED, resp->req->flags))
-	{
+	if (test_bit(TFW_HTTP_CONN_CLOSE, resp->req->flags))
 		resp->msg.ss_flags |= SS_F_CONN_CLOSE;
-	}
 }
 
 /*
@@ -1970,6 +1967,13 @@ tfw_http_set_hdr_date(TfwHttpMsg *hm)
 	return r;
 }
 
+static inline void
+tfw_http_req_set_conn_close(TfwHttpReq *req)
+{
+	__clear_bit(TFW_HTTP_CONN_KA, req->flags);
+	__set_bit(TFW_HTTP_CONN_CLOSE, req->flags);
+}
+
 /**
  * Remove Connection header from HTTP message @msg if @conn_flg is zero,
  * and replace or set a new header value otherwise.
@@ -2174,8 +2178,7 @@ tfw_http_adjust_resp(TfwHttpResp *resp)
 	if (test_bit(TFW_HTTP_CONN_CLOSE, resp->flags)
 	    && (resp->status / 100 == 4))
 	{
-		__clear_bit(TFW_HTTP_CONN_KA, req->flags);
-		__set_bit(TFW_HTTP_CONN_CLOSE, req->flags);
+		tfw_http_req_set_conn_close(req);
 		conn_flg = BIT(TFW_HTTP_CONN_CLOSE);
 	}
 	else
@@ -2370,7 +2373,7 @@ static inline void
 tfw_http_req_mark_error(TfwHttpReq *req, int status)
 {
 	TFW_CONN_TYPE(req->conn) |= Conn_Stop;
-	__set_bit(TFW_HTTP_SUSPECTED, req->flags);
+	tfw_http_req_set_conn_close(req);
 	tfw_http_error_resp_switch(req, status);
 }
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2513,7 +2513,7 @@ tfw_http_cli_error_resp_and_log(TfwHttpReq *req, int status, const char *msg,
 /**
  * Unintentional error happen during request parsing. Stop the client connection
  * from receiving new requests. Caller must return TFW_BLOCK to the
- * ss_tcp_data_ready() function for propper connection close.
+ * ss_tcp_data_ready() function for proper connection close.
  */
 static inline void
 tfw_client_drop(TfwHttpReq *req, int status, const char *msg)
@@ -2524,7 +2524,7 @@ tfw_client_drop(TfwHttpReq *req, int status, const char *msg)
 /**
  * Attack is detected during request parsing.
  * Caller must return TFW_BLOCK to the ss_tcp_data_ready() function for
- * propper connection close.
+ * proper connection close.
  */
 static inline void
 tfw_client_block(TfwHttpReq *req, int status, const char *msg)
@@ -3059,7 +3059,7 @@ drop:	/*
 	return TFW_BLOCK;
 
 block:	/*
-	 * An attack was detected. Shutdown the client connection immediatelly
+	 * An attack was detected. Shutdown the client connection immediately
 	 * and drop all pending requests.
 	 */
 	TFW_INC_STAT_BH(clnt.msgs_filtout);

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2779,249 +2779,276 @@ tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 	struct sk_buff *skb = data->skb;
 	unsigned int off = data->off;
 	unsigned int data_off = off;
-	unsigned int skb_len = skb->len;
 	TfwFsmData data_up;
+	int req_conn_close;
+	bool block = false;
+	TfwHttpError err = { .status = 400 };
+	TfwHttpParser *parser;
+	TfwHttpMsg *hmsib;
+	TfwHttpReq *req;
+
 
 	BUG_ON(!conn->msg);
-	BUG_ON(data_off >= skb_len);
+	BUG_ON(data_off >= skb->len);
 
 	TFW_DBG2("Received %u client data bytes on conn=%p msg=%p\n",
-		 skb_len - off, conn, conn->msg);
+		 skb->len - off, conn, conn->msg);
 
 	/*
 	 * Process pipelined requests in a loop
 	 * until all data in the SKB is processed.
 	 */
-	while (data_off < skb_len) {
-		int req_conn_close;
-		bool block = false;
-		TfwHttpMsg *hmsib = NULL;
-		TfwHttpReq *req = (TfwHttpReq *)conn->msg;
-		TfwHttpParser *parser = &conn->parser;
+next_msg:
+	hmsib = NULL;
+	req = (TfwHttpReq *)conn->msg;
+	parser = &conn->parser;
 
+	/*
+	 * Process/parse data in the SKB.
+	 * @off points at the start of data for processing.
+	 * @data_off is the current offset of data to process in
+	 * the SKB. After processing @data_off points at the end
+	 * of latest data chunk. However processing may have
+	 * stopped in the middle of the chunk. Adjust it to point
+	 * to the right location within the chunk.
+	 */
+	off = data_off;
+	r = ss_skb_process(skb, &data_off, tfw_http_parse_req, req);
+	data_off -= parser->to_go;
+	req->msg.len += data_off - off;
+	ss_rmem_reserve(req->conn->sk, data_off - off);
+	TFW_ADD_STAT_BH(data_off - off, clnt.rx_bytes);
+
+	TFW_DBG2("Request parsed: len=%u parsed=%d msg_len=%lu ver=%d res=%d\n",
+		 skb->len - off, data_off - off, req->msg.len, req->version, r);
+
+	/*
+	 * We have to keep @data the same to pass it as is to FSMs
+	 * registered with lower priorities after us, but we must
+	 * feed the new data version to FSMs registered on our states.
+	 */
+	data_up.skb = skb;
+	data_up.off = off;
+	data_up.req = (TfwMsg *)req;
+	data_up.resp = NULL;
+
+	switch (r) {
+	default:
+		TFW_ERR("Unrecognized HTTP request parser return code, %d\n",
+			r);
+		err.reason = "Unrecognized HTTP request parser return code";
+		TFW_INC_STAT_BH(clnt.msgs_parserr);
+		goto drop;
+
+	case TFW_BLOCK:
 		/*
-		 * Process/parse data in the SKB.
-		 * @off points at the start of data for processing.
-		 * @data_off is the current offset of data to process in
-		 * the SKB. After processing @data_off points at the end
-		 * of latest data chunk. However processing may have
-		 * stopped in the middle of the chunk. Adjust it to point
-		 * to the right location within the chunk.
+		 * Request can't be parsed. Either the client tries to attack,
+		 * or unintentionally sent us invalid request. Don't block
+		 * the client for now, left worries for the Frang.
 		 */
-		off = data_off;
-		r = ss_skb_process(skb, &data_off, tfw_http_parse_req, req);
-		data_off -= parser->to_go;
-		req->msg.len += data_off - off;
-		ss_rmem_reserve(req->conn->sk, data_off - off);
-		TFW_ADD_STAT_BH(data_off - off, clnt.rx_bytes);
+		TFW_DBG2("Block invalid HTTP request\n");
+		err.reason = "failed to parse request";
+		TFW_INC_STAT_BH(clnt.msgs_parserr);
+		goto drop;
 
-		TFW_DBG2("Request parsed: len=%u parsed=%d msg_len=%lu"
-			 " ver=%d res=%d\n",
-			 skb_len - off, data_off - off, req->msg.len,
-			 req->version, r);
-
-		/*
-		 * We have to keep @data the same to pass it as is to FSMs
-		 * registered with lower priorities after us, but we must
-		 * feed the new data version to FSMs registered on our states.
-		 */
-		data_up.skb = skb;
-		data_up.off = off;
-		data_up.req = (TfwMsg *)req;
-		data_up.resp = NULL;
-
-		switch (r) {
-		default:
-			TFW_ERR("Unrecognized HTTP request "
-				"parser return code, %d\n", r);
-			BUG();
-		case TFW_BLOCK:
-			TFW_DBG2("Block invalid HTTP request\n");
-			TFW_INC_STAT_BH(clnt.msgs_parserr);
-			tfw_client_drop(req, 400, "failed to parse request");
-			return TFW_BLOCK;
-		case TFW_POSTPONE:
-			r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_REQ_CHUNK,
-					  &data_up);
-			TFW_DBG3("TFW_HTTP_FSM_REQ_CHUNK return code %d\n", r);
-			if (r == TFW_BLOCK) {
-				TFW_INC_STAT_BH(clnt.msgs_filtout);
-				tfw_client_block(req, 403, "postponed"
-					       " request has been"
-					       " filtered out");
-				return TFW_BLOCK;
-			}
-			/*
-			 * TFW_POSTPONE status means that parsing succeeded
-			 * but more data is needed to complete it. Lower layers
-			 * just supply data for parsing. They only want to know
-			 * if processing of a message should continue or not.
-			 */
-			return TFW_PASS;
-		case TFW_PASS:
-			/*
-			 * The request is fully parsed,
-			 * fall through and process it.
-			 */
-			BUG_ON(!test_bit(TFW_HTTP_CHUNKED, req->flags)
-			       && (req->content_length != req->body.len));
-		}
-
-		/* Assign the right virtual host for current request. */
-		if ((req->vhost = tfw_http_tbl_vhost((TfwMsg *)req, &block)))
-			req->location = tfw_location_match(req->vhost,
-							   &req->uri_path);
-
-		r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_REQ_MSG,
+	case TFW_POSTPONE:
+		r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_REQ_CHUNK,
 				  &data_up);
-		TFW_DBG3("TFW_HTTP_FSM_REQ_MSG return code %d\n", r);
-		/* Don't accept any following requests from the peer. */
+		TFW_DBG3("TFW_HTTP_FSM_REQ_CHUNK return code %d\n", r);
 		if (r == TFW_BLOCK) {
 			TFW_INC_STAT_BH(clnt.msgs_filtout);
-			tfw_client_block(req, 403, "parsed request"
-					 " has been filtered out");
-			return TFW_BLOCK;
+			err.status = 403;
+			err.reason =  "postponed request has been filtered out";
+			goto drop;
 		}
+		goto out;
 
-		if (block) {
-			TFW_INC_STAT_BH(clnt.msgs_filtout);
-			tfw_client_block(req, 403, "request has been filtered"
-					 " out via http table");
-			return TFW_BLOCK;
-		}
-
-		/*
-		 * The time the request was received is used for age
-		 * calculations in cache, and for eviction purposes.
-		 */
-		req->cache_ctl.timestamp = tfw_current_timestamp();
-		req->jrxtstamp = jiffies;
-
-		/*
-		 * In HTTP 0.9 the server always closes the connection
-		 * after sending the response.
-		 *
-		 * In HTTP 1.0 the server always closes the connection
-		 * after sending the response unless the client sent a
-		 * a "Connection: keep-alive" request header, and the
-		 * server sent a "Connection: keep-alive" response header.
-		 *
-		 * This behavior was added to existing HTTP 1.0 protocol.
-		 * RFC 1945 section 1.3 says:
-		 * "Except for experimental applications, current practice
-		 * requires that the connection be established by the client
-		 * prior to each request and closed by the server after
-		 * sending the response."
-		 *
-		 * Make it work this way in Tempesta by setting the flag.
-		 */
-		if ((req->version == TFW_HTTP_VER_09)
-		    || ((req->version == TFW_HTTP_VER_10)
-			&& !test_bit(TFW_HTTP_CONN_KA, req->flags)))
+	case TFW_PASS:
+		if (unlikely(!test_bit(TFW_HTTP_CHUNKED, req->flags)
+			     && (req->content_length != req->body.len)))
 		{
-			__set_bit(TFW_HTTP_CONN_CLOSE, req->flags);
+			err.reason = "Internal parser error";
+			TFW_INC_STAT_BH(clnt.msgs_parserr);
+			goto drop;
 		}
+		/* The request is fully parsed, fall through and process it. */
+	}
 
+	/* Assign the right virtual host for current request. */
+	if ((req->vhost = tfw_http_tbl_vhost((TfwMsg *)req, &block)))
+		req->location = tfw_location_match(req->vhost, &req->uri_path);
+	if (unlikely(block)) {
+		TFW_INC_STAT_BH(clnt.msgs_filtout);
+		err.status = 403;
+		err.reason = "request has been filtered out via http table";
+		goto drop;
+	}
+	/*
+	 * If target VHost is not found, don't close the entire connection,
+	 * leave the client a chance for a error.
+	 */
+
+	r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_REQ_MSG, &data_up);
+	TFW_DBG3("TFW_HTTP_FSM_REQ_MSG return code %d\n", r);
+	if (r == TFW_BLOCK) {
+		err.reason = "parsed request has been filtered out";
+		goto block;
+	}
+
+	/*
+	 * The time the request was received is used for age
+	 * calculations in cache, and for eviction purposes.
+	 */
+	req->cache_ctl.timestamp = tfw_current_timestamp();
+	req->jrxtstamp = jiffies;
+
+	/*
+	 * In HTTP 0.9 the server always closes the connection
+	 * after sending the response.
+	 *
+	 * In HTTP 1.0 the server always closes the connection
+	 * after sending the response unless the client sent a
+	 * a "Connection: keep-alive" request header, and the
+	 * server sent a "Connection: keep-alive" response header.
+	 *
+	 * This behavior was added to existing HTTP 1.0 protocol.
+	 * RFC 1945 section 1.3 says:
+	 * "Except for experimental applications, current practice
+	 * requires that the connection be established by the client
+	 * prior to each request and closed by the server after
+	 * sending the response."
+	 *
+	 * Make it work this way in Tempesta by setting the flag.
+	 */
+	if ((req->version == TFW_HTTP_VER_09)
+	    || ((req->version == TFW_HTTP_VER_10)
+		&& !test_bit(TFW_HTTP_CONN_KA, req->flags)))
+	{
+		__set_bit(TFW_HTTP_CONN_CLOSE, req->flags);
+	}
+
+	/*
+	 * The request has been successfully parsed and processed.
+	 * If the connection will be closed after the response to
+	 * the request is sent to the client, then there's no need
+	 * to process pipelined requests. Also, the request may be
+	 * released when handled in tfw_cache_req_process() below.
+	 * So, save the needed request flag for later use as it
+	 * may not be accessible later through @req->flags.
+	 * If the connection must be closed, it also should be marked
+	 * with @Conn_Stop flag - to left it alive for sending responses
+	 * and, at the same time, to stop passing data for processing
+	 * from the lower layer.
+	 */
+	if((req_conn_close = test_bit(TFW_HTTP_CONN_CLOSE, req->flags)))
+		TFW_CONN_TYPE(req->conn) |= Conn_Stop;
+
+	if (!req_conn_close && (data_off < skb->len)) {
 		/*
-		 * The request has been successfully parsed and processed.
-		 * If the connection will be closed after the response to
-		 * the request is sent to the client, then there's no need
-		 * to process pipelined requests. Also, the request may be
-		 * released when handled in tfw_cache_req_process() below.
-		 * So, save the needed request flag for later use as it
-		 * may not be accessible later through @req->flags.
-		 * If the connection must be closed, it also should be marked
-		 * with @Conn_Stop flag - to left it alive for sending responses
-		 * and, at the same time, to stop passing data for processing
-		 * from the lower layer.
+		 * Pipelined requests: create a new sibling message.
+		 * @skb is replaced with pointer to a new SKB.
 		 */
-		if((req_conn_close = test_bit(TFW_HTTP_CONN_CLOSE, req->flags)))
-			TFW_CONN_TYPE(req->conn) |= Conn_Stop;
-
-		if (!req_conn_close && (data_off < skb_len)) {
+		hmsib = tfw_http_msg_create_sibling((TfwHttpMsg *)req, &skb,
+						    data_off);
+		if (unlikely(!hmsib)) {
 			/*
-			 * Pipelined requests: create a new sibling message.
-			 * @skb is replaced with pointer to a new SKB.
+			 * Unfortunately, there's no recourse. The
+			 * caller expects that data is processed in
+			 * full, and can't deal with partially
+			 * processed data.
 			 */
-			hmsib = tfw_http_msg_create_sibling((TfwHttpMsg *)req,
-							    &skb, data_off);
-			if (unlikely(!hmsib)) {
-				/*
-				 * Unfortunately, there's no recourse. The
-				 * caller expects that data is processed in
-				 * full, and can't deal with partially
-				 * processed data.
-				 */
-				TFW_INC_STAT_BH(clnt.msgs_otherr);
-				tfw_client_drop(req, 500, "cannot create"
-					      " sibling request");
-				return TFW_BLOCK;
-			}
-		}
-
-		/*
-		 * Complete HTTP message has been collected and processed
-		 * with success. Mark the message as complete in @conn as
-		 * further handling of @conn depends on that. Future SKBs
-		 * will be put in a new message.
-		 * On an error the function returns from anywhere inside
-		 * the loop. @conn->msg holds the reference to the message,
-		 * which can be used to release it.
-		 */
-		tfw_connection_unlink_msg(conn);
-
-		/*
-		 * Add the request to the list of the client connection
-		 * to preserve the correct order of responses to requests.
-		 */
-		tfw_http_req_add_seq_queue(req);
-
-		/*
-		 * If no virtual host has been found for current request, there
-		 * is no sense for its further processing, so we drop it, send
-		 * error response to client and move on to the next request.
-		 */
-		if (!req->vhost) {
-			tfw_http_send_resp(req, 404, "request dropped: cannot"
-					   " find appropriate virtual host");
 			TFW_INC_STAT_BH(clnt.msgs_otherr);
-		} else if (tfw_cache_process((TfwHttpMsg *)req,
-					     tfw_http_req_cache_cb))
-		{
-			/*
-			 * The request should either be stored or released.
-			 * Otherwise we lose the reference to it and get a leak.
-			 */
-			tfw_http_send_resp(req, 500, "request dropped:"
-					   " processing error");
-			TFW_INC_STAT_BH(clnt.msgs_otherr);
-		}
-
-		/*
-		 * According to RFC 7230 6.3.2, connection with a client
-		 * must be dropped after a response is sent to that client,
-		 * if the client sends "Connection: close" header field in
-		 * the request. Subsequent requests from the client coming
-		 * over the same connection are ignored.
-		 *
-		 * Note: This connection's @conn must not be dereferenced
-		 * from this point on.
-		 */
-		if (req_conn_close)
-			break;
-
-		if (hmsib) {
-			/*
-			 * Switch connection to the new sibling message.
-			 * Data processing will continue with the new SKB.
-			 */
-			data_off = 0;
-			skb_len = skb->len;
-			conn->msg = (TfwMsg *)hmsib;
+			err.status = 500;
+			err.reason = "Can't create sibling request";
+			goto drop;
 		}
 	}
 
+	/*
+	 * Complete HTTP message has been collected and processed
+	 * with success. Mark the message as complete in @conn as
+	 * further handling of @conn depends on that. Future SKBs
+	 * will be put in a new message.
+	 * On an error the function returns from anywhere inside
+	 * the loop. @conn->msg holds the reference to the message,
+	 * which can be used to release it.
+	 */
+	tfw_connection_unlink_msg(conn);
+
+	/*
+	 * Add the request to the list of the client connection
+	 * to preserve the correct order of responses to requests.
+	 */
+	tfw_http_req_add_seq_queue(req);
+
+	/*
+	 * If no virtual host has been found for current request, there
+	 * is no sense for its further processing, so we drop it, send
+	 * error response to client and move on to the next request.
+	 */
+	if (unlikely(!req->vhost)) {
+		tfw_http_send_resp(req, 404,
+				   "request dropped: can't find virtual host");
+		TFW_INC_STAT_BH(clnt.msgs_otherr);
+	} else if (tfw_cache_process((TfwHttpMsg *)req,
+				     tfw_http_req_cache_cb))
+	{
+		/*
+		 * The request should either be stored or released.
+		 * Otherwise we lose the reference to it and get a leak.
+		 */
+		tfw_http_send_resp(req, 500,
+				   "request dropped: processing error");
+		TFW_INC_STAT_BH(clnt.msgs_otherr);
+	}
+
+	/*
+	 * According to RFC 7230 6.3.2, connection with a client
+	 * must be dropped after a response is sent to that client,
+	 * if the client sends "Connection: close" header field in
+	 * the request. Subsequent requests from the client coming
+	 * over the same connection are ignored.
+	 */
+	if (!req_conn_close && hmsib) {
+		/*
+		 * Switch connection to the new sibling message.
+		 * Data processing will continue with the new SKB.
+		 */
+		data_off = 0;
+		conn->msg = (TfwMsg *)hmsib;
+		goto next_msg;
+	}
+	/*
+	 * This connection's @conn must not be dereferenced from this point on.
+	 */
+out:
+	/*
+	 * TFW_POSTPONE status means that parsing succeeded
+	 * but more data is needed to complete it. Lower layers
+	 * just supply data for parsing. They only want to know
+	 * if processing of a message should continue or not.
+	 */
+	if (r == TFW_POSTPONE)
+		r = TFW_PASS;
 	return r;
+
+drop:	/*
+	 * Unrecoverable error. Stop from parsing new requests,
+	 * but continue to serve previous requests.
+	 */
+	tfw_client_drop(req, err.status, err.reason);
+
+	return TFW_BLOCK;
+
+block:	/*
+	 * An attack was detected. Shutdown the client connection immediatelly
+	 * and drop all pending requests.
+	 */
+	TFW_INC_STAT_BH(clnt.msgs_filtout);
+	err.status = 403;
+	tfw_client_block(req, err.status, err.reason);
+
+	return TFW_BLOCK;
 }
 
 /**

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3898,8 +3898,6 @@ tfw_cfgop_whitelist_mark(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	TFW_CFG_ENTRY_FOR_EACH_VAL(ce, i, val) {
 		if (tfw_cfg_parse_int(val, &tfw_wl_marks.mrks[i])) {
-			TFW_ERR_NL("Unable to parse whitelist"
-				   " mark value: '%s'\n", val);
 			kfree(tfw_wl_marks.mrks);
 			return -EINVAL;
 		}

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1681,7 +1681,7 @@ tfw_http_resp_pair(TfwHttpMsg *hmresp)
  * instance. Increment the number of users of the instance. Initialize
  * GFSM for the message.
  */
-static TfwMsg *
+static TfwHttpMsg *
 tfw_http_conn_msg_alloc(TfwConn *conn)
 {
 	int type = TFW_CONN_TYPE(conn);
@@ -1707,7 +1707,7 @@ tfw_http_conn_msg_alloc(TfwConn *conn)
 		TFW_INC_STAT_BH(serv.rx_messages);
 	}
 
-	return (TfwMsg *)hm;
+	return hm;
 }
 
 /*
@@ -1907,7 +1907,7 @@ tfw_http_msg_create_sibling(TfwHttpMsg *hm, struct sk_buff **skb,
 	TFW_DBG2("Create sibling message: conn %p, skb %p\n", hm->conn, skb);
 
 	/* The sibling message belongs to the same connection. */
-	shm = (TfwHttpMsg *)tfw_http_conn_msg_alloc(hm->conn);
+	shm = tfw_http_conn_msg_alloc(hm->conn);
 	if (unlikely(!shm)) {
 		/*
 		 * Split skb to proceed with current message @hm, or rest of
@@ -3367,12 +3367,13 @@ tfw_http_msg_process(void *conn, const TfwFsmData *data)
 	TfwConn *c = (TfwConn *)conn;
 
 	if (unlikely(!c->msg)) {
-		c->msg = tfw_http_conn_msg_alloc(c);
-		if (!c->msg) {
+		TfwHttpMsg *hm = tfw_http_conn_msg_alloc(c);
+		if (!hm) {
 			__kfree_skb(data->skb);
 			return TFW_BLOCK;
 		}
-		tfw_http_mark_wl_new_msg(c, (TfwHttpMsg *)c->msg, data->skb);
+		c->msg = (TfwMsg *)hm;
+		tfw_http_mark_wl_new_msg(c, hm, data->skb);
 		TFW_DBG2("Link new msg %p with connection %p\n", c->msg, c);
 	}
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -649,7 +649,7 @@ err:
  * a connection failure. There's no option to prohibit re-sending.
  * Thus, request's SKB can't be passed to the network layer until
  * certain changes are implemented. For now there's no choice but
- * make a copy of requests's SKBs in SS layer.
+ * make a copy of request's SKBs in SS layer.
  *
  * TODO: Making a copy of each SKB _IS BAD_. See issues #391 and #488.
  */
@@ -1793,13 +1793,13 @@ tfw_http_resp_pair_free(TfwHttpReq *req)
 /*
  * Drop client connection's resources.
  *
- * Desintegrate the client connection's @seq_list. Requests without a paired
+ * Disintegrate the client connection's @seq_list. Requests without a paired
  * response have not been answered yet. They are held in the lists of server
  * connections until responses come. A paired response may be in use until
  * TFW_HTTP_F_RESP_READY flag is not set.  Don't free any of those requests.
  *
  * If a response comes or gets ready to forward after @seq_list is
- * desintegrated, then both the request and the response are dropped at the
+ * disintegrated, then both the request and the response are dropped at the
  *  sight of an empty list.
  *
  * Locking is necessary as @seq_list is constantly probed from server
@@ -1818,9 +1818,9 @@ tfw_http_conn_cli_drop(TfwCliConn *cli_conn)
 		return;
 
 	/*
-	 * Desintegration of the list must be done under the lock.
+	 * Disintegration of the list must be done under the lock.
 	 * The list can't be just detached from seq_queue, and then
-	 * be desintegrated without the lock. That would open a race
+	 * be disintegrated without the lock. That would open a race
 	 * condition with freeing of a request in tfw_http_resp_fwd().
 	 */
 	spin_lock(&cli_conn->seq_qlock);
@@ -2182,7 +2182,7 @@ tfw_http_adjust_resp(TfwHttpResp *resp)
 
 	if (resp->flags & TFW_HTTP_F_RESP_STALE) {
 #define S_WARN_110 "Warning: 110 - Response is stale"
-		/* TODO: ajust for #215 */
+		/* TODO: adjust for #215 */
 		TfwStr wh = {
 			.ptr	= S_WARN_110,
 			.len	= SLEN(S_WARN_110),
@@ -3274,7 +3274,7 @@ tfw_http_resp_process(TfwConn *conn, const TfwFsmData *data)
 		}
 
 		/*
-		 * If a non critical error occured in further GFSM processing,
+		 * If a non critical error occurred in further GFSM processing,
 		 * then the response and the paired request had been handled.
 		 * Keep the server connection open for data exchange.
 		 */

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3272,197 +3272,199 @@ tfw_http_resp_process(TfwConn *conn, const TfwFsmData *data)
 	struct sk_buff *skb = data->skb;
 	unsigned int off = data->off;
 	unsigned int data_off = off;
-	unsigned int skb_len = skb->len;
 	TfwHttpReq *bad_req;
-	TfwHttpMsg *hmresp;
+	TfwHttpMsg *hmresp, *hmsib;
+	TfwHttpParser *parser;
 	TfwFsmData data_up;
-	bool filtout = false;
+	bool attack = false;
 
 	BUG_ON(!conn->msg);
-	BUG_ON(data_off >= skb_len);
+	BUG_ON(data_off >= skb->len);
 
 	TFW_DBG2("received %u server data bytes on conn=%p msg=%p\n",
 		skb->len - off, conn, conn->msg);
 	/*
-	 * Process pipelined requests in a loop
+	 * Process pipelined responses in a loop
 	 * until all data in the SKB is processed.
 	 */
-	while (data_off < skb_len) {
-		TfwHttpMsg *hmsib = NULL;
-		TfwHttpParser *parser;
+next_msg:
+	hmsib = NULL;
+	hmresp = (TfwHttpMsg *)conn->msg;
+	parser = &conn->parser;
 
-		hmresp = (TfwHttpMsg *)conn->msg;
-		parser = &conn->parser;
+	/*
+	 * Process/parse data in the SKB.
+	 * @off points at the start of data for processing.
+	 * @data_off is the current offset of data to process in
+	 * the SKB. After processing @data_off points at the end
+	 * of latest data chunk. However processing may have
+	 * stopped in the middle of the chunk. Adjust it to point
+	 * at correct location within the chunk.
+	 */
+	off = data_off;
+	r = ss_skb_process(skb, &data_off, tfw_http_parse_resp, hmresp);
+	data_off -= parser->to_go;
+	hmresp->msg.len += data_off - off;
+	TFW_ADD_STAT_BH(data_off - off, serv.rx_bytes);
 
-		/*
-		 * Process/parse data in the SKB.
-		 * @off points at the start of data for processing.
-		 * @data_off is the current offset of data to process in
-		 * the SKB. After processing @data_off points at the end
-		 * of latest data chunk. However processing may have
-		 * stopped in the middle of the chunk. Adjust it to point
-		 * at correct location within the chunk.
-		 */
-		off = data_off;
-		r = ss_skb_process(skb, &data_off, tfw_http_parse_resp, hmresp);
-		data_off -= parser->to_go;
-		hmresp->msg.len += data_off - off;
-		TFW_ADD_STAT_BH(data_off - off, serv.rx_bytes);
+	TFW_DBG2("Response parsed: len=%u parsed=%d msg_len=%lu ver=%d res=%d\n",
+		 skb->len - off, data_off - off, hmresp->msg.len,
+		 hmresp->version, r);
 
-		TFW_DBG2("Response parsed: len=%u parsed=%d msg_len=%lu"
-			 " ver=%d res=%d\n",
-			 skb_len - off, data_off - off, hmresp->msg.len,
-			 hmresp->version, r);
+	/*
+	 * We have to keep @data the same to pass it as is to FSMs
+	 * registered with lower priorities after us, but we must
+	 * feed the new data version to FSMs registered on our states.
+	 */
+	data_up.skb = skb;
+	data_up.off = off;
+	data_up.req = (TfwMsg *)hmresp->req;
+	data_up.resp = (TfwMsg *)hmresp;
 
-		/*
-		 * We have to keep @data the same to pass it as is to FSMs
-		 * registered with lower priorities after us, but we must
-		 * feed the new data version to FSMs registered on our states.
-		 */
-		data_up.skb = skb;
-		data_up.off = off;
-		data_up.req = NULL;
-		data_up.resp = (TfwMsg *)hmresp;
+	switch (r) {
+	default:
+		TFW_ERR("Unrecognized HTTP response parser return code, %d\n",
+			r);
+		TFW_INC_STAT_BH(serv.msgs_parserr);
+		goto bad_msg;
 
-		switch (r) {
-		default:
-			TFW_ERR("Unrecognized HTTP response "
-				"parser return code, %d\n", r);
-			BUG();
-		case TFW_BLOCK:
-			/*
-			 * The response has not been fully parsed. There's no
-			 * choice but report a critical error. The lower layer
-			 * will close the connection and release the response
-			 * message, and well as all request messages that went
-			 * out on this connection and are waiting for paired
-			 * response messages.
-			 */
-			TFW_DBG2("Block invalid HTTP response\n");
-			TFW_INC_STAT_BH(serv.msgs_parserr);
+	case TFW_BLOCK:
+		TFW_DBG2("Block invalid HTTP response\n");
+		TFW_INC_STAT_BH(serv.msgs_parserr);
+		goto bad_msg;
+
+	case TFW_POSTPONE:
+		r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_RESP_CHUNK,
+				  &data_up);
+		TFW_DBG3("TFW_HTTP_FSM_RESP_CHUNK return code %d\n", r);
+		if (r == TFW_BLOCK) {
+			TFW_INC_STAT_BH(serv.msgs_filtout);
+			attack = true;
 			goto bad_msg;
-		case TFW_POSTPONE:
-			r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_RESP_CHUNK,
-					  &data_up);
-			TFW_DBG3("TFW_HTTP_FSM_RESP_CHUNK return code %d\n", r);
-			if (r == TFW_BLOCK) {
-				TFW_INC_STAT_BH(serv.msgs_filtout);
-				filtout = true;
-				goto bad_msg;
-			}
-			/*
-			 * TFW_POSTPONE status means that parsing succeeded
-			 * but more data is needed to complete it. Lower layers
-			 * just supply data for parsing. They only want to know
-			 * if processing of a message should continue or not.
-			 */
-			return TFW_PASS;
-		case TFW_PASS:
-			/*
-			 * The response is fully parsed, fall through and
-			 * process it. If the response has broken length, then
-			 * block it (the server connection will be dropped).
-			 */
-			if (!(test_bit(TFW_HTTP_CHUNKED, hmresp->flags)
-			      || test_bit(TFW_HTTP_VOID_BODY, hmresp->flags))
-			    && (hmresp->content_length != hmresp->body.len))
-			{
-				goto bad_msg;
-			}
 		}
+		goto out;
 
+	case TFW_PASS:
 		/*
-		 * Verify response in context of http health monitor,
-		 * and mark server as disabled/enabled.
-		 *
-		 * TODO (TBD) Probably we should close server connection here to
-		 * make all queued request be rescheduled to other servers.
-		 * Also it's a common practice to reset and reestablish
-		 * connections with buggy applications. Now we stop scheduling
-		 * new requests to the server and forward all, probably error
-		 * responses, for queued requests to clients.
+		 * The response is fully parsed, fall through and
+		 * process it. If the response has broken length, then
+		 * block it (the server connection will be dropped).
 		 */
-		tfw_http_hm_control((TfwHttpResp *)hmresp);
-
-		/*
-		 * Pass the response to GFSM for further processing.
-		 * Drop server connection in case of serious error or security
-		 * event.
-		 */
-		r = tfw_http_resp_gfsm(hmresp, &data_up);
-		if (unlikely(r < TFW_PASS))
-			return TFW_BLOCK;
-
-		/*
-		 * If @skb's data has not been processed in full, then
-		 * we have pipelined responses. Create a sibling message.
-		 * @skb is replaced with a pointer to a new SKB.
-		 */
-		if (data_off < skb_len) {
-			hmsib = tfw_http_msg_create_sibling(hmresp, &skb,
-							    data_off);
-			/*
-			 * In case of an error there's no recourse. The
-			 * caller expects that data is processed in full,
-			 * and can't deal with partially processed data.
-			 */
-			if (unlikely(!hmsib)) {
-				TFW_INC_STAT_BH(serv.msgs_otherr);
-				/*
-				 * Unable to create a sibling message.
-				 * Send the parsed response to the client
-				 * and close the server connection.
-				 */
-				tfw_http_resp_cache(hmresp);
-				return TFW_BLOCK;
-			}
-		}
-
-		/*
-		 * If a non critical error occurred in further GFSM processing,
-		 * then the response and the paired request had been handled.
-		 * Keep the server connection open for data exchange.
-		 */
-		if (unlikely(r != TFW_PASS)) {
-			r = TFW_PASS;
-			goto next_resp;
-		}
-		/*
-		 * Pass the response to cache for further processing.
-		 * In the end, the response is sent on to the client.
-		 */
-		if (tfw_http_resp_cache(hmresp))
-			return TFW_BLOCK;
-next_resp:
-		if (hmsib) {
-			/*
-			 * Switch the connection to the sibling message.
-			 * Data processing will continue with the new SKB.
-			 */
-			data_off = 0;
-			skb_len = skb->len;
-			conn->msg = (TfwMsg *)hmsib;
+		if (!(test_bit(TFW_HTTP_CHUNKED, hmresp->flags)
+		      || test_bit(TFW_HTTP_VOID_BODY, hmresp->flags))
+		    && (hmresp->content_length != hmresp->body.len))
+		{
+			goto bad_msg;
 		}
 	}
 
+	/*
+	 * Verify response in context of http health monitor,
+	 * and mark server as disabled/enabled.
+	 *
+	 * TODO (TBD) Probably we should close server connection here to
+	 * make all queued request be rescheduled to other servers.
+	 * Also it's a common practice to reset and reestablish
+	 * connections with buggy applications. Now we stop scheduling
+	 * new requests to the server and forward all, probably error
+	 * responses, for queued requests to clients.
+	 */
+	tfw_http_hm_control((TfwHttpResp *)hmresp);
+
+	/*
+	 * Pass the response to GFSM for further processing.
+	 * Drop server connection in case of serious error or security
+	 * event.
+	 */
+	/* TODO */
+	r = tfw_http_resp_gfsm(hmresp, &data_up);
+	if (unlikely(r < TFW_PASS))
+		return TFW_BLOCK;
+
+	/*
+	 * If @skb's data has not been processed in full, then
+	 * we have pipelined responses. Create a sibling message.
+	 * @skb is replaced with a pointer to a new SKB.
+	 */
+	if (data_off < skb->len) {
+		hmsib = tfw_http_msg_create_sibling(hmresp, &skb, data_off);
+		/*
+		 * In case of an error there's no recourse. The
+		 * caller expects that data is processed in full,
+		 * and can't deal with partially processed data.
+		 */
+		if (unlikely(!hmsib)) {
+			TFW_INC_STAT_BH(serv.msgs_otherr);
+			/*
+			 * Unable to create a sibling message.
+			 * Send the parsed response to the client
+			 * and close the server connection.
+			 *
+			 * TODO: can't use response if ss_skb_split() failed.
+			 */
+			tfw_http_resp_cache(hmresp);
+			return TFW_BLOCK;
+		}
+	}
+
+	/*
+	 * If a non critical error occurred in further GFSM processing,
+	 * then the response and the paired request had been handled.
+	 * Keep the server connection open for data exchange.
+	 */
+	if (unlikely(r != TFW_PASS)) {
+		/* TODO */
+		r = TFW_PASS;
+		goto next_resp;
+	}
+	/*
+	 * Pass the response to cache for further processing.
+	 * In the end, the response is sent on to the client.
+	 */
+	if (tfw_http_resp_cache(hmresp))
+		return TFW_BLOCK;
+next_resp:
+	if (hmsib) {
+		/*
+		 * Switch the connection to the sibling message.
+		 * Data processing will continue with the new SKB.
+		 */
+		data_off = 0;
+		conn->msg = (TfwMsg *)hmsib;
+		goto next_msg;
+	}
+
+out:
+	/*
+	 * TFW_POSTPONE status means that parsing succeeded
+	 * but more data is needed to complete it. Lower layers
+	 * just supply data for parsing. They only want to know
+	 * if processing of a message should continue or not.
+	 */
+	if (r == TFW_POSTPONE)
+		r = TFW_PASS;
 	return r;
+
 bad_msg:
 	/*
-	 * Send error response for the bad requests if necessary.
-	 * In any case remove the request form forward and nip queues -
-	 * we won't resend it.
+	 * Response can't be parsed. This is not a network failure,
+	 * it's very likely that the same situation happen if the corresponding
+	 * request will be sent once again. Keep buggy request away from
+	 * servers: remove the request from forward and nip queues and send
+	 * a 403 response if necessary.
+	 *
+	 * If the issue was treated as the attack, disconnect the client and
+	 * discard all pending requests.
 	 */
 	bad_req = hmresp->req;
 	tfw_http_req_delist((TfwSrvConn *)conn, bad_req);
 	tfw_http_conn_msg_free(hmresp);
-	if (filtout)
-		tfw_srv_client_block(bad_req, 502,
-				     "response blocked:"
-				     " filtered out");
+	if (attack)
+		tfw_srv_client_block(bad_req, 403,
+				     "response blocked: filtered out");
 	else
-		tfw_srv_client_drop(bad_req, 502,
-				    "response dropped:"
-				    " processing error");
+		tfw_srv_client_drop(bad_req, 403,
+				    "response dropped: processing error");
 	return TFW_BLOCK;
 }
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3094,8 +3094,8 @@ tfw_http_resp_cache_cb(TfwHttpMsg *msg)
 	 */
 	if (tfw_http_adjust_resp(resp)) {
 		tfw_http_conn_msg_free((TfwHttpMsg *)resp);
-		tfw_http_send_resp(req, 500, "response dropped:"
-				   " processing error");
+		tfw_http_send_resp(req, 500,
+				   "response dropped: processing error");
 		TFW_INC_STAT_BH(serv.msgs_otherr);
 		return;
 	}

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2470,8 +2470,8 @@ tfw_http_req_cache_service(TfwHttpResp *resp)
 
 	if (tfw_http_adjust_resp(resp)) {
 		tfw_http_conn_msg_free((TfwHttpMsg *)resp);
-		tfw_http_send_resp(req, 500, "response dropped:"
-				   " processing error");
+		tfw_http_send_resp(req, 500,
+				   "response dropped: processing error");
 		TFW_INC_STAT_BH(clnt.msgs_otherr);
 		return;
 	}

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -692,7 +692,7 @@ static inline void
 tfw_http_conn_nip_reset(TfwSrvConn *srv_conn)
 {
 	if (list_empty(&srv_conn->nip_queue))
-		clear_bit(TFW_CONN_B_HASNIP, &srv_conn->flags);
+		clear_bit(TFW_CONN_HASNIP, &srv_conn->flags);
 }
 
 /*
@@ -704,7 +704,7 @@ tfw_http_req_nip_enlist(TfwSrvConn *srv_conn, TfwHttpReq *req)
 {
 	BUG_ON(!list_empty(&req->nip_list));
 	list_add_tail(&req->nip_list, &srv_conn->nip_queue);
-	set_bit(TFW_CONN_B_HASNIP, &srv_conn->flags);
+	set_bit(TFW_CONN_HASNIP, &srv_conn->flags);
 }
 
 /*
@@ -1291,8 +1291,8 @@ tfw_http_conn_resend(TfwSrvConn *srv_conn, bool first, struct list_head *eq)
 static inline void
 __tfw_srv_conn_clear_restricted(TfwSrvConn *srv_conn)
 {
-	clear_bit(TFW_CONN_B_QFORWD, &srv_conn->flags);
-	if (test_and_clear_bit(TFW_CONN_B_RESEND, &srv_conn->flags))
+	clear_bit(TFW_CONN_QFORWD, &srv_conn->flags);
+	if (test_and_clear_bit(TFW_CONN_RESEND, &srv_conn->flags))
 		TFW_DEC_STAT_BH(serv.conn_restricted);
 }
 
@@ -1324,7 +1324,7 @@ tfw_http_conn_fwd_repair(TfwSrvConn *srv_conn, struct list_head *eq)
 
 	if (tfw_srv_conn_reenable_if_done(srv_conn))
 		return;
-	if (test_bit(TFW_CONN_B_QFORWD, &srv_conn->flags)) {
+	if (test_bit(TFW_CONN_QFORWD, &srv_conn->flags)) {
 		if (tfw_http_conn_need_fwd(srv_conn))
 			tfw_http_conn_fwd_unsent(srv_conn, eq);
 	} else {
@@ -1340,7 +1340,7 @@ tfw_http_conn_fwd_repair(TfwSrvConn *srv_conn, struct list_head *eq)
 		if (srv_conn->msg_sent)
 			srv_conn->msg_sent =
 				tfw_http_conn_resend(srv_conn, false, eq);
-		set_bit(TFW_CONN_B_QFORWD, &srv_conn->flags);
+		set_bit(TFW_CONN_QFORWD, &srv_conn->flags);
 		if (tfw_http_conn_need_fwd(srv_conn))
 			tfw_http_conn_fwd_unsent(srv_conn, eq);
 	}
@@ -1529,7 +1529,7 @@ tfw_http_conn_shrink_fwdq_resched(TfwSrvConn *srv_conn)
 	srv_conn->qsize = 0;
 	srv_conn->msg_sent = NULL;
 	INIT_LIST_HEAD(&srv_conn->nip_queue);
-	clear_bit(TFW_CONN_B_HASNIP, &srv_conn->flags);
+	clear_bit(TFW_CONN_HASNIP, &srv_conn->flags);
 
 	spin_unlock_bh(&srv_conn->fwd_qlock);
 
@@ -1609,7 +1609,7 @@ tfw_http_conn_repair(TfwConn *conn)
 	/* If none re-sent, then send the remaining unsent requests. */
 	if (!srv_conn->msg_sent) {
 		if (!list_empty(&srv_conn->fwd_queue)) {
-			set_bit(TFW_CONN_B_QFORWD, &srv_conn->flags);
+			set_bit(TFW_CONN_QFORWD, &srv_conn->flags);
 			tfw_http_conn_fwd_unsent(srv_conn, &eq);
 		}
 		tfw_srv_conn_reenable_if_done(srv_conn);
@@ -1724,7 +1724,7 @@ tfw_http_conn_init(TfwConn *conn)
 	if (TFW_CONN_TYPE(conn) & Conn_Srv) {
 		TfwSrvConn *srv_conn = (TfwSrvConn *)conn;
 		if (!list_empty(&srv_conn->fwd_queue)) {
-			set_bit(TFW_CONN_B_RESEND, &srv_conn->flags);
+			set_bit(TFW_CONN_RESEND, &srv_conn->flags);
 			TFW_INC_STAT_BH(serv.conn_restricted);
 		}
 	}
@@ -1765,7 +1765,7 @@ tfw_http_conn_release(TfwConn *conn)
 		 * Server is removed from configuration and won't be available
 		 * any more, reschedule it's forward queue.
 		 */
-		if (unlikely(test_bit(TFW_CONN_B_DEL, &srv_conn->flags)))
+		if (unlikely(test_bit(TFW_CONN_DEL, &srv_conn->flags)))
 			tfw_http_conn_shrink_fwdq_resched(srv_conn);
 		__tfw_srv_conn_clear_restricted(srv_conn);
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3457,7 +3457,7 @@ bad_msg:
 	 * discard all pending requests.
 	 */
 	bad_req = hmresp->req;
-	tfw_http_req_delist((TfwSrvConn *)conn, bad_req);
+	tfw_http_popreq(hmresp);
 	tfw_http_conn_msg_free(hmresp);
 	if (attack)
 		tfw_srv_client_block(bad_req, 403,

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2424,7 +2424,7 @@ tfw_http_req_prev_conn_close(TfwHttpReq *req)
  * @status		- response status code to use;
  * @msg			- message to be logged;
  * @attack		- true if the request was sent intentionally, false for
- *			  internal errors or mmisconfigurations;
+ *			  internal errors or misconfigurations;
  * @on_req_recv_event	- true if request is not fully parsed and the caller
  *			  handles the connection closing on its own.
  */
@@ -2473,7 +2473,8 @@ tfw_http_cli_error_resp_and_log(TfwHttpReq *req, int status, const char *msg,
 		 *   response and close connection to allow client to recover.
 		 *   Alternatively, we can only prepare an error response for
 		 *   the request, without stopping the connection or
-		 *   discarding any following requests.
+		 *   discarding any following requests. This
+		 *   isn't supposed to be an attack anyway.
 		 */
 		tfw_http_req_mark_error(req, status);
 	}

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -28,6 +28,7 @@
 #include "cache.h"
 #include "http_limits.h"
 #include "http_tbl.h"
+#include "http_parser.h"
 #include "client.h"
 #include "http_msg.h"
 #include "http_sess.h"

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1680,14 +1680,20 @@ tfw_http_resp_pair(TfwHttpMsg *hmresp)
 static TfwMsg *
 tfw_http_conn_msg_alloc(TfwConn *conn)
 {
-	TfwHttpMsg *hm = __tfw_http_msg_alloc(TFW_CONN_TYPE(conn), true);
+	int type = TFW_CONN_TYPE(conn);
+	TfwHttpMsg *hm = __tfw_http_msg_alloc(type, true);
 	if (unlikely(!hm))
 		return NULL;
 
 	hm->conn = conn;
 	tfw_connection_get(conn);
+	tfw_http_init_parser_req((TfwHttpReq *)hm);
+	if (type & Conn_Clnt)
+		tfw_http_init_parser_req((TfwHttpReq *)hm);
+	else
+		tfw_http_init_parser_resp((TfwHttpResp *)hm);
 
-	if (TFW_CONN_TYPE(conn) & Conn_Clnt) {
+	if (type & Conn_Clnt) {
 		TFW_INC_STAT_BH(clnt.rx_messages);
 	} else {
 		if (unlikely(tfw_http_resp_pair(hm))) {
@@ -2698,7 +2704,7 @@ tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 		bool block = false;
 		TfwHttpMsg *hmsib = NULL;
 		TfwHttpReq *req = (TfwHttpReq *)conn->msg;
-		TfwHttpParser *parser = &req->parser;
+		TfwHttpParser *parser = &conn->parser;
 
 		/*
 		 * Process/parse data in the SKB.
@@ -3165,7 +3171,7 @@ tfw_http_resp_process(TfwConn *conn, const TfwFsmData *data)
 		TfwHttpParser *parser;
 
 		hmresp = (TfwHttpMsg *)conn->msg;
-		parser = &hmresp->parser;
+		parser = &conn->parser;
 
 		/*
 		 * Process/parse data in the SKB.
@@ -4238,10 +4244,6 @@ int __init
 tfw_http_init(void)
 {
 	int r;
-
-	/* Make sure @req->httperr doesn't take too much space. */
-	BUILD_BUG_ON(FIELD_SIZEOF(TfwHttpMsg, httperr)
-		     > FIELD_SIZEOF(TfwHttpMsg, parser));
 
 	r = tfw_gfsm_register_fsm(TFW_FSM_HTTP, tfw_http_msg_process);
 	if (r)

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -592,13 +592,6 @@ tfw_http_resp_code_range(const int n)
 
 typedef void (*tfw_http_cache_cb_t)(TfwHttpMsg *);
 
-/* Internal (parser) HTTP functions. */
-void tfw_http_init_parser_req(TfwHttpReq *req);
-void tfw_http_init_parser_resp(TfwHttpResp *resp);
-int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
-int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
-bool tfw_http_parse_terminate(TfwHttpMsg *hm);
-
 /* External HTTP functions. */
 int tfw_http_msg_process(void *conn, const TfwFsmData *data);
 unsigned long tfw_http_req_key_calc(TfwHttpReq *req);

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -226,8 +226,6 @@ enum {
 	TFW_HTTP_URI_FULL,
 	/* Request is non-idempotent. */
 	TFW_HTTP_NON_IDEMP,
-	/* Request was sent by attacker. */
-	TFW_HTTP_SUSPECTED,
 	/* Request stated 'Accept: text/html' header */
 	TFW_HTTP_ACCEPT_HTML,
 	/* Request is created by HTTP health monitor. */

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -77,7 +77,7 @@ enum {
 	/* Whole response is read. */
 	TFW_HTTP_FSM_RESP_MSG		= TFW_GFSM_HTTP_STATE(4),
 
-	/* Run just before localy generated response sending. */
+	/* Run just before locally generated response sending. */
 	TFW_HTTP_FSM_LOCAL_RESP_FILTER	= TFW_GFSM_HTTP_STATE(5),
 
 	TFW_HTTP_FSM_RESP_MSG_FWD	= TFW_GFSM_HTTP_STATE(6),
@@ -177,7 +177,7 @@ typedef struct {
  * Cookie: singular according to RFC 6265 5.4.
  *
  * TODO split the enumeration to separate server and client sets to avoid
- * vasting of headers array slots.
+ * wasting of headers array slots.
  */
 typedef enum {
 	TFW_HTTP_HDR_HOST,
@@ -225,7 +225,7 @@ typedef struct {
  * Adding a header is faster then modify it, so this speeds up headers
  * adjusting as well as saves cache storage.
  *
- * Headers unconditionaly treated as hop-by-hop must be listed in
+ * Headers unconditionally treated as hop-by-hop must be listed in
  * tfw_http_init_parser_req()/tfw_http_init_parser_resp() functions and must be
  * members of Special headers.
  * group.

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -76,10 +76,14 @@ enum {
 	/* Whole response is read. */
 	TFW_HTTP_FSM_RESP_MSG		= TFW_GFSM_HTTP_STATE(4),
 
-	/* Run just before locally generated response sending. */
-	TFW_HTTP_FSM_LOCAL_RESP_FILTER	= TFW_GFSM_HTTP_STATE(5),
+	/* Response from backend server is received and ready to be processed. */
+	TFW_HTTP_FSM_RESP_MSG_FWD	= TFW_GFSM_HTTP_STATE(5),
 
-	TFW_HTTP_FSM_RESP_MSG_FWD	= TFW_GFSM_HTTP_STATE(6),
+	/*
+	 * Run just before locally generated response sending.
+	 * This is egress state unlike others, see tfw_http_resp_fwd().
+	 */
+	TFW_HTTP_FSM_LOCAL_RESP_FILTER	= TFW_GFSM_HTTP_STATE(6),
 
 	TFW_HTTP_FSM_DONE	= TFW_GFSM_HTTP_STATE(TFW_GFSM_STATE_LAST)
 };

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -600,7 +600,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 		}
 	}
 
-	if (req->flags & TFW_HTTP_F_URI_FULL) {
+	if (test_bit(TFW_HTTP_URI_FULL, req->flags)) {
 		char *hdrhost;
 
 		/* If host in URI is empty, host header also must be empty. */
@@ -904,7 +904,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, const TfwFsmData *data)
 
 	/* Ensure that singular header fields are not duplicated. */
 	__FRANG_FSM_STATE(Frang_Req_Hdr_FieldDup) {
-		if (req->flags & TFW_HTTP_F_FIELD_DUPENTRY) {
+		if (test_bit(TFW_HTTP_FIELD_DUPENTRY, req->flags)) {
 			frang_msg("duplicate header field found",
 				  &FRANG_ACC2CLI(ra)->addr, "\n");
 			r = TFW_BLOCK;
@@ -1047,7 +1047,7 @@ frang_http_req_handler(void *obj, const TfwFsmData *data)
 	FrangAcc *ra = conn->sk->sk_security;
 	bool ip_block = tfw_vhost_global_frang_cfg()->ip_block;
 
-	if (((TfwHttpReq *)data->req)->flags & TFW_HTTP_F_WHITELIST)
+	if (test_bit(TFW_HTTP_WHITELIST, ((TfwHttpReq *)data->req)->flags))
 		return TFW_PASS;
 
 	r = frang_http_req_process(ra, conn, data);

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -485,9 +485,9 @@ __frang_http_field_len(const TfwHttpReq *req, FrangAcc *ra,
 static int
 frang_http_field_len(const TfwHttpReq *req, FrangAcc *ra, unsigned int field_len)
 {
-	if (req->parser.hdr.len > field_len) {
+	if (req->conn->parser.hdr.len > field_len) {
 		frang_limmsg("HTTP in-progress field length",
-			     req->parser.hdr.len, field_len,
+			     req->conn->parser.hdr.len, field_len,
 			     &FRANG_ACC2CLI(ra)->addr);
 		return TFW_BLOCK;
 	}

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -448,11 +448,11 @@ frang_http_uri_len(const TfwHttpReq *req, FrangAcc *ra, unsigned int uri_len)
  * Check all parsed headers in request headers table.
  * We observe all headers many times, actually on each data chunk.
  * However, the check is relatively fast, so that should be Ok.
- * It's necessary to run the ckecks on each data chunk to prevent memory
- * exhausing DoS attack on many large header fields, since we don't know
+ * It's necessary to run the checks on each data chunk to prevent memory
+ * exhausting DoS attack on many large header fields, since we don't know
  * which headers were read on each data chunk.
  *
- * TODO Probably it's better to embedd a hook to HTTP parser directly to
+ * TODO Probably it's better to embed a hook to HTTP parser directly to
  * catch the long headers immediately.
  */
 static int
@@ -534,7 +534,7 @@ frang_http_ct_check(const TfwHttpReq *req, FrangAcc *ra, FrangCtVal *ct_vals)
 	 *	media-type = type "/" subtype *( OWS ";" OWS parameter )
 	 *
 	 * FIXME this matching is too permissive, e.g. we can pass
-	 * "text/plain1", which isn't a correct subtipe. Strong FSM processing
+	 * "text/plain1", which isn't a correct subtype. Strong FSM processing
 	 * is required. Or HTTP parser must pass only known types and Frang
 	 * decides which of them are allowed.
 	 * See also comment in frang_set_ct_vals().
@@ -566,7 +566,7 @@ frang_http_ct_check(const TfwHttpReq *req, FrangAcc *ra, FrangCtVal *ct_vals)
 
 /**
  * Require host header in HTTP request (RFC 7230 5.4).
- * Block HTTP/1.1 requiests w/o host header,
+ * Block HTTP/1.1 requests w/o host header,
  * but just print warning for older HTTP.
  */
 static int
@@ -643,7 +643,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 
 /**
  * Monotonically increasing time quantums. The configured @tframe
- * is devided by FRANG_FREQ slots to get the quantums granularity.
+ * is divided by FRANG_FREQ slots to get the quantums granularity.
  */
 static unsigned int
 frang_resp_quantum(unsigned short tframe)
@@ -831,7 +831,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, const TfwFsmData *data)
 		}
 	}
 
-	/* Сheck for chunk count here to account for possible fragmentation
+	/* Check for chunk count here to account for possible fragmentation
 	 * in HTTP status line. The rationale for not making this one of FSM
 	 * states is the same as for the code block above.
 	 */
@@ -932,7 +932,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, const TfwFsmData *data)
 
 	/*
 	 * Full HTTP header has been processed, and any possible
-	 * header faields are collected. Run final checks on them.
+	 * header fields are collected. Run final checks on them.
 	 */
 	__FRANG_FSM_STATE(Frang_Req_Hdr_FieldLenFinal) {
 		__FRANG_CFG_VAR(field_len, http_field_len);
@@ -985,7 +985,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, const TfwFsmData *data)
 	__FRANG_FSM_STATE(Frang_Req_Body_Timeout) {
 		/*
 		 * Note that this state is skipped on the first data SKB
-		 * with body part as obviously no timeout has occured yet.
+		 * with body part as obviously no timeout has occurred yet.
 		 */
 		__FRANG_CFG_VAR(body_timeout, clnt_body_timeout);
 		if (body_timeout) {
@@ -1060,7 +1060,7 @@ frang_http_req_handler(void *obj, const TfwFsmData *data)
 /*
  * Check response code and record it if it's listed in the filter.
  * Called from tfw_http_resp_fwd() by tfw_gfsm_move()
- * Always returs TFW_PASS because this handler is needed
+ * Always returns TFW_PASS because this handler is needed
  * for collecting purposes only.
  */
 static int

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -25,6 +25,7 @@
 #include "lib/str.h"
 #include "gfsm.h"
 #include "http_msg.h"
+#include "http_parser.h"
 #include "ss_skb.h"
 
 /**

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -305,7 +305,7 @@ __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 	unsigned int id = tfw_http_msg_hdr_lookup(hm, hdr);
 
 	if ((id < hm->h_tbl->off) && __hdr_is_singular(hdr))
-		hm->flags |= TFW_HTTP_F_FIELD_DUPENTRY;
+		__set_bit(TFW_HTTP_FIELD_DUPENTRY, hm->flags);
 
 	return id;
 }
@@ -364,7 +364,7 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 		 * RFC 7230 3.2.2: duplicate of non-singular special
 		 * header - leave the decision to classification layer.
 		 */
-		hm->flags |= TFW_HTTP_F_FIELD_DUPENTRY;
+		__set_bit(TFW_HTTP_FIELD_DUPENTRY, hm->flags);
 		goto duplicate;
 	}
 
@@ -977,9 +977,6 @@ __tfw_http_msg_alloc(int type, bool full)
 			 ((type & Conn_Clnt) ? "request" : "response"));
 		return NULL;
 	}
-
-	BUILD_BUG_ON(FIELD_SIZEOF(TfwHttpMsg, flags) * BITS_PER_BYTE
-		     < _TFW_HTTP_FLAGS_NUM);
 
 	if (full) {
 		hm->h_tbl = (TfwHttpHdrTbl *)tfw_pool_alloc(hm->pool,

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -316,7 +316,7 @@ __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 void
 tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start)
 {
-	TfwStr *hdr = &hm->parser.hdr;
+	TfwStr *hdr = &hm->conn->parser.hdr;
 
 	BUG_ON(!TFW_STR_EMPTY(hdr));
 
@@ -339,11 +339,11 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 	TfwStr *h;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
 
-	BUG_ON(hm->parser.hdr.flags & TFW_STR_DUPLICATE);
+	BUG_ON(hm->conn->parser.hdr.flags & TFW_STR_DUPLICATE);
 	BUG_ON(id > TFW_HTTP_HDR_RAW);
 
 	/* Close just parsed header. */
-	hm->parser.hdr.flags |= TFW_STR_COMPLETE;
+	hm->conn->parser.hdr.flags |= TFW_STR_COMPLETE;
 
 	/* Quick path for special headers. */
 	if (likely(id < TFW_HTTP_HDR_RAW)) {
@@ -374,7 +374,7 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 	 * Both the headers, the new one and existing one, can already be
 	 * compound.
 	 */
-	id = __hdr_lookup(hm, &hm->parser.hdr);
+	id = __hdr_lookup(hm, &hm->conn->parser.hdr);
 
 	/* Allocate some more room if not enough to store the header. */
 	if (unlikely(id == ht->size)) {
@@ -393,14 +393,14 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 duplicate:
 	h = tfw_str_add_duplicate(hm->pool, h);
 	if (unlikely(!h)) {
-		TFW_WARN("Cannot close header %p id=%d\n", &hm->parser.hdr, id);
+		TFW_WARN("Cannot close header %p id=%d\n", &hm->conn->parser.hdr, id);
 		return TFW_BLOCK;
 	}
 
 done:
-	*h = hm->parser.hdr;
+	*h = hm->conn->parser.hdr;
 
-	TFW_STR_INIT(&hm->parser.hdr);
+	TFW_STR_INIT(&hm->conn->parser.hdr);
 	TFW_DBG3("store header w/ ptr=%p len=%lu eolen=%u flags=%x id=%d\n",
 		 h->ptr, h->len, h->eolen, h->flags, id);
 
@@ -994,11 +994,6 @@ __tfw_http_msg_alloc(int type, bool full)
 		hm->h_tbl->size = __HHTBL_SZ(1);
 		hm->h_tbl->off = TFW_HTTP_HDR_RAW;
 		bzero_fast(hm->h_tbl->tbl, __HHTBL_SZ(1) * sizeof(TfwStr));
-
-		if (type & Conn_Clnt)
-			tfw_http_init_parser_req((TfwHttpReq *)hm);
-		else
-			tfw_http_init_parser_resp((TfwHttpResp *)hm);
 	}
 
 	hm->msg.skb_head = NULL;

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -272,7 +272,7 @@ __hdr_is_singular(const TfwStr *hdr)
 /**
  * Lookup for the header @hdr in already collected headers table @ht,
  * i.e. check whether the header is duplicate.
- * The lookup is performed untill ':', so header name only is enough in @hdr.
+ * The lookup is performed until ':', so header name only is enough in @hdr.
  * @return the header id.
  */
 unsigned int
@@ -494,7 +494,7 @@ __hdr_add(TfwHttpMsg *hm, const TfwStr *hdr, unsigned int hid)
 
 	/*
 	 * Initialize the header table item by the iterator chunks.
-	 * While the data references in the item are valid, some convetions
+	 * While the data references in the item are valid, some conventions
 	 * (e.g. header name and value are placed in different chunks) aren't
 	 * satisfied. So don't consider the header for normal HTTP processing.
 	 */
@@ -613,7 +613,7 @@ cleanup:
 
 /**
  * Transform HTTP message @hm header with identifier @hid.
- * @hdr must be compaund string and contain two or three parts:
+ * @hdr must be compound string and contain two or three parts:
  * header name, colon and header value. If @hdr value is empty,
  * then the header will be deleted from @hm.
  * If @hm already has the header it will be replaced by the new header
@@ -852,7 +852,7 @@ this_chunk:
 		if (c_size < f_room) {
 			/*
 			 * The chunk fits in the SKB fragment with room
-			 * to spare. Stay in the same SKB fragment, swith
+			 * to spare. Stay in the same SKB fragment, switch
 			 * to next chunk of the string.
 			 */
 			c_off = 0;

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -4796,3 +4796,22 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 
 	return r;
 }
+
+/**
+ * Checks if it's safe to stream the message.
+ *
+ * It's safe to stream the message in only one case: during message body
+ * parsing. Tempesta requires full set of headers to process the message;
+ * trailer headers can be modified, so must also be buffered.
+ * Return TFW_PASS if it's safe to stream the message, and TFW_POSTPONE
+ * if some buffering is required.
+ */
+int
+tfw_http_parser_msg_may_stream(TfwHttpMsg *hm)
+{
+	if (!(hm->crlf.flags & TFW_STR_COMPLETE))
+		return TFW_POSTPONE;
+	if (!(hm->body.flags & TFW_STR_COMPLETE))
+		return TFW_PASS;
+	return TFW_POSTPONE;
+}

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -552,7 +552,7 @@ mark_raw_hbh(TfwHttpMsg *hm, TfwStr *hdr)
 
 /**
  * Lookup for the header @hdr in already collected headers table @ht,
- * and mark it as hop-by-hop. The lookup is performed untill ':', so header
+ * and mark it as hop-by-hop. The lookup is performed until ':', so header
  * name only is enough in @hdr.
  *
  * @return true if @hdr was found and marked as hop-by-hop
@@ -565,7 +565,7 @@ __mark_hbh_hdr(TfwHttpMsg *hm, TfwStr *hdr)
 
 	/*
 	 * This function is called before hm->h_tbl is fully parsed,
-	 * if header is epmty, don't touch it
+	 * if header is empty, don't touch it
 	 */
 	if ((hid >= ht->off) || (TFW_STR_EMPTY(&ht->tbl[hid])))
 		return false;
@@ -576,7 +576,7 @@ __mark_hbh_hdr(TfwHttpMsg *hm, TfwStr *hdr)
 
 /**
  * Add header name listed in Connection header to table of raw headers.
- * If @last is true then (@data, @len) represnts last chunk of header name and
+ * If @last is true then (@data, @len) represents last chunk of header name and
  * chunk with ':' will be added to the end. Otherwize last header in table stays
  * open to add more data.
  *
@@ -812,7 +812,7 @@ __FSM_STATE(RGen_CRLFCR) {						\
  * We have HTTP message descriptors and special headers,
  * however we still need to store full headers (instead of just their values)
  * as well as store headers which aren't need in further processing
- * (e.g. Content-Length which is doubled by TfwHttpMsg.conent_length)
+ * (e.g. Content-Length which is doubled by TfwHttpMsg.content_length)
  * to mangle row skb data.
  */
 #define __TFW_HTTP_PARSE_SPECHDR_VAL(st_curr, st_i, hm, func, id, saveval) \
@@ -920,7 +920,7 @@ __FSM_STATE(RGen_HdrOtherN) {						\
 }									\
 __FSM_STATE(RGen_HdrOtherV) {						\
 	/*								\
-	 * The header content is opaqueue for us,			\
+	 * The header content is opaque for us,				\
 	 * so pass ctext and VCHAR.					\
 	 */								\
 	__FSM_MATCH_MOVE(ctext_vchar, RGen_HdrOtherV);			\
@@ -1160,7 +1160,7 @@ __parse_connection(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	 * TODO: RFC 6455 WebSocket Protocol
 	 * During handshake client sets "Connection: update" and "Update" header.
 	 * This headers should be passed to server unchanged to allow
-	 * WebSocket porotol.
+	 * WebSocket protocol.
 	 */
 	__FSM_STATE(I_Conn) {
 		/* Boolean connection tokens */
@@ -2123,7 +2123,7 @@ __req_parse_cookie(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	/* ';' was already matched. */
 	__FSM_STATE(Req_I_CookieSemicolon) {
 		/*
-		 * Fixup current delimeters chunk and move to next parameter
+		 * Fixup current delimiters chunk and move to next parameter
 		 * if we can eat ';' and SP at once.
 		 */
 		if (likely(__data_available(p, 2))) {
@@ -2133,7 +2133,7 @@ __req_parse_cookie(TfwHttpMsg *hm, unsigned char *data, size_t len)
 		}
 		/*
 		 * Only ';' is available now: fixup ';' as independent chunk,
-		 * SP willbe fixed up at next enter to the FSM.
+		 * SP will be fixed up at next enter to the FSM.
 		 */
 		__FSM_I_MOVE_fixup(Req_I_CookieSP, 1, 0);
 	}
@@ -2141,7 +2141,7 @@ __req_parse_cookie(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	__FSM_STATE(Req_I_CookieSP) {
 		if (unlikely(c != ' '))
 			return CSTR_NEQ;
-		/* Fixup current delimeters chunk and move to next parameter. */
+		/* Fixup current delimiters chunk and move to next parameter. */
 		__FSM_I_MOVE_fixup(Req_I_CookieStart, 1, 0);
 	}
 
@@ -2168,7 +2168,7 @@ __parse_etag(TfwHttpMsg *hm, unsigned char *data, size_t len)
 
 	/*
 	 * ETag value and closing DQUOTE is placed into separate chunks marked
-	 * with flags TFW_STR_VALUE and TFW_STR_ETAG_WEAK (optionaly).
+	 * with flags TFW_STR_VALUE and TFW_STR_ETAG_WEAK (optionally).
 	 * Closing DQUOTE is used to support empty Etags. Opening is not added
 	 * to simplify usage of tfw_stricmpspn()
 	 *
@@ -2360,7 +2360,7 @@ done:
  * Parse response Expires, RFC 2616 14.21.
  *
  * We support only RFC 1123 date as it's most usable by modern software.
- * However RFC 2616 reuires that all server and client software MUST support
+ * However RFC 2616 requires that all server and client software MUST support
  * all 3 formats specified in 3.3.1 chapter. We leave this for TODO.
  *
  * @return number of seconds since epoch in GMT.
@@ -3109,7 +3109,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 	 * RFC 3986 chapter 3.2: authority = [userinfo@]host[:port]
 	 *
 	 * Authority parsing: it can be "host" or "userinfo@host" (port is
-	 * parsed later). At the begining we don't know, which of variants we
+	 * parsed later). At the beginning we don't know, which of variants we
 	 * have. So we fill req->host, and if we get '@', we copy host to
 	 * req->userinfo, reset req->host and fill it.
 	 */
@@ -4235,7 +4235,7 @@ tfw_http_parse_terminate(TfwHttpMsg *hm)
 	/*
 	 * Set Content-Length header to warn client about end of message.
 	 * Other option is to close connection to client. All the situations
-	 * when Content-Length header must not present in responce were
+	 * when Content-Length header must not present in response were
 	 * checked earlier. Refer to RFC 7230 3.3.3
 	 */
 	if (hm->conn->parser.state == Resp_BodyUnlimRead
@@ -4420,7 +4420,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 			/* Ensure we have enough data for largest match. */
 			if (unlikely(!__data_available(p, 14)))
 				__FSM_MOVE(Resp_HdrC);
-			/* Qick switch for HTTP headers with the same prefix. */
+			/* Quick switch for HTTP headers with the same prefix. */
 			switch (TFW_P2LCINT(p + 1)) {
 			case TFW_CHAR4_INT('a', 'c', 'h', 'e'):
 				if (likely(*(p + 5) == '-'

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -82,7 +82,7 @@ do {									\
 } while (0)
 
 #define __msg_hdr_chunk_fixup(data, len)				\
-	tfw_http_msg_add_str_data(msg, &msg->parser.hdr, data, len)
+	tfw_http_msg_add_str_data(msg, &msg->conn->parser.hdr, data, len)
 
 /**
  * GCC 4.8 (CentOS 7) does a poor work on memory reusage of automatic local
@@ -92,7 +92,7 @@ do {									\
  */
 #define __FSM_DECLARE_VARS(ptr)						\
 	TfwHttpMsg	*msg = (TfwHttpMsg *)(ptr);			\
-	TfwHttpParser	*parser = &msg->parser;				\
+	TfwHttpParser	*parser = &msg->conn->parser;			\
 	unsigned char	*p = data;					\
 	unsigned char	c = *p;						\
 	int		__fsm_const_state;				\
@@ -164,9 +164,11 @@ do {									\
 } while (0)
 
 #define __FSM_MOVE_nofixup(to)		__FSM_MOVE_nofixup_n(to, 1)
-#define __FSM_MOVE_n(to, n)		__FSM_MOVE_nf(to, n, &msg->parser.hdr)
+#define __FSM_MOVE_n(to, n)		__FSM_MOVE_nf(to, n,		\
+						      &msg->conn->parser.hdr)
 #define __FSM_MOVE_f(to, field)		__FSM_MOVE_nf(to, 1, field)
-#define __FSM_MOVE(to)			__FSM_MOVE_nf(to, 1, &msg->parser.hdr)
+#define __FSM_MOVE(to)			__FSM_MOVE_nf(to, 1,		\
+						      &msg->conn->parser.hdr)
 /* The same as __FSM_MOVE_n(), but exactly for jumps w/o data moving. */
 #define __FSM_JMP(to)			do { goto to; } while (0)
 
@@ -184,8 +186,8 @@ do {									\
 	}								\
 } while (0)
 
-#define __FSM_MATCH_MOVE(alphabet, to)	__FSM_MATCH_MOVE_f(alphabet, to, \
-							   &msg->parser.hdr)
+#define __FSM_MATCH_MOVE(alphabet, to)					\
+	__FSM_MATCH_MOVE_f(alphabet, to, &msg->conn->parser.hdr)
 
 #define __FSM_MATCH_MOVE_nofixup(alphabet, to)				\
 do {									\
@@ -207,7 +209,7 @@ do {									\
 #define __FSM_I_chunk_flags(flag)					\
 do {									\
 	TFW_DBG3("parser: add chunk flags: %u\n", flag);		\
-	TFW_STR_CURR(&msg->parser.hdr)->flags |= flag;		  	\
+	TFW_STR_CURR(&msg->conn->parser.hdr)->flags |= flag;		\
 } while (0)
 
 #define __FSM_I_MOVE_finish_n(to, n, finish)				\
@@ -506,7 +508,7 @@ parse_int_hex(unsigned char *data, size_t len, unsigned long *acc, unsigned shor
 static void
 mark_spec_hbh(TfwHttpMsg *hm)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &hm->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &hm->conn->parser.hbh_parser;
 	unsigned int id;
 
 	for (id = 0; id < TFW_HTTP_HDR_RAW; ++id) {
@@ -523,7 +525,7 @@ mark_spec_hbh(TfwHttpMsg *hm)
 static void
 mark_raw_hbh(TfwHttpMsg *hm, TfwStr *hdr)
 {
-	TfwHttpHbhHdrs *hbh = &hm->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh = &hm->conn->parser.hbh_parser;
 	unsigned int i;
 
 	/*
@@ -590,7 +592,7 @@ static int
 __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 {
 	TfwStr *hdr, *append;
-	TfwHttpHbhHdrs *hbh = &hm->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh = &hm->conn->parser.hbh_parser;
 	static const TfwStr block[] = {
 #define TfwStr_string(v) { (v), NULL, sizeof(v) - 1, 0 }
 		/* End-to-end spec and raw headers */
@@ -1128,7 +1130,7 @@ __FSM_STATE(RGen_OWS) {							\
 /**
  * Parse Connection header value, RFC 7230 6.1.
  *
- * Store names of listed headers in @hm->parser.hbh_parser to mark them as
+ * Store names of listed headers in @hm->conn->parser.hbh_parser to mark them as
  * hop-by-hop during parsing. Mark already parsed headers as hop-by-hop once
  * they appear in the header.
  *
@@ -1187,7 +1189,7 @@ __parse_connection(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	 * Other connection tokens. Popular examples of the "Connection:"
 	 * header value are "Keep-Alive, TE" or "TE, close". However,
 	 * it could be names of any headers, including custom headers.
-	 * Raw headers: add to @hm->parser.hbh_parser.raw table.
+	 * Raw headers: add to @hm->conn->parser.hbh_parser.raw table.
 	 */
 	__FSM_STATE(I_ConnOther) {
 		__FSM_I_MATCH_MOVE_finish(token, I_ConnOther, {
@@ -2684,9 +2686,9 @@ __req_parse_if_msince(TfwHttpMsg *msg, unsigned char *data, size_t len)
 	ret = __parse_http_date(msg, data, len);
 	if (ret < CSTR_POSTPONE) {  /* (ret < 0) && (ret != POSTPONE) */
 		/* On error just swallow the rest of the line. */
-		BUG_ON(msg->parser.state != Req_HdrIf_Modified_SinceV);
-		msg->parser._date = 0;
-		msg->parser._i_st = I_EoL;
+		BUG_ON(msg->conn->parser.state != Req_HdrIf_Modified_SinceV);
+		msg->conn->parser._date = 0;
+		msg->conn->parser._i_st = I_EoL;
 		ret = __parse_http_date(msg, data, len);
 	}
 	return ret;
@@ -2894,16 +2896,17 @@ done:
 static inline void
 __parser_init(TfwHttpParser *parser)
 {
+	memset(parser, 0, sizeof(TfwHttpParser));
 	parser->to_read = -1; /* unknown body size */
 }
 
 void
 tfw_http_init_parser_req(TfwHttpReq *req)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &req->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &req->conn->parser.hbh_parser;
 
-	__parser_init(&req->parser);
-	req->parser.state = Req_0;
+	__parser_init(&req->conn->parser);
+	req->conn->parser.state = Req_0;
 
 	/*  Add spec header indexes to list of hop-by-hop headers. */
 	BUG_ON(hbh_hdrs->spec);
@@ -4183,9 +4186,9 @@ __resp_parse_expires(TfwHttpMsg *msg, unsigned char *data, size_t len)
 		 * On error just swallow the rest of the line.
 		 * @resp->expires is set to zero - already expired.
 		 */
-		BUG_ON(msg->parser.state != Resp_HdrExpiresV);
-		msg->parser._date = 0;
-		msg->parser._i_st = I_EoL;
+		BUG_ON(msg->conn->parser.state != Resp_HdrExpiresV);
+		msg->conn->parser._date = 0;
+		msg->conn->parser._i_st = I_EoL;
 		ret = __parse_http_date(msg, data, len);
 	}
 	return ret;
@@ -4235,8 +4238,8 @@ tfw_http_parse_terminate(TfwHttpMsg *hm)
 	 * when Content-Length header must not present in responce were
 	 * checked earlier. Refer to RFC 7230 3.3.3
 	 */
-	if (hm->parser.state == Resp_BodyUnlimRead
-	    || hm->parser.state == Resp_BodyUnlimStart)
+	if (hm->conn->parser.state == Resp_BodyUnlimRead
+	    || hm->conn->parser.state == Resp_BodyUnlimStart)
 	{
 		char c_len[TFW_ULTOA_BUF_SIZ] = {0};
 		size_t digs;
@@ -4260,10 +4263,10 @@ tfw_http_parse_terminate(TfwHttpMsg *hm)
 void
 tfw_http_init_parser_resp(TfwHttpResp *resp)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &resp->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &resp->conn->parser.hbh_parser;
 
-	__parser_init(&resp->parser);
-	resp->parser.state = Resp_0;
+	__parser_init(&resp->conn->parser);
+	resp->conn->parser.state = Resp_0;
 
 	/*  Add spec header indexes to list of hop-by-hop headers. */
 	BUG_ON(hbh_hdrs->spec);

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -106,5 +106,6 @@ void tfw_http_init_parser_resp(TfwHttpResp *resp);
 int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
 bool tfw_http_parse_terminate(TfwHttpMsg *hm);
+int tfw_http_parser_msg_may_stream(TfwHttpMsg *hm);
 
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -1,0 +1,29 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2018 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_HTTP_PARSER_H__
+#define __TFW_HTTP_PARSER_H__
+
+void tfw_http_init_parser_req(TfwHttpReq *req);
+void tfw_http_init_parser_resp(TfwHttpResp *resp);
+int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
+int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
+bool tfw_http_parse_terminate(TfwHttpMsg *hm);
+
+#endif /* __TFW_HTTP_PARSER_H__ */

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -20,8 +20,89 @@
 #ifndef __TFW_HTTP_PARSER_H__
 #define __TFW_HTTP_PARSER_H__
 
+#include "str.h"
+#include "http_types.h"
+
+typedef struct {
+	unsigned int	size;	/* number of elements in the table */
+	unsigned int	off;
+	TfwStr		tbl[0];
+} TfwHttpHdrTbl;
+
+#define __HHTBL_SZ(o)			(TFW_HTTP_HDR_NUM * (o))
+#define TFW_HHTBL_EXACTSZ(s)		(sizeof(TfwHttpHdrTbl)		\
+					 + sizeof(TfwStr) * (s))
+#define TFW_HHTBL_SZ(o)			TFW_HHTBL_EXACTSZ(__HHTBL_SZ(o))
+
+/** Maximum of hop-by-hop tokens listed in Connection header. */
+#define TFW_HBH_TOKENS_MAX		16
+
+/**
+ * Non-cacheable hop-by-hop headers in terms of RFC 7230.
+ *
+ * We don't store the headers in cache and create them from scratch if needed.
+ * Adding a header is faster then modify it, so this speeds up headers
+ * adjusting as well as saves cache storage.
+ *
+ * Headers unconditionally treated as hop-by-hop must be listed in
+ * tfw_http_init_parser_req()/tfw_http_init_parser_resp() functions and must be
+ * members of Special headers.
+ * group.
+ *
+ * @spec	- bit array for special headers. Hop-by-hop special header is
+ *		  stored as (0x1 << tfw_http_hdr_t[hid]);
+ * @raw		- table of raw headers names, parsed form connection field;
+ * @off		- offset of last added raw header name;
+ */
+typedef struct {
+	unsigned int	spec;
+	unsigned int	off;
+	TfwStr		raw[TFW_HBH_TOKENS_MAX];
+} TfwHttpHbhHdrs;
+
+/**
+ * We use goto/switch-driven automaton, so compiler typically generates binary
+ * search code over jump labels, so it gives log(N) lookup complexity where
+ * N is number of states. However, DFA for full HTTP processing can be quite
+ * large and log(N) becomes expensive and hard to code.
+ *
+ * So we use states space splitting to avoid states explosion.
+ * @_i_st is used to save current state and go to interior sub-automaton
+ * (e.g. process OWS using @state while current state is saved in @_i_st
+ * or using @_i_st parse value of a header described.
+ *
+ * @_cnt	- currently the count of hex digits in a body chunk size;
+ * @to_go	- remaining number of bytes to process in the data chunk;
+ *		  (limited by single packet size and never exceeds 64KB)
+ * @state	- current parser state;
+ * @_i_st	- helping (interior) state;
+ * @to_read	- remaining number of bytes to read;
+ * @_hdr_tag	- stores header id which must be closed on generic EoL handling
+ *		  (see RGEN_EOL());
+ * @_acc	- integer accumulator for parsing chunked integers;
+ * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
+ * @hdr		- currently parsed header.
+ * @hbh_parser	- list of special and raw headers names to be treated as
+ *		  hop-by-hop
+ * @_date	- currently parsed http date value;
+ */
+typedef struct {
+	unsigned short	to_go;
+	unsigned short	_cnt;
+	unsigned int	_hdr_tag;
+	int		state;
+	int		_i_st;
+	long		to_read;
+	unsigned long	_acc;
+	time_t		_date;
+	TfwStr		_tmp_chunk;
+	TfwStr		hdr;
+	TfwHttpHbhHdrs	hbh_parser;
+} TfwHttpParser;
+
 void tfw_http_init_parser_req(TfwHttpReq *req);
 void tfw_http_init_parser_resp(TfwHttpResp *resp);
+
 int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
 bool tfw_http_parse_terminate(TfwHttpMsg *hm);

--- a/tempesta_fw/http_sched_hash.c
+++ b/tempesta_fw/http_sched_hash.c
@@ -162,7 +162,7 @@ __find_best_conn(TfwMsg *msg, TfwHashConnList *cl)
 {
 	ssize_t l_idx, r_idx, idx;
 	TfwSrvConn *conn;
-	bool hmonitor = ((TfwHttpReq *)msg)->flags & TFW_HTTP_F_HMONITOR;
+	bool hmonitor = test_bit(TFW_HTTP_HMONITOR, ((TfwHttpReq *)msg)->flags);
 	unsigned long msg_hash = tfw_http_req_key_calc((TfwHttpReq *)msg);
 	unsigned long best_hash = (~0UL ^ msg_hash);
 

--- a/tempesta_fw/http_sched_ratio.c
+++ b/tempesta_fw/http_sched_ratio.c
@@ -860,7 +860,7 @@ tfw_sched_ratio_sched_srv_conn(TfwMsg *msg, TfwServer *srv)
 	 * Bypass the suspend checking if connection is needed for
 	 * helth monitoring of backend server.
 	 */
-	if (!(((TfwHttpReq *)msg)->flags & TFW_HTTP_F_HMONITOR)
+	if (!test_bit(TFW_HTTP_HMONITOR, ((TfwHttpReq *)msg)->flags)
 	    && tfw_srv_suspended(srv))
 		return NULL;
 

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -12,7 +12,7 @@
  * challenge), safe load balancing for session oriented Web apps and so on.
  * The term 'Client' is actually vague. Different human clients can be behind
  * shared proxy having the same source IP (i.e. the same TfwClient descriptor).
- * The same human client can use differnt browsers, so they send different
+ * The same human client can use different browsers, so they send different
  * User-Agent headers and use different sticky cookies. X-Forwarded-For header
  * value can be used to cope the non anonymous forward proxy problem and
  * identify real clients.
@@ -100,7 +100,7 @@ static struct kmem_cache *sess_cache;
  *
  * @body	- body (html with JavaScript code);
  * @delay_min	- minimal timeout to make a client wait;
- * @delay_range	- allowed time range to recieve and accept client's session;
+ * @delay_range	- allowed time range to receive and accept client's session;
  * @delay_limit	- maximum difference between current time and a timestamp
  *		  specified in the sticky cookie;
  * @st_code	- status code for response with JS challenge;
@@ -127,7 +127,7 @@ static const unsigned short tfw_cfg_redirect_st_code_dflt = 302;
  * 'Accept: text/html' and GET method.
  */
 static bool
-tfw_http_sticky_redirect_allied(TfwHttpReq *req)
+tfw_http_sticky_redirect_applied(TfwHttpReq *req)
 {
 	if (!tfw_cfg_js_ch)
 		return true;
@@ -151,11 +151,11 @@ tfw_http_sticky_send_redirect(TfwHttpReq *req, StickyVal *sv)
 	WARN_ON_ONCE(!list_empty(&req->nip_list));
 
 	/*
-	 * TODO: #598 rate limit requests with invalid cookie vaule.
-	 * Non-challengeable requests also must be rate limited.
+	 * TODO: #598 rate limit requests with invalid cookie value.
+	 * Unchallengeable requests also must be rate limited.
 	 */
 
-	if (!tfw_http_sticky_redirect_allied(req))
+	if (!tfw_http_sticky_redirect_applied(req))
 		return TFW_HTTP_SESS_JS_NOT_SUPPORTED;
 
 	if (!(resp = tfw_http_msg_alloc_resp_light(req)))
@@ -166,7 +166,7 @@ tfw_http_sticky_send_redirect(TfwHttpReq *req, StickyVal *sv)
 	 * 	<timestamp> | HMAC(Secret, User-Agent, timestamp, Client IP)
 	 *
 	 * Open <timestamp> is required to be able to recalculate secret HMAC.
-	 * Since the secret is unknown for the attacke, they're still unable to
+	 * Since the secret is unknown for the attackers, they're still unable to
 	 * recalculate HMAC while we don't need to store session information
 	 * until we receive correct cookie value.
 	 */
@@ -620,7 +620,7 @@ tfw_http_sess_check_jsch(StickyVal *sv)
 	if ((min_time <= cur_time) && (cur_time <= max_time))
 		return 0;
 
-	TFW_DBG("sess: jsch block: request recieved outside allowed period.\n");
+	TFW_DBG("sess: jsch block: request received outside allowed period.\n");
 
 	return TFW_HTTP_SESS_VIOLATE;
 }
@@ -783,7 +783,7 @@ tfw_http_sess_pin_srv(TfwStickyConn *st_conn, TfwSrvConn *srv_conn)
 }
 
 /**
- * Find an outgoing connection for client with tempesta sticky cookie.
+ * Find an outgoing connection for client with Tempesta sticky cookie.
  * @sess is not null when calling the function.
  *
  * Reuse req->sess->st_conn.srv_conn if it is alive. If not,

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -950,15 +950,12 @@ tfw_cfgop_sess_lifetime(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
-tfw_cfg_op_jsch_parse_time(TfwCfgSpec *cs, const char *key, const char *val,
-			   time_t *time)
+tfw_cfg_op_jsch_parse_time(const char *val, time_t *time)
 {
 	int r, int_val;
 
-	if ((r = tfw_cfg_parse_int(val, &int_val))) {
-		TFW_ERR_NL("%s: can't parse key '%s'\n", cs->name, key);
+	if ((r = tfw_cfg_parse_int(val, &int_val)))
 		return r;
-	}
 	*time = int_val * HZ / 1000;
 
 	return 0;
@@ -969,10 +966,8 @@ tfw_cfg_op_jsch_parse_resp_code(TfwCfgSpec *cs, const char *val)
 {
 	int r, int_val;
 
-	if ((r = tfw_cfg_parse_int(val, &int_val))) {
-		TFW_ERR_NL("%s: can't parse key 'resp_code'\n", cs->name);
+	if ((r = tfw_cfg_parse_int(val, &int_val)))
 		return r;
-	}
 	if ((r = tfw_cfg_check_range(int_val, 100, 599)))
 		return r;
 	tfw_cfg_js_ch->st_code = int_val;
@@ -1047,17 +1042,17 @@ tfw_cfgop_js_challenge(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	}
 	TFW_CFG_ENTRY_FOR_EACH_ATTR(ce, i, key, val) {
 		if (!strcasecmp(key, "delay_min")) {
-			r = tfw_cfg_op_jsch_parse_time(cs, key, val,
+			r = tfw_cfg_op_jsch_parse_time(val,
 						       &tfw_cfg_js_ch->delay_min);
 			if (r)
 				return r;
 		} else if (!strcasecmp(key, "delay_range")) {
-			r = tfw_cfg_op_jsch_parse_time(cs, key, val,
+			r = tfw_cfg_op_jsch_parse_time(val,
 						       &tfw_cfg_js_ch->delay_range);
 			if (r)
 				return r;
 		} else if (!strcasecmp(key, "delay_limit")) {
-			r = tfw_cfg_op_jsch_parse_time(cs, key, val,
+			r = tfw_cfg_op_jsch_parse_time(val,
 						       &delay_limit);
 			if (r)
 				return r;

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -133,7 +133,7 @@ tfw_http_sticky_redirect_allied(TfwHttpReq *req)
 		return true;
 
 	return (req->method == TFW_HTTP_METH_GET)
-		&& (req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		&& test_bit(TFW_HTTP_ACCEPT_HTML, req->flags);
 }
 
 static int
@@ -497,7 +497,7 @@ ts_finished:
 	BUG_ON(i != STICKY_KEY_MAXLEN);
 
 	/* Sticky cookie is found and verified, now we can set the flag. */
-	req->flags |= TFW_HTTP_F_HAS_STICKY;
+	__set_bit(TFW_HTTP_HAS_STICKY, req->flags);
 
 	return TFW_HTTP_SESS_SUCCESS;
 }
@@ -546,7 +546,7 @@ tfw_http_sess_resp_process(TfwHttpResp *resp)
 {
 	TfwHttpReq *req = resp->req;
 
-	if (!tfw_cfg_sticky.enabled || req->flags & TFW_HTTP_F_WHITELIST)
+	if (!tfw_cfg_sticky.enabled || test_bit(TFW_HTTP_WHITELIST, req->flags))
 		return 0;
 	BUG_ON(!req->sess);
 
@@ -556,7 +556,7 @@ tfw_http_sess_resp_process(TfwHttpResp *resp)
 	 * it seems that we don't enforce them, we can just set the cookie in
 	 * each response forwarded to the client.
 	 */
-	if (req->flags & TFW_HTTP_F_HAS_STICKY)
+	if (test_bit(TFW_HTTP_HAS_STICKY, req->flags))
 		return 0;
 	return tfw_http_sticky_add(resp);
 }
@@ -639,7 +639,7 @@ tfw_http_sess_obtain(TfwHttpReq *req)
 	struct hlist_node *tmp;
 	StickyVal sv = { };
 
-	if (!tfw_cfg_sticky.enabled || req->flags & TFW_HTTP_F_WHITELIST)
+	if (!tfw_cfg_sticky.enabled || test_bit(TFW_HTTP_WHITELIST, req->flags))
 		return TFW_HTTP_SESS_SUCCESS;
 
 	if ((r = tfw_http_sticky_req_process(req, &sv)))

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -33,7 +33,7 @@
  * scheduling routine to obtain target server and pin the session to it.
  *
  * 2. Session pinning is switched to 'disable'. Keep using pinned server until
- * session is expired. (Alternative: unpin sesion from a server and use generic
+ * session is expired. (Alternative: unpin session from a server and use generic
  * scheduling algorithm.)
  *
  * 3. A new server is added to main/backup group. New sessions will be
@@ -47,7 +47,7 @@
  * 5. Main and backup group is removed from new configuration. Same as p. 4.
  *
  * 6. Main and backup group are no more interchangeable; according to the new
- * HTTP match rules sessions must be pinned to complitely other server groups.
+ * HTTP match rules sessions must be pinned to completely other server groups.
  * This cases cannot be deduced during live reconfiguration, manual session
  * removing is required. End user should avoid such configurations.
  *
@@ -81,7 +81,7 @@ struct tfw_http_sess_t {
 enum {
 	/* Internal error, may be any number < 0. */
 	TFW_HTTP_SESS_FAILURE = -1,
-	/* Session successfuly obtained. */
+	/* Session successfully obtained. */
 	TFW_HTTP_SESS_SUCCESS = 0,
 	/* Can't obtain session: new client; a redirection message sent. */
 	TFW_HTTP_SESS_REDIRECT_SENT,

--- a/tempesta_fw/http_types.h
+++ b/tempesta_fw/http_types.h
@@ -1,0 +1,29 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2018 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_HTTP_TYPES_H__
+#define __TFW_HTTP_TYPES_H__
+
+/* Forward declaration of common HTTP types. */
+typedef struct tfw_http_sess_t	TfwHttpSess;
+typedef struct tfw_http_msg_t	TfwHttpMsg;
+typedef struct tfw_http_req_t	TfwHttpReq;
+typedef struct tfw_http_resp_t	TfwHttpResp;
+
+#endif /* __TFW_HTTP_TYPES_H__ */

--- a/tempesta_fw/msg.h
+++ b/tempesta_fw/msg.h
@@ -31,7 +31,7 @@
  * @seq_list	- member in the ordered queue of messages;
  * @ss_flags	- message processing flags;
  * @skb_head	- head of the list of sk_buff that belong to the message;
- * @len		- total message length;
+ * @len		- original (received) message length;
  *
  * TODO: Currently seq_list is used only in requests. Responses are not
  * put in any queues, they are simply attached to requests as req->resp.

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -147,7 +147,7 @@ typedef struct {
 					 | TFW_SG_F_SCHED_RATIO_DYNAMIC	\
 					 | TFW_SG_F_SCHED_RATIO_PREDICT)
 
-#define TFW_SRV_RETRY_NIP		0x0100	/* Retry non-idemporent req. */
+#define TFW_SRV_RETRY_NIP		0x0100	/* Retry non-idempotent req. */
 #define TFW_SRV_STICKY			0x0200	/* Use sticky sessions. */
 #define TFW_SRV_STICKY_FAILOVER		0x0400	/* Allow failovering. */
 #define TFW_SRV_STICKY_FLAGS		\

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -68,7 +68,7 @@ typedef struct {
 /**
  * Node of close backlog.
  *
- * @ticket	- the work ticket used in trurnstile to order items from the
+ * @ticket	- the work ticket used in turnstile to order items from the
  * 		  backlog with ring-buffer items;
  * @list	- list entry in the backlog;
  * @sw		- work descriptor to perform.
@@ -496,7 +496,7 @@ EXPORT_SYMBOL(ss_send);
  * Note: it used to be called in process context as well, at the time when
  * Tempesta starts or stops. That's not the case right now, but it may change.
  *
- * TODO In some cases we need to close socket agresively w/o FIN_WAIT_2 state,
+ * TODO In some cases we need to close socket aggressively w/o FIN_WAIT_2 state,
  * e.g. by sending RST. So we need to add second parameter to the function
  * which says how to close the socket.
  * One of the examples is rcl_req_limit() (it should reset connections).
@@ -862,7 +862,7 @@ ss_tcp_data_ready(struct sock *sk)
 	else {
 		/*
 		 * Check for URG data.
-		 * TODO shouldn't we do it in th_tcp_process_data()?
+		 * TODO shouldn't we do it in ss_tcp_process_data()?
 		 */
 		struct tcp_sock *tp = tcp_sk(sk);
 		if (tp->urg_data & TCP_URG_VALID) {
@@ -972,7 +972,7 @@ ss_tcp_state_change(struct sock *sk)
 		 * TCP_ESTABLISHED state to a closing state, we forcefully
 		 * close the socket before it can reach the final state.
 		 *
-		 * We get here when an error has occured in the connection.
+		 * We get here when an error has occurred in the connection.
 		 * It could be that RST was received which may happen for
 		 * multiple reasons. Or it could be a case of TCP timeout
 		 * where the connection appears to be dead. In all of these
@@ -1210,7 +1210,7 @@ ss_connect(struct sock *sk, struct sockaddr *uaddr, int uaddr_len, int flags)
 	bh_unlock_sock(sk);
 
 	/*
-	 * If connect() successfully returns, then the soket is living somewhere
+	 * If connect() successfully returns, then the socket is living somewhere
 	 * in TCP code and it will move to established or closed state.
 	 * So we decrement __ss_act_cnt when the socket die, no need to do this now.
 	 */
@@ -1315,7 +1315,7 @@ ss_tx_action(void)
 	/*
 	 * @budget limits the loop to prevent live lock on constantly arriving
 	 * new items. We use some small integer as a lower bound to catch just
-	 * ariving items.
+	 * arriving items.
 	 */
 	budget = max(10UL, ss_close_q_sz());
 	while ((!ss_active() || budget--) && !ss_wq_pop(&sw, &ticket)) {
@@ -1423,7 +1423,7 @@ ss_wait_newconn(void)
 EXPORT_SYMBOL(ss_wait_newconn);
 
 /**
- * Wait until there are no queued works and no runnign tasklets.
+ * Wait until there are no queued works and no running tasklets.
  * The function should be used when all sockets are closed.
  * SS upcalls are protected with SS_V_ACT_LIVECONN.
  * Can sleep, so must be called from user-space context.

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -84,7 +84,8 @@ typedef struct {
 static const char *ss_statename[] = {
 	"Unused",	"Established",	"Syn Sent",	"Syn Recv",
 	"Fin Wait 1",	"Fin Wait 2",	"Time Wait",	"Close",
-	"Close Wait",	"Last ACK",	"Listen",	"Closing"
+	"Close Wait",	"Last ACK",	"Listen",	"Closing",
+	"New Syn Recv"
 };
 #endif
 

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -759,6 +759,64 @@ out:
 }
 
 /**
+ * Calculates the appropriate TCP receive buffer space. Same as
+ * tcp_rcv_space_adjust().
+ */
+static void
+ss_rcv_space_adjust(struct sock *sk)
+{
+	struct tcp_sock *tp = tcp_sk(sk);
+	int time;
+	int copied;
+
+	tcp_mstamp_refresh(tp);
+	time = tcp_stamp_us_delta(tp->tcp_mstamp, tp->rcvq_space.time);
+
+	if (time < (tp->rcv_rtt_est.rtt_us >> 3) || tp->rcv_rtt_est.rtt_us == 0)
+		return;
+
+	copied = tp->copied_seq - tp->rcvq_space.seq;
+	if (copied <= tp->rcvq_space.space)
+		goto new_measure;
+
+	/*
+	 * Socket buffer size is locked (SOCK_RCVBUF_LOCK), we manually control
+	 * its size and can moderate it to gain more speed.
+	 */
+	/* TODO:
+	 * if (sysctl_tcp_moderate_rcvbuf) {
+	 */
+	if (true) {
+		int rcvwin, rcvmem, rcvbuf;
+
+		rcvwin = (copied << 1) + 16 * tp->advmss;
+		if (copied >=
+		    tp->rcvq_space.space + (tp->rcvq_space.space >> 2)) {
+			if (copied >=
+			    tp->rcvq_space.space + (tp->rcvq_space.space >> 1))
+				rcvwin <<= 1;
+			else
+				rcvwin += (rcvwin >> 1);
+		}
+
+		rcvmem = SKB_TRUESIZE(tp->advmss + MAX_TCP_HEADER);
+		while (tcp_win_from_space(rcvmem) < tp->advmss)
+			rcvmem += 128;
+
+		rcvbuf = min(rcvwin / tp->advmss * rcvmem, tfw_cfg_cli_rmem);
+		if (rcvbuf > sk->sk_rcvbuf) {
+			sk->sk_rcvbuf = rcvbuf;
+			tp->window_clamp = rcvwin;
+		}
+	}
+	tp->rcvq_space.space = copied;
+
+new_measure:
+	tp->rcvq_space.seq = tp->copied_seq;
+	tp->rcvq_space.time = tp->tcp_mstamp;
+}
+
+/**
  * Receive data on TCP socket. Very similar to standard tcp_recvmsg().
  *
  * We can't use standard tcp_read_sock() with our actor callback, because
@@ -781,7 +839,7 @@ ss_tcp_process_data(struct sock *sk)
 			TFW_WARN("recvmsg bug: TCP sequence gap at seq %X"
 				 " recvnxt %X\n",
 				 tp->copied_seq, TCP_SKB_CB(skb)->seq);
-			goto out;
+			goto drop;
 		}
 
 		__skb_unlink(skb, &sk->sk_receive_queue);
@@ -798,7 +856,7 @@ ss_tcp_process_data(struct sock *sk)
 		processed += count;
 
 		if (r < 0)
-			goto out;
+			goto drop;
 		else if (!count)
 			TFW_WARN("recvmsg bug: overlapping TCP segment at %X"
 				 " seq %X rcvnxt %X len %x\n",
@@ -806,12 +864,15 @@ ss_tcp_process_data(struct sock *sk)
 				 skb_len);
 	}
 	droplink = false;
-out:
+drop:
 	/*
 	 * Recalculate an appropriate TCP receive buffer space
 	 * and send ACK to a client with the new window.
 	 */
-	tcp_rcv_space_adjust(sk);
+	if (sk->sk_userlocks & SOCK_RCVBUF_LOCK)
+		ss_rcv_space_adjust(sk);
+	else
+		tcp_rcv_space_adjust(sk);
 	if (processed)
 		tcp_cleanup_rbuf(sk, processed);
 
@@ -835,7 +896,7 @@ ss_tcp_data_ready(struct sock *sk)
 	assert_spin_locked(&sk->sk_lock.slock);
 	TFW_VALIDATE_SK_LOCK_OWNER(sk);
 
-	if (!skb_queue_empty(&sk->sk_error_queue)) {
+	if (unlikely(!skb_queue_empty(&sk->sk_error_queue))) {
 		/*
 		 * Error packet received.
 		 * See sock_queue_err_skb() in linux/net/core/skbuff.c.

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -783,10 +783,7 @@ ss_rcv_space_adjust(struct sock *sk)
 	 * Socket buffer size is locked (SOCK_RCVBUF_LOCK), we manually control
 	 * its size and can moderate it to gain more speed.
 	 */
-	/* TODO:
-	 * if (sysctl_tcp_moderate_rcvbuf) {
-	 */
-	if (true) {
+	if (sysctl_tcp_moderate_rcvbuf) {
 		int rcvwin, rcvmem, rcvbuf;
 
 		rcvwin = (copied << 1) + 16 * tp->advmss;

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -411,8 +411,7 @@ tfw_listen_sock_start(TfwListenSock *ls)
 	if (tfw_cfg_cli_rmem) {
 		int bsz = tfw_cfg_cli_rmem * 2;
 
-		/* TODO */
-		if (/* sysctl_tcp_moderate_rcvbuf && */ (bsz > sysctl_tcp_rmem[1]))
+		if (sysctl_tcp_moderate_rcvbuf && (bsz > sysctl_tcp_rmem[1]))
 			bsz = sysctl_tcp_rmem[1];
 		sk->sk_userlocks |= SOCK_RCVBUF_LOCK;
 		sk->sk_rcvbuf = bsz;

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -459,7 +459,7 @@ tfw_cfgop_listen(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	 * - a full IP address (e.g. "listen 127.0.0.1:8081").
 	 */
 	in_str = ce->vals[0];
-	r = tfw_cfg_parse_int(in_str, &port);
+	r = __tfw_cfg_parse_int(in_str, &port);
 	if (!r) {
 		r = tfw_cfg_check_range(port, 0, 65535);
 		if (r)
@@ -509,18 +509,15 @@ tfw_cfgop_keepalive_timeout(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	int r;
 
 	if ((r = tfw_cfg_check_val_n(ce, 1)))
-		return -EINVAL;
+		return r;
 
-	if ((r = tfw_cfg_parse_int(ce->vals[0], &tfw_cli_cfg_ka_timeout))) {
-		TFW_ERR_NL("Unable to parse 'keepalive_timeout' value: '%s'\n",
-			   ce->vals[0] ? : "No value specified");
-		return -EINVAL;
-	}
+	if ((r = tfw_cfg_parse_int(ce->vals[0], &tfw_cli_cfg_ka_timeout)))
+		return r;
+	if ((r = tfw_cfg_check_range(tfw_cli_cfg_ka_timeout, 0, INT_MAX)))
+		return r;
 
-	if (tfw_cli_cfg_ka_timeout < 0) {
-		TFW_ERR_NL("Unable to parse 'keepalive_timeout' value: '%s'\n",
-			   "Value less the zero");
-		return -EINVAL;
+	return 0;
+}
 	}
 
 	return 0;

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -207,7 +207,7 @@ err_client:
 }
 
 /**
- * Do the same stuff for intetional client connection closing and due to some
+ * Do the same stuff for intentional client connection closing and due to some
  * error on TCP socket or application layers.
  */
 static void
@@ -266,7 +266,7 @@ static int
 __cli_conn_close_cb(TfwConn *conn)
 {
 	/*
-	 * Use assynchronous closing to release peer connection list and
+	 * Use asynchronous closing to release peer connection list and
 	 * client hash bucket locks as soon as possible and let softirq
 	 * do all the jobs.
 	 */
@@ -590,9 +590,9 @@ tfw_sock_clnt_stop(void)
 	/*
 	 * Now all listening sockets are closed, so no new connections
 	 * can appear. Close all established client connections.
-	 * We're going to acquie client hash bucket and peer connection list
-	 * locks, so disable softiqs to avoid deadlock with the sockets closing
-	 * in softiq context.
+	 * We're going to acquire client hash bucket and peer connection list
+	 * locks, so disable softirq to avoid deadlock with the sockets closing
+	 * in softirq context.
 	 */
 	local_bh_disable();
 	while (tfw_client_for_each(tfw_cli_conn_close_all)) {

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -305,16 +305,16 @@ tfw_srv_conn_release(TfwSrvConn *srv_conn)
 	 * callback). The only reason not to start new reconnect
 	 * attempt is removing server from the current configuration.
 	 *
-	 * TFW_CONN_B_ACTIVE bit is checked here to see if the connection has
+	 * TFW_CONN_ACTIVE bit is checked here to see if the connection has
 	 * already got a server's reference; if so, then server's reference must
 	 * be put. If bit is not set, this means that connection didn't have
 	 * time or was never scheduled to reach server (due to some error in
 	 * sock_srv start procedure) and consequently, it needn't to put
 	 * server here (during stop procedure).
 	 */
-	if (likely(!test_bit(TFW_CONN_B_DEL, &srv_conn->flags)))
+	if (likely(!test_bit(TFW_CONN_DEL, &srv_conn->flags)))
 		tfw_sock_srv_connect_try_later(srv_conn);
-	else if (test_bit(TFW_CONN_B_ACTIVE, &srv_conn->flags))
+	else if (test_bit(TFW_CONN_ACTIVE, &srv_conn->flags))
 		tfw_server_put((TfwServer *)srv_conn->peer);
 }
 
@@ -441,12 +441,12 @@ tfw_sock_srv_disconnect(TfwConn *conn)
 	TfwSrvConn *srv_conn = (TfwSrvConn *)conn;
 
 	/* Server's refcounter is decreased on disconnect. */
-	if (test_bit(TFW_CONN_B_DEL, &srv_conn->flags))
+	if (test_bit(TFW_CONN_DEL, &srv_conn->flags))
 		return 0;
 
 	/* Stop any attempts to reconnect or reschedule. */
 	del_timer_sync(&conn->timer);
-	set_bit(TFW_CONN_B_DEL, &srv_conn->flags);
+	set_bit(TFW_CONN_DEL, &srv_conn->flags);
 
 	/*
 	 * Close the connection if it's not being closed yet. Resources
@@ -485,7 +485,7 @@ static inline void
 tfw_sock_srv_conn_activate(TfwServer *srv, TfwSrvConn *srv_conn)
 {
 	tfw_server_get(srv);
-	set_bit(TFW_CONN_B_ACTIVE, &srv_conn->flags);
+	set_bit(TFW_CONN_ACTIVE, &srv_conn->flags);
 }
 
 static void

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1334,20 +1334,16 @@ tfw_cfgop_server(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwCfgSrvGroup *sg_cfg)
 				TFW_ERR_NL("Duplicate argument: '%s'\n", key);
 				return -EINVAL;
 			}
-			if (tfw_cfg_parse_int(val, &conns_n)) {
-				TFW_ERR_NL("Invalid value: '%s'\n", val);
+			if (tfw_cfg_parse_int(val, &conns_n))
 				return -EINVAL;
-			}
 			has_conns_n = true;
 		} else if (!strcasecmp(key, "weight")) {
 			if (has_weight) {
 				TFW_ERR_NL("Duplicate argument: '%s'\n", key);
 				return -EINVAL;
 			}
-			if (tfw_cfg_parse_int(val, &weight)) {
-				TFW_ERR_NL("Invalid value: '%s'\n", val);
+			if (tfw_cfg_parse_int(val, &weight))
 				return -EINVAL;
-			}
 			has_weight = true;
 		} else {
 			TFW_ERR_NL("Unsupported argument: '%s'\n", key);
@@ -1645,10 +1641,8 @@ tfw_cfg_handle_ratio_predyn_opts(TfwCfgEntry *ce, unsigned int *arg_flags)
 			flags |= TFW_PSTATS_IDX_P90;
 			goto done;
 		}
-		if (tfw_cfg_parse_int(ce->vals[3], &value)) {
-			TFW_ERR_NL("Invalid value: '%s'\n", ce->vals[3]);
+		if (tfw_cfg_parse_int(ce->vals[3], &value))
 			return -EINVAL;
-		}
 		for (idx = 0; idx < ARRAY_SIZE(tfw_pstats_ith); ++idx) {
 			if (!tfw_pstats_ith[idx])
 				continue;
@@ -1694,30 +1688,24 @@ tfw_cfg_handle_ratio_predict(TfwCfgEntry *ce,
 				TFW_ERR_NL("Duplicate argument: '%s'\n", key);
 				return -EINVAL;
 			}
-			if (tfw_cfg_parse_int(val, &arg.past)) {
-				TFW_ERR_NL("Invalid value: '%s'\n", val);
+			if (tfw_cfg_parse_int(val, &arg.past))
 				return -EINVAL;
-			}
 			has_past = true;
 		} else if (!strcasecmp(key, "rate")) {
 			if (has_rate) {
 				TFW_ERR_NL("Duplicate argument: '%s'\n", key);
 				return -EINVAL;
 			}
-			if (tfw_cfg_parse_int(val, &arg.rate)) {
-				TFW_ERR_NL("Invalid value: '%s'\n", val);
+			if (tfw_cfg_parse_int(val, &arg.rate))
 				return -EINVAL;
-			}
 			has_rate = true;
 		} else if (!strcasecmp(key, "ahead")) {
 			if (has_ahead) {
 				TFW_ERR_NL("Duplicate argument: '%s'\n", key);
 				return -EINVAL;
 			}
-			if (tfw_cfg_parse_int(val, &arg.ahead)) {
-				TFW_ERR_NL("Invalid value: '%s'\n", val);
+			if (tfw_cfg_parse_int(val, &arg.ahead))
 				return -EINVAL;
-			}
 			has_ahead = true;
 		}
 	}

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -184,7 +184,7 @@ tfw_str_add_compound(TfwPool *pool, TfwStr *str)
 
 /**
  * Add place for a new duplicate to string tree @str,
- * the string is probably alredy a set of duplicate compound strings.
+ * the string is probably already a set of duplicate compound strings.
  */
 TfwStr *
 tfw_str_add_duplicate(TfwPool *pool, TfwStr *str)
@@ -676,7 +676,7 @@ tfw_str_eq_cstr_off(const TfwStr *str, ssize_t offset, const char *cstr,
 EXPORT_SYMBOL(tfw_str_eq_cstr_off);
 
 /**
- * The function intentionaly breaks zero-copy string design. And should
+ * The function intentionally breaks zero-copy string design. And should
  * be used for short-strings only.
  *
  * Join all chunks of @str to a single plain C string.
@@ -723,11 +723,11 @@ tfw_str_to_cstr(const TfwStr *str, char *out_buf, int buf_size)
 EXPORT_SYMBOL(tfw_str_to_cstr);
 
 /**
- * HTTP parser can break strings into several chuncks and mark some of them
- * with TFW_STR_VALUE flag. Single string value may oqupie more than one chunk,
+ * HTTP parser can break strings into several chunks and mark some of them
+ * with TFW_STR_VALUE flag. Single string value may occupy more than one chunk,
  * independent string values divided by non-flagged chunks.
  *
- * Return compaund TfwStr starting at next string value.
+ * Return compound TfwStr starting at next string value.
  */
 TfwStr
 tfw_str_next_str_val(const TfwStr *str)

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -80,7 +80,7 @@
  * some other context. Keep in mind that TfwStr uses the functions as well.
  *
  * The functions are optimistic for the data of length 64 and more bytes,
- * i.e. comapring or matchin long strings you assume that the strings are
+ * i.e. comparing or matching long strings you assume that the strings are
  * matched (in case of tfw_match_*) or the same (in case of tfw_stricmp).
  * 64 and 128 byte subroutines of the functions load and process 2 and 4
  * 32-byre registers in parallel utilizing the memory bus and avoiding
@@ -183,7 +183,7 @@ size_t tfw_ultoa(unsigned long ai, char *buf, unsigned int len);
 /* Str is compound from many chunks, use indirect table for the chunks. */
 #define __TFW_STR_COMPOUND 	(~((1U << TFW_STR_FBITS) - 1))
 /*
- * Str constists from compound or plain strings.
+ * Str consists from compound or plain strings.
  * Duplicate strings are also always compound on root level.
  */
 #define TFW_STR_DUPLICATE	0x01
@@ -224,7 +224,7 @@ typedef struct {
 /* Use this with "%.*s" in printing calls. */
 #define PR_TFW_STR(s)		(int)min(20UL, (s)->len), (char *)(s)->ptr
 
-/* Numner of chunks in @s. */
+/* Number of chunks in @s. */
 #define TFW_STR_CHUNKN(s)	((s)->flags >> TFW_STR_CN_SHIFT)
 #define TFW_STR_CHUNKN_LIM(s)	((s)->flags >= __TFW_STR_CN_MAX)
 #define TFW_STR_CHUNKN_ADD(s, n) ((s)->flags += ((n) << TFW_STR_CN_SHIFT))

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -62,7 +62,7 @@ typedef struct ss_hooks {
 	 * Drop TCP connection associated with the socket.
 	 * The callback is called on intentional socket closing when the socket
 	 * is already closed (i.e. there could not be ingress data on it) and we
-	 * can safely do some clenup stuff. We need the callback sine socket
+	 * can safely do some cleanup stuff. We need the callback since socket
 	 * closing always has chance to run asynchronously on other CPU and a
 	 * caller doesn't know the it completes.
 	 */
@@ -146,6 +146,22 @@ void ss_stop(void);
 bool ss_active(void);
 void ss_get_stat(SsStat *stat);
 
+static inline void
+ss_rmem_reserve(struct sock *sk, unsigned int sz)
+{
+	BUG_ON(!sk);
+	if (sk->sk_userlocks & SOCK_RCVBUF_LOCK)
+		atomic_add(sz, &sk->sk_rmem_alloc);
+}
+
+static inline void
+ss_rmem_release(struct sock *sk, unsigned int sz)
+{
+	BUG_ON(!sk);
+	if (sk->sk_userlocks & SOCK_RCVBUF_LOCK)
+		atomic_sub(sz, &sk->sk_rmem_alloc);
+}
+
 #define SS_CALL(f, ...)							\
 	(sk->sk_user_data && ((SsProto *)(sk)->sk_user_data)->hooks->f	\
 	? ((SsProto *)(sk)->sk_user_data)->hooks->f(__VA_ARGS__)	\
@@ -153,5 +169,7 @@ void ss_get_stat(SsStat *stat);
 
 #define SS_CONN_TYPE(sk)							\
 	(((SsProto *)(sk)->sk_user_data)->type)
+
+extern int tfw_cfg_cli_rmem;
 
 #endif /* __SS_SOCK_H__ */

--- a/tempesta_fw/t/unit/helpers.c
+++ b/tempesta_fw/t/unit/helpers.c
@@ -56,6 +56,7 @@ test_req_alloc(size_t data_len)
 	tfw_connection_init(&conn_req);
 	conn_req.proto.type = Conn_HttpClnt;
 	hmreq->conn = &conn_req;
+	tfw_http_init_parser_req((TfwHttpReq *)hmreq);
 
 	return (TfwHttpReq *)hmreq;
 }
@@ -87,6 +88,7 @@ test_resp_alloc(size_t data_len)
 	tfw_connection_init(&conn_req);
 	conn_resp.proto.type = Conn_HttpSrv;
 	hmresp->conn = &conn_resp;
+	tfw_http_init_parser_resp((TfwHttpResp *)hmresp);
 
 	return (TfwHttpResp *)hmresp;
 }

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -22,6 +22,7 @@
 #include <linux/vmalloc.h>
 
 #include "http_msg.h"
+#include "http_parser.h"
 
 #include "test.h"
 #include "helpers.h"

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -880,16 +880,18 @@ TEST(http_parser, parses_connection_value)
 		"Connection: Keep-Alive\r\n"
 		"\r\n")
 	{
-		EXPECT_EQ(req->flags & __TFW_HTTP_MSG_M_CONN_MASK,
-			  TFW_HTTP_F_CONN_KA);
+		EXPECT_FALSE(test_bit(TFW_HTTP_CONN_CLOSE, req->flags));
+		EXPECT_TRUE(test_bit(TFW_HTTP_CONN_KA, req->flags));
+		EXPECT_FALSE(test_bit(TFW_HTTP_CONN_EXTRA, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Connection: Close\r\n"
 		"\r\n")
 	{
-		EXPECT_EQ(req->flags & __TFW_HTTP_MSG_M_CONN_MASK,
-			  TFW_HTTP_F_CONN_CLOSE);
+		EXPECT_TRUE(test_bit(TFW_HTTP_CONN_CLOSE, req->flags));
+		EXPECT_FALSE(test_bit(TFW_HTTP_CONN_KA, req->flags));
+		EXPECT_FALSE(test_bit(TFW_HTTP_CONN_EXTRA, req->flags));
 	}
 }
 
@@ -1093,21 +1095,21 @@ TEST(http_parser, accept)
 		"Accept:  text/html \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  text/html, application/xhtml+xml \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  text/html;q=0.8 \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
@@ -1115,21 +1117,21 @@ TEST(http_parser, accept)
 		"q=0.9,image/webp,image/apng,*/*;q=0.8\r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  text/*  \r\n"
 		"\r\n")
 	{
-		EXPECT_FALSE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_FALSE(test_bit(TFW_HTTP_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  text/html, */*  \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_ACCEPT_HTML, req->flags));
 	}
 }
 

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -253,6 +253,8 @@ http_sticky_suite_setup(void)
 
 	mock.req->conn = &mock.conn_req;
 	mock.resp->conn = &mock.conn_resp;
+	tfw_http_init_parser_req(mock.req);
+	tfw_http_init_parser_resp(mock.resp);
 	mock.req->vhost = tfw_vhost_new(TFW_VH_DFT_NAME);
 
 	tfw_http_req_add_seq_queue(mock.req);
@@ -390,6 +392,7 @@ http_parse_helper(TfwHttpMsg *hm, ss_skb_actor_t actor)
 static int
 http_parse_req_helper(void)
 {
+	tfw_http_init_parser_req(mock.req);
 	return http_parse_helper((TfwHttpMsg *)mock.req, tfw_http_parse_req);
 }
 
@@ -397,7 +400,6 @@ static int
 http_parse_resp_helper(void)
 {
 	/* XXX reset parser explicitly to be able to call it multiple times */
-	memset(&mock.resp->parser, 0, sizeof(mock.resp->parser));
 	tfw_http_init_parser_resp(mock.resp);
 	mock.resp->h_tbl->off = TFW_HTTP_HDR_RAW;
 	memset(mock.resp->h_tbl->tbl, 0, __HHTBL_SZ(1) * sizeof(TfwStr));

--- a/tempesta_fw/t/unit/test_http_tbl.c
+++ b/tempesta_fw/t/unit/test_http_tbl.c
@@ -34,6 +34,7 @@
 
 #include "cfg.h"
 #include "http_msg.h"
+#include "http_parser.h"
 #include "helpers.h"
 #include "sched_helper.h"
 #include "test.h"

--- a/tempesta_fw/t/unit/test_sched_hash.c
+++ b/tempesta_fw/t/unit/test_sched_hash.c
@@ -34,6 +34,7 @@
 
 #include "helpers.h"
 #include "http_msg.h"
+#include "http_parser.h"
 #include "sched_helper.h"
 #include "test.h"
 

--- a/tempesta_fw/t/unit/test_sched_ratio.c
+++ b/tempesta_fw/t/unit/test_sched_ratio.c
@@ -35,6 +35,7 @@
 #include "helpers.h"
 #include "sched_helper.h"
 #include "server.h"
+#include "http_parser.h"
 #include "test.h"
 
 static TfwMsg *sched_ratio_get_arg(size_t conn_type);

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1534,11 +1534,8 @@ static int
 frang_parse_ushort(const char *s, unsigned short *out)
 {
 	int n;
-	if (tfw_cfg_parse_int(s, &n)) {
-		TFW_ERR_NL("frang: http_resp_code_block: "
-			   "\"%s\" isn't a valid value\n", s);
+	if (tfw_cfg_parse_int(s, &n))
 		return -EINVAL;
-	}
 	if (tfw_cfg_check_range(n, 1, USHRT_MAX))
 		return -EINVAL;
 	*out = n;


### PR DESCRIPTION
fix #498 

# Streaming of http messages

Directive `proxy_buffering` defines maximum buffered message size. Messages
shorter than `proxy_buffering` size are fully buffered, longer messages
contains from two parts: buffered and streamed.

Headers are always buffered. Full set of headers is required for processing
inside of TempestaFW during whole message lifetime.
Body may be split into two part: streamed and buffered. Body is processed only
right after parsing in cache or health monitor and not required in further
processing. Thus body may be safely streamed to target connection and freed
at any time.
Trailer header is also must be buffered. It extends headers, so it may be
required for message processing. Also trailer headers can be modified before
forwarding (e.g. `resp_hdr_set` directive), this can be done only on fully
buffered trailer.

In the text I say 'headers', 'body' and 'trailer', but 'headers' actually stands
for buffered message part: HTTP headers and buffered part of the body.

## Performance impacts

In general case the incoming message can't be streamed to target connection
right away. When a client message is received, it's placed into a server
connection forwarding queue (`fwd_queue`). Under the load it's never empty, so
immediate streaming is not possible and the message will be _scheduled_
for forwarding. When a server message is received, it's forwarded to client
with respect to client's `seq_queue`. If client pipelines requests, `seq_queue`
may be not empty and the there can be a number of unanswered requests,
so immediate streaming is not possible. Both situations may be worse, if
target connection is occupied by another streamed transmission.

But in the same time servers are much faster than clients, the request
may climb to the begging of the `fwd_queue` before the client finished the
transmission. Same for the backend to the client transmission: `seq_queue`
shouldn't be big, and all previous requests from the queue may be responded
faster than transmission of current response.

This means two things:
- some times messages can be fully assembled before streaming.
- the same message can be processed by two threads, since it's placed into
`seq_queue` and `fwd_queue` in incomplete state.

There is a couple solutions to deal with the first problem.
- Streaming from backend to clients (response streaming): Configuration level.
Use sticky sessions. In this case all requests from one client will be always
forwarded to the same backend connection. So any response can be effectively
streamed to the client.
- Application-aware response streaming. When a new request is received,
user-defined rules are used to check that expected response is to be streamed.
If that true, don't forward the request (and following) to the backends until
all previous requests are responded.
- Request streaming. The request is likely to be buffered if `fwd_queue` is
not empty. Keep a separate pool of backend connections for streaming only
or dynamically allocate a new server connection.

Long-polling requests from multiple clients may fully block backend connections.
Application-aware approach or dynamically allocated backend connections are
required.

This topic requires dedicated discussion.

## Processing of streamed messages

The main difference between buffered and streamed messages is processing
stages. Processing of a buffered connection is straight forward:
```
( receive -> parse ) -> process -> forward
repeat until message
 is fully received
```
Processing of streamed messages is bit complicated:
```
( receive -> parse ) -> [ process -> forward ] ->
 repeat until headers     forward headers to
 are fully received       target connection


 -> ( receive -> parse -> process -> stream ) ->
      repeat until all body fragments are
                    streamed


-> ( receive -> parse ) -> process -> stream
     repeat until trailer
     headers are fully
          received
```

Forwarding may happen in a different tread, so multiple access to the same
message is possible. First idea was to use spinlock to protect the message
from simultaneous parsing and forwarding. But only one spinlock is not enough
and a lot of additional checks and flags are required. Imagine the situation:
Part of request was received, scheduled to backend connection, a new part
is being parsed and processed so the lock is acquired. In the same time
other thread starts forwarding and tries to acquire the lock. Processing error
happens during processing in the first thread and the message must be destroyed.
In this approach reference counting and error flag is required. The same
situation takes place in other cases, so the code becomes very complicated.

Here is the used  solution. Stream message part only from the same thread where
the message is received. Forwarding of headers may (and will) happen in other
thread but that thread must not send streamed message part, only buffered.

So processing looks like:
```
Thread 1                                    Thread 2
--------                                    --------
    |                                           |
(receive headers)                               |
    |                                           |
(schedule to forward)                           |
    |                                           |
(receive, process body part)                    |
    * N                                         |
    |                                           |
    |                             (forward headers only to target connection)
    |                                           |
(receive, process body parts)                   |
    |                                           |
(stream al pending)                             |
    |                                           |
(receive, process, stream body part)            |
    * N                                         |
    |                                           |
(destroy the message)                           |
```

Forwarding in Thread 2 may happen only after the whole streamed message was
received. In this case Thead 1 will never forward streamed part, so the Thread 1
is responsible for streaming and releasing the message.

When a streamed message is forwarded to some connection, no messages allowed to
be forwarded though that connection until the forwarded message is fully
transmitted. Thus connection's `seq_qlock` or `fwd_qlock` is acuired on
streaming message part. In addition to thread role management described above,
this gives thread safety.

Note, that a response to the streamed request may appear earlier than request
is fully received. E.g. sticky cookie violation, serving message from cache.
In this case, request must be received fully to proceed to the next request.

All functions that processes message body, must be capable to process
the body by parts, since full body is never available for streamed messages.

## Close connection on streaming

Sometimes it's needed to close the egress connection after the messaged is fully
transmitted. In this case `CONN_CLOSE` flag must be added to `ss_flags` only
when the last message part is streamed.

## Error handling

Streamed message is partially received, but not forwarded to target connection.
-> Close ingress connection.

Streamed message is partially received and is being streamed to target
connection. -> Close both connection.

Streamed message is fully received and is being streamed to target
connection. -> Close egress connection.

Request was streamed to backend, but backend connection was closed and reopened.
-> Evict request, it's not stored in Tempesta, so it's not possible to
forward it once more time.

Early response is available for the streamed request (from sticky or cache
modules) but the request failed security limits (frang) or other processing
on receiving a new body fragment. -> If the response
is not sent yet (mostly false condition), drop the response and forward
a new one via `tfw_http_error_resp_and_log()` if applied. Close client
connection.

# Caching streamed responses

Message streaming is used to avoid assembling full messages and spending too
lot of memory for just a couple of messages, e.g. DVD images. Same apply
to cache. A new directive is required to limit cache entry size. Caching 1M
small responses may be more effective, than caching just a couple of big ones.

Cache entry size required to store the response may be unknown for streamed
responses. Response in chunked encoding may be very huge. Content-length header
is not provided in this case. It's required to effectively enlarge cache entry to
save a new response fragment. A new response fragment may be not only body, but
trailer headers too.
