### PR TITLE
Fix bugs affecting load balancers

### DIFF
--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -782,6 +782,7 @@ __tfw_apm_rbent_reset(TfwApmRBEnt *crbent, unsigned long jtmistamp)
 	memset(crbent->pcntrng.__reset_from, 0,
 	       offsetof(TfwPcntRanges, __reset_till)
 	       - offsetof(TfwPcntRanges, __reset_from));
+	crbent->pcntrng.min_val = UINT_MAX;
 	crbent->jtmistamp = jtmistamp;
 	smp_mb__before_atomic();
 	atomic_set(&crbent->reset, 1);

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -1536,7 +1536,7 @@ tfw_cfg_sg_ratio_verify(TfwSrvGroup *sg)
 	int count = 0;
 
 	if (sg->flags & (TFW_SG_F_SCHED_RATIO_DYNAMIC
-			 || TFW_SG_F_SCHED_RATIO_PREDICT))
+			 | TFW_SG_F_SCHED_RATIO_PREDICT))
 	{
 		list_for_each_entry(srv, &sg->srv_list, list) {
 			if (srv->weight)


### PR DESCRIPTION
1. Fix incorrect bit operation, leading to incorrect scheduler otions
2. Fix resetting of APM data. `Minimal response time` is initialised as `0`, and can't be updated with real values here:
https://github.com/tempesta-tech/tempesta/blob/8bd88c970348bb3f1cdaa3c70f30a3a89ac6376a/tempesta_fw/apm.c#L319-L327
This lead to incorrect balancing in `ratio [dynamic|predict] minimal` 