### PR TITLE
Fix missed connection header

### DIFF
--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -704,7 +704,7 @@ tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 		},
 		.len = n_len + SLEN(S_DLM) + v_len,
 		.eolen = 2,
-		.flags = 3 << TFW_STR_CN_SHIFT
+		.flags = (val ? 3 : 2) << TFW_STR_CN_SHIFT
 	};
 
 	BUG_ON(!val && v_len);


### PR DESCRIPTION
Fix #1029 

Also found that `TFW_HTTP_MSG_HDR_DEL` macro works incorrect: instead of removing the header, a new header with empty header value is added.