### PR TITLE
Parse "pragma" field in response, honor "pragma" field in request

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -409,6 +409,9 @@ tfw_cache_employ_resp(TfwHttpResp *resp)
 		return false;
 	if (resp->cache_ctl.flags & CC_RESP_DONTCACHE)
 		return false;
+	if (!(req->cache_ctl.flags & TFW_HTTP_CC_IS_PRESENT)
+	    && (req->cache_ctl.flags & TFW_HTTP_CC_PRAGMA_NO_CACHE))
+		return false;
 	if (!(resp->cache_ctl.flags & TFW_HTTP_CC_IS_PRESENT)
 	    && (resp->cache_ctl.flags & TFW_HTTP_CC_PRAGMA_NO_CACHE))
 		return false;


### PR DESCRIPTION
The patchset extends "pragma" field processing a bit. It's now parsed in both request and response headers. Also, both sources are used to decide whenever to cache a response.

Although [RFC 7234, 5.4](https://tools.ietf.org/html/rfc7234#section-5.4) doesn't explicitly specify meaning of "`Pragma: no-cache`" in response header, it is still used by various user agents — at least Firefox and Chromium — perhaps for compatibility reasons. So we probably want to abstain from caching if response comes with "`pragma: no-cache`" too, even if it's not a standard-compliant behavior.

(fixes #1116)