### PR TITLE
Fix the skb fragments extending.

### DIFF
--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -341,7 +341,7 @@ __extend_pgfrags(struct sk_buff *skb_head, struct sk_buff *skb, int from, int n)
 	/*
 	 * Make room for @n page fragments in the SKB. Considering maximum @n
 	 * value must be not greater than 2, the minimum @n_shift value must
-	 * be not less then -1.
+	 * be not less than -1.
 	 */
 	n_shift = tail_frags - n_excess;
 	BUG_ON(n_shift + 1 < 0);

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -329,7 +329,14 @@ __extend_pgfrags(struct sk_buff *skb_head, struct sk_buff *skb, int from, int n)
 		if (!tail_frags)
 			return 0;
 
-		/* Shift @n_excess number of page fragments to new SKB. */
+		/*
+		 * Move @n_excess number of page fragments to new SKB. We
+		 * must move @n_excess fragments to next/new skb, except
+		 * those, which we are inserting (@n fragments) - so we
+		 * must move last @n_excess fragments: not more than
+		 * @tail_frags, and not more than @n_excess itself
+		 * (maximum @n_excess fragments can be moved).
+		 */
 		for (i = n_excess - 1; i >= max(n_excess - tail_frags, 0); --i) {
 			f = &si->frags[MAX_SKB_FRAGS - n + i];
 			skb_shinfo(nskb)->frags[i] = *f;
@@ -339,9 +346,12 @@ __extend_pgfrags(struct sk_buff *skb_head, struct sk_buff *skb, int from, int n)
 		ss_skb_adjust_data_len(nskb, e_size);
 	}
 	/*
-	 * Make room for @n page fragments in the SKB. Considering maximum @n
-	 * value must be not greater than 2, the minimum @n_shift value must
-	 * be not less than -1.
+	 * Make room for @n page fragments in current SKB. We must shift
+	 * @tail_frags fragments inside current skb, except those, which we
+	 * moved to next/new skb (above); in case of too small @tail_frags
+	 * and/or too big @n values, the value of @n_shift will be negative,
+	 * but considering maximum @n value must be not greater than 2, the
+	 * minimum @n_shift value must be not less than -1.
 	 */
 	n_shift = tail_frags - n_excess;
 	BUG_ON(n_shift + 1 < 0);

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -573,9 +573,9 @@ __split_pgfrag_add(struct sk_buff *skb_head, struct sk_buff *skb, int i, int off
 	skb_frag_size_sub(frag, tail_len);
 
 	/* Make the fragment with the tail part. */
-	i = (i + 2) % MAX_SKB_FRAGS;
-	__skb_fill_page_desc(skb_dst, i, skb_frag_page(frag),
-			     frag->page_offset + off, tail_len);
+	__skb_fill_page_desc(skb_dst, (i + 2) % MAX_SKB_FRAGS,
+			     skb_frag_page(frag), frag->page_offset + off,
+			     tail_len);
 	__skb_frag_ref(frag);
 
 	/* Adjust SKB data lengths. */


### PR DESCRIPTION
Patch fixes two problems:
1. In `__extend_pgfrags()` - in case of `n == 2 && si->nr_frags == MAX_SKB_FRAGS && from == MAX_SKB_FRAGS - 1`: a) resolve issue with incorrect fragments shift; b) avoid possible BUG_ON if `n_shift < 0`;
2. In `__split_pgfrag_add()` - in case of `i == MAX_SKB_FRAGS - 1`: resolve issue with incorrect determination of destination `frag` and, as a result, wrong `it->data` and `it->skb` output. 