### PR TITLE
Fix farious frang errors

### DIFF
--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -928,6 +928,7 @@
 #
 # Syntax:
 #   frang_limits {
+#       ip_block off|on;
 #       request_rate NUM;
 #       request_burst NUM;
 #       connection_rate NUM;
@@ -938,6 +939,9 @@
 #       http_uri_len NUM;
 #       http_field_len NUM;
 #       http_body_len NUM;
+#       http_header_cnt NUM;
+#       http_header_chunk_cnt NUM;
+#       http_body_chunk_cnt NUM;
 #       http_host_required true|false;
 #       http_methods [METHOD]...;
 #       http_ct_required true|false;

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -921,7 +921,10 @@
 
 # TAG: frang_limits
 #
-# The section containing static limits for the classifier.
+# The section containing static limits for the classifier. Can apper at top
+# level, inside 'vhost' directive, inside 'location' directive. Once the
+# directive is listed in the configuration it redefine default vaues for
+# following and nested sections of 'vhost' and 'location' directives.
 #
 # Syntax:
 #   frang_limits {

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -921,9 +921,9 @@
 
 # TAG: frang_limits
 #
-# The section containing static limits for the classifier. Can apper at top
+# The section containing static limits for the classifier. Can appear at top
 # level, inside 'vhost' directive, inside 'location' directive. Once the
-# directive is listed in the configuration it redefine default vaues for
+# directive is listed in the configuration it redefines default values for the
 # following and nested sections of 'vhost' and 'location' directives.
 #
 # Syntax:

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta kernel library
  *
- * Copyright (C) 2015-2018 Tempesta Technologies, INC.
+ * Copyright (C) 2015-2019 Tempesta Technologies, INC.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta kernel library
  *
- * Copyright (C) 2015-2018 Tempesta Technologies, INC.
+ * Copyright (C) 2015-2019 Tempesta Technologies, INC.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -404,6 +404,7 @@ enum {
 /* Generic TfwCfgSpec->handler functions. */
 int tfw_cfg_set_bool(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_int(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
+int tfw_cfg_set_long(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_str(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_handle_children(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 void tfw_cfg_cleanup_children(TfwCfgSpec *cs);
@@ -414,6 +415,7 @@ int tfw_cfg_check_multiple_of(long value, int divisor);
 int tfw_cfg_check_val_n(const TfwCfgEntry *e, int val_n);
 int tfw_cfg_check_single_val(const TfwCfgEntry *e);
 int tfw_cfg_parse_int(const char *s, int *out_int);
+int tfw_cfg_parse_long(const char *s, long *out_long);
 int tfw_cfg_parse_uint(const char *s, unsigned int *out_uint);
 int tfw_cfg_parse_intvl(const char *s, unsigned long *i0, unsigned long *i1);
 int tfw_cfg_map_enum(const TfwCfgEnum mappings[],

--- a/tempesta_fw/client.c
+++ b/tempesta_fw/client.c
@@ -24,6 +24,7 @@
 #include <linux/slab.h>
 
 #include "lib/hash.h"
+#include "hash.h"
 #include "client.h"
 #include "connection.h"
 #include "log.h"
@@ -66,8 +67,6 @@ typedef struct {
 } TfwClientEntry;
 
 static TDB *client_db;
-
-unsigned long tfw_hash_str_len(const TfwStr *str, unsigned long str_len);
 
 /**
  * Called when a client socket is closed.

--- a/tempesta_fw/client.h
+++ b/tempesta_fw/client.h
@@ -43,5 +43,6 @@ int tfw_client_for_each(int (*fn)(void *));
 void tfw_client_set_expires_time(unsigned int expires_time);
 void tfw_cli_conn_release(TfwCliConn *cli_conn);
 int tfw_cli_conn_send(TfwCliConn *cli_conn, TfwMsg *msg);
+int tfw_cli_conn_close_all_sync(TfwClient *cli);
 
 #endif /* __TFW_CLIENT_H__ */

--- a/tempesta_fw/hash.c
+++ b/tempesta_fw/hash.c
@@ -73,9 +73,3 @@ next_chunk:
 
 	return (crc1 << 32) | crc0;
 }
-
-unsigned long
-tfw_hash_str(const TfwStr *str)
-{
-	return tfw_hash_str_len(str, ULONG_MAX);
-}

--- a/tempesta_fw/hash.h
+++ b/tempesta_fw/hash.h
@@ -1,5 +1,5 @@
 /**
- *		Tempesta kernel library
+ *		Tempesta FW
  *
  * Copyright (C) 2019 Tempesta Technologies, INC.
  *

--- a/tempesta_fw/hash.h
+++ b/tempesta_fw/hash.h
@@ -1,0 +1,29 @@
+/**
+ *		Tempesta kernel library
+ *
+ * Copyright (C) 2019 Tempesta Technologies, INC.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef __TFW_HASH_H__
+#define __TFW_HASH_H__
+
+#include "str.h"
+
+unsigned long tfw_hash_str_len(const TfwStr *str, unsigned long str_len);
+#define tfw_hash_str(str)     tfw_hash_str_len((str), ULONG_MAX)
+
+#endif /* __TFW_HASH_H__ */

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2270,7 +2270,7 @@ tfw_http_add_x_forwarded_for(TfwHttpMsg *hm)
 		TFW_ERR("can't add X-Forwarded-For header for %.*s to msg %p",
 			(int)(p - buf), buf, hm);
 	else
-		TFW_DBG2("added X-Forwarded-For header for %*s\n",
+		TFW_DBG2("added X-Forwarded-For header for %.*s\n",
 			 (int)(p - buf), buf);
 	return r;
 }

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3221,16 +3221,16 @@ next_msg:
 	 * - get vhost from the HTTP session information (by Sticky cookie);
 	 * - get Vhost according to TLS SNI header parsing.
 	 * But vhost returned from all that functions can be very different
-	 * depending on HTTP chain configuration due to it flexibility and
+	 * depending on HTTP chain configuration due to its flexibility and
 	 * client (attacker) behaviour.
-	 * The most secure and a slow way: compare all of them and reject if
-	 * at least some doesn't match. Can be too strict, service quality can
+	 * The most secure and slow way: compare all of them and reject if
+	 * at least some do not match. Can be too strict, service quality can
 	 * be degraded.
 	 * The fastest way: compute as minimum as possible: use TLS first
 	 * (anyway we use it to send right certificate), then cookie, then HTTP
 	 * chain. There can be possibility that a request will be forwarded to
 	 * a wrong server. May happen when a single certificate is used to
-	 * speak with multiple vhosts (multy-domain (SAN) certificate as
+	 * speak with multiple vhosts (multi-domain (SAN) certificate as
 	 * globally default TLS certificate in Tempesta config file).
 	 * The most reliable way: use the highest OSI level vhost: by HTTP
 	 * session, if no -> by http chain, if no -> by TLS conn.

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -26,6 +26,7 @@
 #include "lib/hash.h"
 #include "lib/str.h"
 #include "cache.h"
+#include "hash.h"
 #include "http_limits.h"
 #include "http_tbl.h"
 #include "http_parser.h"
@@ -335,8 +336,6 @@ tfw_http_prep_date(char *buf)
 {
 	tfw_http_prep_date_from(buf, tfw_current_timestamp());
 }
-
-unsigned long tfw_hash_str(const TfwStr *str);
 
 #define S_REDIR_302	S_302 S_CRLF
 #define S_REDIR_503	S_503 S_CRLF

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3213,6 +3213,28 @@ next_msg:
 	 *
 	 * In the same time location may differ between requests, so the
 	 * sticky module can't fill it.
+	 *
+	 * TODO:
+	 * There are multiple ways to get target vhost:
+	 * - search in HTTP chains (defined in the configuration by admin),
+	 * very slow on big configurations;
+	 * - get vhost from the HTTP session information (by Sticky cookie);
+	 * - get Vhost according to TLS SNI header parsing.
+	 * But vhost returned from all that functions can be very different
+	 * depending on HTTP chain configuration due to it flexibility and
+	 * client (attacker) behaviour.
+	 * The most secure and a slow way: compare all of them and reject if
+	 * at least some doesn't match. Can be too strict, service quality can
+	 * be degraded.
+	 * The fastest way: compute as minimum as possible: use TLS first
+	 * (anyway we use it to send right certificate), then cookie, then HTTP
+	 * chain. There can be possibility that a request will be forwarded to
+	 * a wrong server. May happen when a single certificate is used to
+	 * speak with multiple vhosts (multy-domain (SAN) certificate as
+	 * globally default TLS certificate in Tempesta config file).
+	 * The most reliable way: use the highest OSI level vhost: by HTTP
+	 * session, if no -> by http chain, if no -> by TLS conn.
+	 *
 	 */
 	if (!req->vhost) {
 		req->vhost = tfw_http_tbl_vhost((TfwMsg *)req, &block);

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -230,6 +230,8 @@ enum {
 	TFW_HTTP_B_CONN_EXTRA,
 	/* Chunked transfer encoding. */
 	TFW_HTTP_B_CHUNKED,
+	/* Message has chunked trailer headers part. */
+	TFW_HTTP_B_CHUNKED_TRAILER,
 	/* The message body is limited by the connection closing. */
 	TFW_HTTP_B_UNLIMITED,
 	/* Media type is multipart/form-data. */
@@ -238,6 +240,8 @@ enum {
 	TFW_HTTP_B_CT_MULTIPART_HAS_BOUNDARY,
 	/* Singular header presents more than once. */
 	TFW_HTTP_B_FIELD_DUPENTRY,
+	/* Message is fully parsed */
+	TFW_HTTP_B_FULLY_PARSED,
 
 	/* Request flags. */
 	TFW_HTTP_FLAGS_REQ,

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -1312,7 +1312,7 @@ static FrangGfsmHook frang_gfsm_hooks[] = {
 		.prio		= -1,
 		.hook_state	= TFW_HTTP_FSM_RESP_MSG_FWD,
 		.fsm_id		= TFW_FSM_FRANG_RESP,
-		.st0		= TFW_FRANG_RESP_FSM_INIT,
+		.st0		= TFW_FRANG_RESP_FSM_FWD,
 		.name		= "response_fwd",
 	},
 };

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -373,7 +373,7 @@ frang_conn_new(struct sock *sk)
 	 * TLS-enabled clients will use higher limits than non-TLS clients;
 	 * the same client can break security rules for one vhost, but be a
 	 * legitimate client for other vhosts, so it's a big question how to
-	 * block him by IP or by connection resets; if multy-domain certificate
+	 * block him by IP or by connection resets; if multi-domain certificate
 	 * (SAN) is configured, TLS clients will behave as non-TLS. Too
 	 * complicated for administrator to understand how client is blocked
 	 * and to configure it, while making some of the limits to be global
@@ -822,7 +822,7 @@ block:
  * recipient without buffering the entire response.
  *
  * RFC doesn't prohibit trailers in request, but it always speaks about
- * trailers in response context. But request with trailer headers
+ * trailers in response context. But requests with trailer headers
  * are valid http messages. Support for them is not documented,
  * and implementation-dependent. E.g. Apache doesn't care about trailer
  * headers, but ModSecurity for Apache does.

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -759,7 +759,7 @@ frang_http_req_incomplete_body_check(FrangAcc *ra, TfwFsmData *data,
 				     FrangGlobCfg *fg_cfg, FrangVhostCfg *f_cfg)
 {
 	TfwHttpReq *req = (TfwHttpReq *)data->req;
-	unsigned int body_len = f_cfg->http_body_len;
+	unsigned long body_len = f_cfg->http_body_len;
 	unsigned int bchunk_cnt = fg_cfg->http_bchunk_cnt;
 	unsigned long body_timeout = fg_cfg->clnt_body_timeout;
 	struct sk_buff *skb = data->skb;

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -264,7 +264,7 @@ typedef struct {
 do {									\
 	char abuf[TFW_ADDR_STR_BUF_SIZE] = {0};				\
 	tfw_addr_fmt(addr, TFW_NO_PORT, abuf);				\
-	TFW_DBG("frang: " fmt_msg, abuf, ##__VA_ARGS__);		\
+	T_DBG("frang: " fmt_msg, abuf, ##__VA_ARGS__);			\
 } while (0)
 #else
 #define frang_dbg(...)
@@ -348,7 +348,7 @@ frang_conn_new(struct sock *sk)
 	ss_getpeername(sk, &addr);
 	cli = tfw_client_obtain(addr, NULL, NULL, __frang_init_acc);
 	if (unlikely(!cli)) {
-		TFW_ERR("can't obtain a client for frang accounting\n");
+		T_ERR("can't obtain a client for frang accounting\n");
 		tfw_vhost_put(dflt_vh);
 		return TFW_BLOCK;
 	}
@@ -626,7 +626,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 
 		hdrhost = tfw_pool_alloc(req->pool, field.len + 1);
 		if (unlikely(!hdrhost)) {
-			TFW_ERR("Can not allocate memory\n");
+			T_ERR("Can not allocate memory\n");
 			return TFW_BLOCK;
 		}
 		tfw_str_to_cstr(&field, hdrhost, field.len + 1);
@@ -1292,7 +1292,7 @@ tfw_http_limits_hooks_register(void)
 						 h->hook_state, h->fsm_id,
 						 h->st0);
 		if (h->prio < 0) {
-			TFW_ERR_NL("frang: can't register %s hook\n", h->name);
+			T_ERR_NL("frang: can't register %s hook\n", h->name);
 			return -EINVAL;
 		}
 	}
@@ -1313,13 +1313,13 @@ tfw_http_limits_init(void)
 
 	r = tfw_gfsm_register_fsm(TFW_FSM_FRANG_REQ, frang_http_req_handler);
 	if (r) {
-		TFW_ERR_NL("frang: can't register request fsm\n");
+		T_ERR_NL("frang: can't register request fsm\n");
 		goto err_fsm;
 	}
 
 	r = tfw_gfsm_register_fsm(TFW_FSM_FRANG_RESP, frang_resp_handler);
 	if (r) {
-		TFW_ERR_NL("frang: can't register response fsm\n");
+		T_ERR_NL("frang: can't register response fsm\n");
 		goto err_fsm_resp;
 	}
 
@@ -1342,7 +1342,7 @@ err_fsm:
 void
 tfw_http_limits_exit(void)
 {
-	TFW_DBG("frang exit\n");
+	T_DBG("frang exit\n");
 
 	tfw_http_limits_hooks_remove();
 	tfw_gfsm_unregister_fsm(TFW_FSM_FRANG_RESP);

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -1050,6 +1050,8 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, TfwFsmData *data,
 
 	/* All limits are verified for current request. */
 	T_FSM_STATE(Frang_Req_Done) {
+		frang_dbg("checks done for client %s\n",
+			  &FRANG_ACC2CLI(ra)->addr);
 		tfw_gfsm_move(&conn->state, TFW_FRANG_REQ_FSM_DONE, data);
 		T_FSM_EXIT();
 	}

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -533,7 +533,7 @@ frang_http_methods(const TfwHttpReq *req, FrangAcc *ra, unsigned long m_mask)
 }
 
 static int
-frang_http_ct_check(const TfwHttpReq *req, FrangAcc *ra, FrangCtVal *ct_vals)
+frang_http_ct_check(const TfwHttpReq *req, FrangAcc *ra, FrangCtVals *ct_vals)
 {
 	TfwStr field, *s;
 	FrangCtVal *curr;
@@ -569,7 +569,7 @@ frang_http_ct_check(const TfwHttpReq *req, FrangAcc *ra, FrangCtVal *ct_vals)
 	 * switch between the two if performance is critical here,
 	 * but benchmarks should be done to measure the impact.
 	 */
-	for (curr = ct_vals; curr->str; ++curr) {
+	for (curr = ct_vals->vals; curr->str; ++curr) {
 		if (tfw_str_eq_cstr(&field, curr->str, curr->len,
 				    TFW_STR_EQ_PREFIX_CASEI))
 			return TFW_PASS;

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -197,9 +197,6 @@ static TempestaOps tempesta_ops = {
  * ------------------------------------------------------------------------
  */
 
-/* We account users with FRANG_FREQ frequency per second. */
-#define FRANG_FREQ	8
-
 typedef struct {
 	unsigned long	ts;
 	unsigned int	conn_new;
@@ -1104,11 +1101,13 @@ frang_resp_process(TfwHttpResp *resp)
 /**
  * Monotonically increasing time quantums. The configured @tframe
  * is divided by FRANG_FREQ slots to get the quantums granularity.
+ * To reduce calculations, tframe is already stored as result of multiplication
+ * operation, see __tfw_cfgop_frang_rsp_code_block().
  */
 static inline unsigned int
 frang_resp_quantum(unsigned short tframe)
 {
-	return jiffies * FRANG_FREQ / (tframe * HZ);
+	return jiffies / tframe;
 }
 
 static int

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -703,10 +703,6 @@ enum {
 	TFW_FRANG_RESP_FSM_DONE	= TFW_GFSM_FRANG_RESP_STATE(TFW_GFSM_STATE_LAST)
 };
 
-/* Extend basic FSM with necessary ad-hoc logic. */
-#define FSM_HDR_STATE(state)						\
-	((state > Frang_Req_Hdr_Start) && (state < Frang_Req_Hdr_NoState))
-
 #define __FRANG_FSM_MOVE(st)	T_FSM_MOVE(st, if (r) T_FSM_EXIT(); )
 
 #define __FRANG_FSM_JUMP_EXIT(st)					\
@@ -766,7 +762,6 @@ frang_http_req_incomplete_body_check(FrangAcc *ra, TfwFsmData *data,
 	unsigned int body_len = f_cfg->http_body_len;
 	unsigned int bchunk_cnt = fg_cfg->http_bchunk_cnt;
 	unsigned long body_timeout = fg_cfg->clnt_body_timeout;
-
 	struct sk_buff *skb = data->skb;
 
 	frang_dbg("check incomplete request body for client %s, acc=%p\n",

--- a/tempesta_fw/http_limits.h
+++ b/tempesta_fw/http_limits.h
@@ -131,7 +131,7 @@ typedef struct {
 
 /**
  * Global Frang limits. As a request is received, it's not possible to determine
- * it's target vhost or/and location until all the headers are parsed. Thus some
+ * its target vhost or/and location until all the headers are parsed. Thus some
  * limits can't be redefined for vhost or location and can exist only as
  * unique top-level limits.
  *
@@ -168,7 +168,9 @@ struct frang_global_cfg_t {
 };
 
 /**
- * Vhost|location -specific Frang directives.
+ * Vhost and location specific Frang limits. As soon as full headers set is
+ * received, it's possible to determine target vhost and location. The structure
+ * contains full effective set of limits for chosen vhost and location.
  *
  * @http_methods_mask	- Allowed HTTP request methods;
  * @http_uri_len	- Maximum allowed URI len;

--- a/tempesta_fw/http_limits.h
+++ b/tempesta_fw/http_limits.h
@@ -186,9 +186,9 @@ struct frang_global_cfg_t {
  */
 struct frang_vhost_cfg_t {
 	unsigned long		http_methods_mask;
+	unsigned long		http_body_len;
 	unsigned int		http_uri_len;
 	unsigned int		http_field_len;
-	unsigned int		http_body_len;
 	unsigned int		http_hdr_cnt;
 
 	FrangCtVal		*http_ct_vals;

--- a/tempesta_fw/http_limits.h
+++ b/tempesta_fw/http_limits.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/http_limits.h
+++ b/tempesta_fw/http_limits.h
@@ -124,10 +124,39 @@ typedef struct {
 	unsigned short	tf;
 } FrangHttpRespCodeBlock;
 
+/**
+ * Single allowed Content-Type value.
+ * @str			- pointer to allowed value;
+ * @len			- The pre-computed strlen(@str);
+ */
 typedef struct {
-	char   *str;
-	size_t len;	/* The pre-computed strlen(@str). */
+	char		*str;
+	size_t		len;
 } FrangCtVal;
+
+/**
+ * Variable-sized array of allowed Content-Type values. It's allocated by single
+ * memory piece to keep all the data as close as possible.
+ * @alloc_sz		- Full size of the structure;
+ * @vals		- Variable array of allowed values;
+ * @data		- Variable sized data area where @vals points to.
+ *
+ * Basically that will look like:
+ *   [@vals                                   ][@data               ]
+ *   [FrangCtVal, FrangCtVal, FrangCtVal, NULL][str1\0\str2\0\str3\0]
+ *           +         +         +              ^      ^      ^
+ *           |         |         |              |      |      |
+ *           +----------------------------------+      |      |
+ *                     |         |                     |      |
+ *                     +-------------------------------+      |
+ *                               |                            |
+ *                               +----------------------------+
+ */
+typedef struct {
+	size_t		alloc_sz;
+	FrangCtVal	*vals;
+	char		*data;
+} FrangCtVals;
 
 /**
  * Global Frang limits. As a request is received, it's not possible to determine
@@ -191,8 +220,7 @@ struct frang_vhost_cfg_t {
 	unsigned int		http_field_len;
 	unsigned int		http_hdr_cnt;
 
-	FrangCtVal		*http_ct_vals;
-	size_t			http_ct_vals_sz;
+	FrangCtVals		*http_ct_vals;
 	FrangHttpRespCodeBlock	*http_resp_code_block;
 
 	bool			http_ct_required;

--- a/tempesta_fw/http_limits.h
+++ b/tempesta_fw/http_limits.h
@@ -108,6 +108,9 @@ extern void tfw_classifier_unregister(void);
  * ------------------------------------------------------------------------
  */
 
+/* We account users with FRANG_FREQ frequency per second. */
+#define FRANG_FREQ	8
+
 /**
  * Response code block setting
  *

--- a/tempesta_fw/http_limits.h
+++ b/tempesta_fw/http_limits.h
@@ -195,6 +195,7 @@ struct frang_vhost_cfg_t {
 
 	bool			http_ct_required;
 	bool			http_host_required;
+	bool			http_trailer_split;
 };
 
 #endif /* __HTTP_LIMITS__ */

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -108,5 +108,6 @@ int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len,
 			unsigned int *parsed);
 int tfw_http_parse_terminate(TfwHttpMsg *hm);
+bool tfw_http_parse_is_done(TfwHttpMsg *hm);
 
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/tempesta_fw/http_tbl.c
+++ b/tempesta_fw/http_tbl.c
@@ -458,7 +458,7 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 	} else if ((chain = tfw_chain_lookup(action))) {
 		rule->act.type = TFW_HTTP_MATCH_ACT_CHAIN;
 		rule->act.chain = chain;
-	} else if ((vhost = tfw_vhost_lookup(action))) {
+	} else if ((vhost = tfw_vhost_lookup_reconfig(action))) {
 		rule->act.type = TFW_HTTP_MATCH_ACT_VHOST;
 		rule->act.vhost = vhost;
 	} else {
@@ -473,7 +473,7 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 		return -EINVAL;
 	}
 
-	if (vhost && !strcasecmp(vhost->name, TFW_VH_DFT_NAME))
+	if (vhost && !strcasecmp(vhost->name.data, TFW_VH_DFT_NAME))
 		tfw_table_reconfig->chain_dflt = true;
 
 	return 0;
@@ -551,7 +551,7 @@ tfw_http_tbl_cfgend(void)
 	if (tfw_table_reconfig->chain_dflt)
 		return 0;
 
-	if (!(vhost_dflt = tfw_vhost_lookup(TFW_VH_DFT_NAME)))
+	if (!(vhost_dflt = tfw_vhost_lookup_reconfig(TFW_VH_DFT_NAME)))
 		return 0;
 
 	rule = tfw_http_rule_new(chain, TFW_HTTP_MATCH_A_WILDCARD, 0);

--- a/tempesta_fw/http_tbl.c
+++ b/tempesta_fw/http_tbl.c
@@ -83,7 +83,7 @@
  *   - Extended string matching operators: "regex", "substring".
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/http_types.h
+++ b/tempesta_fw/http_types.h
@@ -21,10 +21,12 @@
 #define __TFW_HTTP_TYPES_H__
 
 /* Forward declaration of common HTTP types. */
-typedef struct tfw_http_sess_t	TfwHttpSess;
-typedef struct tfw_http_msg_t	TfwHttpMsg;
-typedef struct tfw_http_req_t	TfwHttpReq;
-typedef struct tfw_http_resp_t	TfwHttpResp;
-typedef struct tfw_vhost_t	TfwVhost;
+typedef struct tfw_http_sess_t		TfwHttpSess;
+typedef struct tfw_http_msg_t		TfwHttpMsg;
+typedef struct tfw_http_req_t		TfwHttpReq;
+typedef struct tfw_http_resp_t		TfwHttpResp;
+typedef struct tfw_vhost_t		TfwVhost;
+typedef struct frang_global_cfg_t	FrangGlobCfg;
+typedef struct frang_vhost_cfg_t	FrangCfg;
 
 #endif /* __TFW_HTTP_TYPES_H__ */

--- a/tempesta_fw/http_types.h
+++ b/tempesta_fw/http_types.h
@@ -25,5 +25,7 @@ typedef struct tfw_http_sess_t	TfwHttpSess;
 typedef struct tfw_http_msg_t	TfwHttpMsg;
 typedef struct tfw_http_req_t	TfwHttpReq;
 typedef struct tfw_http_resp_t	TfwHttpResp;
+typedef struct tfw_vhost_t	TfwVhost;
+
 
 #endif /* __TFW_HTTP_TYPES_H__ */

--- a/tempesta_fw/http_types.h
+++ b/tempesta_fw/http_types.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2018-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -26,6 +26,5 @@ typedef struct tfw_http_msg_t	TfwHttpMsg;
 typedef struct tfw_http_req_t	TfwHttpReq;
 typedef struct tfw_http_resp_t	TfwHttpResp;
 typedef struct tfw_vhost_t	TfwVhost;
-
 
 #endif /* __TFW_HTTP_TYPES_H__ */

--- a/tempesta_fw/http_types.h
+++ b/tempesta_fw/http_types.h
@@ -27,6 +27,6 @@ typedef struct tfw_http_req_t		TfwHttpReq;
 typedef struct tfw_http_resp_t		TfwHttpResp;
 typedef struct tfw_vhost_t		TfwVhost;
 typedef struct frang_global_cfg_t	FrangGlobCfg;
-typedef struct frang_vhost_cfg_t	FrangCfg;
+typedef struct frang_vhost_cfg_t	FrangVhostCfg;
 
 #endif /* __TFW_HTTP_TYPES_H__ */

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -297,9 +297,8 @@ __cli_conn_close_sync_cb(TfwConn *conn)
 
 /**
  * Asynchronously close all client connections. Some connection close requests
- * may be lost due to workqueue overrun. So the function must be closed
- * repeatedly to guarantee that all the connection was closed.
- *
+ * may be lost due to workqueue overrun. So the function must be called
+ * repeatedly until 0 is returned to guarantee that all connections are closed.
  */
 static int
 tfw_cli_conn_close_all(void *data)
@@ -311,10 +310,10 @@ tfw_cli_conn_close_all(void *data)
 }
 
 /**
- * Close all connections with given client, called on security events. Unlike
- * asynchronous function above, this one must guarantee that all the close
+ * Close all connections with a given client, called on security events. Unlike
+ * @tfw_cli_conn_close_all(), this one must guarantee that all the close
  * requests will be done. Attackers can spam Tempesta with lot of requests and
- * connections, trying to cause work queue overrun and delay of security events
+ * connections, trying to cause a work queue overrun and delay security events
  * handlers. To detach attackers efficiently, we have to use synchronous close.
  */
 int tfw_cli_conn_close_all_sync(TfwClient *cli)

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -295,6 +295,12 @@ __cli_conn_close_sync_cb(TfwConn *conn)
 	return tfw_connection_close(conn, true);
 }
 
+/**
+ * Asynchronously close all client connections. Some connection close requests
+ * may be lost due to workqueue overrun. So the function must be closed
+ * repeatedly to guarantee that all the connection was closed.
+ *
+ */
 static int
 tfw_cli_conn_close_all(void *data)
 {
@@ -304,6 +310,13 @@ tfw_cli_conn_close_all(void *data)
 	return tfw_peer_for_each_conn(cli, conn, list, __cli_conn_close_cb);
 }
 
+/**
+ * Close all connections with given client, called on security events. Unlike
+ * asynchronous function above, this one must guarantee that all the close
+ * requests will be done. Attackers can spam Tempesta with lot of requests and
+ * connections, trying to cause work queue overrun and delay of security events
+ * handlers. To detach attackers efficiently, we have to use synchronous close.
+ */
 int tfw_cli_conn_close_all_sync(TfwClient *cli)
 {
 	TfwConn *conn;

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -290,12 +290,26 @@ __cli_conn_close_cb(TfwConn *conn)
 }
 
 static int
+__cli_conn_close_sync_cb(TfwConn *conn)
+{
+	return tfw_connection_close(conn, true);
+}
+
+static int
 tfw_cli_conn_close_all(void *data)
 {
 	TfwClient *cli = (TfwClient *)data;
 	TfwConn *conn;
 
 	return tfw_peer_for_each_conn(cli, conn, list, __cli_conn_close_cb);
+}
+
+int tfw_cli_conn_close_all_sync(TfwClient *cli)
+{
+	TfwConn *conn;
+
+	return tfw_peer_for_each_conn(cli, conn, list,
+				      __cli_conn_close_sync_cb);
 }
 
 /*

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -202,6 +202,8 @@ size_t tfw_ultohex(unsigned long ai, char *buf, unsigned int len);
 #define TFW_STR_HBH_HDR		0x10
 /* Weak identifier was set for Etag value. */
 #define TFW_STR_ETAG_WEAK	0x20
+/* Trailer  header. */
+#define TFW_STR_TRAILER		0x40
 
 /*
  * @ptr		- pointer to string data or array of nested strings;

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -116,8 +116,8 @@ test_sg_release_all_reconfig(void)
 	down_write(sg_sem);
 
 	/* Copy of hash_for_each_safe() which needs locally defined hash. */
-        for ( ; !sg && i < (1 << TFW_SG_HBITS); i++) {
-                hlist_for_each_entry_safe(sg, tmp, &sg_hash_reconfig[i],
+	for ( ; !sg && i < (1 << TFW_SG_HBITS); i++) {
+		hlist_for_each_entry_safe(sg, tmp, &sg_hash_reconfig[i],
 					  list_reconfig)
 		{
 			TfwServer *srv, *srv_tmp;

--- a/tempesta_fw/t/unit/test_hash.c
+++ b/tempesta_fw/t/unit/test_hash.c
@@ -22,9 +22,8 @@
 #include <linux/bug.h>
 
 #include "str.h"
+#include "hash.h"
 #include "test.h"
-
-unsigned long tfw_hash_str(const TfwStr *str);
 
 /* NOTE: hashing is a probabilistic thing. Some tests may give false results. */
 

--- a/tempesta_fw/t/unit/test_hash.c
+++ b/tempesta_fw/t/unit/test_hash.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/t/unit/test_http_tbl.c
+++ b/tempesta_fw/t/unit/test_http_tbl.c
@@ -31,6 +31,7 @@
 
 #include "sock_srv.c"
 #include "vhost.c"
+#include "tls_conf.c"
 #include "http_tbl.c"
 
 #include "cfg.h"

--- a/tempesta_fw/t/unit/test_http_tbl.c
+++ b/tempesta_fw/t/unit/test_http_tbl.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -118,7 +118,7 @@ next_msg:
 		return r;
 	case T_POSTPONE:
 		/*
-		 * No data to pass to upper protolos, could be a handshake
+		 * No data to pass to upper protocols, could be a handshake
 		 * message spread over several skbs and/or incomplete TLS
 		 * record. Typically, handshake messages fit the same skb and
 		 * all the messages are processed in one ss_skb_process() call.
@@ -233,7 +233,7 @@ int
 tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int limit)
 {
 	/*
-	 * TODO #1103 currently even trivail 500-bytes HTTP message generates
+	 * TODO #1103 currently even trivial 500-bytes HTTP message generates
 	 * 6 segment skb. After the fix the number probably should be decreased.
 	 */
 #define AUTO_SEGS_N	8

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -706,7 +706,7 @@ tfw_tls_get_if_configured(TlsCtx *ctx, TfwVhost *vhost)
 /**
  * Find matching vhost according to server name in SNI extension. The function
  * is also called if there is no SNI extension and fallback to some default
- * configuration is required. In the last case @data is NULL and @len is 0.
+ * configuration is required. In the latter case @data is NULL and @len is 0.
  */
 static int
 tfw_tls_sni(void *p_sni, TlsCtx *ctx, const unsigned char *data, size_t len)
@@ -721,7 +721,7 @@ tfw_tls_sni(void *p_sni, TlsCtx *ctx, const unsigned char *data, size_t len)
 		return -TTLS_ERR_BAD_HS_CLIENT_HELLO;
 
 	if (data && len)
-		 vhost = tfw_vhost_lookup(&srv_name);
+		vhost = tfw_vhost_lookup(&srv_name);
 	if (READ_ONCE(tfw_tls.allow_unknown_sni) && !vhost)
 		vhost = tfw_vhost_lookup_default();
 
@@ -731,9 +731,9 @@ tfw_tls_sni(void *p_sni, TlsCtx *ctx, const unsigned char *data, size_t len)
 	found = tfw_tls_get_if_configured(ctx, vhost);
 	if (DBG_TLS && found) {
 		vhost = tfw_vhost_from_tls_conf(ctx->peer_conf);
-		T_DBG2("%s: for server name '%.*s' vhost '%.*s' is chosen\n",
-		       __func__, PR_TFW_STR(&srv_name),
-		       PR_TFW_STR(&vhost->name));
+		T_DBG("%s: for server name '%.*s' vhost '%.*s' is chosen\n",
+		      __func__, PR_TFW_STR(&srv_name),
+		      PR_TFW_STR(&vhost->name));
 	}
 
 	return found ? 0 : -TTLS_ERR_CERTIFICATE_REQUIRED;

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -26,13 +26,12 @@
 #include "procfs.h"
 #include "http_frame.h"
 #include "tls.h"
+#include "vhost.h"
 
 static struct {
 	ttls_config	cfg;
-	ttls_x509_crt	crt;
-	ttls_pk_context	key;
-	unsigned long	crt_pg_addr;
-	unsigned int	crt_pg_order;
+	bool		allow_unknown_sni;
+	bool		fallback_to_dflt_sni;
 } tfw_tls;
 
 /**
@@ -546,6 +545,10 @@ tfw_tls_conn_dtor(void *c)
 	}
 
 	tfw_h2_context_clear(h2);
+	if (tls && tls->peer_conf) {
+		tfw_vhost_put(tfw_vhost_from_tls_conf(tls->peer_conf));
+		tls->peer_conf = NULL;
+	}
 	ttls_ctx_clear(tls);
 	tfw_cli_conn_release((TfwCliConn *)c);
 }
@@ -556,6 +559,8 @@ tfw_tls_conn_init(TfwConn *c)
 	int r;
 	TlsCtx *tls = tfw_tls_context(c);
 	TfwH2Ctx *h2 = tfw_h2_context(c);
+
+	T_DBG2("%s: conn=[%p]\n", __func__, c);
 
 	if ((r = ttls_ctx_init(tls, &tfw_tls.cfg))) {
 		TFW_ERR("TLS (%pK) setup failed (%x)\n", tls, -r);
@@ -655,6 +660,74 @@ static TfwConnHooks tls_conn_hooks = {
 	.conn_send	= tfw_tls_conn_send,
 };
 
+static bool
+tfw_tls_get_if_configured(TlsCtx *ctx, TfwVhost *vhost)
+{
+	TlsPeerCfg *cfg;
+
+	if (unlikely(!vhost))
+		return false;
+
+	cfg = &vhost->tls_cfg;
+	if (likely(cfg->key_cert)) {
+		ctx->peer_conf = cfg;
+		return true;
+	}
+
+	if (!READ_ONCE(tfw_tls.fallback_to_dflt_sni) || !vhost->vhost_dflt) {
+		tfw_vhost_put(vhost);
+		return false;
+	}
+
+	cfg = &vhost->vhost_dflt->tls_cfg;
+	if (!cfg->key_cert) {
+		tfw_vhost_put(vhost);
+		return false;
+	}
+
+	tfw_vhost_get(vhost->vhost_dflt);
+	ctx->peer_conf = cfg;
+	tfw_vhost_put(vhost);
+
+	return true;
+}
+
+/**
+ * Find matching vhost according to server name in SNI extension. The function
+ * is also called if there is no SNI extension and fallback to some default
+ * configuration is required. In the last case @data is NULL and @len is 0.
+ */
+static int
+tfw_tls_sni(void *p_sni, TlsCtx *ctx, const unsigned char *data, size_t len)
+{
+	const TfwStr srv_name = {.data = (unsigned char *)data, .len = len};
+	TfwVhost *vhost = NULL;
+	bool found;
+
+	T_DBG2("%s: server name '%.*s'\n",  __func__, (int)len, data);
+
+	if (WARN_ON_ONCE(ctx->peer_conf))
+		return -TTLS_ERR_BAD_HS_CLIENT_HELLO;
+
+	if (data && len)
+		 vhost = tfw_vhost_lookup(&srv_name);
+	if (READ_ONCE(tfw_tls.allow_unknown_sni) && !vhost)
+		vhost = tfw_vhost_lookup_default();
+
+	if (unlikely(!vhost))
+		return -TTLS_ERR_CERTIFICATE_REQUIRED;
+
+	found = tfw_tls_get_if_configured(ctx, vhost);
+	if (DBG_TLS && found) {
+		vhost = tfw_vhost_from_tls_conf(ctx->peer_conf);
+		T_DBG2("%s: for server name '%.*s' vhost '%.*s' is chosen\n",
+		       __func__, PR_TFW_STR(&srv_name),
+		       PR_TFW_STR(&vhost->name));
+	}
+
+	return found ? 0 : -TTLS_ERR_CERTIFICATE_REQUIRED;
+}
+
 /*
  * ------------------------------------------------------------------------
  *	TLS library configuration
@@ -672,11 +745,7 @@ tfw_tls_do_init(void)
 		TFW_ERR_NL("TLS: can't set config defaults (%x)\n", -r);
 		return -EINVAL;
 	}
-
-	/*
-	 * TODO #715 set SNI callback with ttls_conf_sni() to get per-vhost
-	 * certificates.
-	 */
+	ttls_conf_sni(&tfw_tls.cfg, tfw_tls_sni, NULL);
 
 	return 0;
 }
@@ -684,8 +753,6 @@ tfw_tls_do_init(void)
 static void
 tfw_tls_do_cleanup(void)
 {
-	ttls_x509_crt_free(&tfw_tls.crt);
-	ttls_pk_free(&tfw_tls.key);
 	ttls_config_free(&tfw_tls.cfg);
 }
 
@@ -697,9 +764,6 @@ tfw_tls_do_cleanup(void)
 /* TLS configuration state. */
 #define TFW_TLS_CFG_F_DISABLED	0U
 #define TFW_TLS_CFG_F_REQUIRED	1U
-#define TFW_TLS_CFG_F_CERT	2U
-#define TFW_TLS_CFG_F_CKEY	4U
-#define TFW_TLS_CFG_M_ALL	(TFW_TLS_CFG_F_CERT | TFW_TLS_CFG_F_CKEY)
 
 static unsigned int tfw_tls_cgf = TFW_TLS_CFG_F_DISABLED;
 
@@ -707,6 +771,13 @@ void
 tfw_tls_cfg_require(void)
 {
 	tfw_tls_cgf |= TFW_TLS_CFG_F_REQUIRED;
+}
+
+void
+tfw_tls_cfg_allow_fallback(bool allow_any_sni, bool fbk_dflt_vhost)
+{
+	WRITE_ONCE(tfw_tls.allow_unknown_sni, allow_any_sni);
+	WRITE_ONCE(tfw_tls.fallback_to_dflt_sni, fbk_dflt_vhost);
 }
 
 int
@@ -796,128 +867,6 @@ tfw_tls_free_alpn_protos(void)
 }
 
 static int
-tfw_tls_start(void)
-{
-	int r;
-
-	if (tfw_runstate_is_reconfig())
-		return 0;
-
-	ttls_conf_ca_chain(&tfw_tls.cfg, tfw_tls.crt.next, NULL);
-	r = ttls_conf_own_cert(&tfw_tls.cfg, &tfw_tls.crt, &tfw_tls.key);
-	if (r) {
-		TFW_ERR_NL("TLS: can't set own certificate (%x)\n", -r);
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-/**
- * Handle 'tls_certificate <path>' config entry.
- */
-static int
-tfw_cfgop_tls_certificate(TfwCfgSpec *cs, TfwCfgEntry *ce)
-{
-	int r;
-	void *crt_data;
-	size_t crt_size;
-
-	ttls_x509_crt_init(&tfw_tls.crt);
-
-	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
-			   cs->name);
-		return -EINVAL;
-	}
-	if (ce->val_n != 1) {
-		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
-			   cs->name, (int)ce->val_n);
-		return -EINVAL;
-	}
-
-	crt_data = tfw_cfg_read_file((const char *)ce->vals[0], &crt_size);
-	if (!crt_data) {
-		TFW_ERR_NL("%s: Can't read certificate file '%s'\n",
-			   ce->name, (const char *)ce->vals[0]);
-		return -EINVAL;
-	}
-
-	r = ttls_x509_crt_parse(&tfw_tls.crt, (unsigned char *)crt_data,
-				crt_size);
-	if (r) {
-		TFW_ERR_NL("%s: Invalid certificate specified (%x)\n",
-			   cs->name, -r);
-		free_pages((unsigned long)crt_data, get_order(crt_size));
-		return -EINVAL;
-	}
-	tfw_tls.crt_pg_addr = (unsigned long)crt_data;
-	tfw_tls.crt_pg_order = get_order(crt_size);
-	tfw_tls_cgf |= TFW_TLS_CFG_F_CERT;
-
-	return 0;
-}
-
-static void
-tfw_cfgop_cleanup_tls_certificate(TfwCfgSpec *cs)
-{
-	ttls_x509_crt_free(&tfw_tls.crt);
-	free_pages(tfw_tls.crt_pg_addr, tfw_tls.crt_pg_order);
-	tfw_tls_cgf &= ~TFW_TLS_CFG_F_CERT;
-}
-
-/**
- * Handle 'tls_certificate_key <path>' config entry.
- */
-static int
-tfw_cfgop_tls_certificate_key(TfwCfgSpec *cs, TfwCfgEntry *ce)
-{
-	int r;
-	void *key_data;
-	size_t key_size;
-
-	ttls_pk_init(&tfw_tls.key);
-
-	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
-			   cs->name);
-		return -EINVAL;
-	}
-	if (ce->val_n != 1) {
-		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
-			   cs->name, (int)ce->val_n);
-		return -EINVAL;
-	}
-
-	key_data = tfw_cfg_read_file((const char *)ce->vals[0], &key_size);
-	if (!key_data) {
-		TFW_ERR_NL("%s: Can't read certificate file '%s'\n",
-			   ce->name, (const char *)ce->vals[0]);
-		return -EINVAL;
-	}
-
-	r = ttls_pk_parse_key(&tfw_tls.key, (unsigned char *)key_data,
-			      key_size);
-	/* The key is copied, so free the paged data. */
-	free_pages((unsigned long)key_data, get_order(key_size));
-	if (r) {
-		TFW_ERR_NL("%s: Invalid private key specified (%x)\n",
-			   cs->name, -r);
-		return -EINVAL;
-	}
-	tfw_tls_cgf |= TFW_TLS_CFG_F_CKEY;
-
-	return 0;
-}
-
-static void
-tfw_cfgop_cleanup_tls_certificate_key(TfwCfgSpec *cs)
-{
-	ttls_pk_free(&tfw_tls.key);
-	tfw_tls_cgf &= ~TFW_TLS_CFG_F_CKEY;
-}
-
-static int
 tfw_tls_cfgend(void)
 {
 	if (!(tfw_tls_cgf & TFW_TLS_CFG_F_REQUIRED)) {
@@ -926,44 +875,17 @@ tfw_tls_cfgend(void)
 				    " configuration ignored\n");
 		return 0;
 	}
-	if (!(tfw_tls_cgf & TFW_TLS_CFG_F_CERT)) {
-		TFW_ERR_NL("TLS: please specify a certificate with"
-			   " tls_certificate configuration option\n");
-		return -EINVAL;
-	}
-	if (!(tfw_tls_cgf & TFW_TLS_CFG_F_CKEY)) {
-		TFW_ERR_NL("TLS: please specify a certificate key with"
-			   " tls_certificate_key configuration option\n");
-		return -EINVAL;
-	}
 
 	return 0;
 }
 
 static TfwCfgSpec tfw_tls_specs[] = {
-	{
-		.name = "tls_certificate",
-		.deflt = NULL,
-		.handler = tfw_cfgop_tls_certificate,
-		.allow_none = true,
-		.allow_repeat = false,
-		.cleanup = tfw_cfgop_cleanup_tls_certificate,
-	},
-	{
-		.name = "tls_certificate_key",
-		.deflt = NULL,
-		.handler = tfw_cfgop_tls_certificate_key,
-		.allow_none = true,
-		.allow_repeat = false,
-		.cleanup = tfw_cfgop_cleanup_tls_certificate_key,
-	},
 	{ 0 }
 };
 
 TfwMod tfw_tls_mod = {
 	.name	= "tls",
 	.cfgend = tfw_tls_cfgend,
-	.start	= tfw_tls_start,
 	.specs	= tfw_tls_specs,
 };
 

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -40,7 +40,7 @@
  *			  vhost chosen by server name tls extension.
  */
 static struct {
-	ttls_config	cfg;
+	TlsCfg		cfg;
 	bool		allow_unknown_sni;
 	bool		fallback_to_dflt_sni;
 } tfw_tls;

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -28,6 +28,17 @@
 #include "tls.h"
 #include "vhost.h"
 
+/**
+ * Global level TLS configuration.
+ *
+ * @cfg			- common tls configuration for all vhosts;
+ * @allow_unknown_sni	- if server name requested by client is not known
+ *			  (no such vhost), or client doesn't provide server
+ *			  name extension, use global-level certificates
+ *			  for the connection.
+ * @fallback_to_dflt_sni - use global-level certificates if no provided by
+ *			  vhost chosen by server name tls extension.
+ */
 static struct {
 	ttls_config	cfg;
 	bool		allow_unknown_sni;

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -44,7 +44,6 @@ enum {
 
 void tfw_tls_cfg_require(void);
 void tfw_tls_cfg_configured(bool global);
-void tfw_tls_cfg_allow_fallback(bool allow_any_sni, bool fbk_dflt_vhost);
 int tfw_tls_cfg_alpn_protos(const char *cfg_str);
 void tfw_tls_free_alpn_protos(void);
 int tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int limit);

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -43,6 +43,7 @@ enum {
 	 && tfw_tls_context(c)->alpn_chosen->id == TTLS_ALPN_ID_HTTP2)
 
 void tfw_tls_cfg_require(void);
+void tfw_tls_cfg_allow_fallback(bool allow_any_sni, bool fbk_dflt_vhost);
 int tfw_tls_cfg_alpn_protos(const char *cfg_str);
 void tfw_tls_free_alpn_protos(void);
 int tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int limit);

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -43,6 +43,7 @@ enum {
 	 && tfw_tls_context(c)->alpn_chosen->id == TTLS_ALPN_ID_HTTP2)
 
 void tfw_tls_cfg_require(void);
+void tfw_tls_cfg_configured(bool global);
 void tfw_tls_cfg_allow_fallback(bool allow_any_sni, bool fbk_dflt_vhost);
 int tfw_tls_cfg_alpn_protos(const char *cfg_str);
 void tfw_tls_free_alpn_protos(void);

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -44,6 +44,7 @@ enum {
 
 void tfw_tls_cfg_require(void);
 void tfw_tls_cfg_configured(bool global);
+void tfw_tls_match_any_sni_to_dflt(bool match);
 int tfw_tls_cfg_alpn_protos(const char *cfg_str);
 void tfw_tls_free_alpn_protos(void);
 int tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int limit);

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -209,6 +209,8 @@ tfw_tls_cert_cfg_finish(TfwVhost *vhost)
 	TlsCertConf *curr_cert_conf;
 
 	BUG_ON(!vhost->tls_cfg.priv);
+	if (conf->certs_num)
+		tfw_tls_cfg_configured(tfw_vhost_is_default_reconfig(vhost));
 	if (conf->certs_num >= TLS_CONF_CERT_NUM)
 		return 0;
 	curr_cert_conf = &conf->certs[conf->certs_num];

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -1,0 +1,255 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2019 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include "tls_conf.h"
+#include "tls.h"
+#include "vhost.h"
+
+#define TFW_TLS_CFG_F_EMPY	0U
+#define TFW_TLS_CFG_F_CERT	1U
+#define TFW_TLS_CFG_F_CKEY	2U
+
+#define TLS_CONF_CERT_NUM	8
+
+typedef struct {
+	ttls_x509_crt	crt;
+	ttls_pk_context	key;
+	unsigned long	crt_pg_addr;
+	unsigned int	crt_pg_order;
+	unsigned int	conf_stage;
+} TlsCertConf;
+
+typedef struct {
+	TlsCertConf	certs[TLS_CONF_CERT_NUM];
+	unsigned int	certs_num;
+	unsigned int	init_done:1;
+} TlsConfEntry;
+
+size_t tfw_tls_vhost_priv_data_sz(void)
+{
+	return sizeof(TlsConfEntry);
+}
+
+static int
+tfw_tls_peer_tls_init(TfwVhost *vhost)
+{
+	TlsConfEntry *conf = (TlsConfEntry *)vhost->tls_cfg.priv;
+	int r;
+
+	if (conf->init_done)
+		return 0;
+
+	if ((r = ttls_config_peer_defaults(&vhost->tls_cfg, TTLS_IS_SERVER)))
+		return r;
+	conf->init_done = 1;
+
+	return 0;
+}
+
+static inline TlsCertConf *
+tfw_tls_get_cert_conf(TfwVhost *vhost, unsigned int directive)
+{
+	TlsConfEntry *conf = (TlsConfEntry *)vhost->tls_cfg.priv;
+	TlsCertConf *curr_cert_conf;
+
+	if (conf->certs_num >= TLS_CONF_CERT_NUM) {
+		T_WARN_NL("Too many certificates defined!\n");
+		return NULL;
+	}
+
+	curr_cert_conf = &conf->certs[conf->certs_num];
+	switch (directive)
+	{
+	case TFW_TLS_CFG_F_CERT:
+		if (curr_cert_conf->conf_stage & TFW_TLS_CFG_F_CERT) {
+			T_WARN_NL("'tls_certificate_key' directive was expected,"
+				  "but 'tls_certificate' was found first.\n");
+			curr_cert_conf = NULL;
+		}
+		break;
+
+	case TFW_TLS_CFG_F_CKEY:
+		if (!(curr_cert_conf->conf_stage & TFW_TLS_CFG_F_CERT)) {
+			T_WARN_NL("'tls_certificate_key' directive was found"
+				  "before 'tls_certificate' has encountered.\n");
+			curr_cert_conf = NULL;
+		}
+		break;
+
+	default:
+		BUG();
+	}
+	if (curr_cert_conf)
+		curr_cert_conf->conf_stage |= directive;
+
+	return curr_cert_conf;
+}
+
+/**
+ * Handle 'tls_certificate <path>' config entry.
+ */
+int
+tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	int r;
+	void *crt_data;
+	size_t crt_size;
+	TlsCertConf *conf;
+
+	BUG_ON(!vhost->tls_cfg.priv);
+	if ((r = tfw_tls_peer_tls_init(vhost)))
+		return r;
+	if (!(conf = tfw_tls_get_cert_conf(vhost, TFW_TLS_CFG_F_CERT)))
+		return -EINVAL;
+
+	if (tfw_cfg_check_single_val(ce))
+		return -EINVAL;
+
+	ttls_x509_crt_init(&conf->crt);
+	crt_data = tfw_cfg_read_file(ce->vals[0], &crt_size);
+	if (!crt_data) {
+		TFW_ERR_NL("%s: Can't read certificate file '%s'\n",
+			   ce->name, ce->vals[0]);
+		return -EINVAL;
+	}
+
+	r = ttls_x509_crt_parse(&conf->crt, crt_data, crt_size);
+	if (r) {
+		TFW_ERR_NL("%s: Invalid certificate specified (%x)\n",
+			   cs->name, -r);
+		free_pages((unsigned long)crt_data, get_order(crt_size));
+		return -EINVAL;
+	}
+	conf->crt_pg_addr = (unsigned long)crt_data;
+	conf->crt_pg_order = get_order(crt_size);
+
+	return 0;
+}
+
+int
+tfw_tls_cert_cfg_finish_cert(TfwVhost *vhost)
+{
+	TlsConfEntry *conf_entry = (TlsConfEntry *)vhost->tls_cfg.priv;
+	TlsCertConf *conf = &conf_entry->certs[conf_entry->certs_num];
+	int r;
+
+	r = ttls_conf_own_cert(&vhost->tls_cfg, &conf->crt, &conf->key,
+			       conf->crt.next, NULL);
+	if (r) {
+		TFW_ERR_NL("TLS: can't set own certificate (%x)\n", r);
+		return -EINVAL;
+	}
+	conf_entry->certs_num++;
+
+	return 0;
+}
+
+/**
+ * Handle 'tls_certificate_key <path>' config entry.
+ */
+int
+tfw_tls_set_cert_key(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	int r;
+	void *key_data;
+	size_t key_size;
+	TlsCertConf *conf;
+
+	BUG_ON(!vhost->tls_cfg.priv);
+	if (tfw_cfg_check_single_val(ce))
+		return -EINVAL;
+	if (!(conf = tfw_tls_get_cert_conf(vhost, TFW_TLS_CFG_F_CKEY)))
+		return -EINVAL;
+
+	ttls_pk_init(&conf->key);
+
+	key_data = tfw_cfg_read_file(ce->vals[0], &key_size);
+	if (!key_data) {
+		TFW_ERR_NL("%s: Can't read certificate file '%s'\n",
+			   ce->name, ce->vals[0]);
+		return -EINVAL;
+	}
+
+	r = ttls_pk_parse_key(&conf->key, key_data, key_size);
+	/* The key is copied, so free the paged data. */
+	free_pages((unsigned long)key_data, get_order(key_size));
+	if (r) {
+		TFW_ERR_NL("%s: Invalid private key specified (%x)\n",
+			   cs->name, -r);
+		return -EINVAL;
+	}
+
+	if ((r = tfw_tls_cert_cfg_finish_cert(vhost)))
+		return r;
+
+	return 0;
+}
+
+int
+tfw_tls_cert_cfg_finish(TfwVhost *vhost)
+{
+	TlsConfEntry *conf = (TlsConfEntry *)vhost->tls_cfg.priv;
+	TlsCertConf *curr_cert_conf;
+
+	BUG_ON(!vhost->tls_cfg.priv);
+	if (conf->certs_num >= TLS_CONF_CERT_NUM)
+		return 0;
+	curr_cert_conf = &conf->certs[conf->certs_num];
+	if (curr_cert_conf->conf_stage) {
+		TFW_ERR_NL("TLS: certificate configuration is not done, "
+			   "directive 'tls_certificate_key'is missing. \n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static void
+tfw_tls_cleanup_tls_cert(TlsCertConf *conf)
+{
+	if (!(conf->conf_stage & TFW_TLS_CFG_F_CERT))
+		return;
+	ttls_x509_crt_free(&conf->crt);
+	free_pages(conf->crt_pg_addr, conf->crt_pg_order);
+}
+
+static void
+tfw_tls_cleanup_tls_ckey(TlsCertConf *conf)
+{
+	if (!(conf->conf_stage & TFW_TLS_CFG_F_CKEY))
+		return;
+	ttls_pk_free(&conf->key);
+}
+
+void
+tfw_tls_cert_clean(TfwVhost *vhost)
+{
+	TlsConfEntry *conf = (TlsConfEntry *)vhost->tls_cfg.priv;
+	int i;
+
+	ttls_key_cert_free(vhost->tls_cfg.key_cert);
+	for (i = 0; i < TLS_CONF_CERT_NUM; i++) {
+		TlsCertConf *cconf = &conf->certs[i];
+
+		tfw_tls_cleanup_tls_cert(cconf);
+		tfw_tls_cleanup_tls_ckey(cconf);
+	}
+	ttls_config_peer_free(&vhost->tls_cfg);
+}

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -50,7 +50,7 @@ size_t tfw_tls_vhost_priv_data_sz(void)
 static int
 tfw_tls_peer_tls_init(TfwVhost *vhost)
 {
-	TlsConfEntry *conf = (TlsConfEntry *)vhost->tls_cfg.priv;
+	TlsConfEntry *conf = vhost->tls_cfg.priv;
 	int r;
 
 	if (conf->init_done)
@@ -66,7 +66,7 @@ tfw_tls_peer_tls_init(TfwVhost *vhost)
 static inline TlsCertConf *
 tfw_tls_get_cert_conf(TfwVhost *vhost, unsigned int directive)
 {
-	TlsConfEntry *conf = (TlsConfEntry *)vhost->tls_cfg.priv;
+	TlsConfEntry *conf = vhost->tls_cfg.priv;
 	TlsCertConf *curr_cert_conf;
 
 	if (conf->certs_num >= TLS_CONF_CERT_NUM) {
@@ -146,7 +146,7 @@ tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 int
 tfw_tls_cert_cfg_finish_cert(TfwVhost *vhost)
 {
-	TlsConfEntry *conf_entry = (TlsConfEntry *)vhost->tls_cfg.priv;
+	TlsConfEntry *conf_entry = vhost->tls_cfg.priv;
 	TlsCertConf *conf = &conf_entry->certs[conf_entry->certs_num];
 	int r;
 
@@ -205,7 +205,7 @@ tfw_tls_set_cert_key(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 int
 tfw_tls_cert_cfg_finish(TfwVhost *vhost)
 {
-	TlsConfEntry *conf = (TlsConfEntry *)vhost->tls_cfg.priv;
+	TlsConfEntry *conf = vhost->tls_cfg.priv;
 	TlsCertConf *curr_cert_conf;
 
 	BUG_ON(!vhost->tls_cfg.priv);
@@ -214,7 +214,7 @@ tfw_tls_cert_cfg_finish(TfwVhost *vhost)
 	curr_cert_conf = &conf->certs[conf->certs_num];
 	if (curr_cert_conf->conf_stage) {
 		TFW_ERR_NL("TLS: certificate configuration is not done, "
-			   "directive 'tls_certificate_key'is missing. \n");
+			   "directive 'tls_certificate_key' is missing. \n");
 		return -EINVAL;
 	}
 
@@ -241,7 +241,7 @@ tfw_tls_cleanup_tls_ckey(TlsCertConf *conf)
 void
 tfw_tls_cert_clean(TfwVhost *vhost)
 {
-	TlsConfEntry *conf = (TlsConfEntry *)vhost->tls_cfg.priv;
+	TlsConfEntry *conf = vhost->tls_cfg.priv;
 	int i;
 
 	ttls_key_cert_free(vhost->tls_cfg.key_cert);

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -91,6 +91,12 @@ tfw_tls_get_cert_conf(TfwVhost *vhost, unsigned int directive)
 				  "before 'tls_certificate' has encountered.\n");
 			curr_cert_conf = NULL;
 		}
+		if (curr_cert_conf->conf_stage & TFW_TLS_CFG_F_CKEY) {
+			T_WARN_NL("'tls_certificate_key' directive was found"
+				  "twice for the same 'tls_certificate' "
+				  "directive.\n");
+			curr_cert_conf = NULL;
+		}
 		break;
 
 	default:

--- a/tempesta_fw/tls_conf.h
+++ b/tempesta_fw/tls_conf.h
@@ -1,0 +1,35 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2019 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_TLS_CONF_H__
+#define __TFW_TLS_CONF_H__
+
+#include "str.h"
+#include "http_types.h"
+#include "cfg.h"
+
+int tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce);
+int tfw_tls_set_cert_key(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce);
+
+int tfw_tls_cert_cfg_finish(TfwVhost *vhost);
+void tfw_tls_cert_clean(TfwVhost *vhost);
+
+size_t tfw_tls_vhost_priv_data_sz(void);
+
+#endif /* __TFW_TLS_CONF_H__ */

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1922,6 +1922,20 @@ tfw_cfgop_frang_ct_required(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
+tfw_cfgop_frang_trailer_split(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	int r;
+	FrangCfg *cfg = tfw_cfgop_frang_get_cfg();
+
+	if (ce->dflt_value && cfg->http_trailer_split)
+		return 0;
+	cs->dest = &cfg->http_trailer_split;
+	r = tfw_cfg_set_bool(cs, ce);
+	cs->dest = NULL;
+	return r;
+}
+
+static int
 tfw_cfgop_frang_http_methods(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	FrangCfg *cfg = tfw_cfgop_frang_get_cfg();
@@ -2410,6 +2424,12 @@ static TfwCfgSpec tfw_global_frang_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
+		.name = "http_trailer_split_allowed",
+		.deflt = "false",
+		.handler = tfw_cfgop_frang_trailer_split,
+		.allow_reconfig = true,
+	},
+	{
 		.name = "http_methods",
 		.deflt = "",
 		.handler = tfw_cfgop_frang_http_methods,
@@ -2529,6 +2549,12 @@ static TfwCfgSpec tfw_vhost_frang_specs[] = {
 		.name = "http_ct_required",
 		.deflt = "false",
 		.handler = tfw_cfgop_frang_ct_required,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "http_trailer_split_allowed",
+		.deflt = "false",
+		.handler = tfw_cfgop_frang_trailer_split,
 		.allow_reconfig = true,
 	},
 	{

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -2217,16 +2217,6 @@ tfw_vhost_start(void)
 {
 	TfwVhostList *vh_list;
 
-	if (!tfw_runstate_is_reconfig()) {
-		/* Convert Frang global timeouts to jiffies for convenience */
-		frang_cfg.clnt_hdr_timeout =
-			*(unsigned int *)&frang_cfg.clnt_hdr_timeout *
-			(unsigned long)HZ;
-		frang_cfg.clnt_body_timeout =
-			*(unsigned int *)&frang_cfg.clnt_body_timeout *
-			(unsigned long)HZ;
-	}
-
 	rcu_read_lock();
 	vh_list = rcu_dereference(tfw_vhosts);
 	rcu_read_unlock();

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -33,11 +33,11 @@
  * Control object for holding full set of virtual hosts specific for current
  * configuration/reconfiguration stage.
  *
- * @head	- List of configured virtual hosts.
  * @vhost_dflt	- Default virtual host with global policies (always present in
  *		  current configuration).
  * @expl_dflt	- Flag to indicate explicit configuration of default
  *		  virtual host.
+ * @vh_hash	- Hashtable with configured virtual hosts.
  */
 typedef struct {
 	TfwVhost	*vhost_dflt;
@@ -394,9 +394,11 @@ __tfw_vhost_lookup(TfwVhostList *vh_list, const TfwStr *name,
 	return NULL;
 }
 
-/*
- * Get vhost matching the specified name. Vhost's reference counter
- * is incremented in case of successful search.
+/**
+ * Find vhost named @name in the _currently parsed and not yet applied_
+ * configuration. The operation is safe to use in process context.
+ * If vhost is found, an additional reference is taken. Caller is responsible to
+ * release the reference after use.
  */
 TfwVhost *
 tfw_vhost_lookup_reconfig(const char *name)
@@ -406,6 +408,12 @@ tfw_vhost_lookup_reconfig(const char *name)
 				  tfw_vhost_name_match);
 }
 
+/**
+ * Find vhost in the _running_ configuration, matching name @name. The operation
+ * involves fast avx2 operations and can be done only in softirq context.
+ * If vhost is found, an additional reference is taken. Caller is responsible to
+ * release the reference after use.
+ */
 TfwVhost *
 tfw_vhost_lookup(const TfwStr *name)
 {

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1755,6 +1755,8 @@ __tfw_cfgop_frang_rsp_code_block(TfwCfgSpec *cs, TfwCfgEntry *ce,
 	 * closed
 	 */
 	tfw_client_set_expires_time(cb->tf);
+	/* Update time frame value to reduce calculations in hot-path. */
+	cb->tf = (cb->tf * HZ) / FRANG_FREQ;
 
 	return 0;
 }

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -297,20 +297,20 @@ tfw_vhost_get_srv_conn(TfwMsg *msg)
 
 	if (unlikely(!main_sg))
 		return NULL;
-	TFW_DBG2("vhost: use server group: '%s'\n", main_sg->name);
+	T_DBG2("vhost: use server group: '%s'\n", main_sg->name);
 
 	if (likely(main_sg->sched))
 		srv_conn = main_sg->sched->sched_sg_conn(msg, main_sg);
 
 	if (unlikely(!srv_conn && backup_sg && backup_sg->sched)) {
-		TFW_DBG("vhost: the main group is offline, use backup: '%s'\n",
-			backup_sg->name);
+		T_DBG("vhost: the main group is offline, use backup: '%s'\n",
+		      backup_sg->name);
 		srv_conn = backup_sg->sched->sched_sg_conn(msg, backup_sg);
 	}
 
 	if (unlikely(!srv_conn))
-		TFW_DBG2("vhost: Unable to select server from group '%s'\n",
-			 backup_sg ? backup_sg->name : main_sg->name);
+		T_DBG2("vhost: Unable to select server from group '%s'\n",
+		       backup_sg ? backup_sg->name : main_sg->name);
 
 	return srv_conn;
 }
@@ -587,12 +587,12 @@ tfw_cfgop_nonidempotent(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 		     < _TFW_HTTP_METH_COUNT);
 
 	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
-			   cs->name);
+		T_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			 cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 3) {
-		TFW_ERR_NL("%s: Invalid number of arguments.\n", cs->name);
+		T_ERR_NL("%s: Invalid number of arguments.\n", cs->name);
 		return -EINVAL;
 	}
 
@@ -600,8 +600,8 @@ tfw_cfgop_nonidempotent(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 	in_method = ce->vals[0];
 	ret = tfw_cfg_map_enum(tfw_method_enum, in_method, &method);
 	if (ret) {
-		TFW_ERR_NL("Unsupported HTTP method: '%s %s'\n",
-			   cs->name, in_method);
+		T_ERR_NL("Unsupported HTTP method: '%s %s'\n",
+			 cs->name, in_method);
 		return -EINVAL;
 	}
 
@@ -609,7 +609,7 @@ tfw_cfgop_nonidempotent(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 	in_op = ce->vals[1];
 	ret = tfw_cfg_map_enum(tfw_match_enum, in_op, &op);
 	if (ret) {
-		TFW_ERR_NL("Unsupported match OP: '%s %s'\n", cs->name, in_op);
+		T_ERR_NL("Unsupported match OP: '%s %s'\n", cs->name, in_op);
 		return -EINVAL;
 	}
 
@@ -623,10 +623,10 @@ tfw_cfgop_nonidempotent(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 	 */
 	vh_dflt = tfw_vhosts_reconfig->vhost_dflt;
 	if (tfw_nipdef_lookup_dup(loc, method, op, arg, len))
-		TFW_WARN_NL("%s: Duplicate entry in location '%s': "
-			    "'%s %s %s %s'\n", cs->name,
-			    loc == vh_dflt->loc_dflt ? "default" : loc->arg,
-			    cs->name, in_method, in_op, arg);
+		T_WARN_NL("%s: Duplicate entry in location '%s': "
+			  "'%s %s %s %s'\n", cs->name,
+			  loc == vh_dflt->loc_dflt ? "default" : loc->arg,
+			  cs->name, in_method, in_op, arg);
 
 	/*
 	 * Do not add a "duplicate" entry within a location. If the
@@ -675,12 +675,12 @@ tfw_cfgop_mod_hdr_add(TfwLocation *loc, const char *name, const char *value,
 	TfwHdrModsDesc *desc = &h_mods->hdrs[h_mods->sz];
 
 	if (h_mods->sz == TFW_USRHDRS_ARRAY_SZ) {
-		TFW_WARN_NL("Too lot of custom headers, %d supported.\n",
-			    TFW_USRHDRS_ARRAY_SZ);
+		T_WARN_NL("Too lot of custom headers, %d supported.\n",
+			  TFW_USRHDRS_ARRAY_SZ);
 		return -EINVAL;
 	}
 	if (!(hdr = tfw_http_msg_make_hdr(loc->hdrs_pool, name, value))) {
-		TFW_WARN_NL("Can't create header.\n");
+		T_WARN_NL("Can't create header.\n");
 		return -ENOMEM;
 	}
 	desc->hdr = hdr;
@@ -707,8 +707,8 @@ tfw_cfgop_mod_hdr(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc,
 	const char *value = NULL;
 
 	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
-			   cs->name);
+		T_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			 cs->name);
 		return -EINVAL;
 	}
 	switch (ce->val_n)
@@ -720,7 +720,7 @@ tfw_cfgop_mod_hdr(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc,
 			break;
 		/* Fall through */
 	default:
-		TFW_ERR_NL("%s: Invalid number of values.\n", cs->name);
+		T_ERR_NL("%s: Invalid number of values.\n", cs->name);
 		return -EINVAL;
 	}
 
@@ -884,13 +884,13 @@ tfw_cfgop_capolicy(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc, int cmd)
 	BUG_ON((cmd != TFW_D_CACHE_BYPASS) && (cmd != TFW_D_CACHE_FULFILL));
 
 	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
-			   cs->name);
+		T_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			 cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n < 2) {
-		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
-			   cs->name, (int)ce->val_n);
+		T_ERR_NL("%s: Invalid number of arguments: %d\n",
+			 cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
 
@@ -899,7 +899,7 @@ tfw_cfgop_capolicy(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc, int cmd)
 	/* Convert the match operator string to the enum value. */
 	ret = tfw_cfg_map_enum(tfw_match_enum, in_op, &op);
 	if (ret) {
-		TFW_ERR_NL("Unknown match OP: '%s %s'\n", cs->name, in_op);
+		T_ERR_NL("Unknown match OP: '%s %s'\n", cs->name, in_op);
 		return -EINVAL;
 	}
 
@@ -911,8 +911,8 @@ tfw_cfgop_capolicy(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc, int cmd)
 		len = strlen(arg);
 
 		if (tfw_capolicy_lookup(loc, cmd, op, arg, len)) {
-			TFW_WARN_NL("%s: Duplicate entry: '%s %s %s'\n",
-				    cs->name, cs->name, in_op, arg);
+			T_WARN_NL("%s: Duplicate entry: '%s %s %s'\n",
+				  cs->name, cs->name, in_op, arg);
 			continue;
 		}
 		if (loc->capo_sz == TFW_CAPOLICY_ARRAY_SZ)
@@ -1116,12 +1116,12 @@ tfw_cfgop_location_begin(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwVhost *vhost)
 	const char *in_op, *arg;
 
 	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+		T_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
 			   cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 2) {
-		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
+		T_ERR_NL("%s: Invalid number of arguments: %d\n",
 			   cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
@@ -1134,21 +1134,21 @@ tfw_cfgop_location_begin(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwVhost *vhost)
 	/* Convert the match operator string to the enum value. */
 	ret = tfw_cfg_map_enum(tfw_match_enum, in_op, &op);
 	if (ret) {
-		TFW_ERR_NL("%s: Unknown match OP: '%s %s %s'\n",
+		T_ERR_NL("%s: Unknown match OP: '%s %s %s'\n",
 			   cs->name, cs->name, in_op, arg);
 		return -EINVAL;
 	}
 
 	/* Make sure the location is not a duplicate. */
 	if (tfw_location_lookup(vhost, op, arg, len)) {
-		TFW_ERR_NL("%s: Duplicate entry: '%s %s %s'\n",
+		T_ERR_NL("%s: Duplicate entry: '%s %s %s'\n",
 			   cs->name, cs->name, in_op, arg);
 		return -EINVAL;
 	}
 
 
 	if (vhost->loc_sz == TFW_LOCATION_ARRAY_SZ) {
-		TFW_ERR_NL("%s: There is no empty slots in '%s' vhost to"
+		T_ERR_NL("%s: There is no empty slots in '%s' vhost to"
 			   " add new location: '%s %s %s'\n", cs->name,
 			   vhost->name.data, cs->name, in_op, arg);
 		return -EINVAL;
@@ -1157,7 +1157,7 @@ tfw_cfgop_location_begin(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwVhost *vhost)
 	/* Add new location and set it to be the current one. */
 	tfwcfg_this_location = tfw_location_new(vhost, op, arg, len);
 	if (!tfwcfg_this_location) {
-		TFW_ERR_NL("%s: Unable to create new location: '%s %s %s'\n",
+		T_ERR_NL("%s: Unable to create new location: '%s %s %s'\n",
 			   cs->name, cs->name, in_op, arg);
 		return -ENOMEM;
 	}
@@ -1193,7 +1193,7 @@ tfw_cfgop_in_location_finish(TfwCfgSpec *cs)
 	if (!tfw_vhost_is_default_reconfig(tfw_vhost_entry)
 	    && !tfwcfg_this_location->main_sg)
 	{
-		TFW_ERR_NL("Directive 'proxy_pass' is not specified for"
+		T_ERR_NL("Directive 'proxy_pass' is not specified for"
 			   " location (with arg '%s') inside not default"
 			   " vhost '%s'.\n", tfwcfg_this_location->arg,
 			   tfw_vhost_entry->name.data);
@@ -1295,7 +1295,7 @@ tfw_cfgop_cache_purge_acl(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	const char *val;
 
 	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+		T_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
 			cs->name);
 		return -EINVAL;
 	}
@@ -1304,20 +1304,20 @@ tfw_cfgop_cache_purge_acl(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		TfwAddr addr = { 0 };
 
 		if (tfw_addr_pton_cidr(val, &addr)) {
-			TFW_ERR_NL("%s: Invalid ACL entry: '%s'\n",
-				   cs->name, val);
+			T_ERR_NL("%s: Invalid ACL entry: '%s'\n",
+				 cs->name, val);
 			return -EINVAL;
 		}
 		/* Make sure the address is not a duplicate. */
 		if (tfw_capuacl_lookup(&addr)) {
-			TFW_ERR_NL("%s: Duplicate IP address or prefix: '%s'\n",
-				   cs->name, val);
+			T_ERR_NL("%s: Duplicate IP address or prefix: '%s'\n",
+				 cs->name, val);
 			return -EINVAL;
 		}
 		/* Add new ACL entry. */
 		if (tfw_global.capuacl_sz == TFW_CAPUACL_ARRAY_SZ) {
-			TFW_ERR_NL("%s: Unable to add new ACL: '%s'\n",
-				   cs->name, val);
+			T_ERR_NL("%s: Unable to add new ACL: '%s'\n",
+				 cs->name, val);
 			return -EINVAL;
 		}
 		tfw_global.capuacl[tfw_global.capuacl_sz++] = addr;
@@ -1337,8 +1337,8 @@ tfw_cfgop_cache_purge(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	const char *val;
 
 	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
-			cs->name);
+		T_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			 cs->name);
 		return -EINVAL;
 	}
 	if (!ce->val_n) {
@@ -1350,8 +1350,8 @@ tfw_cfgop_cache_purge(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		if (!strcasecmp(val, "invalidate")) {
 			tfw_global.cache_purge_mode = TFW_D_CACHE_PURGE_INVALIDATE;
 		} else {
-			TFW_ERR_NL("%s: unsupported argument: '%s'\n",
-				   cs->name, val);
+			T_ERR_NL("%s: unsupported argument: '%s'\n",
+				 cs->name, val);
 			return -EINVAL;
 		}
 	}
@@ -1371,13 +1371,13 @@ tfw_cfgop_hdr_via(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	size_t len;
 
 	if (ce->attr_n) {
-		TFW_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
-			   cs->name);
+		T_ERR_NL("%s: Arguments may not have the \'=\' sign\n",
+			 cs->name);
 		return -EINVAL;
 	}
 	if (ce->val_n != 1) {
-		TFW_ERR_NL("%s: Invalid number of arguments: %d\n",
-			   cs->name, (int)ce->val_n);
+		T_ERR_NL("%s: Invalid number of arguments: %d\n",
+			 cs->name, (int)ce->val_n);
 		return -EINVAL;
 	}
 
@@ -1401,9 +1401,9 @@ tfw_cfgop_vhost_check_flags(TfwSrvGroup *main_sg, TfwSrvGroup *backup_sg)
 	int r = ((main_sg->flags & TFW_SRV_STICKY_FLAGS) ^
 		 (backup_sg->flags & TFW_SRV_STICKY_FLAGS));
 	if (r)
-		TFW_ERR_NL("vhost: srv_groups '%s' and '%s' must "
-			   "have the same sticky sessions settings\n",
-			   main_sg->name, backup_sg->name);
+		T_ERR_NL("vhost: srv_groups '%s' and '%s' must "
+			 "have the same sticky sessions settings\n",
+			 main_sg->name, backup_sg->name);
 
 	return r;
 }
@@ -1417,16 +1417,16 @@ __tfw_cfgop_proxy_pass(const char *main_sg_nm, const char *backup_sg_nm,
 
 	main_sg = tfw_sg_lookup_reconfig(main_sg_nm, strlen(main_sg_nm));
 	if (!main_sg) {
-		TFW_ERR_NL("proxy_pass: srv_group is not found: '%s'\n",
-			   main_sg_nm);
+		T_ERR_NL("proxy_pass: srv_group is not found: '%s'\n",
+			 main_sg_nm);
 		return -EINVAL;
 	}
 	if (backup_sg_nm) {
 		backup_sg = tfw_sg_lookup_reconfig(backup_sg_nm,
 						   strlen(backup_sg_nm));
 		if (!backup_sg) {
-			TFW_ERR_NL("proxy_pass: backup srv_group is not found:"
-				   " '%s'\n", backup_sg_nm);
+			T_ERR_NL("proxy_pass: backup srv_group is not found:"
+				 " '%s'\n", backup_sg_nm);
 			r = -EINVAL;
 			goto err;
 		}
@@ -1470,10 +1470,10 @@ tfw_cfgop_proxy_pass(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 		    && (!in_backup_sg
 			|| !strcasecmp(in_backup_sg, TFW_VH_DFT_NAME)))
 			return 0;
-		TFW_ERR_NL("Default vhost must point to default server"
-			   " group only, so it is not allowed to specify"
-			   " any not default 'proxy_pass' directive inside of"
-			   " default vhost.\n");
+		T_ERR_NL("Default vhost must point to default server"
+			 " group only, so it is not allowed to specify"
+			 " any not default 'proxy_pass' directive inside of"
+			 " default vhost.\n");
 		return -EINVAL;
 	}
 	return __tfw_cfgop_proxy_pass(in_main_sg, in_backup_sg, loc);
@@ -1525,7 +1525,7 @@ tfw_vhost_create(const char *name)
 
 	if (!(vhost = kzalloc(size, GFP_KERNEL))) {
 		tfw_pool_destroy(pool);
-		TFW_ERR_NL("Cannot allocate vhost entry '%s'\n", name);
+		T_ERR_NL("Cannot allocate vhost entry '%s'\n", name);
 		return NULL;
 	}
 	INIT_HLIST_NODE(&vhost->hlist);
@@ -1621,16 +1621,16 @@ __tfw_cfgop_frang_http_methods(TfwCfgSpec *cs, TfwCfgEntry *ce,
 		int r = tfw_cfg_map_enum(frang_http_methods_enum, method_str,
 					 &method_id);
 		if (r) {
-			TFW_ERR_NL("frang: invalid method: '%s'\n", method_str);
+			T_ERR_NL("frang: invalid method: '%s'\n", method_str);
 			return -EINVAL;
 		}
 
-		TFW_DBG3("frang: parsed method: %s => %d\n",
-			 method_str, method_id);
+		T_DBG3("frang: parsed method: %s => %d\n",
+		       method_str, method_id);
 		methods_mask |= (1UL << method_id);
 	}
 
-	TFW_DBG3("parsed methods_mask: %#lx\n", methods_mask);
+	T_DBG3("parsed methods_mask: %#lx\n", methods_mask);
 	*cfg_methods_mask = methods_mask;
 	return 0;
 }
@@ -1680,7 +1680,7 @@ __tfw_cfgop_frang_http_ct_vals(TfwCfgSpec *cs, TfwCfgEntry *ce, FrangCfg *conf)
 		vals_pos->str = strs_pos;
 		vals_pos->len = (len - 1);
 
-		TFW_DBG3("parsed Content-Type value: '%s'\n", in_str);
+		T_DBG3("parsed Content-Type value: '%s'\n", in_str);
 
 		vals_pos++;
 		strs_pos += len;
@@ -1698,8 +1698,8 @@ frang_parse_ushort(const char *s, unsigned short *out)
 {
 	int n;
 	if (tfw_cfg_parse_int(s, &n)) {
-		TFW_ERR_NL("frang: http_resp_code_block: "
-			   "\"%s\" isn't a valid value\n", s);
+		T_ERR_NL("frang: http_resp_code_block: "
+			 "\"%s\" isn't a valid value\n", s);
 		return -EINVAL;
 	}
 	if (tfw_cfg_check_range(n, 1, USHRT_MAX))
@@ -1720,13 +1720,13 @@ __tfw_cfgop_frang_rsp_code_block(TfwCfgSpec *cs, TfwCfgEntry *ce,
 	int n, i;
 
 	if (ce->attr_n) {
-		TFW_ERR_NL("%s arguments may not have the \'=\' sign\n",
-			   error_msg_begin);
+		T_ERR_NL("%s arguments may not have the \'=\' sign\n",
+			 error_msg_begin);
 		return -EINVAL;
 	}
 
 	if (ce->val_n < 3) {
-		TFW_ERR_NL("%s too few arguments\n", error_msg_begin);
+		T_ERR_NL("%s too few arguments\n", error_msg_begin);
 		return -EINVAL;
 	}
 
@@ -1739,8 +1739,8 @@ __tfw_cfgop_frang_rsp_code_block(TfwCfgSpec *cs, TfwCfgEntry *ce,
 	while (--i >= 0) {
 		if (tfw_cfg_parse_int(ce->vals[i], &n)
 		    || !tfw_http_resp_code_range(n)) {
-			TFW_ERR_NL("%s invalid HTTP code \"%s\"",
-				   error_msg_begin, ce->vals[i]);
+			T_ERR_NL("%s invalid HTTP code \"%s\"",
+				 error_msg_begin, ce->vals[i]);
 			return -EINVAL;
 		}
 		/* Atomic restriction isn't needed here */
@@ -2073,14 +2073,14 @@ tfw_vhost_cfgstart(void)
 	BUG_ON(tfw_vhosts_reconfig);
 	tfw_vhosts_reconfig = kmalloc(sizeof(TfwVhostList), GFP_KERNEL);
 	if (!tfw_vhosts_reconfig) {
-		TFW_ERR_NL("Unable to allocate vhosts' list.\n");
+		T_ERR_NL("Unable to allocate vhosts' list.\n");
 		return -ENOMEM;
 	}
 
 	tfw_vhosts_reconfig->expl_dflt = false;
 	hash_init(tfw_vhosts_reconfig->vh_hash);
 	if(!(vh_dflt = tfw_vhost_new(TFW_VH_DFT_NAME))) {
-		TFW_ERR_NL("Unable to create default vhost.\n");
+		T_ERR_NL("Unable to create default vhost.\n");
 		return -ENOMEM;
 	}
 
@@ -2139,13 +2139,13 @@ tfw_cfgop_vhost_begin(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (tfw_cfg_check_val_n(ce, 1))
 		return -EINVAL;
 	if (ce->attr_n) {
-		TFW_ERR_NL("Unexpected attributes\n");
+		T_ERR_NL("Unexpected attributes\n");
 		return -EINVAL;
 	}
 	hash_for_each(tfw_vhosts_reconfig->vh_hash, i, vhost, hlist) {
 		if (!strcasecmp(vhost->name.data, ce->vals[0])) {
-			TFW_ERR_NL("Duplicate vhost entry: '%s'\n",
-				   ce->vals[0]);
+			T_ERR_NL("Duplicate vhost entry: '%s'\n",
+				 ce->vals[0]);
 			return -EINVAL;
 		}
 	}
@@ -2160,8 +2160,8 @@ tfw_cfgop_vhost_begin(TfwCfgSpec *cs, TfwCfgEntry *ce)
 			return -ENOMEM;
 	} else {
 		if (!(tfw_vhost_entry = tfw_vhost_new(ce->vals[0]))) {
-			TFW_ERR_NL("Unable to create new vhost entry: '%s'\n",
-				   ce->vals[0]);
+			T_ERR_NL("Unable to create new vhost entry: '%s'\n",
+				 ce->vals[0]);
 			return -ENOMEM;
 		}
 	}
@@ -2180,9 +2180,9 @@ tfw_cfgop_vhost_finish(TfwCfgSpec *cs)
 	BUG_ON(!tfw_vhost_entry);
 	if (!tfw_vhost_entry->loc_dflt->main_sg) {
 		BUG_ON(tfw_vhost_is_default_reconfig(tfw_vhost_entry));
-		TFW_ERR_NL("Directive 'proxy_pass' is not specified"
-			   " for not default vhost '%s'.\n",
-			   tfw_vhost_entry->name.data);
+		T_ERR_NL("Directive 'proxy_pass' is not specified"
+			 " for not default vhost '%s'.\n",
+			 tfw_vhost_entry->name.data);
 		return -EINVAL;
 	}
 	if ((r = tfw_tls_cert_cfg_finish(tfw_vhost_entry)))

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -361,7 +361,8 @@ static TfwGlobal		tfw_global = {
 };
 
 /**
- * comparing during configuration processing, both string are plain.
+ * Match vhost to requested name. Called in process context during configuration
+ * processing, both string are guaranteed to be plain.
  */
 static bool
 tfw_vhost_name_match(TfwVhost *vh, const TfwStr *name)
@@ -372,6 +373,9 @@ tfw_vhost_name_match(TfwVhost *vh, const TfwStr *name)
 		&& !strncasecmp(vh->name.data, name->data, vh->name.len);
 }
 
+/**
+ *  Match vhost to requested name. Can be called in softirq context only.
+ */
 static bool
 tfw_vhost_name_match_fast(TfwVhost *vh, const TfwStr *name)
 {

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1875,7 +1875,7 @@ tfw_cfgop_frang_body_len(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (ce->dflt_value && cfg->http_body_len)
 		return 0;
 	cs->dest = &cfg->http_body_len;
-	r = tfw_cfg_set_int(cs, ce);
+	r = tfw_cfg_set_long(cs, ce);
 	cs->dest = NULL;
 	return r;
 }

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1498,8 +1498,6 @@ tfw_vhost_destroy(TfwVhost *vhost)
 {
 	int i;
 
-	T_DBG2("destroy vhost '%s'\n", vhost->name);
-
 	for (i = 0; i < vhost->loc_sz; ++i)
 		tfw_location_del(&vhost->loc[i]);
 	tfw_location_del(vhost->loc_dflt);

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1569,9 +1569,8 @@ tfw_vhost_new(const char *name)
 		return NULL;
 	}
 	if (strcasecmp(name, TFW_VH_DFT_NAME)) {
-		TfwVhost *dvh = tfw_vhosts_reconfig->vhost_dflt;
 		if (tfw_frang_cfg_inherit(vhost->loc_dflt->frang_cfg,
-					  dvh->loc_dflt->frang_cfg))
+					  &tfw_frang_vhost_reconfig))
 		{
 			tfw_vhost_destroy(vhost);
 			return NULL;

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -37,7 +37,7 @@
  *		  current configuration).
  * @expl_dflt	- Flag to indicate explicit configuration of default
  *		  virtual host.
- * @vh_hash	- Hashtable with configured virtual hosts.
+ * @vh_hash	- Hash table with configured virtual hosts.
  */
 typedef struct {
 	TfwVhost	*vhost_dflt;

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1987,12 +1987,6 @@ tfw_cfgop_tls_fallback(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
-tfw_cfgop_in_tls_fallback(TfwCfgSpec *cs, TfwCfgEntry *ce)
-{
-	return tfw_cfgop_tls_fallback(tfw_vhost_entry, cs, ce);
-}
-
-static int
 tfw_cfgop_out_tls_fallback(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	return tfw_cfgop_tls_fallback(tfw_vhosts_reconfig->vhost_dflt, cs, ce);
@@ -2469,12 +2463,6 @@ static TfwCfgSpec tfw_vhost_internal_specs[] = {
 		.handler = tfw_cfgop_in_tls_certificate_key,
 		.allow_none = true,
 		.allow_repeat = true,
-		.allow_reconfig = true,
-	},
-	{
-		.name = "tls_fallback_default",
-		.deflt = "off",
-		.handler = tfw_cfgop_in_tls_fallback,
 		.allow_reconfig = true,
 	},
 	{

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -362,7 +362,7 @@ static TfwGlobal		tfw_global = {
 
 /**
  * Match vhost to requested name. Called in process context during configuration
- * processing, both string are guaranteed to be plain.
+ * processing, both strings are guaranteed to be plain.
  */
 static bool
 tfw_vhost_name_match(TfwVhost *vh, const TfwStr *name)

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -116,7 +116,7 @@ typedef struct {
 	size_t			nipdef_sz;
 	TfwCaPolicy		**capo;
 	TfwNipDef		**nipdef;
-	struct frang_cfg_t	*frang_cfg;
+	FrangCfg		*frang_cfg;
 	TfwSrvGroup		*main_sg;
 	TfwSrvGroup		*backup_sg;
 	TfwPool			*hdrs_pool;
@@ -144,6 +144,10 @@ enum {
  * @loc_dflt	- Default policy.
  * @vhost_dflt	- Pointer to default virtual host with global policies.
  * @hdrs_pool	- Modification headers allocation pool for vhost's policies.
+ * @frang_gconf	- Global frang configuration. Applicable only for 'default'
+ *		  vhost and NULL for others. Provides frang configuration
+ *		  options used before request is parsed and assigned to any
+ *		  vhost.
  * @refcnt	- Number of users of the virtual host object.
  * @loc_sz	- Count of elements in @loc array.
  * @flags	- flags.
@@ -156,6 +160,7 @@ struct  tfw_vhost_t {
 	TfwLocation		*loc_dflt;
 	TfwVhost		*vhost_dflt;
 	TfwPool			*hdrs_pool;
+	FrangGlobCfg		*frang_gconf;
 	atomic64_t		refcnt;
 	size_t			loc_sz;
 	unsigned long		flags;
@@ -214,9 +219,9 @@ bool tfw_vhost_is_default_reconfig(TfwVhost *vhost);
 TfwSrvConn *tfw_vhost_get_srv_conn(TfwMsg *msg);
 TfwVhost *tfw_vhost_new(const char *name);
 TfwGlobal *tfw_vhost_get_global(void);
+TfwLocation *tfw_vhost_get_global_location(void);
 TfwHdrMods *tfw_vhost_get_hdr_mods(TfwLocation *loc, TfwVhost *vhost,
 				   int mod_type);
-struct frang_cfg_t *tfw_vhost_global_frang_cfg(void);
 
 static inline TfwVhost*
 tfw_vhost_from_tls_conf(const TlsPeerCfg *cfg)

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -219,7 +219,6 @@ bool tfw_vhost_is_default_reconfig(TfwVhost *vhost);
 TfwSrvConn *tfw_vhost_get_srv_conn(TfwMsg *msg);
 TfwVhost *tfw_vhost_new(const char *name);
 TfwGlobal *tfw_vhost_get_global(void);
-TfwLocation *tfw_vhost_get_global_location(void);
 TfwHdrMods *tfw_vhost_get_hdr_mods(TfwLocation *loc, TfwVhost *vhost,
 				   int mod_type);
 

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -210,6 +210,7 @@ TfwLocation *tfw_location_match(TfwVhost *vhost, TfwStr *arg);
 TfwVhost *tfw_vhost_lookup_reconfig(const char *name);
 TfwVhost *tfw_vhost_lookup(const TfwStr *name);
 TfwVhost *tfw_vhost_lookup_default(void);
+bool tfw_vhost_is_default_reconfig(TfwVhost *vhost);
 TfwSrvConn *tfw_vhost_get_srv_conn(TfwMsg *msg);
 TfwVhost *tfw_vhost_new(const char *name);
 TfwGlobal *tfw_vhost_get_global(void);

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -116,7 +116,7 @@ typedef struct {
 	size_t			nipdef_sz;
 	TfwCaPolicy		**capo;
 	TfwNipDef		**nipdef;
-	FrangCfg		*frang_cfg;
+	FrangVhostCfg		*frang_cfg;
 	TfwSrvGroup		*main_sg;
 	TfwSrvGroup		*backup_sg;
 	TfwPool			*hdrs_pool;

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -133,13 +133,12 @@ enum {
 	TFW_VHOST_B_REMOVED = 0,
 };
 
-typedef struct tfw_vhost_t TfwVhost;
-
 /**
  * Virtual host defined by directives and policies.
  *
  * @list	- Entry in list of all configured virtual hosts.
- * @name	- Name of virtual host.
+ * @name	- Name of virtual host. Contains zero terminator in the end,
+ *		  which is not counted by 'len' member.
  * @loc		- Array of groups of policies by specific location.
  * @loc_dflt	- Default policy.
  * @vhost_dflt	- Pointer to default virtual host with global policies.
@@ -149,8 +148,8 @@ typedef struct tfw_vhost_t TfwVhost;
  * @flags	- flags.
  */
 struct  tfw_vhost_t {
-	struct list_head	list;
-	const char		*name;
+	struct hlist_node	hlist;
+	TfwStr			name;
 	TfwLocation		*loc;
 	TfwLocation		*loc_dflt;
 	TfwVhost		*vhost_dflt;
@@ -205,7 +204,9 @@ TfwNipDef *tfw_nipdef_match(TfwLocation *loc, unsigned char meth, TfwStr *arg);
 bool tfw_capuacl_match(TfwAddr *addr);
 TfwCaPolicy *tfw_capolicy_match(TfwLocation *loc, TfwStr *arg);
 TfwLocation *tfw_location_match(TfwVhost *vhost, TfwStr *arg);
-TfwVhost *tfw_vhost_lookup(const char *name);
+TfwVhost *tfw_vhost_lookup_reconfig(const char *name);
+TfwVhost *tfw_vhost_lookup(const TfwStr *name);
+TfwVhost *tfw_vhost_lookup_default(void);
 TfwSrvConn *tfw_vhost_get_srv_conn(TfwMsg *msg);
 TfwVhost *tfw_vhost_new(const char *name);
 TfwGlobal *tfw_vhost_get_global(void);

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -24,6 +24,7 @@
 #include "addr.h"
 #include "msg.h"
 #include "server.h"
+#include "tls.h"
 
 /**
  * Non-Idempotent Request definition.
@@ -146,6 +147,7 @@ enum {
  * @refcnt	- Number of users of the virtual host object.
  * @loc_sz	- Count of elements in @loc array.
  * @flags	- flags.
+ * @tls_cfg	- TLS per-vhost configuration data used in data processing.
  */
 struct  tfw_vhost_t {
 	struct hlist_node	hlist;
@@ -157,6 +159,7 @@ struct  tfw_vhost_t {
 	atomic64_t		refcnt;
 	size_t			loc_sz;
 	unsigned long		flags;
+	TlsPeerCfg		tls_cfg;
 };
 
 #define TFW_VH_DFT_NAME		"default"
@@ -213,5 +216,11 @@ TfwGlobal *tfw_vhost_get_global(void);
 TfwHdrMods *tfw_vhost_get_hdr_mods(TfwLocation *loc, TfwVhost *vhost,
 				   int mod_type);
 struct frang_cfg_t *tfw_vhost_global_frang_cfg(void);
+
+static inline TfwVhost*
+tfw_vhost_from_tls_conf(const TlsPeerCfg *cfg)
+{
+	return  container_of(cfg, TfwVhost, tls_cfg);
+}
 
 #endif /* __TFW_VHOST_H__ */

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -87,16 +87,25 @@
 
 /*
  * Abstraction for a grid of allowed signature-hash-algorithm pairs.
+ *
+ * @rsa			- bitmap to store values from ttls_md_type_t;
+ * @ecdsa		- bitmap to store values from ttls_md_type_t;
+ *
+ * When signature_algorithm extension in ClientHello is parsed, target server
+ * is not known, and the grit contain all (known) client capabilities.
+ * After target server is determined, the most preferred hash function is
+ * stored in the grid while others are dropped.
+ *
+ * At the moment, we only need to remember and use a single suitable
+ * hash algorithm per signature algorithm. As long as that's
+ * the case - and we don't need a general lookup function -
+ * we can implement the sig-hash-set as a map from signatures
+ * to hash algorithms
  */
 struct ttls_sig_hash_set_t
 {
-	/* At the moment, we only need to remember a single suitable
-	 * hash algorithm per signature algorithm. As long as that's
-	 * the case - and we don't need a general lookup function -
-	 * we can implement the sig-hash-set as a map from signatures
-	 * to hash algorithms. */
-	ttls_md_type_t rsa;
-	ttls_md_type_t ecdsa;
+	unsigned int rsa;
+	unsigned int ecdsa;
 };
 
 /*
@@ -192,7 +201,6 @@ ttls_md_type_t ttls_sig_hash_set_find(ttls_sig_hash_set_t *set,
 void ttls_sig_hash_set_add(ttls_sig_hash_set_t *set,
 			   ttls_pk_type_t sig_alg,
 			   ttls_md_type_t md_alg);
-void ttls_set_default_sig_hash(TlsCtx *tls);
 
 int ttls_handshake_client_step(ttls_context *tls, unsigned char *buf,
 			       size_t len, size_t hh_len, unsigned int *read);
@@ -231,6 +239,7 @@ int ttls_set_calc_verify_md(ttls_context *tls, int md);
 int ttls_check_curve(const ttls_context *tls, ttls_ecp_group_id grp_id);
 
 int ttls_check_sig_hash(const ttls_context *tls, ttls_md_type_t md);
+int ttls_match_sig_hashes(const TlsCtx *tls);
 void ttls_update_checksum(TlsCtx *tls, const unsigned char *buf, size_t len);
 
 /**

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -133,7 +133,7 @@ struct ttls_sig_hash_set_t
  * @premaster	- premaster secret;
  * @tmp		- buffer to store temporary data between data chunks;
  */
-typedef struct tls_handshake_t {
+struct tls_handshake_t {
 	ttls_sig_hash_set_t		hash_algs;
 	int				sni_authmode;
 
@@ -175,7 +175,7 @@ typedef struct tls_handshake_t {
 		unsigned char		premaster[TTLS_PREMASTER_SIZE];
 		unsigned char		tmp[TTLS_HS_RBUF_SZ];
 	};
-} TlsHandshake;
+};
 
 /*
  * List of certificate + private key pairs

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -114,9 +114,6 @@ struct ttls_sig_hash_set_t
  * @cli_exts	- client extension presence;
  * @pmslen	- premaster length;
  * @key_cert	- chosen key/cert pair (server);
- * @sni_key_cert - key/cert list from SNI;
- * @sni_ca_chain - trusted CAs from SNI callback;
- * @sni_ca_crl	- trusted CAs CRLs from SNI;
  * @dhm_ctx	- DHM key exchange;
  * @ecdh_ctx	- ECDH key exchange;
  * @fin_sha{256,512} - checksum contexts;
@@ -141,9 +138,6 @@ typedef struct tls_handshake_t {
 
 	size_t				pmslen;
 	ttls_key_cert			*key_cert;
-	ttls_key_cert			*sni_key_cert;
-	ttls_x509_crt			*sni_ca_chain;
-	ttls_x509_crl			*sni_ca_crl;
 
 	void (*calc_verify)(ttls_context *, unsigned char *);
 	void (*calc_finished)(ttls_context *, unsigned char *, int);
@@ -176,11 +170,18 @@ typedef struct tls_handshake_t {
 
 /*
  * List of certificate + private key pairs
+ *
+ * @cert		- Server certificate;
+ * @key			- key for the certificate;
+ * @ca_chain		- trusted CA chain for the issues certificate;
+ * @ca_crl		- trusted CAs CRLs
  */
 struct ttls_key_cert
 {
 	ttls_x509_crt			*cert;
 	ttls_pk_context			*key;
+	ttls_x509_crt			*ca_chain;
+	ttls_x509_crl			*ca_crl;
 	ttls_key_cert			*next;
 };
 
@@ -253,7 +254,7 @@ ttls_own_key(ttls_context *tls)
 	if (tls->hs && tls->hs->key_cert)
 		key_cert = tls->hs->key_cert;
 	else
-		key_cert = tls->conf->key_cert;
+		key_cert = tls->peer_conf ? tls->peer_conf->key_cert : NULL;
 
 	return key_cert ? key_cert->key : NULL;
 }
@@ -266,7 +267,7 @@ ttls_own_cert(TlsCtx *tls)
 	if (tls->hs && tls->hs->key_cert)
 		key_cert = tls->hs->key_cert;
 	else
-		key_cert = tls->conf->key_cert;
+		key_cert = tls->peer_conf ? tls->peer_conf->key_cert : NULL;
 
 	return key_cert ? key_cert->cert : NULL;
 }

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -92,7 +92,7 @@
  * @ecdsa		- bitmap to store values from ttls_md_type_t;
  *
  * When signature_algorithm extension in ClientHello is parsed, target server
- * is not known, and the grit contain all (known) client capabilities.
+ * is not known, and the grid contain all (known) client capabilities.
  * After target server is determined, the most preferred hash function is
  * stored in the grid while others are dropped.
  *
@@ -102,11 +102,11 @@
  * we can implement the sig-hash-set as a map from signatures
  * to hash algorithms
  */
-struct ttls_sig_hash_set_t
+typedef struct
 {
 	unsigned int rsa;
 	unsigned int ecdsa;
-};
+} TlsSigHashSet;
 
 /*
  * This structure contains the parameters only needed during handshake.
@@ -134,7 +134,7 @@ struct ttls_sig_hash_set_t
  * @tmp		- buffer to store temporary data between data chunks;
  */
 struct tls_handshake_t {
-	ttls_sig_hash_set_t		hash_algs;
+	TlsSigHashSet			hash_algs;
 	int				sni_authmode;
 
 	unsigned char			point_form		: 1,
@@ -195,10 +195,10 @@ struct ttls_key_cert
 };
 
 /* Find an entry in a signature-hash set matching a given hash algorithm. */
-ttls_md_type_t ttls_sig_hash_set_find(ttls_sig_hash_set_t *set,
-			 ttls_pk_type_t sig_alg);
+ttls_md_type_t ttls_sig_hash_set_find(TlsSigHashSet *set,
+				      ttls_pk_type_t sig_alg);
 /* Add a signature-hash-pair to a signature-hash set */
-void ttls_sig_hash_set_add(ttls_sig_hash_set_t *set,
+void ttls_sig_hash_set_add(TlsSigHashSet *set,
 			   ttls_pk_type_t sig_alg,
 			   ttls_md_type_t md_alg);
 

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -88,7 +88,7 @@ ttls_parse_servername_ext(TlsCtx *tls, const unsigned char *buf, size_t len)
 					     hostname_len);
 			if (!r)
 				return 0;
-			T_DBG("ClientHello: SNI error\n");
+			T_WARN("TLS: server requested by client is not known.\n");
 			ttls_send_alert(tls, TTLS_ALERT_LEVEL_FATAL,
 					TTLS_ALERT_MSG_UNRECOGNIZED_NAME);
 			return TTLS_ERR_BAD_HS_CLIENT_HELLO;
@@ -1066,7 +1066,7 @@ ttls_parse_client_hello(TlsCtx *tls, unsigned char *buf, size_t len,
 		if (tls->conf->f_sni)
 			r = tls->conf->f_sni(tls->conf->p_sni, tls, NULL, 0);
 		if (!tls->conf->f_sni || r || !tls->peer_conf) {
-			T_DBG2("No matching server certificate found.\n");
+			T_WARN("TLS: server requested by client is not known.\n");
 			return -TTLS_ERR_BAD_HS_CLIENT_HELLO;
 		}
 	}

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -35,7 +35,7 @@ ttls_check_scsvs(TlsCtx *tls, unsigned short cipher_suite)
 	case TTLS_FALLBACK_SCSV_VALUE:
 		T_DBG("received FALLBACK_SCSV\n");
 		if (tls->minor < tls->conf->max_minor_ver) {
-			T_DBG("inapropriate fallback\n");
+			T_DBG("inappropriate fallback\n");
 			ttls_send_alert(tls, TTLS_ALERT_LEVEL_FATAL,
 					TTLS_ALERT_MSG_INAPROPRIATE_FALLBACK);
 			return TTLS_ERR_BAD_HS_CLIENT_HELLO;
@@ -1402,7 +1402,7 @@ ttls_write_server_key_exchange(TlsCtx *tls, struct sg_table *sgt,
 	 * ServerKeyExchange, so end here.
 	 */
 	if (ttls_ciphersuite_no_pfs(ci)) {
-		T_DBG("the key exchanges isn't involving ephimeral keys\n");
+		T_DBG("the key exchanges isn't involving ephemeral keys\n");
 		return 0;
 	}
 
@@ -2210,7 +2210,7 @@ ttls_handshake_server_hello(TlsCtx *tls)
 		} else {
 			tls->state = TTLS_CLIENT_CERTIFICATE;
 		}
-		/* All the writers getted their frags, so put our reference. */
+		/* All the writers got their frags, so put our reference. */
 		put_page(pg);
 		sg_mark_end(&sgt.sgl[sgt.nents - 1]);
 		/* Exit, enter the FSM on more data from the client. */

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1833,7 +1833,7 @@ ttls_handshake_params_init(TlsHandshake *hs)
 }
 
 int
-ttls_ctx_init(TlsCtx *tls, const ttls_config *conf)
+ttls_ctx_init(TlsCtx *tls, const TlsCfg *conf)
 {
 	bzero_fast(tls, sizeof(*tls));
 	spin_lock_init(&tls->lock);
@@ -1850,7 +1850,7 @@ ttls_ctx_init(TlsCtx *tls, const ttls_config *conf)
 EXPORT_SYMBOL(ttls_ctx_init);
 
 void
-ttls_conf_authmode(ttls_config *conf, int authmode)
+ttls_conf_authmode(TlsCfg *conf, int authmode)
 {
 	conf->authmode = authmode;
 }
@@ -1886,7 +1886,7 @@ ttls_conf_ciphersuites_for_version(const int **ciphersuite_list,
 }
 
 void
-ttls_conf_cert_profile(ttls_config *conf, const ttls_x509_crt_profile *profile)
+ttls_conf_cert_profile(TlsCfg *conf, const ttls_x509_crt_profile *profile)
 {
 	conf->cert_profile = profile;
 }
@@ -1942,9 +1942,9 @@ ttls_set_hs_authmode(ttls_context *tls, int authmode)
 
 #if defined(TTLS_DHM_C)
 
-int ttls_conf_dh_param_bin(ttls_config *conf,
-		const unsigned char *dhm_P, size_t P_len,
-		const unsigned char *dhm_G, size_t G_len)
+int ttls_conf_dh_param_bin(TlsCfg *conf,
+			   const unsigned char *dhm_P, size_t P_len,
+			   const unsigned char *dhm_G, size_t G_len)
 {
 	int r;
 
@@ -1959,7 +1959,7 @@ int ttls_conf_dh_param_bin(ttls_config *conf,
 	return 0;
 }
 
-int ttls_conf_dh_param_ctx(ttls_config *conf, ttls_dhm_context *dhm_ctx)
+int ttls_conf_dh_param_ctx(TlsCfg *conf, ttls_dhm_context *dhm_ctx)
 {
 	int r;
 
@@ -1979,8 +1979,8 @@ int ttls_conf_dh_param_ctx(ttls_config *conf, ttls_dhm_context *dhm_ctx)
 /*
  * Set the minimum length for Diffie-Hellman parameters
  */
-void ttls_conf_dhm_min_bitlen(ttls_config *conf,
-		unsigned int bitlen)
+void ttls_conf_dhm_min_bitlen(TlsCfg *conf,
+			      unsigned int bitlen)
 {
 	conf->dhm_min_bitlen = bitlen;
 }
@@ -2049,7 +2049,7 @@ int ttls_set_hostname(ttls_context *tls, const char *hostname)
 }
 
 void
-ttls_conf_sni(ttls_config *conf,
+ttls_conf_sni(TlsCfg *conf,
 	      int (*f_sni)(void *, ttls_context *, const unsigned char *,
 			   size_t),
 	      void *p_sni)
@@ -2066,17 +2066,17 @@ ttls_get_alpn_protocol(const TlsCtx *tls)
 }
 
 void
-ttls_conf_version(ttls_config *conf, int min_minor, int max_minor)
+ttls_conf_version(TlsCfg *conf, int min_minor, int max_minor)
 {
 	conf->min_minor_ver = min_minor;
 	conf->max_minor_ver = max_minor;
 }
 
 #if defined(TTLS_SESSION_TICKETS)
-void ttls_conf_session_tickets_cb(ttls_config *conf,
-		ttls_ticket_write_t *f_ticket_write,
-		ttls_ticket_parse_t *f_ticket_parse,
-		void *p_ticket)
+void ttls_conf_session_tickets_cb(TlsCfg *conf,
+				  ttls_ticket_write_t *f_ticket_write,
+				  ttls_ticket_parse_t *f_ticket_parse,
+				  void *p_ticket)
 {
 	conf->f_ticket_write = f_ticket_write;
 	conf->f_ticket_parse = f_ticket_parse;
@@ -2373,9 +2373,9 @@ ttls_ctx_clear(TlsCtx *tls)
 EXPORT_SYMBOL(ttls_ctx_clear);
 
 void
-ttls_config_init(ttls_config *conf)
+ttls_config_init(TlsCfg *conf)
 {
-	bzero_fast(conf, sizeof(ttls_config));
+	bzero_fast(conf, sizeof(TlsCfg));
 }
 EXPORT_SYMBOL(ttls_config_init);
 
@@ -2432,7 +2432,7 @@ static ttls_ecp_group_id ssl_preset_suiteb_curves[] = {
  * Use NSA Suite B as a preset-specific defaults.
  */
 int
-ttls_config_defaults(ttls_config *conf, int endpoint)
+ttls_config_defaults(TlsCfg *conf, int endpoint)
 {
 	conf->endpoint = endpoint;
 
@@ -2491,9 +2491,9 @@ ttls_config_peer_defaults(TlsPeerCfg *conf, int endpoint)
 EXPORT_SYMBOL(ttls_config_peer_defaults);
 
 void
-ttls_config_free(ttls_config *conf)
+ttls_config_free(TlsCfg *conf)
 {
-	bzero_fast(conf, sizeof(ttls_config));
+	bzero_fast(conf, sizeof(TlsCfg));
 }
 EXPORT_SYMBOL(ttls_config_free);
 
@@ -2536,7 +2536,7 @@ ttls_pk_alg_from_sig(unsigned char sig)
  * Most secure are preferred.
  */
 ttls_md_type_t
-ttls_sig_hash_set_find(ttls_sig_hash_set_t *set, ttls_pk_type_t sig_alg)
+ttls_sig_hash_set_find(TlsSigHashSet *set, ttls_pk_type_t sig_alg)
 {
 	/* fls(0x1) == fls(0x0) = TTLS_MD_NONE. */
 	switch (sig_alg) {
@@ -2553,7 +2553,7 @@ ttls_sig_hash_set_find(ttls_sig_hash_set_t *set, ttls_pk_type_t sig_alg)
  * Add a signature-hash-pair to a signature-hash set/
  */
 void
-ttls_sig_hash_set_add(ttls_sig_hash_set_t *set, ttls_pk_type_t sig_alg,
+ttls_sig_hash_set_add(TlsSigHashSet *set, ttls_pk_type_t sig_alg,
 		      ttls_md_type_t md_alg)
 {
 	switch (sig_alg) {
@@ -2569,7 +2569,7 @@ ttls_sig_hash_set_add(ttls_sig_hash_set_t *set, ttls_pk_type_t sig_alg,
 }
 
 bool
-ttls_sig_hash_set_has(ttls_sig_hash_set_t *set, ttls_pk_type_t sig_alg,
+ttls_sig_hash_set_has(TlsSigHashSet *set, ttls_pk_type_t sig_alg,
 		      ttls_md_type_t md_alg)
 {
 	switch (sig_alg) {
@@ -2583,8 +2583,8 @@ ttls_sig_hash_set_has(ttls_sig_hash_set_t *set, ttls_pk_type_t sig_alg,
 }
 
 void
-ttls_sig_hash_set_const(ttls_sig_hash_set_t *set, ttls_pk_type_t sig_alg,
-		      ttls_md_type_t md_alg)
+ttls_sig_hash_set_const(TlsSigHashSet *set, ttls_pk_type_t sig_alg,
+			ttls_md_type_t md_alg)
 {
 	switch (sig_alg) {
 	case TTLS_PK_RSA:
@@ -2680,7 +2680,7 @@ ttls_check_sig_hash(const TlsCtx *tls, ttls_md_type_t md)
 int
 ttls_match_sig_hashes(const TlsCtx *tls)
 {
-	ttls_sig_hash_set_t *set = &tls->hs->hash_algs;
+	TlsSigHashSet *set = &tls->hs->hash_algs;
 	bool dflt_available = false, has_rsa = false, has_ecdsa = false;
 	const int *cur;
 

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1525,7 +1525,7 @@ parse:
 	}
 	sess->peer_cert = kmalloc(sizeof(ttls_x509_crt), GFP_KERNEL);
 	if (!sess->peer_cert) {
-		T_DBG("can npt allocacte a certificate (%lu bytes)\n",
+		T_DBG("can not allocate a certificate (%lu bytes)\n",
 		      sizeof(ttls_x509_crt));
 		ttls_send_alert(tls, TTLS_ALERT_LEVEL_FATAL,
 				    TTLS_ALERT_MSG_INTERNAL_ERROR);
@@ -2122,12 +2122,12 @@ ttls_hs_checksumable(TlsCtx *tls)
  * execution of this function. Do not call this function if state is
  * TTLS_HANDSHAKE_OVER.
  *
- * The step callees must return T_POSTPONE if more input data is required to
+ * The step callers must return T_POSTPONE if more input data is required to
  * completely read current ingress record and 0 (T_OK) if current FSM state
  * finished successfully. All other return codes are treated as errors.
  *
  * @hh_len is pure optimization argument: it defines a backward offset in
- * @buf of size of hadshake header if the header is in the @buf, so this way
+ * @buf of size of handshake header if the header is in the @buf, so this way
  * we can compute the whole message checksum in one shot. Only handshake steps
  * reading ingress data use the argument.
  */
@@ -2227,7 +2227,7 @@ next_record:
 		}
 
 		/*
-		 * We add ingress messages to the handhsake session checksum
+		 * We add ingress messages to the handshake session checksum
 		 * in two different places: here for message chunks and inside
 		 * the handshake state machine. @hh_len is used for the
 		 * checksumming only. We can not compute checksum for complete

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -356,6 +356,29 @@ typedef struct {
 	unsigned char			iv_dec[16];
 } TlsXfrm;
 
+typedef struct {
+	/** allowed ciphersuites per version */
+	const int			*ciphersuite_list[4];
+	/** allowed curves	*/
+	const ttls_ecp_group_id		*curve_list;
+	/** allowed signature hashes	*/
+	const int			*sig_hashes;
+
+	/** Own certificate/key list */
+	ttls_key_cert			*key_cert;
+	/** Private section, used for configuration storing. */
+	void				*priv;
+
+	unsigned char			min_minor_ver;
+	unsigned char			max_minor_ver;
+
+	unsigned int endpoint : 1;	/*!< 0: client, 1: server	*/
+	unsigned int authmode : 2;	/*!< TTLS_VERIFY_XXX	*/
+	unsigned int session_tickets : 1; /*!< use session tickets?	*/
+	unsigned int cert_req_ca_list : 1; /*!< enable sending CA list in
+	Certificate Request messages?	*/
+} TlsPeerCfg;
+
 /**
  * SSL/TLS configuration to be shared between ttls_context structures.
  *
@@ -366,8 +389,6 @@ typedef struct {
 struct ttls_config
 {
 	/* Group items by size (largest first) to minimize padding overhead */
-
-	const int *ciphersuite_list[4]; /*!< allowed ciphersuites per version */
 
 	/** Callback to retrieve a session from the cache	*/
 	int (*f_get_cache)(void *, TlsSess *);
@@ -390,13 +411,6 @@ struct ttls_config
 	void *p_ticket;	/*!< context for the ticket callbacks */
 
 	const ttls_x509_crt_profile *cert_profile; /*!< verification profile */
-	ttls_key_cert *key_cert; /*!< own certificate/key pair(s)	*/
-	ttls_x509_crt *ca_chain;	/*!< trusted CAs	*/
-	ttls_x509_crl *ca_crl;	/*!< trusted CAs CRLs	*/
-
-	const int *sig_hashes;	/*!< allowed signature hashes	*/
-
-	const ttls_ecp_group_id *curve_list; /*!< allowed curves	*/
 
 #if defined(TTLS_DHM_C)
 	ttls_mpi dhm_P;	/*!< prime modulus for DHM	*/
@@ -408,15 +422,13 @@ struct ttls_config
 	/*
 	* Numerical settings (int then char)
 	*/
-
 	uint32_t read_timeout;	/*!< timeout for ttls_recv (ms) */
+	unsigned char			min_minor_ver;
+	unsigned char			max_minor_ver;
 
 #if defined(TTLS_DHM_C) && defined(TTLS_CLI_C)
 	unsigned int dhm_min_bitlen;	/*!< min. bit length of the DHM prime */
 #endif
-
-	unsigned char	min_minor_ver;
-	unsigned char	max_minor_ver;
 
 	/*
 	* Flags (bitfields)
@@ -505,6 +517,7 @@ typedef struct tls_handshake_t TlsHandshake;
 typedef struct ttls_context {
 	spinlock_t		lock;
 	const ttls_config	*conf;
+	const TlsPeerCfg	*peer_conf;
 	TlsHandshake		*hs;
 	const ttls_alpn_proto	*alpn_chosen;
 
@@ -666,13 +679,14 @@ int ttls_set_session(ttls_context *ssl, const TlsSess *session);
  *		The ciphersuites array is not copied, and must remain
  *		valid for the lifetime of the ssl_config.
  *
- * \param conf	SSL configuration
+ * \param ciphersuite_list	ciphersuite list
  * \param ciphersuites 0-terminated list of allowed ciphersuites
  * \param minor	Minor version number (TTLS_MINOR_VERSION_3 and
  *  			TTLS_MINOR_VERSION_2 supported)
  */
-void ttls_conf_ciphersuites_for_version(ttls_config *conf,
-					const int *ciphersuites, int minor);
+void ttls_conf_ciphersuites_for_version(const int **ciphersuite_list,
+					const int *ciphersuites,
+					int minor);
 
 /**
  * \brief	Set the X.509 security profile used for verification
@@ -686,17 +700,6 @@ void ttls_conf_ciphersuites_for_version(ttls_config *conf,
  */
 void ttls_conf_cert_profile(ttls_config *conf,
 			    const ttls_x509_crt_profile *profile);
-
-/**
- * \brief	Set the data required to verify peer certificate
- *
- * \param conf	SSL configuration
- * \param ca_chain trusted CA chain (meaning all fully trusted top-level CAs)
- * \param ca_crl trusted CA CRLs
- */
-void ttls_conf_ca_chain(ttls_config *conf,
-	ttls_x509_crt *ca_chain,
-	ttls_x509_crl *ca_crl);
 
 /**
  * \brief	Set own certificate chain and private key
@@ -723,12 +726,16 @@ void ttls_conf_ca_chain(ttls_config *conf,
  * \param conf	SSL configuration
  * \param own_cert own public certificate chain
  * \param pk_key own private key
+ * \param ca_chain trusted CA chain (meaning all fully trusted top-level CAs)
+ * \param ca_crl trusted CA CRLs
  *
  * \return	0 on success or TTLS_ERR_ALLOC_FAILED
  */
-int ttls_conf_own_cert(ttls_config *conf,
-	ttls_x509_crt *own_cert,
-	ttls_pk_context *pk_key);
+int ttls_conf_own_cert(TlsPeerCfg *conf,
+		       ttls_x509_crt *own_cert,
+		       ttls_pk_context *pk_key,
+		       ttls_x509_crt *ca_chain,
+		       ttls_x509_crl *ca_crl);
 
 #if defined(TTLS_DHM_C)
 
@@ -797,12 +804,12 @@ void ttls_conf_dhm_min_bitlen(ttls_config *conf,
  * \note	This list should be ordered by decreasing preference
  *		(preferred curve first).
  *
- * \param conf	SSL configuration
+ * \param conf	TLS peer configuration
  * \param curves Ordered list of allowed curves,
  *		terminated by TTLS_ECP_DP_NONE.
  */
-void ttls_conf_curves(ttls_config *conf,
-	const ttls_ecp_group_id *curves);
+void ttls_conf_curves(TlsPeerCfg *conf,
+		      const ttls_ecp_group_id *curves);
 
 /**
  * \brief	Set the allowed hashes for signatures during the handshake.
@@ -818,11 +825,11 @@ void ttls_conf_curves(ttls_config *conf,
  * \note	This list should be ordered by decreasing preference
  *		(preferred hash first).
  *
- * \param conf	SSL configuration
+ * \param conf	TLS peer configuration
  * \param hashes Ordered list of allowed signature hashes,
  *		terminated by \c TTLS_MD_NONE.
  */
-void ttls_conf_sig_hashes(ttls_config *conf, const int *hashes);
+void ttls_conf_sig_hashes(TlsPeerCfg *conf, const int *hashes);
 
 /**
  * \brief	Set or reset the hostname to check against the received 
@@ -845,35 +852,6 @@ void ttls_conf_sig_hashes(ttls_config *conf, const int *hashes);
 int ttls_set_hostname(ttls_context *ssl, const char *hostname);
 
 /**
- * \brief	Set own certificate and key for the current handshake
- *
- * \note	Same as \c ttls_conf_own_cert() but for use within
- *		the SNI callback.
- *
- * \param ssl	SSL context
- * \param own_cert own public certificate chain
- * \param pk_key own private key
- *
- * \return	0 on success or TTLS_ERR_ALLOC_FAILED
- */
-int ttls_set_hs_own_cert(ttls_context *ssl, ttls_x509_crt *own_cert,
-			 ttls_pk_context *pk_key);
-
-/**
- * \brief	Set the data required to verify peer certificate for the
- *		current handshake
- *
- * \note	Same as \c ttls_conf_ca_chain() but for use within
- *		the SNI callback.
- *
- * \param ssl	SSL context
- * \param ca_chain trusted CA chain (meaning all fully trusted top-level CAs)
- * \param ca_crl trusted CA CRLs
- */
-void ttls_set_hs_ca_chain(ttls_context *ssl, ttls_x509_crt *ca_chain,
-			  ttls_x509_crl *ca_crl);
-
-/**
  * \brief	Set authmode for the current handshake.
  *
  * \note	Same as \c ttls_conf_authmode() but for use within
@@ -894,17 +872,17 @@ void ttls_set_hs_authmode(ttls_context *ssl, int authmode);
  *		during a handshake. The ServerName callback has the
  *		following parameters: (void *parameter, ttls_context *ssl,
  *		const unsigned char *hostname, size_t len). If a suitable
- *		certificate is found, the callback must set the
- *		certificate(s) and key(s) to use with \c
- *		ttls_set_hs_own_cert() (can be called repeatedly),
- *		and may optionally adjust the CA and associated CRL with \c
- *		ttls_set_hs_ca_chain() as well as the client
- *		authentication mode with \c ttls_set_hs_authmode(),
+ *		certificate is found, the callback must fill the
+ *		peer tls configuration part in TLS context,
+ *		and may optionally adjust authentication mode with
+ *		\c ttls_set_hs_authmode(),
  *		then must return 0. If no matching name is found, the
- *		callback must either set a default cert, or
+ *		callback must either set a default peer configuration, or
  *		return non-zero to abort the handshake at this point.
+ *		The function is also called if there is no ServerName Extension
+ *		found and no peer configuration can be assigned.
  *
- * \param conf	SSL configuration
+ * \param conf	TLS configuration
  * \param f_sni	verification function
  * \param p_sni	verification parameter
  */
@@ -960,18 +938,21 @@ int ttls_send_alert(TlsCtx *tls, unsigned char lvl, unsigned char msg);
  * \return	0 if successful, or a specific SSL error code.
  *
  * \note	If this function returns something other than 0 or
- *		TTLS_ERR_WANT_READ/WRITE, then the ssl context
+ *		TTLS_ERR_WANT_READ/WRITE, then the tls context
  *		becomes unusable, and you should either free it or call
  *		\c ttls_session_reset() on it before re-using it for
  *		a new connection; the current connection must be closed.
  */
-int ttls_close_notify(TlsCtx *ssl);
+int ttls_close_notify(TlsCtx *tls);
 
-void ttls_ctx_clear(ttls_context *ssl);
+void ttls_ctx_clear(ttls_context *tls);
+void ttls_key_cert_free(ttls_key_cert *key_cert);
 
 void ttls_config_init(ttls_config *conf);
 int ttls_config_defaults(ttls_config *conf, int endpoint);
+int ttls_config_peer_defaults(TlsPeerCfg *conf, int endpoint);
 void ttls_config_free(ttls_config *conf);
+void ttls_config_peer_free(TlsPeerCfg *conf);
 
 void ttls_strerror(int errnum, char *buffer, size_t buflen);
 

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -2,7 +2,7 @@
  *		Tempesta TLS
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -893,7 +893,7 @@ void ttls_set_hs_authmode(ttls_context *ssl, int authmode);
  *		following parameters: (void *parameter, ttls_context *ssl,
  *		const unsigned char *hostname, size_t len). If a suitable
  *		certificate is found, the callback must fill the
- *		peer tls configuration part in TLS context,
+ *		peer tls configuration part in the TLS context,
  *		and may optionally adjust authentication mode with
  *		\c ttls_set_hs_authmode(),
  *		then must return 0. If no matching name is found, the

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -276,8 +276,6 @@ typedef struct ttls_context ttls_context;
 typedef struct ttls_config ttls_config;
 
 /* Defined in tls_internal.h */
-typedef struct TtlsXfrm ttls_transform;
-typedef struct ttls_handshake_params ttls_handshake_params;
 typedef struct ttls_sig_hash_set_t ttls_sig_hash_set_t;
 typedef struct ttls_key_cert ttls_key_cert;
 

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -324,7 +324,7 @@ typedef struct {
  * This structure contains a full set of runtime transform parameters
  * either in negotiation or active.
  *
- * @ciphersuite_info	- chosen cipersuite_info;
+ * @ciphersuite_info	- chosen ciphersuite_info;
  * @md_ctx_enc		- MAC encryption context;
  * @md_ctx_dec		- MAC decryption context;
  * @cipher_ctx_enc	- encryption crypto context;


### PR DESCRIPTION
fix #1028 

Fixed:
- test trailer headers across frang limits after body is processed: maximum header len, don't allow same header  in header and trailer parts. Last check requires to know, whether is message is fully parsed.
- close|block client connection immediately once response breaking code block rules is encountered
- fix possible null pointer dereferencing while testing response code block rules for Health Monitor originated requests.
- add missing frang limits names to tempesta_fw.conf 
- ~~`TfwHttpReq->frang_st` duplicates existing Gfsm state in frang FSM and it was removed. Frang states are hookable now, so advanced analytics can be attached to it.~~


**UPD**

Major updates in handling frang directives.

* Frang directives now are really per-vhost and per-location. Each vhost and location may include `frang_limits` section now. Previous behaviour: frang limits may be defined only globally and only inside locations (and not inside vhosts!), but limits was listed in locations without grouping into section `frang_limits`

* Nested locations and vhosts inherit Frang configuration from parents. `frang_limits` section now can appear many times on the same level to force new defaults before new bunch of vhosts|locations. Previous behaviour: no inheritance, every location must define it's own frang settings, so less copy-paste now.

* Frang limits was split into two groups: global and per-vhost. Since messages are received by parts, it's not possible to deduce which per-vhost limits should be applied before the whole message is received. So some limits has no sense in beeing per-vhost, they're global now.

* 
