### PR TITLE
Encode message to chunked encoding

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2054,7 +2054,8 @@ tfw_http_conn_drop(TfwConn *conn)
 		tfw_http_conn_cli_drop((TfwCliConn *)conn);
 	}
 	else if (conn->msg) { /* server connection */
-		if (tfw_http_parse_terminate((TfwHttpMsg *)conn->msg))
+		int r = tfw_http_parse_terminate((TfwHttpMsg *)conn->msg);
+		if (r == TFW_PASS)
 			tfw_http_resp_terminate((TfwHttpMsg *)conn->msg);
 	}
 	tfw_http_conn_msg_free((TfwHttpMsg *)conn->msg);
@@ -3554,6 +3555,26 @@ static void
 tfw_http_resp_terminate(TfwHttpMsg *hm)
 {
 	TfwFsmData data;
+	int r;
+
+	/*
+	 * Add absent message framing information. If there is no body, add
+	 *  Content-length header: it requires less modifications.
+	 */
+	r = (hm->body.len)
+		? tfw_http_msg_to_chunked(hm)
+		: TFW_HTTP_MSG_HDR_XFRM(hm, "Content-Length", "0",
+					TFW_HTTP_HDR_CONTENT_LENGTH, 0);
+
+	if (r) {
+		TfwHttpReq *req = hm->req;
+
+		tfw_http_popreq(hm, false);
+		tfw_http_conn_msg_free(hm);
+		tfw_http_req_block(req, 502, "response blocked: filtered out");
+		TFW_INC_STAT_BH(serv.msgs_filtout);
+		return;
+	}
 
 	/*
 	 * Note that in this case we don't have data to process.

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2054,8 +2054,7 @@ tfw_http_conn_drop(TfwConn *conn)
 		tfw_http_conn_cli_drop((TfwCliConn *)conn);
 	}
 	else if (conn->msg) { /* server connection */
-		int r = tfw_http_parse_terminate((TfwHttpMsg *)conn->msg);
-		if (r == TFW_PASS)
+		if (!tfw_http_parse_terminate((TfwHttpMsg *)conn->msg))
 			tfw_http_resp_terminate((TfwHttpMsg *)conn->msg);
 	}
 	tfw_http_conn_msg_free((TfwHttpMsg *)conn->msg);

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2678,6 +2678,7 @@ tfw_http_cli_error_resp_and_log(TfwHttpReq *req, int status, const char *msg,
 		reply = tfw_blk_flags & TFW_BLK_ERR_REPLY;
 		nolog = tfw_blk_flags & TFW_BLK_ERR_NOLOG;
 	}
+	reply &= !test_bit(TFW_HTTP_B_REQ_DROP, req->flags);
 
 	if (!nolog)
 		TFW_WARN_ADDR(msg, &req->conn->peer->addr, TFW_WITH_PORT);

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -780,7 +780,13 @@ tfw_http_msg_body_xfrm(TfwHttpMsg *hm, TfwStr *data, bool append)
 	struct sk_buff *skb = append
 		? ss_skb_peek_tail(&hm->msg.skb_head)
 		: hm->body.skb;
-
+	/*
+	 * TODO: #498. During stream forwarding the message is to be forwarded
+	 * skb by skb without full assembling in memory and chunked encoding
+	 * is to be applied on the fly. It's crucial to write last-chunk at the
+	 * skb->tail to reuse allocation overhead and avoid possible skb
+	 * allocations.
+	 */
 	r = ss_skb_get_room(hm->msg.skb_head, skb, st, data->len, &it);
 	if (r)
 		return r;

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -760,6 +760,74 @@ tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm)
 }
 
 /**
+ * Modify message body, add string @data to the end of the body (if @append) or
+ * to its beginning.
+ */
+static int
+tfw_http_msg_body_xfrm(TfwHttpMsg *hm, TfwStr *data, bool append)
+{
+	int r;
+	TfwStr it = {};
+	char *st = append
+		? (TFW_STR_CURR(&hm->body)->data + TFW_STR_CURR(&hm->body)->len)
+		: (TFW_STR_CHUNK(&hm->body, 0)->data);
+
+	r = ss_skb_get_room(hm->msg.skb_head, hm->body.skb,
+			    st,
+			    data->len, &it);
+	if (r)
+		return r;
+
+	if ((r = tfw_strcpy(&it, data)))
+		return r;
+	r = tfw_str_insert(hm->pool, &hm->body, &it,
+			   append ? hm->body.nchunks : 0);
+	if (r) {
+		TFW_WARN("Can't concatenate body %.*s with %.*s\n",
+			 PR_TFW_STR(&hm->body), PR_TFW_STR(data));
+		return r;
+	}
+
+	return 0;
+}
+
+/**
+ * Transform message to chunked encoding.
+ */
+int
+tfw_http_msg_to_chunked(TfwHttpMsg *hm)
+{
+	int r;
+	DEFINE_TFW_STR(chunked_body_end, "\r\n0\r\n\r\n");
+
+	r = TFW_HTTP_MSG_HDR_XFRM(hm, "Transfer-Encoding", "chunked",
+				  TFW_HTTP_HDR_TRANSFER_ENCODING, 1);
+	if (r)
+		return r;
+
+	if (hm->body.len) {
+		char data[TFW_ULTOA_BUF_SIZ + 2] = {0};
+		TfwStr sz = {.data = data};
+
+		sz.len = tfw_ultoa(hm->body.len, sz.data, TFW_ULTOA_BUF_SIZ);
+		if (!sz.len)
+			return -EINVAL;
+		*(short *)(sz.data + sz.len) = 0x0a0d; /* CRLF, '\r\n' */
+		sz.len += 2;
+
+		if ((r = tfw_http_msg_body_xfrm(hm, &sz, false)))
+			return r;
+	}
+
+	if ((r = tfw_http_msg_body_xfrm(hm, &chunked_body_end, true)))
+		return r;
+
+	__set_bit(TFW_HTTP_B_CHUNKED, hm->flags);
+
+	return 0;
+}
+
+/**
  * Add a header, probably duplicated, without any checking of current headers.
  */
 int

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -115,6 +115,7 @@ int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 
 int tfw_http_msg_del_str(TfwHttpMsg *hm, TfwStr *str);
 int tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm);
+int tfw_http_msg_to_chunked(TfwHttpMsg *hm);
 
 int tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len);
 int tfw_http_msg_add_data(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -107,6 +107,6 @@ int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 		       unsigned int *parsed);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len,
 			unsigned int *parsed);
-bool tfw_http_parse_terminate(TfwHttpMsg *hm);
+int tfw_http_parse_terminate(TfwHttpMsg *hm);
 
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -123,7 +123,7 @@
 static const unsigned long tfw_srv_tmo_vals[] = { 1, 10, 100, 250, 500, 1000 };
 
 #define srv_warn(check, addr, fmt, ...)					\
-	TFW_WARN_MOD_ADDR(sock_srv, check, addr, TFW_NO_PORT, fmt,	\
+	TFW_WARN_MOD_ADDR(sock_srv, check, addr, TFW_WITH_PORT, fmt,	\
 	                  ##__VA_ARGS__)
 
 static inline void

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -407,16 +407,14 @@ __tfw_str_insert(TfwPool *pool, TfwStr *dst, TfwStr *src, unsigned int chunk)
 
 	if (chunk != last_chunk) {
 		memmove(dst->chunks + chunk + n, dst->chunks + chunk,
-			sizeof(TfwStr) * (dst->nchunks - chunk));
+			sizeof(TfwStr) * (dst->nchunks - chunk - n));
 		to = dst->chunks + chunk;
 	}
 
 	n = 0;
 	TFW_STR_FOR_EACH_CHUNK(c, src, end) {
 		n += c->len;
-		to->data = c->data;
-		to->len = c->len;
-		to->skb = c->skb;
+		*to = *c;
 		++to;
 	}
 	dst->len += n;
@@ -430,7 +428,7 @@ __tfw_str_insert(TfwPool *pool, TfwStr *dst, TfwStr *src, unsigned int chunk)
 int
 tfw_str_insert(TfwPool *pool, TfwStr *dst, TfwStr *src, unsigned int chunk)
 {
-	if (chunk > (TFW_STR_PLAIN(dst) ? 2 : dst->nchunks + 1))
+	if (unlikely(chunk > (TFW_STR_PLAIN(dst) ? 1 : dst->nchunks)))
 		return -ERANGE;
 
 	return __tfw_str_insert(pool, dst, src, chunk);

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -391,18 +391,25 @@ tfw_strcpy_desc(TfwStr *dst, TfwStr *src)
 }
 EXPORT_SYMBOL(tfw_strcpy_desc);
 
-int
-tfw_strcat(TfwPool *pool, TfwStr *dst, TfwStr *src)
+static inline int
+__tfw_str_insert(TfwPool *pool, TfwStr *dst, TfwStr *src, unsigned int chunk)
 {
-	int n = src->nchunks;
+	int n = src->nchunks ? : 1;
+	int last_chunk = TFW_STR_PLAIN(dst) ? 1 : dst->nchunks;
 	TfwStr *to, *c, *end;
 
 	BUG_ON(TFW_STR_DUP(dst));
 	BUG_ON(TFW_STR_DUP(src));
 
-	to = __str_grow_tree(pool, dst, 0, n ? : 1);
+	to = __str_grow_tree(pool, dst, 0, n);
 	if (!to)
 		return -ENOMEM;
+
+	if (chunk != last_chunk) {
+		memmove(dst->chunks + chunk + n, dst->chunks + chunk,
+			sizeof(TfwStr) * (dst->nchunks - chunk));
+		to = dst->chunks + chunk;
+	}
 
 	n = 0;
 	TFW_STR_FOR_EACH_CHUNK(c, src, end) {
@@ -415,6 +422,26 @@ tfw_strcat(TfwPool *pool, TfwStr *dst, TfwStr *src)
 	dst->len += n;
 
 	return 0;
+}
+
+/**
+ * Insert string @src into @dst string before chunk @chunk.
+ */
+int
+tfw_str_insert(TfwPool *pool, TfwStr *dst, TfwStr *src, unsigned int chunk)
+{
+	if (chunk > (TFW_STR_PLAIN(dst) ? 2 : dst->nchunks + 1))
+		return -ERANGE;
+
+	return __tfw_str_insert(pool, dst, src, chunk);
+}
+EXPORT_SYMBOL(tfw_str_insert);
+
+int
+tfw_strcat(TfwPool *pool, TfwStr *dst, TfwStr *src)
+{
+	return __tfw_str_insert(pool, dst, src,
+				TFW_STR_PLAIN(dst) ? 1 : dst->nchunks);
 }
 EXPORT_SYMBOL(tfw_strcat);
 

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -363,6 +363,7 @@ int tfw_strcpy(TfwStr *dst, const TfwStr *src);
 TfwStr *tfw_strdup(TfwPool *pool, const TfwStr *src);
 int tfw_strcpy_desc(TfwStr *dst, TfwStr *src);
 int tfw_strcat(TfwPool *pool, TfwStr *dst, TfwStr *src);
+int tfw_str_insert(TfwPool *pool, TfwStr *dst, TfwStr *src, unsigned int chunk);
 
 int __tfw_strcmp(const TfwStr *s1, const TfwStr *s2, int cs);
 #define tfw_stricmp(s1, s2)		__tfw_strcmp((s1), (s2), 0)

--- a/tempesta_fw/t/unit/test_tfw_str.c
+++ b/tempesta_fw/t/unit/test_tfw_str.c
@@ -668,7 +668,20 @@ TEST(tfw_str_insert, compound_append)
 TEST(tfw_str_insert, compound_insert)
 {
 	int chunks1, chunks2;
-	TFW_STR(s1, "abcdefghijklmnop");
+	TfwStr s0 = {
+		.chunks = (TfwStr []){
+			{ .data = "a",		.len = 1 },
+			{ .data = "bc",		.len = 2 },
+			{ .data = "def",	.len = 3 },
+			{ .data = "g",		.len = 1 },
+			{ .data = "h",		.len = 1 },
+			{ .data = "ijklmno",	.len = 7 },
+			{ .data = "p", 		.len = 1 }
+		},
+		.len = sizeof("abcdefghijklmnop") - 1,
+		.nchunks = 7
+	};
+	TfwStr *s1 = tfw_strdup(str_pool, &s0);
 	TFW_STR(s2, "0123456789");
 
 	chunks1 = s1->nchunks;
@@ -676,10 +689,6 @@ TEST(tfw_str_insert, compound_insert)
 
 	EXPECT_ZERO(tfw_str_insert(str_pool, s1, s2, 3));
 	EXPECT_EQ(s1->nchunks, chunks1 + chunks2);
-	/*
-	 * Second string is inserted after 3rd chunk,
-	 * First 3 chunks of s1: 'a', 'bc', 'def'.
-	 */
 	EXPECT_TRUE(tfw_str_eq_cstr(s1, "abcdef0123456789ghijklmnop",
 				    SLEN("abcdef0123456789ghijklmnop"),
 				    0));
@@ -694,8 +703,8 @@ TEST(tfw_str_insert, out_of_range)
 
 	chunks2 = s2->nchunks;
 
-	EXPECT_NE(tfw_str_insert(str_pool, s1, s3, 2), 2);
-	EXPECT_NE(tfw_str_insert(str_pool, s2, s3, 2), chunks2 + 1);
+	EXPECT_NE(tfw_str_insert(str_pool, s1, s3, 2), 0);
+	EXPECT_NE(tfw_str_insert(str_pool, s2, s3, chunks2 + 1), 0);
 }
 
 TEST(tfw_strdup, plain)
@@ -1598,15 +1607,15 @@ TEST_SUITE(tfw_str)
 	TEST_RUN(tfw_strcat, plain);
 	TEST_RUN(tfw_strcat, compound);
 
+	TEST_RUN(tfw_strdup, plain);
+	TEST_RUN(tfw_strdup, compound);
+
 	TEST_RUN(tfw_str_insert, plain_prepend);
 	TEST_RUN(tfw_str_insert, plain_append);
 	TEST_RUN(tfw_str_insert, compound_prepend);
 	TEST_RUN(tfw_str_insert, compound_append);
 	TEST_RUN(tfw_str_insert, compound_insert);
 	TEST_RUN(tfw_str_insert, out_of_range);
-
-	TEST_RUN(tfw_strdup, plain);
-	TEST_RUN(tfw_strdup, compound);
 
 	TEST_RUN(tfw_stricmp, returns_true_only_for_equal_tfw_strs);
 	TEST_RUN(tfw_stricmp, handles_plain_and_compound_strs);


### PR DESCRIPTION
Fix #639 If response has no framing information, server closes the connection to indicate message end. There is three ways how Tempesta can forward this message to the client:
- Forward as is and close connection. It's the worst variant, there can be newer requests from that client already forwarded to backends and will be discarded.
- Add `Content-Length` header. Better, but still problematic solution: the message must be fully assembled to supply valid content-length value. This is current approach.
- Transform message to `chunked` encoding. No need to assemlbe message fully, and it's possible to stream the message by parts.  This is the approach in the patch set.