### PR TITLE
fix tail length calculation in tfw_hash_str()

### DIFF
--- a/tempesta_fw/hash.c
+++ b/tempesta_fw/hash.c
@@ -61,7 +61,7 @@ tfw_hash_str(const TfwStr *str)
 			}
 
 			__hash_calc(&crc0, &crc1, p, e - p);
-			tail = c->len & 0xf;
+			tail = (e - p) & 0xf;
 next_chunk:
 			++c;
 		}

--- a/tempesta_fw/t/unit/test_hash.c
+++ b/tempesta_fw/t/unit/test_hash.c
@@ -62,43 +62,43 @@ TEST(tfw_hash_str, calcs_diff_hash_for_diff_str)
 
 TEST(tfw_hash_str, calcs_same_hash_for_diff_chunks_n)
 {
-	unsigned long h1, h2, h3;
+	const char data_const[] = "The quick brown fox jumps over the lazy dog";
+	size_t len = sizeof(data_const) - 1;
+	char *data = (char *)data_const;
+	TfwStr s_single_piece = {.data = data, .len = len};
+	int a1, a2;
+	unsigned long hash_fast_expected = tfw_hash_str(&s_single_piece);
+	unsigned long hash_fast;
+	unsigned int hash_crc32_expected = tfw_str_crc32_calc(&s_single_piece);
+	unsigned int hash_crc32;
 
-	TfwStr s1 = { .len = 17, .data = (void *)"Host: example.com" };
+	/* Iterate over all possible splits by two points. */
+	for (a1 = 0; a1 < len; a1++) {
+		for (a2 = a1; a2 < len; a2++) {
+			TfwStr s = {
+				.chunks = (TfwStr[]){
+					{.data = data,      .len = a1 - 0},
+					{.data = data + a1, .len = a2 - a1},
+					{.data = data + a2, .len = len - a2},
+				},
+				.nchunks = 3,
+				.len = len,
+			};
 
-	TfwStr s2c1 = {	.len = 14, .data = (void *)"Host: example." };
-	TfwStr s2c2 = {	.len = 3, .data = (void *)"com" };
-	TfwStr s2chunks[] = { s2c1, s2c2 };
-	TfwStr s2 = {
-		.len = 14 + 3,
-		.chunks = s2chunks
-	};
+			EXPECT_EQ(s.chunks[0].len + s.chunks[1].len +
+				  s.chunks[2].len, len);
 
-	TfwStr s3c1 = {	.len = 1, .data = (void *)"H" };
-	TfwStr s3c2 = {	.len = 0, .data = (void *)"" };
-	TfwStr s3c3 = {	.len = 3, .data = (void *)"ost" };
-	TfwStr s3c4 = {	.len = 1, .data = (void *)":" };
-	TfwStr s3c5 = {	.len = 12, .data = (void *)" example.com" };
-	TfwStr s3c6 = {	.len = 0, .data = NULL };
-	TfwStr s3chunks[] = { s3c1, s3c2, s3c3, s3c4, s3c5, s3c6 };
-	TfwStr s3 = {
-		.len = 1 + 0 + 3 + 1 + 12 + 0,
-		.chunks = s3chunks
-	};
+			hash_fast = tfw_hash_str(&s);
+			EXPECT_EQ(hash_fast, hash_fast_expected);
+			if (hash_fast != hash_fast_expected)
+				return;
 
-	s2.nchunks = 2;
-	s3.nchunks = 6;
-
-	h1 = tfw_hash_str(&s1);
-	h2 = tfw_hash_str(&s2);
-	h3 = tfw_hash_str(&s3);
-
-	EXPECT_EQ(h1, h2);
-	EXPECT_EQ(h1, h3);
-	EXPECT_EQ(h2, h1);
-	EXPECT_EQ(h2, h3);
-	EXPECT_EQ(h3, h1);
-	EXPECT_EQ(h3, h2);
+			hash_crc32 = tfw_str_crc32_calc(&s);
+			EXPECT_EQ(hash_crc32, hash_crc32_expected);
+			if (hash_crc32 != hash_crc32_expected)
+				return;
+		}
+	}
 }
 
 TEST(tfw_hash_str, hashes_all_chars)


### PR DESCRIPTION
`tfw_hash_str()` tries to hash strings in blocks of 16 bytes. To achieve that it tracks the number of remainder bytes, and then computes hashes byte-by-byte until total number of bytes processed becomes a multiple of 16. Since that effectively cuts the size of the current piece, remaining length (`e - p`) should be used instead of the chunk length (`c->len`) in tail length calculation for the next round. Existing test wasn't reproducing conditions to trigger the issue, so it was also updated.