### PR TITLE
resolve missing symbol warning in sticky cookie test

### DIFF
--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -34,6 +34,7 @@
 #define __init
 #endif
 
+#include "tls.c"
 #include "http_msg.c"
 
 #include "http_sess.c"


### PR DESCRIPTION
694140f837475261f95cacad86235a3f8bc2c503 added code that calls tfw_tls_cfg_require() from tls.c. Without direct including `tls.c`, there is a missing symbol warning, which in turn prevents unit tests from starting. (At least on my machine.)