### PR TITLE
Fix #852: don't drop a connection if it coulnd't be created due to an error.

### DIFF
--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -175,7 +175,7 @@ tfw_sock_clnt_new(struct sock *sk)
 
 	r = tfw_connection_new(conn);
 	if (r) {
-		TFW_ERR("conn_init() hook returned error\n");
+		TFW_ERR("cannot establish a new client connection\n");
 		goto err_conn;
 	}
 
@@ -196,7 +196,6 @@ tfw_sock_clnt_new(struct sock *sk)
 	return 0;
 
 err_conn:
-	tfw_connection_drop(conn);
 	tfw_cli_conn_free((TfwCliConn *)conn);
 err_client:
 	tfw_client_put(cli);

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -20,15 +20,16 @@
  * this program; if not, write to the Free Software Foundation, Inc., 59
  * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
+#include "tempesta_fw.h"
 #include "cfg.h"
-#include "http_limits.h"
 #include "client.h"
 #include "connection.h"
+#include "http_limits.h"
 #include "log.h"
-#include "sync_socket.h"
-#include "tempesta_fw.h"
-#include "server.h"
 #include "procfs.h"
+#include "server.h"
+#include "sync_socket.h"
+#include "tls.h"
 
 /*
  * ------------------------------------------------------------------------
@@ -482,12 +483,16 @@ tfw_cfgop_listen(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (!in_str)
 		goto parse_err;
 
-	if (!strcasecmp(in_str, "http"))
+	if (!strcasecmp(in_str, "http")) {
 		return tfw_listen_sock_add(&addr, TFW_FSM_HTTP);
-	else if (!strcasecmp(in_str, "https"))
+	}
+	else if (!strcasecmp(in_str, "https")) {
+		tfw_tls_cfg_require();
 		return tfw_listen_sock_add(&addr, TFW_FSM_HTTPS);
-	else
+	}
+	else {
 		goto parse_err;
+	}
 
 parse_err:
 	TFW_ERR_NL("Unable to parse 'listen' value: '%s'\n",

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -402,10 +402,10 @@ tfw_tls_do_cleanup(void)
  */
 
 /* TLS configuration state. */
-#define TFW_TLS_CFG_F_DISABLED	0
-#define TFW_TLS_CFG_F_REQUIRED	1
-#define TFW_TLS_CFG_F_CERT	2
-#define TFW_TLS_CFG_F_CKEY	4
+#define TFW_TLS_CFG_F_DISABLED	0U
+#define TFW_TLS_CFG_F_REQUIRED	1U
+#define TFW_TLS_CFG_F_CERT	2U
+#define TFW_TLS_CFG_F_CKEY	4U
 #define TFW_TLS_CFG_M_ALL	(TFW_TLS_CFG_F_CERT | TFW_TLS_CFG_F_CKEY)
 
 static unsigned int tfw_tls_cgf = TFW_TLS_CFG_F_DISABLED;
@@ -483,6 +483,7 @@ static void
 tfw_cfgop_cleanup_ssl_certificate(TfwCfgSpec *cs)
 {
 	mbedtls_x509_crt_free(&tfw_tls.crt);
+	tfw_tls_cgf &= ~TFW_TLS_CFG_F_CERT;
 }
 
 /**
@@ -534,26 +535,26 @@ static void
 tfw_cfgop_cleanup_ssl_certificate_key(TfwCfgSpec *cs)
 {
 	mbedtls_pk_free(&tfw_tls.key);
+	tfw_tls_cgf &= ~TFW_TLS_CFG_F_CKEY;
 }
 
 static int
 tfw_tls_cfgend(void)
 {
 	if (!(tfw_tls_cgf & TFW_TLS_CFG_F_REQUIRED)) {
-		if (tfw_tls_cgf & TFW_TLS_CFG_F_REQUIRED)
+		if (tfw_tls_cgf)
 			TFW_WARN_NL("TLS: no HTTPS listener,"
 				    " configuration ignored\n");
 		return 0;
 	}
-
 	if (!(tfw_tls_cgf & TFW_TLS_CFG_F_CERT)) {
-		TFW_ERR_NL("TLS: please spcify a certificate with"
+		TFW_ERR_NL("TLS: please specify a certificate with"
 			   " tls_certificate configuration option\n");
 		return -EINVAL;
 	}
-
-	if ((tfw_tls_cgf & TFW_TLS_CFG_M_ALL) != TFW_TLS_CFG_M_ALL) {
-		TFW_ERR_NL("TLS: SSL certificate/key pair is incomplete\n");
+	if (!(tfw_tls_cgf & TFW_TLS_CFG_F_CKEY)) {
+		TFW_ERR_NL("TLS: please specify a certificate key with"
+			   " tls_certificate_key configuration option\n");
 		return -EINVAL;
 	}
 

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2015 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -62,6 +62,8 @@ typedef struct {
 	struct sk_buff		*tx_queue;
 	spinlock_t		lock;
 } TfwTlsContext;
+
+void tfw_tls_cfg_require(void);
 
 #endif /* __TFW_TLS_H__ */
 


### PR DESCRIPTION
Move non-configured certificate error to start phase.
Cleanups and more user-friendly error messages.
#715: rename SSL to TLS configuration options (wiki and tests are updated as well)