### PR TITLE
copy network headers in ss_skb_split()

### DIFF
--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -927,6 +927,31 @@ ss_skb_process(struct sk_buff *skb, unsigned int *off, ss_skb_actor_t actor,
 }
 EXPORT_SYMBOL(ss_skb_process);
 
+/**
+ * Tempesta makes use of the source IP address that is kept in the IP
+ * header of the original skb @from. Copy the needed IP header contents to
+ * the new skb @to.
+ */
+static inline void
+__copy_ip_header(struct sk_buff *to, const struct sk_buff *from)
+{
+	const struct iphdr *ip4 = ip_hdr(from);
+	const struct ipv6hdr *ip6 = ipv6_hdr(from);
+
+	/*
+	 * Place IP header just after link layer headers,
+	 * see definitions of MAX_TCP_HEADER and MAX_IP_HDR_LEN.
+	 * Note that only new skbs allocated by ss_skb_alloc() are used here,
+	 * so all of them have reserved MAX_TCP_HEADER areas.
+	 */
+	BUG_ON(skb_headroom(to) < MAX_TCP_HEADER);
+	skb_set_network_header(to, -(MAX_TCP_HEADER - MAX_HEADER));
+	if (ip6->version == 6)
+		memcpy_fast(skb_network_header(to), ip6, sizeof(*ip6));
+	else
+		memcpy_fast(skb_network_header(to), ip4, sizeof(*ip4));
+}
+
 /*
  * Split @skb in two at a given offset. The original SKB is shrunk
  * to specified size @len, and the remaining data is put into a new SKB.
@@ -969,6 +994,7 @@ ss_skb_split(struct sk_buff *skb, int len)
 	 * or recalculate the checksum.
 	 */
 	skb_split(skb, buff, len);
+	__copy_ip_header(buff, skb);
 
 	return buff;
 }
@@ -1017,31 +1043,6 @@ ss_skb_queue_coalesce_tail(struct sk_buff **skb_head, const struct sk_buff *skb)
 	}
 
 	return 0;
-}
-
-/**
- * Tempesta makes use of the source IP address that is kept in the IP
- * header of the original skb @from. Copy the needed IP header contents to
- * the new skb @to.
- */
-static inline void
-__copy_ip_header(struct sk_buff *to, const struct sk_buff *from)
-{
-	const struct iphdr *ip4 = ip_hdr(from);
-	const struct ipv6hdr *ip6 = ipv6_hdr(from);
-
-	/*
-	 * Place IP header just after link layer headers,
-	 * see definitions of MAX_TCP_HEADER and MAX_IP_HDR_LEN.
-	 * Note that only new skbs allocated by ss_skb_alloc() are used here,
-	 * so all of them have reserved MAX_TCP_HEADER areas.
-	 */
-	BUG_ON(skb_headroom(to) < MAX_TCP_HEADER);
-	skb_set_network_header(to, -(MAX_TCP_HEADER - MAX_HEADER));
-	if (ip6->version == 6)
-		memcpy_fast(skb_network_header(to), ip6, sizeof(*ip6));
-	else
-		memcpy_fast(skb_network_header(to), ip4, sizeof(*ip4));
 }
 
 /**


### PR DESCRIPTION
With HTTP request pipelining, multiple requests can fit into a single network packet, and so end up sharing the same `struct sk_buff`. In that case, after processing the first request, `struct sk_buff` is split into two, with remaining data going into another `sk_buff`. However, newly created `struct sk_buff` has no IP header, albeit has enough room reserved. That causes `ss_skb_fmt_src_addr()` used in address extraction for `X-Forwarded-For` header field, to use uninitialized data. 

The patch adds needed header copying.

(related to #1099)