### PR TITLE
Fix build of TLS module

### DIFF
--- a/tls/Makefile
+++ b/tls/Makefile
@@ -16,7 +16,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-EXTRA_CFLAGS += $(TFW_CFLAGS) -I $(src)/../ -I$(src)/../tls/dummy_headers
+EXTRA_CFLAGS += $(TFW_CFLAGS) -I$(src)/../ -I$(src)/../tls/dummy_headers
 
 obj-m = tempesta_tls.o
 

--- a/tls/pk.c
+++ b/tls/pk.c
@@ -21,7 +21,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include "lib/log.h"
+#include "debug.h"
 #include "pk.h"
 #include "pk_internal.h"
 #include "rsa.h"


### PR DESCRIPTION
Error is trivial: extra whitespace in Makefile which prevented to include `/lib` directory. I've also replaced direct include of `lib/log.h` with `debug.h` which also defines required `BANNER` variable.