### PR TITLE
Fix #852

### DIFF
--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -20,15 +20,16 @@
  * this program; if not, write to the Free Software Foundation, Inc., 59
  * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
+#include "tempesta_fw.h"
 #include "cfg.h"
 #include "classifier.h"
 #include "client.h"
 #include "connection.h"
 #include "log.h"
-#include "sync_socket.h"
-#include "tempesta_fw.h"
-#include "server.h"
 #include "procfs.h"
+#include "server.h"
+#include "sync_socket.h"
+#include "tls.h"
 
 /*
  * ------------------------------------------------------------------------
@@ -482,12 +483,16 @@ tfw_cfgop_listen(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (!in_str)
 		goto parse_err;
 
-	if (!strcasecmp(in_str, "http"))
+	if (!strcasecmp(in_str, "http")) {
 		return tfw_listen_sock_add(&addr, TFW_FSM_HTTP);
-	else if (!strcasecmp(in_str, "https"))
+	}
+	else if (!strcasecmp(in_str, "https")) {
+		tfw_tls_cfg_require();
 		return tfw_listen_sock_add(&addr, TFW_FSM_HTTPS);
-	else
+	}
+	else {
 		goto parse_err;
+	}
 
 parse_err:
 	TFW_ERR_NL("Unable to parse 'listen' value: '%s'\n",

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -175,7 +175,7 @@ tfw_sock_clnt_new(struct sock *sk)
 
 	r = tfw_connection_new(conn);
 	if (r) {
-		TFW_ERR("conn_init() hook returned error\n");
+		TFW_ERR("cannot establish a new client connection\n");
 		goto err_conn;
 	}
 
@@ -196,7 +196,6 @@ tfw_sock_clnt_new(struct sock *sk)
 	return 0;
 
 err_conn:
-	tfw_connection_drop(conn);
 	tfw_cli_conn_free((TfwCliConn *)conn);
 err_client:
 	tfw_client_put(cli);

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -32,7 +32,7 @@
 
 #define TFW_AUTHOR		"Tempesta Technologies, Inc"
 #define TFW_NAME		"Tempesta FW"
-#define TFW_VERSION		"0.5.2"
+#define TFW_VERSION		"0.5.3"
 
 #define DEF_MAX_PORTS		8
 

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Transport Layer Security (TLS) implementation.
+ * Transport Layer Security (TLS) interfaces to Tempesta TLS.
  *
  * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
@@ -19,8 +19,6 @@
  * this program; if not, write to the Free Software Foundation, Inc., 59
  * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
-#include <linux/vmalloc.h>
-
 #include "cfg.h"
 #include "connection.h"
 #include "client.h"
@@ -282,11 +280,6 @@ tfw_tls_conn_init(TfwConn *c)
 	ss_skb_queue_head_init(&tls->rx_queue);
 	ss_skb_queue_head_init(&tls->tx_queue);
 
-	if (!tfw_tls.crt.version) {
-		TFW_ERR("TLS:%p no certificate specified\n", tls);
-		return -EINVAL;
-	}
-
 	r = mbedtls_ssl_setup(&tls->ssl, &tfw_tls.cfg);
 	if (r) {
 		TFW_ERR("TLS:%p setup failed (%x)\n", tls, -r);
@@ -296,9 +289,8 @@ tfw_tls_conn_init(TfwConn *c)
 	mbedtls_ssl_set_bio(&tls->ssl, c,
 			    tfw_tls_send_cb, tfw_tls_recv_cb, NULL);
 
-	if (tfw_conn_hook_call(TFW_FSM_HTTP, c, conn_init)) {
+	if (tfw_conn_hook_call(TFW_FSM_HTTP, c, conn_init))
 		return -EINVAL;
-	}
 
 	spin_lock_init(&tls->lock);
 	tfw_gfsm_state_init(&c->state, c, TFW_TLS_FSM_INIT);
@@ -413,9 +405,14 @@ tfw_tls_do_cleanup(void)
 static int
 tfw_tls_start(void)
 {
-	int r;
+	int r = tfw_runstate_is_reconfig();
 
-	if (tfw_runstate_is_reconfig())
+	if (!tfw_tls.crt.version) {
+		TFW_ERR("TLS: please spcify a certificate with"
+			" tls_certificate configuration option\n");
+		return -EINVAL;
+	}
+	if (r)
 		return 0;
 
 	mbedtls_ssl_conf_ca_chain(&tfw_tls.cfg, tfw_tls.crt.next, NULL);
@@ -542,7 +539,7 @@ tfw_tls_cfgend(void)
 
 static TfwCfgSpec tfw_tls_specs[] = {
 	{
-		.name = "ssl_certificate",
+		.name = "tls_certificate",
 		.deflt = NULL,
 		.handler = tfw_cfgop_ssl_certificate,
 		.allow_none = true,
@@ -550,7 +547,7 @@ static TfwCfgSpec tfw_tls_specs[] = {
 		.cleanup = tfw_cfgop_cleanup_ssl_certificate,
 	},
 	{
-		.name = "ssl_certificate_key",
+		.name = "tls_certificate_key",
 		.deflt = NULL,
 		.handler = tfw_cfgop_ssl_certificate_key,
 		.allow_none = true,

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2015 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -62,6 +62,8 @@ typedef struct {
 	SsSkbList		tx_queue;
 	spinlock_t		lock;
 } TfwTlsContext;
+
+void tfw_tls_cfg_require(void);
 
 #endif /* __TFW_TLS_H__ */
 


### PR DESCRIPTION
    Backport of https://github.com/tempesta-tech/tempesta/pull/1015 to 0.5
    Fix #852: don't drop a connection if it coulnd't be created due to an error
    Move non-configured certificate error to start phase.
    Cleanups and more user-friendly error messages.
