### PR TITLE
follow-up changes (see #1139)

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2153,7 +2153,7 @@ tfw_http_should_validate_post_req(TfwHttpReq *req)
 	if (req->location && req->location->validate_post_req)
 		return true;
 
-	if (!req->vhost)
+	if (WARN_ON_ONCE(!req->vhost))
 		return false;
 
 	if (req->vhost->loc_dflt && req->vhost->loc_dflt->validate_post_req)

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -231,7 +231,7 @@ enum {
 	TFW_HTTP_B_CHUNKED,
 	/* Media type is multipart/form-data. */
 	TFW_HTTP_B_CT_MULTIPART,
-	/* Multipart/form-data request have boundary parameter. */
+	/* Multipart/form-data request has a boundary parameter. */
 	TFW_HTTP_B_CT_MULTIPART_HAS_BOUNDARY,
 	/* Singular header presents more than once. */
 	TFW_HTTP_B_FIELD_DUPENTRY,

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -2419,7 +2419,7 @@ static TfwCfgSpec tfw_vhost_specs[] = {
 		.deflt = NULL,
 		.handler = tfw_cfgop_out_http_post_validate,
 		.allow_none = true,
-		.allow_repeat = true,
+		.allow_repeat = false,
 		.allow_reconfig = true,
 	},
 	{


### PR DESCRIPTION
* `req->vhost` is expected to be non-NULL, as it was checked before;
* disallow multiple instances of `http_post_validate` at topmost level;
* a typo.