### PR TITLE
Fix #1034: Counting of client objects to avoid use-after-free case.

### DIFF
--- a/tempesta_fw/client.h
+++ b/tempesta_fw/client.h
@@ -49,5 +49,6 @@ void tfw_client_put(TfwClient *cli);
 int tfw_client_for_each(int (*fn)(TfwClient *));
 void tfw_cli_conn_release(TfwCliConn *cli_conn);
 int tfw_cli_conn_send(TfwCliConn *cli_conn, TfwMsg *msg);
+void tfw_cli_wait_release(void);
 
 #endif /* __TFW_CLIENT_H__ */

--- a/tempesta_fw/main.c
+++ b/tempesta_fw/main.c
@@ -25,12 +25,12 @@
 
 #include "tempesta_fw.h"
 #include "cfg.h"
+#include "client.h"
 #include "log.h"
 #include "str.h"
 #include "sync_socket.h"
 #include "server.h"
 #include "vhost.h"
-#include "client.h"
 
 MODULE_AUTHOR(TFW_AUTHOR);
 MODULE_DESCRIPTION(TFW_NAME);

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -115,6 +115,7 @@ static const char *ss_statename[] = {
 #define SS_V_ACT_NEWCONN	0x0000000000000001UL
 #define SS_M_ACT_NEWCONN	0x00000000ffffffffUL
 #define SS_V_ACT_LIVECONN	0x0000000100000000UL
+#define SS_ACT_SHIFT		32
 
 static bool __ss_active = false;
 static DEFINE_PER_CPU(atomic64_t, __ss_act_cnt) ____cacheline_aligned
@@ -1460,7 +1461,8 @@ ss_synchronize(void)
 	might_sleep();
 	while (1) {
 		for_each_online_cpu(cpu) {
-			int n_conn = atomic64_read(&per_cpu(__ss_act_cnt, cpu)) >> 32;
+			atomic64_t *act_cnt = &per_cpu(__ss_act_cnt, cpu);
+			int n_conn = atomic64_read(act_cnt) >> SS_ACT_SHIFT;
 			int n_q = ss_wq_size(cpu);
 			if (n_conn + n_q) {
 				irq_work_sync(&per_cpu(ipi_work, cpu));

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -100,6 +100,8 @@ TfwMod *tfw_mod_find(const char *name);
 
 bool tfw_runstate_is_reconfig(void);
 
+void tfw_objects_wait_release(const atomic64_t *counter, int delay,
+			      const char *name);
 /**
  * For !CONFIG_PREEMPT kernels, a CPU looping anywhere in the kernel without
  * invoking schedule() can lead to RCU CPU stall, so the function call the


### PR DESCRIPTION
The cause of the crash is attempt to access to `TfwClient` object (from `frang_conn_close()` callback during socket removal) - after the object had already been destroyed in Tempesta exit procedure. In fact there were three problems:
1. In `ss_tcp_state_change()` if client connection successfully acquired `SS_V_ACT_NEWCONN` guard, but `ss_stop` occurred before acquiring `SS_V_ACT_LIVECONN` - this will lead to mismatching in `__ss_act_cnt` (-1 live connections) since we did not check return value of guard operation in `SS_CALL_GUARD_ENTER`.
2. The above problem was hidden because in `ss_synchronize()` we were collecting the value of four lower bytes (instead of four upper ones) of `__ss_act_cnt`, which constantly resulted in zero live connections on exit.
3. However correction of the second problem does not guarantee complete avoidance of use-after-free case with `TfwClient` object: `frang_conn_close()` callback is called from `sk_free()` function which in turn called from `sock_put()` when the socket's `refcount` becomes zero, and this can happen in the TСP/IP stack - after releasing of all connection guards inside Tempesta. As a solution in this PR, a general accounting of TfwClient objects was added.