### PR TITLE
Move http parser to connection

### DIFF
--- a/tempesta_fw/addr.c
+++ b/tempesta_fw/addr.c
@@ -53,7 +53,7 @@ tfw_addr_pton_v4(const TfwStr *s, TfwAddr *addr)
 
 	TFW_STR_FOR_EACH_CHUNK(c, s, end) {
 		for (k = 0; k != c->len; ++k) {
-			p = c->ptr + k;
+			p = (char *)c->ptr + k;
 			if (isdigit(*p)) {
 				octet = (octet == -1)
 					? *p - '0'
@@ -101,7 +101,7 @@ tfw_addr_pton_v6(const TfwStr *s, TfwAddr *addr)
 
 	TFW_STR_FOR_EACH_CHUNK(c, s, end) {
 		for (k = 0; k != c->len; ++k) {
-			p = c->ptr + k;
+			p = (char *)c->ptr + k;
 			if (i > 7 && !(i == 8 && port == 1))
 				return -EINVAL;
 
@@ -249,7 +249,7 @@ tfw_addr_pton(const TfwStr *str, TfwAddr *addr)
 		TFW_STR_FOR_EACH_CHUNK(c, str, end) {
 			int i;
 			for (i = 0; i != c->len; ++i) {
-				pos = c->ptr + i;
+				pos = (char *)c->ptr + i;
 				if (!isdigit(*pos))
 					goto delim;
 			}

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -29,6 +29,8 @@
 #include "msg.h"
 #include "peer.h"
 
+#include "http_parser.h"
+
 #include "sync_socket.h"
 #include "tls.h"
 
@@ -93,6 +95,7 @@ enum {
 #define TFW_CONN_COMMON					\
 	SsProto			proto;			\
 	TfwGState		state;			\
+	TfwHttpParser		parser;			\
 	struct list_head	list;			\
 	atomic_t		refcnt;			\
 	struct timer_list	timer;			\

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1692,14 +1692,20 @@ tfw_http_resp_pair(TfwHttpMsg *hmresp)
 static TfwMsg *
 tfw_http_conn_msg_alloc(TfwConn *conn)
 {
-	TfwHttpMsg *hm = __tfw_http_msg_alloc(TFW_CONN_TYPE(conn), true);
+	int type = TFW_CONN_TYPE(conn);
+	TfwHttpMsg *hm = __tfw_http_msg_alloc(type, true);
 	if (unlikely(!hm))
 		return NULL;
 
 	hm->conn = conn;
 	tfw_connection_get(conn);
 
-	if (TFW_CONN_TYPE(conn) & Conn_Clnt) {
+	if (type & Conn_Clnt)
+		tfw_http_init_parser_req((TfwHttpReq *)hm);
+	else
+		tfw_http_init_parser_resp((TfwHttpResp *)hm);
+
+	if (type & Conn_Clnt) {
 		TFW_INC_STAT_BH(clnt.rx_messages);
 	} else {
 		if (unlikely(tfw_http_resp_pair(hm))) {
@@ -2706,7 +2712,7 @@ tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 		bool block = false;
 		TfwHttpMsg *hmsib = NULL;
 		TfwHttpReq *req = (TfwHttpReq *)conn->msg;
-		TfwHttpParser *parser = &req->parser;
+		TfwHttpParser *parser = &conn->parser;
 
 		/*
 		 * Process/parse data in the SKB.
@@ -3171,7 +3177,7 @@ tfw_http_resp_process(TfwConn *conn, const TfwFsmData *data)
 		TfwHttpParser *parser;
 
 		hmresp = (TfwHttpMsg *)conn->msg;
-		parser = &hmresp->parser;
+		parser = &conn->parser;
 
 		/*
 		 * Process/parse data in the SKB.
@@ -4182,10 +4188,6 @@ int __init
 tfw_http_init(void)
 {
 	int r;
-
-	/* Make sure @req->httperr doesn't take too much space. */
-	BUILD_BUG_ON(FIELD_SIZEOF(TfwHttpMsg, httperr)
-		     > FIELD_SIZEOF(TfwHttpMsg, parser));
 
 	r = tfw_gfsm_register_fsm(TFW_FSM_HTTP, tfw_http_msg_process);
 	if (r)

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -28,6 +28,7 @@
 #include "cache.h"
 #include "http_limits.h"
 #include "http_tbl.h"
+#include "http_parser.h"
 #include "client.h"
 #include "http_msg.h"
 #include "http_sess.h"

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -594,13 +594,6 @@ tfw_http_resp_code_range(const int n)
 
 typedef void (*tfw_http_cache_cb_t)(TfwHttpMsg *);
 
-/* Internal (parser) HTTP functions. */
-void tfw_http_init_parser_req(TfwHttpReq *req);
-void tfw_http_init_parser_resp(TfwHttpResp *resp);
-int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
-int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
-bool tfw_http_parse_terminate(TfwHttpMsg *hm);
-
 /* External HTTP functions. */
 int tfw_http_msg_process(void *conn, const TfwFsmData *data);
 unsigned long tfw_http_req_key_calc(TfwHttpReq *req);

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -481,9 +481,11 @@ __frang_http_field_len(const TfwHttpReq *req, FrangAcc *ra,
 static int
 frang_http_field_len(const TfwHttpReq *req, FrangAcc *ra, unsigned int field_len)
 {
-	if (req->parser.hdr.len > field_len) {
+	TfwHttpParser *parser = &req->conn->parser;
+
+	if (parser->hdr.len > field_len) {
 		frang_limmsg("HTTP in-progress field length",
-			     req->parser.hdr.len, field_len,
+			     parser->hdr.len, field_len,
 			     &FRANG_ACC2CLI(ra)->addr);
 		return TFW_BLOCK;
 	}

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -25,6 +25,7 @@
 #include "lib/str.h"
 #include "gfsm.h"
 #include "http_msg.h"
+#include "http_parser.h"
 #include "ss_skb.h"
 
 /**

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -316,7 +316,7 @@ __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 void
 tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start)
 {
-	TfwStr *hdr = &hm->parser.hdr;
+	TfwStr *hdr = &hm->conn->parser.hdr;
 
 	BUG_ON(!TFW_STR_EMPTY(hdr));
 
@@ -338,12 +338,13 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 {
 	TfwStr *h;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
+	TfwHttpParser *parser = &hm->conn->parser;
 
-	BUG_ON(hm->parser.hdr.flags & TFW_STR_DUPLICATE);
+	BUG_ON(parser->hdr.flags & TFW_STR_DUPLICATE);
 	BUG_ON(id > TFW_HTTP_HDR_RAW);
 
 	/* Close just parsed header. */
-	hm->parser.hdr.flags |= TFW_STR_COMPLETE;
+	parser->hdr.flags |= TFW_STR_COMPLETE;
 
 	/* Quick path for special headers. */
 	if (likely(id < TFW_HTTP_HDR_RAW)) {
@@ -374,7 +375,7 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 	 * Both the headers, the new one and existing one, can already be
 	 * compound.
 	 */
-	id = __hdr_lookup(hm, &hm->parser.hdr);
+	id = __hdr_lookup(hm, &parser->hdr);
 
 	/* Allocate some more room if not enough to store the header. */
 	if (unlikely(id == ht->size)) {
@@ -393,14 +394,14 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 duplicate:
 	h = tfw_str_add_duplicate(hm->pool, h);
 	if (unlikely(!h)) {
-		TFW_WARN("Cannot close header %p id=%d\n", &hm->parser.hdr, id);
+		TFW_WARN("Cannot close header %p id=%d\n", &parser->hdr, id);
 		return TFW_BLOCK;
 	}
 
 done:
-	*h = hm->parser.hdr;
+	*h = parser->hdr;
 
-	TFW_STR_INIT(&hm->parser.hdr);
+	TFW_STR_INIT(&parser->hdr);
 	TFW_DBG3("store header w/ ptr=%p len=%lu eolen=%u flags=%x id=%d\n",
 		 h->ptr, h->len, h->eolen, h->flags, id);
 
@@ -1013,11 +1014,6 @@ __tfw_http_msg_alloc(int type, bool full)
 		hm->h_tbl->size = __HHTBL_SZ(1);
 		hm->h_tbl->off = TFW_HTTP_HDR_RAW;
 		bzero_fast(hm->h_tbl->tbl, __HHTBL_SZ(1) * sizeof(TfwStr));
-
-		if (type & Conn_Clnt)
-			tfw_http_init_parser_req((TfwHttpReq *)hm);
-		else
-			tfw_http_init_parser_resp((TfwHttpResp *)hm);
 	}
 
 	hm->msg.skb_head = NULL;

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -25,6 +25,7 @@
 #include "http_msg.h"
 #include "htype.h"
 #include "http_sess.h"
+#include "lib/str.h"
 
 /*
  * ------------------------------------------------------------------------
@@ -95,7 +96,7 @@ do {									\
 } while (0)
 
 #define __msg_hdr_chunk_fixup(data, len)				\
-	tfw_http_msg_add_str_data(msg, &msg->parser.hdr, data, len)
+	tfw_http_msg_add_str_data(msg, &msg->conn->parser.hdr, data, len)
 
 /**
  * GCC 4.8 (CentOS 7) does a poor work on memory reusage of automatic local
@@ -105,7 +106,7 @@ do {									\
  */
 #define __FSM_DECLARE_VARS(ptr)						\
 	TfwHttpMsg	*msg = (TfwHttpMsg *)(ptr);			\
-	TfwHttpParser	*parser = &msg->parser;				\
+	TfwHttpParser	*parser = &msg->conn->parser;			\
 	unsigned char	*p = data;					\
 	unsigned char	c = *p;						\
 	int		__fsm_const_state;				\
@@ -177,9 +178,11 @@ do {									\
 } while (0)
 
 #define __FSM_MOVE_nofixup(to)		__FSM_MOVE_nofixup_n(to, 1)
-#define __FSM_MOVE_n(to, n)		__FSM_MOVE_nf(to, n, &msg->parser.hdr)
+#define __FSM_MOVE_n(to, n)						\
+	__FSM_MOVE_nf(to, n, &msg->conn->parser.hdr)
 #define __FSM_MOVE_f(to, field)		__FSM_MOVE_nf(to, 1, field)
-#define __FSM_MOVE(to)			__FSM_MOVE_nf(to, 1, &msg->parser.hdr)
+#define __FSM_MOVE(to)							\
+	__FSM_MOVE_nf(to, 1, &msg->conn->parser.hdr)
 /* The same as __FSM_MOVE_n(), but exactly for jumps w/o data moving. */
 #define __FSM_JMP(to)			do { goto to; } while (0)
 
@@ -206,8 +209,8 @@ do {									\
 #define __FSM_MATCH_MOVE_pos_f(alphabet, to, field)			\
 	__FSM_MATCH_MOVE_fixup_pos(alphabet, to, field, true)
 
-#define __FSM_MATCH_MOVE(alphabet, to)	__FSM_MATCH_MOVE_f(alphabet, to, \
-							   &msg->parser.hdr)
+#define __FSM_MATCH_MOVE(alphabet, to)					\
+	__FSM_MATCH_MOVE_f(alphabet, to, &msg->conn->parser.hdr)
 
 #define __FSM_MATCH_MOVE_nofixup(alphabet, to)				\
 do {									\
@@ -233,7 +236,7 @@ do {									\
 } while (0)
 
 #define __FSM_I_chunk_flags(flag)					\
-	__FSM_I_field_chunk_flags(&msg->parser.hdr, flag)
+	__FSM_I_field_chunk_flags(&msg->conn->parser.hdr, flag)
 
 #define __FSM_I_MOVE_finish_n(to, n, finish)				\
 do {									\
@@ -296,7 +299,7 @@ do {									\
 } while (0)
 
 #define __FSM_I_MOVE_fixup(to, n, flag)					\
-	__FSM_I_MOVE_fixup_f(to, n, &msg->parser.hdr, flag)
+	__FSM_I_MOVE_fixup_f(to, n, &msg->conn->parser.hdr, flag)
 
 #define __FSM_I_MATCH_MOVE_fixup(alphabet, to, flag)			\
 do {									\
@@ -552,7 +555,7 @@ parse_int_hex(unsigned char *data, size_t len, unsigned long *acc, unsigned shor
 static void
 mark_spec_hbh(TfwHttpMsg *hm)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &hm->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &hm->conn->parser.hbh_parser;
 	unsigned int id;
 
 	for (id = 0; id < TFW_HTTP_HDR_RAW; ++id) {
@@ -569,7 +572,7 @@ mark_spec_hbh(TfwHttpMsg *hm)
 static void
 mark_raw_hbh(TfwHttpMsg *hm, TfwStr *hdr)
 {
-	TfwHttpHbhHdrs *hbh = &hm->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh = &hm->conn->parser.hbh_parser;
 	unsigned int i;
 
 	/*
@@ -636,7 +639,7 @@ static int
 __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 {
 	TfwStr *hdr, *append;
-	TfwHttpHbhHdrs *hbh = &hm->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh = &hm->conn->parser.hbh_parser;
 	static const TfwStr block[] = {
 #define TfwStr_string(v) { (v), NULL, sizeof(v) - 1, 0 }
 		/* End-to-end spec and raw headers */
@@ -2764,12 +2767,14 @@ static int
 __req_parse_if_msince(TfwHttpMsg *msg, unsigned char *data, size_t len)
 {
 	int ret;
+	TfwHttpParser *parser = &msg->conn->parser;
+
 	ret = __parse_http_date(msg, data, len);
 	if (ret < CSTR_POSTPONE) {  /* (ret < 0) && (ret != POSTPONE) */
 		/* On error just swallow the rest of the line. */
-		BUG_ON(msg->parser.state != Req_HdrIf_Modified_SinceV);
-		msg->parser._date = 0;
-		msg->parser._i_st = I_EoL;
+		BUG_ON(parser->state != Req_HdrIf_Modified_SinceV);
+		parser->_date = 0;
+		parser->_i_st = I_EoL;
 		ret = __parse_http_date(msg, data, len);
 	}
 	return ret;
@@ -3030,20 +3035,25 @@ done:
 static inline void
 __parser_init(TfwHttpParser *parser)
 {
+	bzero_fast(parser, sizeof(TfwHttpParser));
 	parser->to_read = -1; /* unknown body size */
 }
 
 void
 tfw_http_init_parser_req(TfwHttpReq *req)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &req->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &req->conn->parser.hbh_parser;
 
-	__parser_init(&req->parser);
-	req->parser.state = Req_0;
+	__parser_init(&req->conn->parser);
+	req->conn->parser.state = Req_0;
 
-	/*  Add spec header indexes to list of hop-by-hop headers. */
-	BUG_ON(hbh_hdrs->spec);
-	/* Connection is hop-by-hop header by RFC 7230 6.1 */
+	/*
+	 * Expected hop-by-hop headers:
+	 * - spec:
+	 *     none;
+	 * - raw:
+	 *     Connection: RFC 7230 6.1.
+	 */
 	hbh_hdrs->spec = 0x1 << TFW_HTTP_HDR_CONNECTION;
 }
 
@@ -4353,6 +4363,7 @@ static int
 __resp_parse_expires(TfwHttpMsg *msg, unsigned char *data, size_t len)
 {
 	int ret;
+	TfwHttpParser *parser = &msg->conn->parser;
 
 	ret = __parse_http_date(msg, data, len);
 	if (ret < CSTR_POSTPONE) {  /* (ret < 0) && (ret != POSTPONE) */
@@ -4360,9 +4371,9 @@ __resp_parse_expires(TfwHttpMsg *msg, unsigned char *data, size_t len)
 		 * On error just swallow the rest of the line.
 		 * @resp->expires is set to zero - already expired.
 		 */
-		BUG_ON(msg->parser.state != Resp_HdrExpiresV);
-		msg->parser._date = 0;
-		msg->parser._i_st = I_EoL;
+		BUG_ON(parser->state != Resp_HdrExpiresV);
+		parser->_date = 0;
+		parser->_i_st = I_EoL;
 		ret = __parse_http_date(msg, data, len);
 	}
 	return ret;
@@ -4412,8 +4423,8 @@ tfw_http_parse_terminate(TfwHttpMsg *hm)
 	 * when Content-Length header must not present in response were
 	 * checked earlier. Refer to RFC 7230 3.3.3
 	 */
-	if (hm->parser.state == Resp_BodyUnlimRead
-	    || hm->parser.state == Resp_BodyUnlimStart)
+	if (hm->conn->parser.state == Resp_BodyUnlimRead
+	    || hm->conn->parser.state == Resp_BodyUnlimStart)
 	{
 		char c_len[TFW_ULTOA_BUF_SIZ] = {0};
 		size_t digs;
@@ -4437,18 +4448,18 @@ tfw_http_parse_terminate(TfwHttpMsg *hm)
 void
 tfw_http_init_parser_resp(TfwHttpResp *resp)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &resp->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &resp->conn->parser.hbh_parser;
 
-	__parser_init(&resp->parser);
-	resp->parser.state = Resp_0;
+	__parser_init(&resp->conn->parser);
+	resp->conn->parser.state = Resp_0;
 
-	/*  Add spec header indexes to list of hop-by-hop headers. */
-	BUG_ON(hbh_hdrs->spec);
 	/*
-	 * Connection is hop-by-hop header by RFC 7230 6.1
-	 *
-	 * Server header isn't defined as hop-by-hop by the RFC, but we
-	 * don't show protected server to world.
+	 * Expected hop-by-hop headers:
+	 * - spec:
+	 *     none;
+	 * - raw:
+	 *     Connection: RFC 7230 6.1,
+	 *     Server: hide protected server from the world.
 	 */
 	hbh_hdrs->spec = (0x1 << TFW_HTTP_HDR_CONNECTION) |
 			 (0x1 << TFW_HTTP_HDR_SERVER);

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -1,0 +1,29 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2018 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_HTTP_PARSER_H__
+#define __TFW_HTTP_PARSER_H__
+
+void tfw_http_init_parser_req(TfwHttpReq *req);
+void tfw_http_init_parser_resp(TfwHttpResp *resp);
+int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
+int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
+bool tfw_http_parse_terminate(TfwHttpMsg *hm);
+
+#endif /* __TFW_HTTP_PARSER_H__ */

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -20,8 +20,89 @@
 #ifndef __TFW_HTTP_PARSER_H__
 #define __TFW_HTTP_PARSER_H__
 
+#include "str.h"
+#include "http_types.h"
+
+typedef struct {
+	unsigned int	size;	/* number of elements in the table */
+	unsigned int	off;
+	TfwStr		tbl[0];
+} TfwHttpHdrTbl;
+
+#define __HHTBL_SZ(o)			(TFW_HTTP_HDR_NUM * (o))
+#define TFW_HHTBL_EXACTSZ(s)		(sizeof(TfwHttpHdrTbl)		\
+					 + sizeof(TfwStr) * (s))
+#define TFW_HHTBL_SZ(o)			TFW_HHTBL_EXACTSZ(__HHTBL_SZ(o))
+
+/** Maximum of hop-by-hop tokens listed in Connection header. */
+#define TFW_HBH_TOKENS_MAX		16
+
+/**
+ * Non-cacheable hop-by-hop headers in terms of RFC 7230.
+ *
+ * We don't store the headers in cache and create them from scratch if needed.
+ * Adding a header is faster then modify it, so this speeds up headers
+ * adjusting as well as saves cache storage.
+ *
+ * Headers unconditionally treated as hop-by-hop must be listed in
+ * tfw_http_init_parser_req()/tfw_http_init_parser_resp() functions and must be
+ * members of Special headers.
+ * group.
+ *
+ * @spec	- bit array for special headers. Hop-by-hop special header is
+ *		  stored as (0x1 << tfw_http_hdr_t[hid]);
+ * @raw		- table of raw headers names, parsed form connection field;
+ * @off		- offset of last added raw header name;
+ */
+typedef struct {
+	unsigned int	spec;
+	unsigned int	off;
+	TfwStr		raw[TFW_HBH_TOKENS_MAX];
+} TfwHttpHbhHdrs;
+
+/**
+ * We use goto/switch-driven automaton, so compiler typically generates binary
+ * search code over jump labels, so it gives log(N) lookup complexity where
+ * N is number of states. However, DFA for full HTTP processing can be quite
+ * large and log(N) becomes expensive and hard to code.
+ *
+ * So we use states space splitting to avoid states explosion.
+ * @_i_st is used to save current state and go to interior sub-automaton
+ * (e.g. process OWS using @state while current state is saved in @_i_st
+ * or using @_i_st parse value of a header described.
+ *
+ * @_cnt	- currently the count of hex digits in a body chunk size;
+ * @to_go	- remaining number of bytes to process in the data chunk;
+ *		  (limited by single packet size and never exceeds 64KB)
+ * @state	- current parser state;
+ * @_i_st	- helping (interior) state;
+ * @to_read	- remaining number of bytes to read;
+ * @_hdr_tag	- stores header id which must be closed on generic EoL handling
+ *		  (see RGEN_EOL());
+ * @_acc	- integer accumulator for parsing chunked integers;
+ * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
+ * @hdr		- currently parsed header.
+ * @hbh_parser	- list of special and raw headers names to be treated as
+ *		  hop-by-hop
+ * @_date	- currently parsed http date value;
+ */
+typedef struct {
+	unsigned short	to_go;
+	unsigned short	_cnt;
+	unsigned int	_hdr_tag;
+	int		state;
+	int		_i_st;
+	long		to_read;
+	unsigned long	_acc;
+	time_t		_date;
+	TfwStr		_tmp_chunk;
+	TfwStr		hdr;
+	TfwHttpHbhHdrs	hbh_parser;
+} TfwHttpParser;
+
 void tfw_http_init_parser_req(TfwHttpReq *req);
 void tfw_http_init_parser_resp(TfwHttpResp *resp);
+
 int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
 bool tfw_http_parse_terminate(TfwHttpMsg *hm);

--- a/tempesta_fw/http_types.h
+++ b/tempesta_fw/http_types.h
@@ -1,0 +1,29 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2018 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_HTTP_TYPES_H__
+#define __TFW_HTTP_TYPES_H__
+
+/* Forward declaration of common HTTP types. */
+typedef struct tfw_http_sess_t	TfwHttpSess;
+typedef struct tfw_http_msg_t	TfwHttpMsg;
+typedef struct tfw_http_req_t	TfwHttpReq;
+typedef struct tfw_http_resp_t	TfwHttpResp;
+
+#endif /* __TFW_HTTP_TYPES_H__ */

--- a/tempesta_fw/t/unit/helpers.c
+++ b/tempesta_fw/t/unit/helpers.c
@@ -56,6 +56,7 @@ test_req_alloc(size_t data_len)
 	tfw_connection_init(&conn_req);
 	conn_req.proto.type = Conn_HttpClnt;
 	hmreq->conn = &conn_req;
+	tfw_http_init_parser_req((TfwHttpReq *)hmreq);
 
 	return (TfwHttpReq *)hmreq;
 }
@@ -87,6 +88,7 @@ test_resp_alloc(size_t data_len)
 	tfw_connection_init(&conn_req);
 	conn_resp.proto.type = Conn_HttpSrv;
 	hmresp->conn = &conn_resp;
+	tfw_http_init_parser_resp((TfwHttpResp *)hmresp);
 
 	return (TfwHttpResp *)hmresp;
 }

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -60,7 +60,7 @@ split_and_parse_n(unsigned char *str, int type, size_t len, size_t chunks)
 			r = tfw_http_parse_resp(resp, str + pos, step);
 
 		pos += step;
-		hm->msg.len += step - hm->parser.to_go;
+		hm->msg.len += step - hm->conn->parser.to_go;
 
 		if (r != TFW_POSTPONE)
 			return r;

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -22,6 +22,7 @@
 #include <linux/vmalloc.h>
 
 #include "http_msg.h"
+#include "http_parser.h"
 
 #include "test.h"
 #include "helpers.h"

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -349,6 +349,8 @@ http_sticky_suite_setup(void)
 
 	mock.req->conn = &mock.conn_req;
 	mock.resp->conn = &mock.conn_resp;
+	tfw_http_init_parser_req(mock.req);
+	tfw_http_init_parser_resp(mock.resp);
 	mock.req->vhost = tfw_vhost_new(TFW_VH_DFT_NAME);
 
 	tfw_http_req_add_seq_queue(mock.req);
@@ -514,7 +516,6 @@ static int
 http_parse_req_helper(void)
 {
 	/* XXX reset parser explicitly to be able to call it multiple times */
-	memset(&mock.req->parser, 0, sizeof(mock.req->parser));
 	tfw_http_init_parser_req(mock.req);
 	mock.req->h_tbl->off = TFW_HTTP_HDR_RAW;
 	memset(mock.req->h_tbl->tbl, 0, __HHTBL_SZ(1) * sizeof(TfwStr));
@@ -532,7 +533,6 @@ static int
 http_parse_resp_helper(void)
 {
 	/* XXX reset parser explicitly to be able to call it multiple times */
-	memset(&mock.resp->parser, 0, sizeof(mock.resp->parser));
 	tfw_http_init_parser_resp(mock.resp);
 	mock.resp->h_tbl->off = TFW_HTTP_HDR_RAW;
 	memset(mock.resp->h_tbl->tbl, 0, __HHTBL_SZ(1) * sizeof(TfwStr));

--- a/tempesta_fw/t/unit/test_http_tbl.c
+++ b/tempesta_fw/t/unit/test_http_tbl.c
@@ -34,6 +34,7 @@
 
 #include "cfg.h"
 #include "http_msg.h"
+#include "http_parser.h"
 #include "helpers.h"
 #include "sched_helper.h"
 #include "test.h"

--- a/tempesta_fw/t/unit/test_sched_hash.c
+++ b/tempesta_fw/t/unit/test_sched_hash.c
@@ -34,6 +34,7 @@
 
 #include "helpers.h"
 #include "http_msg.h"
+#include "http_parser.h"
 #include "sched_helper.h"
 #include "test.h"
 

--- a/tempesta_fw/t/unit/test_sched_ratio.c
+++ b/tempesta_fw/t/unit/test_sched_ratio.c
@@ -35,6 +35,7 @@
 #include "helpers.h"
 #include "sched_helper.h"
 #include "server.h"
+#include "http_parser.h"
 #include "test.h"
 
 static TfwMsg *sched_ratio_get_arg(size_t conn_type);


### PR DESCRIPTION
There is no need to allocate a new instance of http parser for each incoming message. It can be allocated once per connection.