### PR TITLE
Fix TDB build issue

### DIFF
--- a/tempesta_db/Makefile
+++ b/tempesta_db/Makefile
@@ -18,7 +18,7 @@
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 all: libtdb tdbq
-.PHONY: all
+.PHONY: all libtdb tdbq
 
 libtdb:
 	$(MAKE) -C libtdb


### PR DESCRIPTION
At some random moment without any preconditions, my IDE has started to fail building the TDB. `tdbq` is trying to be built before `libtdb`. This happens even with the single make  job. I couldn't reproduce the issue manually.
According to the documentation PHONY property is not inherited and must be set for both targets individually. This fixes the issue for me.