### PR TITLE
tls: free memory allocated during handshake

### DIFF
--- a/tls/dhm.c
+++ b/tls/dhm.c
@@ -94,6 +94,21 @@ void ttls_dhm_init(ttls_dhm_context *ctx)
 	memset(ctx, 0, sizeof(ttls_dhm_context));
 }
 
+void
+ttls_dhm_free(ttls_dhm_context *ctx)
+{
+	ttls_mpi_free(&ctx->pX);
+	ttls_mpi_free(&ctx->Vf);
+	ttls_mpi_free(&ctx->Vi);
+	ttls_mpi_free(&ctx->RP);
+	ttls_mpi_free(&ctx->K);
+	ttls_mpi_free(&ctx->GY);
+	ttls_mpi_free(&ctx->GX);
+	ttls_mpi_free(&ctx->X);
+	ttls_mpi_free(&ctx->G);
+	ttls_mpi_free(&ctx->P);
+}
+
 /*
  * Parse the ServerKeyExchange parameters
  */

--- a/tls/dhm.h
+++ b/tls/dhm.h
@@ -103,6 +103,13 @@ ttls_dhm_context;
 void ttls_dhm_init(ttls_dhm_context *ctx);
 
 /**
+ * \brief Frees the components of the DHM context.
+ *
+ * \param ctx DHM context.
+ */
+void ttls_dhm_free(ttls_dhm_context *ctx);
+
+/**
  * \brief		  This function parses the ServerKeyExchange parameters.
  *
  * \param ctx	  The DHM context.

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1249,6 +1249,11 @@ ttls_handshake_free(TlsHandshake *hs)
 
 	crypto_free_shash(hs->desc.tfm);
 
+#if defined(TTLS_DHM_C)
+	ttls_dhm_free(&hs->dhm_ctx);
+#endif
+	ttls_ecdh_free(&hs->ecdh_ctx);
+
 	bzero_fast(hs, sizeof(TlsHandshake));
 	kmem_cache_free(ttls_hs_cache, hs);
 }
@@ -2396,6 +2401,11 @@ ttls_ctx_clear(TlsCtx *tls)
 
 	ttls_cipher_free(&tls->xfrm.cipher_ctx_enc);
 	ttls_cipher_free(&tls->xfrm.cipher_ctx_dec);
+
+	if (tls->sess.peer_cert) {
+		ttls_x509_crt_free(tls->sess.peer_cert);
+		ttls_free(tls->sess.peer_cert);
+	}
 
 	bzero_fast(tls, sizeof(TlsCtx));
 }


### PR DESCRIPTION
Structures used on handshake phase may use dynamically allocated memory which needs to be freed.