### PR TITLE
Fix skb leakage on HTTP request processing errors.

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2259,7 +2259,6 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 	}
 	if (!req_retent) {
 		spin_unlock_bh(&cli_conn->seq_qlock);
-		tfw_http_resp_pair_free(resp->req);
 		return;
 	}
 	__list_cut_position(&ret_queue, seq_queue, req_retent);

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -598,7 +598,7 @@ __tfw_http_send_resp(TfwHttpReq *req, resp_code_t code)
 	};
 
 	if (tfw_strcpy_desc(&msg, &http_predef_resps[code]))
-		return;
+		goto err;
 
 	crlf = TFW_STR_CRLF_CH(&msg);
 	if (conn_flag) {
@@ -614,7 +614,7 @@ __tfw_http_send_resp(TfwHttpReq *req, resp_code_t code)
 	}
 
 	if (!(resp = tfw_http_msg_alloc_resp_light(req)))
-		goto err_create;
+		goto err;
 	if (tfw_http_msg_setup((TfwHttpMsg *)resp, &it, msg.len))
 		goto err_setup;
 
@@ -635,7 +635,7 @@ err_setup:
 	TFW_DBG2("%s: Response message allocation error: conn=[%p]\n",
 		 __func__, req->conn);
 	tfw_http_msg_free((TfwHttpMsg *)resp);
-err_create:
+err:
 	tfw_http_resp_build_error(req);
 }
 
@@ -2231,7 +2231,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 	 * If the list is empty, then it's either a bug, or the client
 	 * connection had been closed. If it's a bug, then the correct
 	 * order of responses to requests may be broken. The connection
-	 * with the client must to be closed immediately.
+	 * with the client must be closed immediately.
 	 *
 	 * Doing ss_close_sync() on client connection's socket is safe
 	 * as long as @req that holds a reference to the connection is
@@ -2259,6 +2259,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 	}
 	if (!req_retent) {
 		spin_unlock_bh(&cli_conn->seq_qlock);
+		tfw_http_resp_pair_free(resp->req);
 		return;
 	}
 	__list_cut_position(&ret_queue, seq_queue, req_retent);


### PR DESCRIPTION
tfw_http_resp_process() calls ss_skb_queue_purge() on bad_msg label, however
tfw_http_req_process() on TFW_BLOCK returned from the parser calls
tfw_client_drop() which not always free the request. (The ingress skb is
linked with the request in tfw_http_msg_process(), so we have to call
ss_skb_queue_purge() even on not parsed request.)

There is a case when we do not free skb on HTTP request processing errors.
tfw_http_cli_error_resp_and_log() -> tfw_http_req_mark_error()
-> __tfw_http_send_resp(): on bad return code from tfw_strcpy_desc()
just returns w/o calling tfw_http_resp_build_error().