### PR TITLE
tdb: make tdbq depend on libtdb

### DIFF
--- a/tempesta_db/Makefile
+++ b/tempesta_db/Makefile
@@ -24,7 +24,7 @@ libtdb:
 	$(MAKE) -C libtdb
 
 .PHONY: tdbq
-tdbq:
+tdbq: libtdb
 	$(MAKE) -C tdbq
 
 .PHONY: clean


### PR DESCRIPTION
Sometimes with make -jN, tdbq fails to link with libtdb, since there is
no libtdb yet.