### PR TITLE
Sanitize Content-Type for multipart/form-data requests

### DIFF
--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -656,8 +656,8 @@
 # from HTTP tables (see 'http_chain' directive).
 #
 # <directive> is one of 'location', 'proxy_pass', 'cache_bypass', 'cache_fulfill',
-# 'nonidempotent' or 'hdr_add' directives (see the corresponding directives'
-# description).
+# 'nonidempotent', 'hdr_add' or 'http_post_validate' directives (see the
+# corresponding directives' description).
 #
 # Example:
 #   vhost app {
@@ -693,7 +693,7 @@
 # <OP> is a match operator, one of 'eq', 'prefix', 'suffix', or '*'.
 # <string> is a verbatim string matched against URL in a request.
 # <directive> is one of 'proxy_pass', 'cache_bypass', 'cache_fulfill',
-# 'nonidempotent', 'hdr_add' or Frang limit directives.
+# 'nonidempotent', 'hdr_add', 'http_post_validate' or Frang limit directives.
 #
 # Default:
 #   None.
@@ -892,6 +892,20 @@
 # Example:
 #   js_challenge resp_code=503 delay_min=1000 delay_range=3000 delay_limit=300
 #                /etc/ddos_redirect.html
+#
+
+# TAG: http_post_validate
+#
+# Validate POST requests.
+# Parses Content-Type header field, and rewrites it for multipart/form-data type
+# of payload, to prevent evasion attacks. All parameters other than "boundary"
+# are removed.
+#
+# Syntax:
+#   http_post_validate
+#
+# Default:
+#   Validation is disabled.
 #
 
 #

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -229,6 +229,10 @@ enum {
 	TFW_HTTP_B_CONN_EXTRA,
 	/* Chunked transfer encoding. */
 	TFW_HTTP_B_CHUNKED,
+	/* Media type is multipart/form-data. */
+	TFW_HTTP_B_CT_MULTIPART,
+	/* Multipart/form-data request have boundary parameter. */
+	TFW_HTTP_B_CT_MULTIPART_HAS_BOUNDARY,
 	/* Singular header presents more than once. */
 	TFW_HTTP_B_FIELD_DUPENTRY,
 
@@ -369,6 +373,8 @@ typedef struct {
  * @host	- host in URI, may differ from Host header;
  * @uri_path	- path + query + fragment from URI (RFC3986.3);
  * @mark	- special hash mark for redirects handling in session module;
+ * @multipart_boundary_raw - multipart boundary as is, maybe with escaped chars;
+ * @multipart_boundary - decoded multipart boundary;
  * @fwd_list	- member in the queue of forwarded/backlogged requests;
  * @nip_list	- member in the queue of non-idempotent requests;
  * @method	- HTTP request method, one of GET/PORT/HEAD/etc;
@@ -394,6 +400,8 @@ struct tfw_http_req_t {
 	TfwStr			host;
 	TfwStr			uri_path;
 	TfwStr			mark;
+	TfwStr			multipart_boundary_raw;
+	TfwStr			multipart_boundary;
 	struct list_head	fwd_list;
 	struct list_head	nip_list;
 	unsigned char		method;

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -879,6 +879,13 @@ tfw_cfgop_in_cache_bypass(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
+tfw_cfgop_in_http_post_validate(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	tfw_vhost_entry->loc_dflt->validate_post_req = 1;
+	return 0;
+}
+
+static int
 tfw_cfgop_out_cache_fulfill(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	TfwVhost *vh_dflt = tfw_vhosts_reconfig->vhost_dflt;
@@ -892,6 +899,13 @@ tfw_cfgop_out_cache_bypass(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	TfwVhost *vh_dflt = tfw_vhosts_reconfig->vhost_dflt;
 	return tfw_cfgop_capolicy(cs, ce, vh_dflt->loc_dflt,
 				  TFW_D_CACHE_BYPASS);
+}
+
+static int
+tfw_cfgop_out_http_post_validate(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	tfw_vhosts_reconfig->vhost_dflt->loc_dflt->validate_post_req = 1;
+	return 0;
 }
 
 /*
@@ -1768,6 +1782,13 @@ tfw_cfgop_frang_out_http_ct_vals(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
+tfw_cfgop_http_post_validate(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	tfwcfg_this_location->validate_post_req = 1;
+	return 0;
+}
+
+static int
 tfw_cfgop_frang_loc_rsp_code_block(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	BUG_ON(!tfwcfg_this_location);
@@ -2121,6 +2142,13 @@ static TfwCfgSpec tfw_vhost_location_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
+		.name = "http_post_validate",
+		.handler = tfw_cfgop_http_post_validate,
+		.allow_none = true,
+		.allow_repeat = false,
+		.allow_reconfig = true,
+	},
+	{
 		.name = "http_resp_code_block",
 		.handler = tfw_cfgop_frang_loc_rsp_code_block,
 		.allow_none = true,
@@ -2153,6 +2181,14 @@ static TfwCfgSpec tfw_vhost_internal_specs[] = {
 		.handler = tfw_cfgop_in_cache_fulfill,
 		.allow_none = true,
 		.allow_repeat = true,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "http_post_validate",
+		.deflt = NULL,
+		.handler = tfw_cfgop_in_http_post_validate,
+		.allow_none = true,
+		.allow_repeat = false,
 		.allow_reconfig = true,
 	},
 	{
@@ -2374,6 +2410,14 @@ static TfwCfgSpec tfw_vhost_specs[] = {
 		.name = "cache_fulfill",
 		.deflt = NULL,
 		.handler = tfw_cfgop_out_cache_fulfill,
+		.allow_none = true,
+		.allow_repeat = true,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "http_post_validate",
+		.deflt = NULL,
+		.handler = tfw_cfgop_out_http_post_validate,
 		.allow_none = true,
 		.allow_repeat = true,
 		.allow_reconfig = true,

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -120,6 +120,7 @@ typedef struct {
 	TfwSrvGroup		*backup_sg;
 	TfwPool			*hdrs_pool;
 	TfwHdrMods		mod_hdrs[TFW_VHOST_HDRMOD_NUM];
+	unsigned int		validate_post_req:1;
 } TfwLocation;
 
 /* Cache purge configuration modes. */


### PR DESCRIPTION
Some application servers parse `Content-Type` header field in a non-standard way, which is used to bypass web application firewalls. For example, PHP checks whenever parameter name contains substring `boundary`, and that way matches `xxboundaryxx` and the like.

To make life easier for backend servers, this patch makes Tempesta to validate `Content-Type` header field format by parsing it in a strict way. More over it makes possible to recompose its value from parsed data, with any other unrelated parameter dropped. Behavior is controlled by `http_post_validate` configuration parameter; valid in vhost and location context.

(partially addresses #902)