### PR TITLE
Use standart bitops functions for message flags.

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -111,9 +111,9 @@ typedef struct {
 	long		hdrs;
 	long		body;
 	long		hdrs_304[TFW_CACHE_304_HDRS_NUM];
+	DECLARE_BITMAP	(hmflags, _TFW_HTTP_FLAGS_NUM);
 	unsigned char	version;
 	unsigned short	resp_status;
-	unsigned int	hmflags;
 	TfwStr		etag;
 } TfwCacheEntry;
 
@@ -1211,7 +1211,7 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, size_t tot_len)
 	/* Write HTTP response body. */
 	ce->body = TDB_OFF(db->hdr, p);
 	n = tfw_cache_strcpy_eol(&p, &trec, &resp->body, &tot_len,
-				 resp->flags & TFW_HTTP_F_CHUNKED);
+				 test_bit(TFW_HTTP_B_CHUNKED, resp->flags));
 	if (n < 0) {
 		TFW_ERR("Cache: cannot copy HTTP body\n");
 		return -ENOMEM;
@@ -1219,7 +1219,7 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, size_t tot_len)
 	BUG_ON(tot_len != 0);
 
 	ce->version = resp->version;
-	ce->hmflags = resp->flags;
+	tfw_http_copy_flags(ce->hmflags, resp->flags);
 
 	if (resp->cache_ctl.flags
 	    & (TFW_HTTP_CC_MUST_REVAL | TFW_HTTP_CC_PROXY_REVAL))
@@ -1301,7 +1301,7 @@ __cache_entry_size(TfwHttpResp *resp)
 
 	/* Add body size accounting CRLF after the last chunk */
 	size += resp->body.len;
-	if (resp->flags & TFW_HTTP_F_CHUNKED)
+	if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags))
 		size += SLEN(S_CRLF);
 
 	return size;
@@ -1574,7 +1574,7 @@ tfw_cache_build_resp(TfwHttpReq *req, TfwCacheEntry *ce)
 		goto err;
 
 	resp->version = ce->version;
-	resp->flags = ce->hmflags;
+	tfw_http_copy_flags(resp->flags, ce->hmflags);
 
 	return resp;
 err:
@@ -1640,7 +1640,7 @@ cache_req_process_node(TfwHttpReq *req, tfw_http_cache_cb_t action)
 		goto out;
 	}
 	if (lifetime > ce->lifetime)
-		resp->flags |= TFW_HTTP_F_RESP_STALE;
+		__set_bit(TFW_HTTP_B_RESP_STALE, resp->flags);
 out:
 	if (!resp && (req->cache_ctl.flags & TFW_HTTP_CC_OIFCACHED))
 		tfw_http_send_resp(req, 504, "resource not cached");

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -198,11 +198,6 @@ enum {
 	TFW_CONN_B_ACTIVE
 };
 
-#define TFW_CONN_F_RESEND	(1 << TFW_CONN_B_RESEND)
-#define TFW_CONN_F_QFORWD	(1 << TFW_CONN_B_QFORWD)
-#define TFW_CONN_F_HASNIP	(1 << TFW_CONN_B_HASNIP)
-
-
 /**
  * TLS hardened connection.
  */

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1961,8 +1961,8 @@ tfw_http_set_hdr_date(TfwHttpMsg *hm)
 static int
 tfw_http_set_hdr_connection(TfwHttpMsg *hm, unsigned long conn_flg)
 {
-	BUILD_BUG_ON(BIT_WORD(__TFW_HTTP_MSG_M_CONN_MASK) != 0);
-	if (((hm->flags[0] & __TFW_HTTP_MSG_M_CONN_MASK) == conn_flg)
+	BUILD_BUG_ON(BIT_WORD(__TFW_HTTP_MSG_M_CONN) != 0);
+	if (((hm->flags[0] & __TFW_HTTP_MSG_M_CONN) == conn_flg)
 	    && (!TFW_STR_EMPTY(&hm->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION]))
 	    && !test_bit(TFW_HTTP_B_CONN_EXTRA, hm->flags))
 		return 0;
@@ -1988,8 +1988,8 @@ tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, unsigned long conn_flg)
 {
 	int r;
 
-	BUILD_BUG_ON(BIT_WORD(__TFW_HTTP_MSG_M_CONN_MASK) != 0);
-	if ((hm->flags[0] & __TFW_HTTP_MSG_M_CONN_MASK) == conn_flg)
+	BUILD_BUG_ON(BIT_WORD(__TFW_HTTP_MSG_M_CONN) != 0);
+	if ((hm->flags[0] & __TFW_HTTP_MSG_M_CONN) == conn_flg)
 		return 0;
 
 	switch (conn_flg) {

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -358,7 +358,7 @@ tfw_http_prep_redirect(TfwHttpMsg *resp, unsigned short status, TfwStr *rmark,
 {
 	TfwHttpReq *req = resp->req;
 	size_t data_len;
-	int conn_flag = req->flags & __TFW_HTTP_MSG_M_CONN_MASK, ret = 0;
+	int ret = 0;
 	TfwMsgIter it;
 	static TfwStr rh_302 = {
 		.ptr = S_REDIR_302, .len = SLEN(S_REDIR_302) };
@@ -420,9 +420,9 @@ tfw_http_prep_redirect(TfwHttpMsg *resp, unsigned short status, TfwStr *rmark,
 					 TFW_HTTP_HDR_HOST, &host);
 
 	/* Set "Connection:" header field if needed. */
-	if (conn_flag == TFW_HTTP_F_CONN_CLOSE)
+	if (test_bit(TFW_HTTP_B_CONN_CLOSE, req->flags))
 		cookie_crlf = &crlf_close;
-	else if (conn_flag == TFW_HTTP_F_CONN_KA)
+	else if (test_bit(TFW_HTTP_B_CONN_KA, req->flags))
 		cookie_crlf = &crlf_keep;
 
 	/* Add variable part of data length to get the total */
@@ -473,7 +473,7 @@ tfw_http_prep_304(TfwHttpMsg *resp, TfwHttpReq *req, void *msg_it,
 {
 	size_t data_len = SLEN(S_304_PART_01);
 	TfwMsgIter *it = (TfwMsgIter *)msg_it;
-	int conn_flag = req->flags & __TFW_HTTP_MSG_M_CONN_MASK, ret = 0;
+	int ret = 0;
 	static TfwStr rh = {
 		.ptr = S_304_PART_01, .len = SLEN(S_304_PART_01) };
 	static TfwStr crlf_keep = {
@@ -483,9 +483,9 @@ tfw_http_prep_304(TfwHttpMsg *resp, TfwHttpReq *req, void *msg_it,
 	TfwStr *end = NULL;
 
 	/* Set "Connection:" header field if needed. */
-	if (conn_flag == TFW_HTTP_F_CONN_CLOSE)
+	if (test_bit(TFW_HTTP_B_CONN_CLOSE, req->flags))
 		end = &crlf_close;
-	else if (conn_flag == TFW_HTTP_F_CONN_KA)
+	else if (test_bit(TFW_HTTP_B_CONN_KA, req->flags))
 		end = &crlf_keep;
 
 	/* Add variable part of data length to get the total */
@@ -605,7 +605,6 @@ __tfw_http_send_resp(TfwHttpReq *req, resp_code_t code)
 	TfwMsgIter it;
 	TfwHttpResp *resp;
 	TfwStr *date, *crlf, *body;
-	int conn_flag = req->flags & __TFW_HTTP_MSG_M_CONN_MASK;
 	TfwStr msg = {
 		.ptr = (TfwStr []){ {}, {}, {}, {}, {}, {} },
 		.len = 0,
@@ -616,14 +615,16 @@ __tfw_http_send_resp(TfwHttpReq *req, resp_code_t code)
 		goto err;
 
 	crlf = TFW_STR_CRLF_CH(&msg);
-	if (conn_flag) {
+	if (test_bit(TFW_HTTP_B_CONN_KA, req->flags)
+	    || test_bit(TFW_HTTP_B_CONN_CLOSE, req->flags))
+	{
 		unsigned long crlf_len = crlf->len;
-		if (conn_flag == TFW_HTTP_F_CONN_KA) {
-			crlf->ptr = S_H_CONN_KA;
-			crlf->len = SLEN(S_H_CONN_KA);
-		} else {
+		if (test_bit(TFW_HTTP_B_CONN_CLOSE, req->flags)) {
 			crlf->ptr = S_H_CONN_CLOSE;
 			crlf->len = SLEN(S_H_CONN_CLOSE);
+		} else {
+			crlf->ptr = S_H_CONN_KA;
+			crlf->len = SLEN(S_H_CONN_KA);
 		}
 		msg.len += crlf->len - crlf_len;
 	}
@@ -674,10 +675,13 @@ tfw_http_req_init_ss_flags(TfwSrvConn *srv_conn, TfwHttpReq *req)
 }
 
 static inline void
-tfw_http_resp_init_ss_flags(TfwHttpResp *resp, const TfwHttpReq *req)
+tfw_http_resp_init_ss_flags(TfwHttpResp *resp)
 {
-	if (req->flags & (TFW_HTTP_F_CONN_CLOSE | TFW_HTTP_F_SUSPECTED))
-		((TfwMsg *)resp)->ss_flags |= SS_F_CONN_CLOSE;
+	if (test_bit(TFW_HTTP_B_CONN_CLOSE, resp->req->flags)
+	    || test_bit(TFW_HTTP_B_SUSPECTED, resp->req->flags))
+	{
+		resp->msg.ss_flags |= SS_F_CONN_CLOSE;
+	}
 }
 
 /*
@@ -686,7 +690,7 @@ tfw_http_resp_init_ss_flags(TfwHttpResp *resp, const TfwHttpReq *req)
 static inline bool
 tfw_http_req_is_nip(TfwHttpReq *req)
 {
-	return (req->flags & TFW_HTTP_F_NON_IDEMP);
+	return test_bit(TFW_HTTP_B_NON_IDEMP, req->flags);
 }
 
 /*
@@ -973,7 +977,9 @@ tfw_http_mark_wl_new_msg(TfwConn *conn, TfwHttpMsg *msg,
 
 	if (bsearch(&skb->mark, tfw_wl_marks.mrks, tfw_wl_marks.sz,
 		    sizeof(tfw_wl_marks.mrks[0]), tfw_http_marks_cmp))
-		msg->flags |= TFW_HTTP_F_WHITELIST;
+	{
+		__set_bit(TFW_HTTP_B_WHITELIST, msg->flags);
+	}
 }
 
 
@@ -999,7 +1005,7 @@ tfw_http_req_zap_error(struct list_head *eq)
 
 	list_for_each_entry_safe(req, tmp, eq, fwd_list) {
 		list_del_init(&req->fwd_list);
-		if (!(req->flags & TFW_HTTP_F_REQ_DROP))
+		if (!test_bit(TFW_HTTP_B_REQ_DROP, req->flags))
 			tfw_http_send_resp(req, req->httperr.status,
 					   req->httperr.reason);
 		else
@@ -1015,7 +1021,7 @@ tfw_http_req_zap_error(struct list_head *eq)
 static inline bool
 tfw_http_req_evict_dropped(TfwSrvConn *srv_conn, TfwHttpReq *req)
 {
-	if (unlikely(req->flags & TFW_HTTP_F_REQ_DROP)) {
+	if (unlikely(test_bit(TFW_HTTP_B_REQ_DROP, req->flags))) {
 		TFW_DBG2("%s: Eviction: req=[%p] client disconnected\n",
 			 __func__, req);
 		if (srv_conn)
@@ -1105,7 +1111,7 @@ tfw_http_req_fwd_send(TfwSrvConn *srv_conn, TfwServer *srv,
 	if (tfw_connection_send((TfwConn *)srv_conn, (TfwMsg *)req)) {
 		TFW_DBG2("%s: Forwarding error: conn=[%p] req=[%p]\n",
 			 __func__, srv_conn, req);
-		if (req->flags & TFW_HTTP_F_HMONITOR) {
+		if (test_bit(TFW_HTTP_B_HMONITOR, req->flags)) {
 			tfw_http_req_delist(srv_conn, req);
 			WARN_ON_ONCE(req->pair);
 			tfw_http_msg_free((TfwHttpMsg *)req);
@@ -1410,7 +1416,7 @@ tfw_http_req_resched(TfwHttpReq *req, TfwServer *srv, struct list_head *eq)
 	 * the same server (other servers may not have enabled
 	 * health monitor).
 	 */
-	if (req->flags & TFW_HTTP_F_HMONITOR) {
+	if (test_bit(TFW_HTTP_B_HMONITOR, req->flags)) {
 		sch_conn = srv->sg->sched->sched_srv_conn((TfwMsg *)req,
 							  srv);
 		if (!sch_conn) {
@@ -1814,7 +1820,7 @@ tfw_http_resp_pair_free(TfwHttpReq *req)
  * Disintegrate the client connection's @seq_list. Requests without a paired
  * response have not been answered yet. They are held in the lists of server
  * connections until responses come. A paired response may be in use until
- * TFW_HTTP_F_RESP_READY flag is not set.  Don't free any of those requests.
+ * TFW_HTTP_B_RESP_READY flag is not set.  Don't free any of those requests.
  *
  * If a response comes or gets ready to forward after @seq_list is
  * disintegrated, then both the request and the response are dropped at the
@@ -1843,13 +1849,15 @@ tfw_http_conn_cli_drop(TfwCliConn *cli_conn)
 	 */
 	spin_lock(&cli_conn->seq_qlock);
 	list_for_each_entry_safe(req, tmp, seq_queue, msg.seq_list) {
-		req->flags |= TFW_HTTP_F_REQ_DROP;
+		set_bit(TFW_HTTP_B_REQ_DROP, req->flags);
 		list_del_init(&req->msg.seq_list);
 		/*
 		 * Response is processed and removed from fwd_queue, need to be
 		 * destroyed.
 		 */
-		if (req->resp && (req->resp->flags & TFW_HTTP_F_RESP_READY)) {
+		if (req->resp
+		    && test_bit(TFW_HTTP_B_RESP_READY, req->resp->flags))
+		{
 			tfw_http_resp_pair_free(req);
 			TFW_INC_STAT_BH(serv.msgs_otherr);
 		}
@@ -1913,7 +1921,8 @@ tfw_http_msg_create_sibling(TfwHttpMsg *hm, struct sk_buff *skb)
 	 * we have new skb here and 'mark' propagation is needed.
 	 */
 	if (TFW_CONN_TYPE(hm->conn) & Conn_Clnt) {
-		shm->flags |= hm->flags & TFW_HTTP_F_WHITELIST;
+		if (test_bit(TFW_HTTP_B_WHITELIST, hm->flags))
+			__set_bit(TFW_HTTP_B_WHITELIST, shm->flags);
 		skb->mark = hm->msg.skb_head->mark;
 	}
 
@@ -1950,18 +1959,19 @@ tfw_http_set_hdr_date(TfwHttpMsg *hm)
  * but safely modified. Thus, a shared SKB is still owned by one CPU.
  */
 static int
-tfw_http_set_hdr_connection(TfwHttpMsg *hm, int conn_flg)
+tfw_http_set_hdr_connection(TfwHttpMsg *hm, unsigned long conn_flg)
 {
-	if (((hm->flags & __TFW_HTTP_MSG_M_CONN_MASK) == conn_flg)
+	BUILD_BUG_ON(__TFW_HTTP_MSG_M_CONN_MASK > BITS_PER_LONG);
+	if (((hm->flags[0] & __TFW_HTTP_MSG_M_CONN_MASK) == conn_flg)
 	    && (!TFW_STR_EMPTY(&hm->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION]))
-	    && !(hm->flags & TFW_HTTP_F_CONN_EXTRA))
+	    && !test_bit(TFW_HTTP_B_CONN_EXTRA, hm->flags))
 		return 0;
 
 	switch (conn_flg) {
-	case TFW_HTTP_F_CONN_CLOSE:
+	case BIT(TFW_HTTP_B_CONN_CLOSE):
 		return TFW_HTTP_MSG_HDR_XFRM(hm, "Connection", "close",
 					     TFW_HTTP_HDR_CONNECTION, 0);
-	case TFW_HTTP_F_CONN_KA:
+	case BIT(TFW_HTTP_B_CONN_KA):
 		return TFW_HTTP_MSG_HDR_XFRM(hm, "Connection", "keep-alive",
 					     TFW_HTTP_HDR_CONNECTION, 0);
 	default:
@@ -1974,22 +1984,24 @@ tfw_http_set_hdr_connection(TfwHttpMsg *hm, int conn_flg)
  * Add/Replace/Remove Keep-Alive header field to/from HTTP message.
  */
 static int
-tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, int conn_flg)
+tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, unsigned long conn_flg)
 {
 	int r;
 
-	if ((hm->flags & __TFW_HTTP_MSG_M_CONN_MASK) == conn_flg)
+	BUILD_BUG_ON(__TFW_HTTP_MSG_M_CONN_MASK > BITS_PER_LONG);
+	if ((hm->flags[0] & __TFW_HTTP_MSG_M_CONN_MASK) == conn_flg)
 		return 0;
 
 	switch (conn_flg) {
-	case TFW_HTTP_F_CONN_CLOSE:
-		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive", TFW_HTTP_HDR_KEEP_ALIVE);
+	case BIT(TFW_HTTP_B_CONN_CLOSE):
+		r = TFW_HTTP_MSG_HDR_DEL(hm, "Keep-Alive",
+					 TFW_HTTP_HDR_KEEP_ALIVE);
 		if (unlikely(r && r != -ENOENT)) {
 			TFW_WARN("Cannot delete Keep-Alive header (%d)\n", r);
 			return r;
 		}
 		return 0;
-	case TFW_HTTP_F_CONN_KA:
+	case BIT(TFW_HTTP_B_CONN_KA):
 		/*
 		 * If present, "Keep-Alive" header informs the other side
 		 * of the timeout policy for a connection. Otherwise, it's
@@ -2126,7 +2138,7 @@ tfw_http_adjust_req(TfwHttpReq *req)
 	if (r < 0)
 		return r;
 
-	return tfw_http_set_hdr_connection(hm, TFW_HTTP_F_CONN_KA);
+	return tfw_http_set_hdr_connection(hm, BIT(TFW_HTTP_B_CONN_KA));
 }
 
 /**
@@ -2137,7 +2149,8 @@ tfw_http_adjust_resp(TfwHttpResp *resp)
 {
 	TfwHttpReq *req = resp->req;
 	TfwHttpMsg *hm = (TfwHttpMsg *)resp;
-	int r, conn_flg;
+	unsigned long conn_flg = 0;
+	int r;
 
 	/*
 	 * If request violated backend rules, backend may respond with 4xx code
@@ -2145,13 +2158,19 @@ tfw_http_adjust_resp(TfwHttpResp *resp)
 	 * more such requests and cause performance degradation, close the
 	 * client connection.
 	 */
-	if ((resp->flags & TFW_HTTP_F_CONN_CLOSE) && (resp->status / 100 == 4)) {
-		req->flags = (req->flags & ~TFW_HTTP_F_CONN_KA)
-				| TFW_HTTP_F_CONN_CLOSE;
-		conn_flg = TFW_HTTP_F_CONN_CLOSE;
+	if (test_bit(TFW_HTTP_B_CONN_CLOSE, resp->flags)
+	    && (resp->status / 100 == 4))
+	{
+		__clear_bit(TFW_HTTP_B_CONN_KA, req->flags);
+		__set_bit(TFW_HTTP_B_CONN_CLOSE, req->flags);
+		conn_flg = BIT(TFW_HTTP_B_CONN_CLOSE);
 	}
-	else {
-		conn_flg = req->flags & __TFW_HTTP_MSG_M_CONN_MASK;
+	else
+	{
+		if (unlikely(test_bit(TFW_HTTP_B_CONN_CLOSE, req->flags)))
+			conn_flg = BIT(TFW_HTTP_B_CONN_CLOSE);
+		else if (test_bit(TFW_HTTP_B_CONN_KA, req->flags))
+			conn_flg = BIT(TFW_HTTP_B_CONN_KA);
 	}
 
 	r = tfw_http_sess_resp_process(resp);
@@ -2178,7 +2197,7 @@ tfw_http_adjust_resp(TfwHttpResp *resp)
 	if (r < 0)
 		return r;
 
-	if (resp->flags & TFW_HTTP_F_RESP_STALE) {
+	if (test_bit(TFW_HTTP_B_RESP_STALE, resp->flags)) {
 #define S_WARN_110 "Warning: 110 - Response is stale"
 		/* TODO: adjust for #215 */
 		TfwStr wh = {
@@ -2192,7 +2211,7 @@ tfw_http_adjust_resp(TfwHttpResp *resp)
 #undef S_WARN_110
 	}
 
-	if (!(resp->flags & TFW_HTTP_F_HDR_DATE)) {
+	if (!test_bit(TFW_HTTP_B_HDR_DATE, resp->flags)) {
 		r =  tfw_http_set_hdr_date(hm);
 		if (r < 0)
 			return r;
@@ -2216,7 +2235,7 @@ __tfw_http_resp_fwd(TfwCliConn *cli_conn, struct list_head *ret_queue)
 
 	list_for_each_entry_safe(req, tmp, ret_queue, msg.seq_list) {
 		BUG_ON(!req->resp);
-		tfw_http_resp_init_ss_flags(req->resp, req);
+		tfw_http_resp_init_ss_flags(req->resp);
 		if (tfw_cli_conn_send(cli_conn, (TfwMsg *)req->resp)) {
 			ss_close_sync(cli_conn->sk, true);
 			return;
@@ -2268,11 +2287,14 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 		return;
 	}
 	BUG_ON(list_empty(&req->msg.seq_list));
-	resp->flags |= TFW_HTTP_F_RESP_READY;
+	set_bit(TFW_HTTP_B_RESP_READY, resp->flags);
 	/* Move consecutive requests with @req->resp to @ret_queue. */
 	list_for_each_entry(req, seq_queue, msg.seq_list) {
-		if (!req->resp || !(req->resp->flags & TFW_HTTP_F_RESP_READY))
+		if (!req->resp
+		    || !test_bit(TFW_HTTP_B_RESP_READY, req->resp->flags))
+		{
 			break;
+		}
 		req_retent = &req->msg.seq_list;
 	}
 	if (!req_retent) {
@@ -2335,7 +2357,7 @@ static inline void
 tfw_http_req_mark_error(TfwHttpReq *req, int status)
 {
 	TFW_CONN_TYPE(req->conn) |= Conn_Stop;
-	req->flags |= TFW_HTTP_F_SUSPECTED;
+	__set_bit(TFW_HTTP_B_SUSPECTED, req->flags);
 	tfw_http_error_resp_switch(req, status);
 }
 
@@ -2595,7 +2617,7 @@ nip_match:
 	TFW_DBG2("non-idempotent: method=[%d] uri=[%.*s]\n",
 		 req->method, (int)TFW_STR_CHUNK(&req->uri_path, 0)->len,
 		 (char *)TFW_STR_CHUNK(&req->uri_path, 0)->ptr);
-	req->flags |= TFW_HTTP_F_NON_IDEMP;
+	__set_bit(TFW_HTTP_B_NON_IDEMP, req->flags);
 	return;
 }
 
@@ -2618,7 +2640,7 @@ tfw_http_req_add_seq_queue(TfwHttpReq *req)
 	req_prev = list_empty(seq_queue) ?
 		   NULL : list_last_entry(seq_queue, TfwHttpReq, msg.seq_list);
 	if (req_prev && tfw_http_req_is_nip(req_prev))
-		req_prev->flags &= ~TFW_HTTP_F_NON_IDEMP;
+		clear_bit(TFW_HTTP_B_NON_IDEMP, req_prev->flags);
 	list_add_tail(&req->msg.seq_list, seq_queue);
 	spin_unlock(&cli_conn->seq_qlock);
 }
@@ -2753,7 +2775,7 @@ tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 			 * The request is fully parsed,
 			 * fall through and process it.
 			 */
-			BUG_ON(!(req->flags & TFW_HTTP_F_CHUNKED)
+			BUG_ON(!test_bit(TFW_HTTP_B_CHUNKED, req->flags)
 			       && (req->content_length != req->body.len));
 		}
 
@@ -2827,9 +2849,9 @@ tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 		 */
 		if ((req->version == TFW_HTTP_VER_09)
 		    || ((req->version == TFW_HTTP_VER_10)
-			&& !(req->flags & __TFW_HTTP_MSG_M_CONN_MASK)))
+			&& !test_bit(TFW_HTTP_B_CONN_KA, req->flags)))
 		{
-			req->flags |= TFW_HTTP_F_CONN_CLOSE;
+			__set_bit(TFW_HTTP_B_CONN_CLOSE, req->flags);
 		}
 
 		/*
@@ -2845,7 +2867,7 @@ tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 		 * and, at the same time, to stop passing data for processing
 		 * from the lower layer.
 		 */
-		if ((req_conn_close = req->flags & TFW_HTTP_F_CONN_CLOSE)) {
+		if ((req_conn_close = test_bit(TFW_HTTP_B_CONN_CLOSE, req->flags))) {
 			TFW_CONN_TYPE(req->conn) |= Conn_Stop;
 			if (unlikely(skb)) {
 				__kfree_skb(skb);
@@ -2864,7 +2886,7 @@ tfw_http_req_process(TfwConn *conn, const TfwFsmData *data)
 							    skb);
 			if (unlikely(!hmsib)) {
 				TFW_INC_STAT_BH(clnt.msgs_otherr);
-				req->flags |= TFW_HTTP_F_CONN_CLOSE;
+				__set_bit(TFW_HTTP_B_CONN_CLOSE, req->flags);
 				TFW_CONN_TYPE(conn) |= Conn_Stop;
 				tfw_http_conn_error_log(conn,
 							"Can't create pipelined"
@@ -3096,7 +3118,7 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 	 * If 'Date:' header is missing in the response, then
 	 * set the date to the time the response was received.
 	 */
-	if (!(hmresp->flags & TFW_HTTP_F_HDR_DATE))
+	if (!test_bit(TFW_HTTP_B_HDR_DATE, hmresp->flags))
 		((TfwHttpResp *)hmresp)->date = timestamp;
 	/*
 	 * Response is fully received, delist corresponding request from
@@ -3107,7 +3129,7 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 	 * Health monitor request means that its response need not to
 	 * send anywhere.
 	 */
-	if (req->flags & TFW_HTTP_F_HMONITOR) {
+	if (test_bit(TFW_HTTP_B_HMONITOR, req->flags)) {
 		tfw_http_hm_drop_resp((TfwHttpResp *)hmresp);
 		return 0;
 	}
@@ -3268,10 +3290,12 @@ tfw_http_resp_process(TfwConn *conn, const TfwFsmData *data)
 			 * process it. If the response has broken length, then
 			 * block it (the server connection will be dropped).
 			 */
-			if (!(hmresp->flags & (TFW_HTTP_F_CHUNKED
-					       | TFW_HTTP_F_VOID_BODY))
+			if (!(test_bit(TFW_HTTP_B_CHUNKED, hmresp->flags)
+			      || test_bit(TFW_HTTP_B_VOID_BODY, hmresp->flags))
 			    && (hmresp->content_length != hmresp->body.len))
+			{
 				goto bad_msg;
+			}
 		}
 
 		/*
@@ -3448,7 +3472,7 @@ tfw_http_hm_srv_send(TfwServer *srv, char *data, unsigned long len)
 	if (tfw_http_msg_write(&it, hmreq, &msg))
 		goto cleanup;
 
-	req->flags |= TFW_HTTP_F_HMONITOR;
+	__set_bit(TFW_HTTP_B_HMONITOR, req->flags);
 	req->jrxtstamp = jiffies;
 
 	srv_conn = srv->sg->sched->sched_srv_conn((TfwMsg *)req, srv);
@@ -3483,7 +3507,7 @@ tfw_http_req_key_calc(TfwHttpReq *req)
 
 	req->hash = tfw_hash_str(&req->uri_path);
 
-	if (req->flags & TFW_HTTP_F_HMONITOR)
+	if (test_bit(TFW_HTTP_B_HMONITOR, req->flags))
 		return req->hash;
 
 	tfw_http_msg_clnthdr_val(&req->h_tbl->tbl[TFW_HTTP_HDR_HOST],

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1961,7 +1961,7 @@ tfw_http_set_hdr_date(TfwHttpMsg *hm)
 static int
 tfw_http_set_hdr_connection(TfwHttpMsg *hm, unsigned long conn_flg)
 {
-	BUILD_BUG_ON(__TFW_HTTP_MSG_M_CONN_MASK > BITS_PER_LONG);
+	BUILD_BUG_ON(BIT_WORD(__TFW_HTTP_MSG_M_CONN_MASK) != 0);
 	if (((hm->flags[0] & __TFW_HTTP_MSG_M_CONN_MASK) == conn_flg)
 	    && (!TFW_STR_EMPTY(&hm->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION]))
 	    && !test_bit(TFW_HTTP_B_CONN_EXTRA, hm->flags))
@@ -1988,7 +1988,7 @@ tfw_http_set_hdr_keep_alive(TfwHttpMsg *hm, unsigned long conn_flg)
 {
 	int r;
 
-	BUILD_BUG_ON(__TFW_HTTP_MSG_M_CONN_MASK > BITS_PER_LONG);
+	BUILD_BUG_ON(BIT_WORD(__TFW_HTTP_MSG_M_CONN_MASK) != 0);
 	if ((hm->flags[0] & __TFW_HTTP_MSG_M_CONN_MASK) == conn_flg)
 		return 0;
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -253,28 +253,8 @@ enum {
 	_TFW_HTTP_FLAGS_NUM
 };
 
-#define TFW_HTTP_F_CONN_CLOSE		(1U << TFW_HTTP_B_CONN_CLOSE)
-#define TFW_HTTP_F_CONN_KA		(1U << TFW_HTTP_B_CONN_KA)
-#define __TFW_HTTP_MSG_M_CONN_MASK	\
-	(TFW_HTTP_F_CONN_KA | TFW_HTTP_F_CONN_CLOSE)
-#define TFW_HTTP_F_CONN_EXTRA		(1U << TFW_HTTP_B_CONN_EXTRA)
-#define TFW_HTTP_F_CHUNKED		(1U << TFW_HTTP_B_CHUNKED)
-#define TFW_HTTP_F_FIELD_DUPENTRY	(1U << TFW_HTTP_B_FIELD_DUPENTRY)
-
-#define TFW_HTTP_F_HAS_STICKY		(1U << TFW_HTTP_B_HAS_STICKY)
-#define TFW_HTTP_F_URI_FULL		(1U << TFW_HTTP_B_URI_FULL)
-#define TFW_HTTP_F_NON_IDEMP		(1U << TFW_HTTP_B_NON_IDEMP)
-#define TFW_HTTP_F_SUSPECTED		(1U << TFW_HTTP_B_SUSPECTED)
-#define TFW_HTTP_F_ACCEPT_HTML		(1U << TFW_HTTP_B_ACCEPT_HTML)
-#define TFW_HTTP_F_HMONITOR		(1U << TFW_HTTP_B_HMONITOR)
-#define TFW_HTTP_F_WHITELIST		(1U << TFW_HTTP_B_WHITELIST)
-#define TFW_HTTP_F_REQ_DROP		(1U << TFW_HTTP_B_REQ_DROP)
-
-#define TFW_HTTP_F_VOID_BODY		(1U << TFW_HTTP_B_VOID_BODY)
-#define TFW_HTTP_F_HDR_DATE		(1U << TFW_HTTP_B_HDR_DATE)
-#define TFW_HTTP_F_HDR_LMODIFIED	(1U << TFW_HTTP_B_HDR_LMODIFIED)
-#define TFW_HTTP_F_RESP_STALE		(1U << TFW_HTTP_B_RESP_STALE)
-#define TFW_HTTP_F_RESP_READY		(1U << TFW_HTTP_B_RESP_READY)
+#define __TFW_HTTP_MSG_M_CONN_MASK					\
+	(BIT(TFW_HTTP_B_CONN_CLOSE) | BIT(TFW_HTTP_B_CONN_KA))
 
 /**
  * The structure to hold data for an HTTP error response.
@@ -326,13 +306,19 @@ typedef struct {
 	TfwHttpError	httperr;					\
 	TfwCacheControl	cache_ctl;					\
 	unsigned char	version;					\
-	unsigned int	flags;						\
-	unsigned long	content_length;					\
 	unsigned int	keep_alive;					\
+	unsigned long	content_length;					\
+	DECLARE_BITMAP	(flags, _TFW_HTTP_FLAGS_NUM);			\
 	TfwConn		*conn;						\
 	void (*destructor)(void *msg);					\
 	TfwStr		crlf;						\
 	TfwStr		body;
+
+static inline void
+tfw_http_copy_flags(unsigned long *to, unsigned long *from)
+{
+	bitmap_copy(to, from, _TFW_HTTP_FLAGS_NUM);
+}
 
 /**
  * A helper structure for operations common for requests and responses.

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -207,11 +207,26 @@ typedef enum {
 enum {
 	/* Common flags for requests and responses. */
 	TFW_HTTP_FLAGS_COMMON	= 0,
-	/* 'Connection:' header contains 'close'. */
+	/*
+	 * Connection management flags.
+	 *
+	 * CONN_CLOSE: the connection is to be closed after response is
+	 * forwarded to the client. Set if:
+	 * - 'Connection:' header contains 'close' term;
+	 * - there is no possibility to serve further requests from the same
+	 * connection due to errors or protocol restrictions.
+	 *
+	 * CONN_KA: 'Connection:' header contains 'keep-alive' term. The flag
+	 * is not set for HTTP/1.1 connections which are persistent by default.
+	 * CONN_EXTRA: 'Connection:' header contains additional terms.
+	 *
+	 * There is no requirement for mutual exclusivity for CONN_CLOSE and
+	 * CONN_KA flags, their meaning is not limited by connection
+	 * persistence and states about 'Connection:' header value. CONN_CLOSE
+	 * always takes precedence over CONN_KA flag.
+	 */
 	TFW_HTTP_B_CONN_CLOSE	= TFW_HTTP_FLAGS_COMMON,
-	/* 'Connection:' header contains 'keep-alive'. */
 	TFW_HTTP_B_CONN_KA,
-	/* 'Connection:' header contains additional terms. */
 	TFW_HTTP_B_CONN_EXTRA,
 	/* Chunked transfer encoding. */
 	TFW_HTTP_B_CHUNKED,

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -268,7 +268,7 @@ enum {
 	_TFW_HTTP_FLAGS_NUM
 };
 
-#define __TFW_HTTP_MSG_M_CONN_MASK					\
+#define __TFW_HTTP_MSG_M_CONN						\
 	(BIT(TFW_HTTP_B_CONN_CLOSE) | BIT(TFW_HTTP_B_CONN_KA))
 
 /**

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -598,7 +598,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 		}
 	}
 
-	if (req->flags & TFW_HTTP_F_URI_FULL) {
+	if (test_bit(TFW_HTTP_B_URI_FULL, req->flags)) {
 		char *hdrhost;
 
 		/* If host in URI is empty, host header also must be empty. */
@@ -902,7 +902,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, const TfwFsmData *data)
 
 	/* Ensure that singular header fields are not duplicated. */
 	__FRANG_FSM_STATE(Frang_Req_Hdr_FieldDup) {
-		if (req->flags & TFW_HTTP_F_FIELD_DUPENTRY) {
+		if (test_bit(TFW_HTTP_B_FIELD_DUPENTRY, req->flags)) {
 			frang_msg("duplicate header field found",
 				  &FRANG_ACC2CLI(ra)->addr, "\n");
 			r = TFW_BLOCK;
@@ -1045,7 +1045,7 @@ frang_http_req_handler(void *obj, const TfwFsmData *data)
 	FrangAcc *ra = conn->sk->sk_security;
 	bool ip_block = tfw_vhost_global_frang_cfg()->ip_block;
 
-	if (((TfwHttpReq *)data->req)->flags & TFW_HTTP_F_WHITELIST)
+	if (test_bit(TFW_HTTP_B_WHITELIST, ((TfwHttpReq *)data->req)->flags))
 		return TFW_PASS;
 
 	r = frang_http_req_process(ra, conn, data);

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -305,7 +305,7 @@ __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 	unsigned int id = tfw_http_msg_hdr_lookup(hm, hdr);
 
 	if ((id < hm->h_tbl->off) && __hdr_is_singular(hdr))
-		hm->flags |= TFW_HTTP_F_FIELD_DUPENTRY;
+		__set_bit(TFW_HTTP_B_FIELD_DUPENTRY, hm->flags);
 
 	return id;
 }
@@ -365,7 +365,7 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 		 * RFC 7230 3.2.2: duplicate of non-singular special
 		 * header - leave the decision to classification layer.
 		 */
-		hm->flags |= TFW_HTTP_F_FIELD_DUPENTRY;
+		__set_bit(TFW_HTTP_B_FIELD_DUPENTRY, hm->flags);
 		goto duplicate;
 	}
 
@@ -997,9 +997,6 @@ __tfw_http_msg_alloc(int type, bool full)
 			 ((type & Conn_Clnt) ? "request" : "response"));
 		return NULL;
 	}
-
-	BUILD_BUG_ON(FIELD_SIZEOF(TfwHttpMsg, flags) * BITS_PER_BYTE
-		     < _TFW_HTTP_FLAGS_NUM);
 
 	if (full) {
 		hm->h_tbl = (TfwHttpHdrTbl *)tfw_pool_alloc(hm->pool,

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -1007,8 +1007,8 @@ __FSM_STATE(RGen_HdrOtherV) {						\
 __FSM_STATE(RGen_BodyInit) {						\
 	TfwStr *tbl = msg->h_tbl->tbl;					\
 									\
-	TFW_DBG3("parse request body: flags=%#x content_length=%lu\n",	\
-		 msg->flags, msg->content_length);			\
+	TFW_DBG3("parse request body: flags=%#lx content_length=%lu\n",	\
+		 msg->flags[0], msg->content_length);			\
 									\
 	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_TRANSFER_ENCODING])) {	\
 		/*							\
@@ -1019,7 +1019,7 @@ __FSM_STATE(RGen_BodyInit) {						\
 		 */							\
 		if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH]))	\
 			TFW_PARSER_BLOCK(RGen_BodyInit);		\
-		if (msg->flags & TFW_HTTP_F_CHUNKED)			\
+		if (test_bit(TFW_HTTP_B_CHUNKED, msg->flags))		\
 			__FSM_MOVE_nofixup(RGen_BodyStart);		\
 		/*							\
 		 * If "Transfer-Encoding:" header is present and	\
@@ -1042,11 +1042,11 @@ __FSM_STATE(RGen_BodyInit) {						\
 __FSM_STATE(RGen_BodyInit) {						\
 	TfwStr *tbl = msg->h_tbl->tbl;					\
 									\
-	TFW_DBG3("parse response body: flags=%#x content_length=%lu\n",	\
-		 msg->flags, msg->content_length);			\
+	TFW_DBG3("parse response body: flags=%#lx content_length=%lu\n",\
+		 msg->flags[0], msg->content_length);			\
 									\
 	/* There's no body. */						\
-	if (msg->flags & TFW_HTTP_F_VOID_BODY) {			\
+	if (test_bit(TFW_HTTP_B_VOID_BODY, msg->flags)) {		\
 		msg->body.flags |= TFW_STR_COMPLETE;			\
 		FSM_EXIT(TFW_PASS);					\
 	}								\
@@ -1059,7 +1059,7 @@ __FSM_STATE(RGen_BodyInit) {						\
 		 */							\
 		if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH]))	\
 			TFW_PARSER_BLOCK(RGen_BodyInit);		\
-		if (msg->flags & TFW_HTTP_F_CHUNKED)			\
+		if (test_bit(TFW_HTTP_B_CHUNKED, msg->flags))		\
 			__FSM_MOVE_nofixup(RGen_BodyStart);		\
 		__FSM_MOVE_nofixup(Resp_BodyUnlimStart);		\
 	}								\
@@ -1111,11 +1111,11 @@ __FSM_STATE(RGen_BodyChunk) {						\
 }									\
 __FSM_STATE(RGen_BodyReadChunk) {					\
 	BUG_ON(parser->to_read < 0);					\
-	__fsm_sz = min_t(long, parser->to_read, __data_remain(p));      \
+	__fsm_sz = min_t(long, parser->to_read, __data_remain(p));	\
 	parser->to_read -= __fsm_sz;					\
 	if (parser->to_read)						\
 		__FSM_MOVE_nf(RGen_BodyReadChunk, __fsm_sz, &msg->body); \
-	if (msg->flags & TFW_HTTP_F_CHUNKED) {				\
+	if (test_bit(TFW_HTTP_B_CHUNKED, msg->flags)) {			\
 		parser->to_read = -1;					\
 		__FSM_MOVE_nf(RGen_BodyEoL, __fsm_sz, &msg->body);	\
 	}								\
@@ -1236,17 +1236,17 @@ __parse_connection(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	__FSM_STATE(I_Conn) {
 		/* Boolean connection tokens */
 		TRY_HBH_TOKEN("close", {
-			if (msg->flags & TFW_HTTP_F_CONN_KA)
+			if (test_bit(TFW_HTTP_B_CONN_KA, msg->flags))
 				return CSTR_NEQ;
-			msg->flags |= TFW_HTTP_F_CONN_CLOSE;
+			__set_bit(TFW_HTTP_B_CONN_CLOSE, msg->flags);
 		});
 		/* Spec headers */
 		TRY_HBH_TOKEN("keep-alive", {
 			unsigned int hid = TFW_HTTP_HDR_KEEP_ALIVE;
 
-			if (msg->flags & TFW_HTTP_F_CONN_CLOSE)
+			if (test_bit(TFW_HTTP_B_CONN_CLOSE, msg->flags))
 				return CSTR_NEQ;
-			msg->flags |= TFW_HTTP_F_CONN_KA;
+			__set_bit(TFW_HTTP_B_CONN_KA, msg->flags);
 
 			parser->hbh_parser.spec |= 0x1 << hid;
 			if (!TFW_STR_EMPTY(&msg->h_tbl->tbl[hid]))
@@ -1267,7 +1267,7 @@ __parse_connection(TfwHttpMsg *hm, unsigned char *data, size_t len)
 			if (__hbh_parser_add_data(hm, p, __fsm_sz, false))
 				r = CSTR_NEQ;
 		});
-		msg->flags |= TFW_HTTP_F_CONN_EXTRA;
+		__set_bit(TFW_HTTP_B_CONN_EXTRA, msg->flags);
 		c = *(p + __fsm_sz);
 		if (__hbh_parser_add_data(hm, p, __fsm_sz, true))
 			return  CSTR_NEQ;
@@ -1291,7 +1291,7 @@ __parse_connection(TfwHttpMsg *hm, unsigned char *data, size_t len)
 
 	} /* FSM END */
 done:
-	TFW_DBG3("parser: Connection parsed: flags %#x\n", msg->flags);
+	TFW_DBG3("parser: Connection parsed: flags %#lx\n", msg->flags[0]);
 
 	return r;
 }
@@ -1407,9 +1407,9 @@ __parse_transfer_encoding(TfwHttpMsg *hm, unsigned char *data, size_t len)
 		 * chunked message is not allowed). RFC 7230 3.3.1.
 		 */
 		TRY_STR_LAMBDA("chunked", {
-			if (unlikely(msg->flags & TFW_HTTP_F_CHUNKED))
+			if (unlikely(test_bit(TFW_HTTP_B_CHUNKED, msg->flags)))
 				return CSTR_NEQ;
-			msg->flags |= TFW_HTTP_F_CHUNKED;
+			__set_bit(TFW_HTTP_B_CHUNKED, msg->flags);
 		}, I_EoT);
 		TRY_STR_INIT();
 		__FSM_I_MOVE_n(I_TransEncodOther, 0);
@@ -1426,7 +1426,7 @@ __parse_transfer_encoding(TfwHttpMsg *hm, unsigned char *data, size_t len)
 			__FSM_I_MOVE_n(I_EoT, __fsm_sz + 1);
 		if (IS_CRLF(c)) {
 			/* "chunked" must be the last coding. */
-			if (unlikely(msg->flags & TFW_HTTP_F_CHUNKED))
+			if (unlikely(test_bit(TFW_HTTP_B_CHUNKED, msg->flags)))
 				return CSTR_NEQ;
 			return __data_off(p + __fsm_sz);
 		}
@@ -1937,10 +1937,10 @@ __req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len)
 
 	__FSM_STATE(Req_I_Accept) {
 		TRY_STR_LAMBDA("text/html", {
-			msg->flags |= TFW_HTTP_F_ACCEPT_HTML;
+			__set_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags);
 		}, I_EoT);
 		TRY_STR_LAMBDA("*/*", {
-			msg->flags |= TFW_HTTP_F_ACCEPT_HTML;
+			__set_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags);
 		}, I_EoT);
 		TRY_STR_INIT();
 		__FSM_I_MOVE_n(Req_I_AcceptOther, 0);
@@ -2518,11 +2518,11 @@ __parse_http_date(TfwHttpMsg *hm, unsigned char *data, size_t len)
 				__FSM_I_MOVE_n(I_EoL, 0);
 			break;
 		case Resp_HdrDateV:
-			if (resp->flags & TFW_HTTP_F_HDR_DATE)
+			if (test_bit(TFW_HTTP_B_HDR_DATE, resp->flags))
 				return CSTR_NEQ;
 			break;
 		case Resp_HdrLast_ModifiedV:
-			if (resp->flags & TFW_HTTP_F_HDR_LMODIFIED)
+			if (test_bit(TFW_HTTP_B_HDR_LMODIFIED, resp->flags))
 				return CSTR_NEQ;
 			break;
 		case Req_HdrIf_Modified_SinceV:
@@ -2739,11 +2739,11 @@ __parse_http_date(TfwHttpMsg *hm, unsigned char *data, size_t len)
 			break;
 		case Resp_HdrDateV:
 			resp->date = parser->_date;
-			resp->flags |= TFW_HTTP_F_HDR_DATE;
+			__set_bit(TFW_HTTP_B_HDR_DATE, resp->flags);
 			break;
 		case Resp_HdrLast_ModifiedV:
 			resp->last_modified = parser->_date;
-			resp->flags |= TFW_HTTP_F_HDR_LMODIFIED;
+			__set_bit(TFW_HTTP_B_HDR_LMODIFIED, resp->flags);
 			break;
 		case Req_HdrIf_Modified_SinceV:
 			req->cond.m_date = parser->_date;
@@ -3256,7 +3256,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 	 * req->userinfo, reset req->host and fill it.
 	 */
 	__FSM_STATE(Req_UriAuthorityStart) {
-		req->flags |= TFW_HTTP_F_URI_FULL;
+		__set_bit(TFW_HTTP_B_URI_FULL, req->flags);
 		if (likely(isalnum(c) || c == '.' || c == '-')) {
 			__msg_field_open(&req->host, p);
 			__FSM_MOVE_f(Req_UriAuthority, &req->host);
@@ -4474,7 +4474,7 @@ tfw_http_adj_parser_resp(TfwHttpResp *resp)
 	TfwHttpReq *req = resp->req;
 
 	if (req->method == TFW_HTTP_METH_HEAD)
-		resp->flags |= TFW_HTTP_F_VOID_BODY;
+		__set_bit(TFW_HTTP_B_VOID_BODY, resp->flags);
 }
 
 int
@@ -4558,7 +4558,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 			if (resp->status - 100U < 100U || resp->status == 204
 			    || resp->status == 304)
 			{
-				msg->flags |= TFW_HTTP_F_VOID_BODY;
+				__set_bit(TFW_HTTP_B_VOID_BODY, resp->flags);
 			}
 			__FSM_MOVE_nf(Resp_ReasonPhrase, __fsm_n,
 				      &resp->s_line);

--- a/tempesta_fw/http_sched_hash.c
+++ b/tempesta_fw/http_sched_hash.c
@@ -163,7 +163,8 @@ __find_best_conn(TfwMsg *msg, TfwHashConnList *cl)
 {
 	ssize_t l_idx, r_idx, idx;
 	TfwSrvConn *conn;
-	bool hmonitor = ((TfwHttpReq *)msg)->flags & TFW_HTTP_F_HMONITOR;
+	bool hmonitor = test_bit(TFW_HTTP_B_HMONITOR,
+				 ((TfwHttpReq *)msg)->flags);
 	unsigned long msg_hash = tfw_http_req_key_calc((TfwHttpReq *)msg);
 	unsigned long best_hash = (~0UL ^ msg_hash);
 

--- a/tempesta_fw/http_sched_ratio.c
+++ b/tempesta_fw/http_sched_ratio.c
@@ -860,7 +860,7 @@ tfw_sched_ratio_sched_srv_conn(TfwMsg *msg, TfwServer *srv)
 	 * Bypass the suspend checking if connection is needed for
 	 * health monitoring of backend server.
 	 */
-	if (!(((TfwHttpReq *)msg)->flags & TFW_HTTP_F_HMONITOR)
+	if (!test_bit(TFW_HTTP_B_HMONITOR, ((TfwHttpReq *)msg)->flags)
 	    && tfw_srv_suspended(srv))
 		return NULL;
 

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -1088,16 +1088,18 @@ TEST(http_parser, parses_connection_value)
 		"Connection: Keep-Alive\r\n"
 		"\r\n")
 	{
-		EXPECT_EQ(req->flags & __TFW_HTTP_MSG_M_CONN_MASK,
-			  TFW_HTTP_F_CONN_KA);
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_CONN_CLOSE, req->flags));
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_CONN_KA, req->flags));
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_CONN_EXTRA, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Connection: Close\r\n"
 		"\r\n")
 	{
-		EXPECT_EQ(req->flags & __TFW_HTTP_MSG_M_CONN_MASK,
-			  TFW_HTTP_F_CONN_CLOSE);
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_CONN_CLOSE, req->flags));
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_CONN_KA, req->flags));
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_CONN_EXTRA, req->flags));
 	}
 }
 
@@ -1301,21 +1303,21 @@ TEST(http_parser, accept)
 		"Accept:  text/html \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  text/html, application/xhtml+xml \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  text/html;q=0.8 \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
@@ -1323,28 +1325,28 @@ TEST(http_parser, accept)
 		"q=0.9,image/webp,image/apng,*/*;q=0.8\r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  text/*  \r\n"
 		"\r\n")
 	{
-		EXPECT_FALSE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  text/html, */*  \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  */*  \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(req->flags & TFW_HTTP_F_ACCEPT_HTML);
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 }
 


### PR DESCRIPTION
There was a discussion that a HTTP message flags defined as enum and a set of macroses doesn't look good, in the same time usage of standard bit operations looks cleaner and provide atomic possibilities.