### PR TITLE
Backport chunked sticky cookie handling to 0.5

### DIFF
--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -468,6 +468,7 @@ tfw_http_sticky_verify(TfwHttpReq *req, TfwStr *value, StickyVal *sv)
 	if (value->len != sizeof(StickyVal) * 2) {
 		sess_warn("bad sticky cookie length", addr, ": %lu(%lu)\n",
 			  value->len, sizeof(StickyVal) * 2);
+		tfw_http_sticky_calc(req, sv);
 		return TFW_HTTP_SESS_VIOLATE;
 	}
 


### PR DESCRIPTION
If request comes in multiple packets, cookie may be split into a number of chunks. These changes address such a case.

This is a backport of https://github.com/tempesta-tech/tempesta/pull/1088.