### PR TITLE
Contrived integer overflows

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -432,7 +432,7 @@ tfw_cache_employ_resp(TfwHttpResp *resp)
 static time_t
 tfw_cache_calc_lifetime(TfwHttpResp *resp)
 {
-	unsigned int lifetime;
+	time_t lifetime;
 
 	if (resp->cache_ctl.flags & TFW_HTTP_CC_S_MAXAGE)
 		lifetime = resp->cache_ctl.s_maxage;

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -622,7 +622,8 @@ tfw_http_sess_check_redir_mark(TfwHttpReq *req, RedirMarkVal *mv)
 		if (tfw_http_redir_mark_verify(req, &mark_val, mv)
 		    || ++mv->att_no > tfw_cfg_sticky.max_misses
 		    || (tfw_cfg_sticky.tmt_sec
-			&& mv->ts + HZ * tfw_cfg_sticky.tmt_sec < jiffies))
+		        && mv->ts + HZ * (unsigned long)tfw_cfg_sticky.tmt_sec
+		           < jiffies))
 		{
 			tfw_filter_block_ip(&req->conn->peer->addr);
 			return TFW_HTTP_SESS_VIOLATE;
@@ -970,7 +971,8 @@ tfw_http_sess_obtain(TfwHttpReq *req)
 	 */
 	atomic_set(&sess->users, 1);
 	sess->ts = sv.ts;
-	sess->expires = sv.ts + tfw_cfg_sticky.sess_lifetime * HZ;
+	sess->expires =
+		sv.ts + (unsigned long)tfw_cfg_sticky.sess_lifetime * HZ;
 	sess->st_conn.srv_conn = NULL;
 	rwlock_init(&sess->st_conn.lock);
 

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -970,9 +970,7 @@ tfw_http_sess_obtain(TfwHttpReq *req)
 	 */
 	atomic_set(&sess->users, 1);
 	sess->ts = sv.ts;
-	sess->expires = tfw_cfg_sticky.sess_lifetime
-			? sv.ts + tfw_cfg_sticky.sess_lifetime * HZ
-			: 0;
+	sess->expires = sv.ts + tfw_cfg_sticky.sess_lifetime * HZ;
 	sess->st_conn.srv_conn = NULL;
 	rwlock_init(&sess->st_conn.lock);
 

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -125,7 +125,8 @@ tfw_cli_conn_send(TfwCliConn *cli_conn, TfwMsg *msg)
 
 	r = tfw_connection_send((TfwConn *)cli_conn, msg);
 	mod_timer(&cli_conn->timer,
-		  jiffies + msecs_to_jiffies(tfw_cli_cfg_ka_timeout * 1000));
+		  jiffies +
+		  msecs_to_jiffies((long)tfw_cli_cfg_ka_timeout * 1000));
 
 	if (r)
 		/* Quite usual on system shutdown. */
@@ -192,7 +193,8 @@ tfw_sock_clnt_new(struct sock *sk)
 
 	/* Activate keepalive timer. */
 	mod_timer(&conn->timer,
-		  jiffies + msecs_to_jiffies(tfw_cli_cfg_ka_timeout * 1000));
+		  jiffies +
+		  msecs_to_jiffies((long)tfw_cli_cfg_ka_timeout * 1000));
 
 	TFW_DBG3("new client socket is accepted: sk=%p, conn=%p, cli=%p\n",
 		 sk, conn, cli);

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -2263,7 +2263,7 @@ static TfwCfgSpec tfw_srv_group_specs[] = {
 		.deflt = "5",
 		.handler = tfw_cfgop_in_fwd_retries,
 		.spec_ext = &(TfwCfgSpecInt) {
-			.range = { 0, INT_MAX },
+			.range = { 0, USHRT_MAX },
 		},
 		.allow_none = true,
 		.allow_repeat = false,
@@ -2356,7 +2356,7 @@ static TfwCfgSpec tfw_sock_srv_specs[] = {
 		.handler = tfw_cfgop_out_fwd_retries,
 		.cleanup = tfw_cfgop_cleanup_srv_groups,
 		.spec_ext = &(TfwCfgSpecInt) {
-			.range = { 0, INT_MAX },
+			.range = { 0, USHRT_MAX },
 		},
 		.allow_none = true,
 		.allow_repeat = false,

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -740,7 +740,8 @@ tfw_sock_srv_grace_shutdown_srv(TfwSrvGroup *sg, TfwServer *srv, void *data)
 		setup_timer(&srv->gs_timer, tfw_sock_srv_grace_shutdown_cb,
 			    (unsigned long)srv);
 		tfw_sock_srv_grace_list_add(srv);
-		mod_timer(&srv->gs_timer, jiffies + tfw_cfg_grace_time * HZ);
+		mod_timer(&srv->gs_timer,
+		          jiffies + (unsigned long)tfw_cfg_grace_time * HZ);
 	}
 	tfw_server_put(srv);
 
@@ -1078,7 +1079,7 @@ tfw_cfgop_fwd_timeout(TfwCfgSpec *cs, TfwCfgEntry *ce, unsigned long *to)
 
 	if((r = tfw_cfgop_intval(cs, ce, &time)))
 		return r;
-	*to = time ? msecs_to_jiffies(time * 1000) : ULONG_MAX;
+	*to = time ? msecs_to_jiffies((unsigned long)time * 1000) : ULONG_MAX;
 
 	return 0;
 }

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1909,9 +1909,11 @@ tfw_vhost_start(void)
 	if (!tfw_runstate_is_reconfig()) {
 		/* Convert Frang global timeouts to jiffies for convenience */
 		frang_cfg.clnt_hdr_timeout =
-			*(unsigned int *)&frang_cfg.clnt_hdr_timeout * HZ;
+			*(unsigned int *)&frang_cfg.clnt_hdr_timeout *
+			(unsigned long)HZ;
 		frang_cfg.clnt_body_timeout =
-			*(unsigned int *)&frang_cfg.clnt_body_timeout * HZ;
+			*(unsigned int *)&frang_cfg.clnt_body_timeout *
+			(unsigned long)HZ;
 	}
 
 	tfw_cfgop_vhosts_list_free(tfw_vhosts);


### PR DESCRIPTION
In some cases it's possible to specify numbers in the configuration file that may cause integer overflows. In such cases timeouts, for example, may be different from expected. Explicit up-casting before multiplications should prevent that.

fixes #1091