### PR TITLE
tls: stop changing io->rlen at buffer end

### DIFF
--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -360,13 +360,14 @@ enum {
 #define TTLS_HS_FSM_FINISH()						\
 	T_FSM_FINISH(r, tls->state);					\
 	*read += p - buf;						\
-	io->rlen += p - buf;
+	io->rlen += p - state_p;
 
 /* Move to @st if we have some bytes to process. */
 #define TTLS_HS_FSM_MOVE(st)						\
 do {									\
 	WARN_ON_ONCE(p - buf > len);					\
 	io->rlen = 0;							\
+	state_p = p;							\
 	T_FSM_MOVE(st, if (unlikely(p - buf >= len)) T_FSM_EXIT(); );	\
 } while (0)
 

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1421,6 +1421,7 @@ ttls_parse_certificate(TlsCtx *tls, unsigned char *buf, size_t len,
 	TlsSess *sess = &tls->sess;
 	struct page *pg;
 	unsigned char *p = buf;
+	unsigned char *state_p = buf;
 	T_FSM_INIT(ttls_substate(tls), "TLS ClientCertificate");
 
 	BUG_ON(io->msgtype != TTLS_MSG_HANDSHAKE);


### PR DESCRIPTION
`io->rlen` is used to track how many bytes were processed by a particular FSM state. It should not be touched when we exit the state machine in `TTLS_HS_FSM_FINISH()`.

Having `io->rlen` increased in `TTLS_HS_FSM_FINISH()` causes #1187. Here is why.

Let's assume we are entering `T_FSM_STATE(TTLS_CH_HS_SESS)` and there are some unprocessed data bytes left. Say, it's `10`. We copy ten bytes of session ID into the `tls->sess.id`, then increase `io->rlen` by `10`, making it `10`. As `10` bytes are not the full session ID, we call `T_FSM_EXIT()`, which jumps out of state machine, causing `io->rlen` to be increased by size of data processed so far, which may be about 50 bytes. `io->rlen` becomes `60`. Next time we enter state machine, statement `BUG_ON(io->rlen >= tls->sess.id_len);` triggers.

(related: #1187)