### PR TITLE
fixups for sticky cookie calculation in case of segmented data

### DIFF
--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -709,6 +709,7 @@ tfw_http_sticky_verify(TfwHttpReq *req, TfwStr *value, StickyVal *sv)
 	if (value->len != sizeof(StickyVal) * 2) {
 		sess_warn("bad sticky cookie length", addr, ": %lu(%lu)\n",
 			  value->len, sizeof(StickyVal) * 2);
+		tfw_http_sticky_calc(req, sv);
 		return TFW_HTTP_SESS_VIOLATE;
 	}
 

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -517,14 +517,20 @@ tfw_http_redir_mark_get(TfwHttpReq *req, TfwStr *out_val)
 #define HEX_STR_TO_BIN_GET(obj, f)					\
 ({									\
 	int count = 0;							\
-	if (!tr && c < end)						\
+	if (c >= end)							\
+		goto end_##f;						\
+	if (!tr)							\
 		tr = c->ptr;						\
-	for ( ; c < end; ++c) {						\
+	for (;;) {							\
 		for ( ; tr < (unsigned char *)c->ptr + c->len; ++tr) {	\
 			if (count++ == sizeof((obj)->f) * 2)		\
 				goto end_##f;				\
 			(obj)->f = ((obj)->f << 4) + hex_to_bin(*tr);	\
 		}							\
+		++c;							\
+		if (c >= end)						\
+			break;						\
+		tr = c->ptr;						\
 	}								\
 end_##f:								\
 	;								\
@@ -533,8 +539,11 @@ end_##f:								\
 #define HEX_STR_TO_BIN_HMAC(hmac, ts, addr)				\
 ({									\
 	unsigned char b;						\
-	int i, hi, r = TFW_HTTP_SESS_SUCCESS;				\
-	for (i = 0, hi = 1; c < end; ++c) {				\
+	int i = 0, hi = 1, r = TFW_HTTP_SESS_SUCCESS;			\
+									\
+	if (c >= end)							\
+		goto end;						\
+	for (;;) {							\
 		for ( ; tr < (unsigned char *)c->ptr + c->len; ++tr) {	\
 			b = hi ? hex_asc_hi((hmac)[i])			\
 			       : hex_asc_lo((hmac)[i]);			\
@@ -552,6 +561,10 @@ end_##f:								\
 			hi = !hi;					\
 			i += hi;					\
 		}							\
+		++c;							\
+		if (c >= end)						\
+			break;						\
+		tr = c->ptr;						\
 	}								\
 	BUG_ON(i != STICKY_KEY_MAXLEN);					\
 end:									\

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -140,6 +140,11 @@ void tfw_str_collect_cmp(TfwStr *chunk, TfwStr *end, TfwStr *out,
 
 	BUG_ON(!TFW_STR_PLAIN(chunk));
 
+	if (unlikely(chunk == end)) {
+		bzero_fast(out, sizeof(*out));
+		return;
+	}
+
 	/* If this is last chunk, just return it in this case. */
 	next = chunk + 1;
 	if (likely(next == end || (stop && *(char *)next->ptr == *stop))) {
@@ -149,8 +154,11 @@ void tfw_str_collect_cmp(TfwStr *chunk, TfwStr *end, TfwStr *out,
 
 	/* Add chunks to out-string. */
 	out->ptr = chunk;
-	TFW_STR_CHUNKN_ADD(out, 1);
-	out->len = chunk->len;
+	out->flags = 0;
+	out->len = 0;
+	out->eolen = 0;
+	/* __TFW_STR_CHUNKN_SET(out, 0); is done by out->flags = 0 */
+
 	for (; chunk != end; ++chunk) {
 		if (stop && *(char *)chunk->ptr == *stop)
 			break;


### PR DESCRIPTION
If request comes in more than one packet, sticky cookie value may be in chunks. The patches handle that case, and also force cookie to be regenerated if inbound cookie was of wrong length.