### PR TITLE
remove request from seq_list when errors occur (backport to 0.5)

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2283,6 +2283,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 			TFW_DBG2("%s: Forwarding error: conn=[%p] resp=[%p]\n",
 				 __func__, cli_conn, req->resp);
 			BUG_ON(!req->resp);
+			list_del_init(&req->msg.seq_list);
 			tfw_http_resp_pair_free(req);
 			TFW_INC_STAT_BH(serv.msgs_otherr);
 		}


### PR DESCRIPTION
Adds missing error handling. If a request cannot be forwarded, it's dropped. In that case we need to remove it from the connection's queue.

(backport of #1110)