### PR TITLE
tests: fix ttls_rsa_context initialisation

### DIFF
--- a/tempesta_fw/t/unit/test_tls.c
+++ b/tempesta_fw/t/unit/test_tls.c
@@ -351,7 +351,7 @@ TEST(tls, rsa)
 {
 	int ret = 0;
 	size_t len;
-	ttls_rsa_context rsa;
+	ttls_rsa_context rsa = { 0 };
 	unsigned char rsa_plaintext[PT_LEN];
 	unsigned char rsa_decrypted[PT_LEN];
 	unsigned char rsa_ciphertext[KEY_LEN];


### PR DESCRIPTION
The `ttls_rsa_context` structure is not initialised and filled with garbage.
The crash may happen since the code relies on uninitialised struct
members.

The issue happens only in unit tests since in normal code it's  prepended by `kzalloc` zeroing the memory.

Very funny that I looked to this issue in clang analysis report this evening and just got it on my VM.