### PR TITLE
always expand debug macros into expressions

### DIFF
--- a/ktest/linux/threads.h
+++ b/ktest/linux/threads.h
@@ -28,8 +28,8 @@
  * In user space all threads have different identifiers,
  * so there is no problems with preemption.
  */
-#define local_bh_disable()
-#define local_bh_enable()
+#define local_bh_disable()	do { } while (0)
+#define local_bh_enable()	do { } while (0)
 
 static size_t __thr_max = 0;
 static size_t __thread __thr_id;

--- a/lib/log.h
+++ b/lib/log.h
@@ -67,13 +67,13 @@ enum {
 #if defined(DEBUG) && (DEBUG >= 1)
 #define T_DBG(...) 	__T_DBG1(__VA_ARGS__)
 #else
-#define T_DBG(...)
+#define T_DBG(...)	do { } while (0)
 #endif
 
 #if defined(DEBUG) && (DEBUG >= 2)
 #define T_DBG2(...)	__T_DBG2(__VA_ARGS__)
 #else
-#define T_DBG2(...)
+#define T_DBG2(...)	do { } while (0)
 #endif
 
 #if defined(DEBUG) && (DEBUG == 3)
@@ -128,9 +128,9 @@ do {									\
 #define T_ERR(...)	net_err_ratelimited(__BNR "ERROR: " __VA_ARGS__)
 #define T_WARN(...)	net_warn_ratelimited(__BNR "Warning: "	__VA_ARGS__)
 #define T_LOG(...)	net_info_ratelimited(__BNR __VA_ARGS__)
-#define T_DBG3(...)
-#define T_DBG3_BUF(...)
-#define T_DBG3_SL(...)
+#define T_DBG3(...)	do { } while (0)
+#define T_DBG3_BUF(...)	do { } while (0)
+#define T_DBG3_SL(...)	do { } while (0)
 /* Non-limited printing. */
 #define T_ERR_NL(...)	pr_err(__BNR "ERROR: " __VA_ARGS__)
 #define T_WARN_NL(...)	pr_warn(__BNR "Warning: " __VA_ARGS__)

--- a/tempesta_db/core/tdb.h
+++ b/tempesta_db/core/tdb.h
@@ -152,7 +152,7 @@ typedef struct {
 #if defined(DEBUG) && (DEBUG >= 2)
 #define TDB_DBG(...)		pr_debug(TDB_BANNER "  " __VA_ARGS__)
 #else
-#define TDB_DBG(...)
+#define TDB_DBG(...)		do { } while (0)
 #endif
 #define TDB_LOG(...)		pr_info(TDB_BANNER __VA_ARGS__)
 #define TDB_WARN(...)		pr_warn(TDB_BANNER "Warning: " __VA_ARGS__)

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -268,7 +268,7 @@ do {									\
 	TFW_DBG("frang: " fmt_msg, abuf, ##__VA_ARGS__);		\
 } while (0)
 #else
-#define frang_dbg(...)
+#define frang_dbg(...)	do { } while (0)
 #endif
 
 static int

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -353,7 +353,7 @@ do {									\
 	tfw_str_dprint(ua, "\t...User-Agent");				\
 } while (0)
 #else
-#define TFW_DBG_PRINT_STICKY_COOKIE(addr, ua, sv)
+#define TFW_DBG_PRINT_STICKY_COOKIE(addr, ua, sv)	do { } while (0)
 #endif
 
 /*

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -95,7 +95,7 @@ static const char *ss_statename[] = {
 #define TFW_VALIDATE_SK_LOCK_OWNER(sk)	\
 	BUG_ON(sk->sk_lock.slock.rlock.owner_cpu != raw_smp_processor_id())
 #else
-#define TFW_VALIDATE_SK_LOCK_OWNER(sk)
+#define TFW_VALIDATE_SK_LOCK_OWNER(sk)	do { } while (0)
 #endif
 
 /**

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -388,7 +388,7 @@ u32 tfw_str_crc32_calc(const TfwStr *str);
 #ifdef DEBUG
 void tfw_str_dprint(const TfwStr *str, const char *msg);
 #else
-#define tfw_str_dprint(str, msg)
+#define tfw_str_dprint(str, msg)	do { } while (0)
 #endif
 
 #endif /* __TFW_STR_H__ */

--- a/tempesta_fw/str_simd.c
+++ b/tempesta_fw/str_simd.c
@@ -154,8 +154,8 @@ tfw_dbg_vprint32(const char *prefix, const __m256i *v)
 		 D(24), D(25), D(26), D(27), D(28), D(29), D(30), D(31));
 }
 #else
-#define tfw_dbg_vprint16(...)
-#define tfw_dbg_vprint32(...)
+#define tfw_dbg_vprint16(...)	do { } while (0)
+#define tfw_dbg_vprint32(...)	do { } while (0)
 #endif
 
 static void

--- a/tempesta_fw/t/unit/test.h
+++ b/tempesta_fw/t/unit/test.h
@@ -60,19 +60,19 @@ do {				\
 #if defined(DEBUG) && (DEBUG >= 1)
 #define TEST_DBG(...) pr_debug(TEST_BANNER "  " __VA_ARGS__)
 #else
-#define TEST_DBG(...)
+#define TEST_DBG(...) do { } while (0)
 #endif
 
 #if defined(DEBUG) && (DEBUG >= 2)
 #define TEST_DBG2(...) pr_debug(TEST_BANNER "    " __VA_ARGS__)
 #else
-#define TEST_DBG2(...)
+#define TEST_DBG2(...) do { } while (0)
 #endif
 
 #if defined(DEBUG) && (DEBUG >= 3)
 #define TEST_DBG3(...) pr_debug(TEST_BANNER "      " __VA_ARGS__)
 #else
-#define TEST_DBG3(...)
+#define TEST_DBG3(...) do { } while (0)
 #endif
 
 /*

--- a/tls/debug.h
+++ b/tls/debug.h
@@ -51,9 +51,9 @@ void ttls_dbg_print_scatterlist(const char *str, struct scatterlist *sg,
 
 #else
 
-#define TTLS_DEBUG_MPI(text, X)
-#define TTLS_DEBUG_ECP(text, X)
-#define TTLS_DEBUG_CRT(text, crt)
+#define TTLS_DEBUG_MPI(text, X)		do { } while (0)
+#define TTLS_DEBUG_ECP(text, X)		do { } while (0)
+#define TTLS_DEBUG_CRT(text, crt)	do { } while (0)
 
 #endif
 

--- a/tls/ecp_curves.c
+++ b/tls/ecp_curves.c
@@ -557,7 +557,7 @@ static int ecp_mod_p521(ttls_mpi *);
 
 #define NIST_MODP(P)	  grp->modp = ecp_mod_ ## P;
 #else
-#define NIST_MODP(P)
+#define NIST_MODP(P)	do { } while (0)
 #endif /* TTLS_ECP_NIST_OPTIM */
 
 /* Additional forward declarations */


### PR DESCRIPTION
**Upd.** I was wrong, see comments below for details.

In release builds, debug macros like `T_DBG()` are expanded to nothing. This allows to remove debug code from resulting build completely, but makes code counter-intuitive and bug-prone. Such macros are expected to behave like statements, but they are not. For example, code:
```c
int
ttls_md_update(TlsMdCtx *ctx, const unsigned char *input, size_t ilen)
{
        int r;

        BUG_ON(!ctx || !ctx->md_info);

        r = crypto_shash_update(&ctx->md_ctx, input, ilen);
        if (r)
                T_DBG("cannot update hash ctx, %d\n", r);

        return r;
}
```
expands to
```c
int
ttls_md_update(TlsMdCtx *ctx, const unsigned char *input, size_t ilen)
{
        int r;

        BUG_ON(!ctx || !ctx->md_info);

        r = crypto_shash_update(&ctx->md_ctx, input, ilen);
        if (r)
                

        return r;
}
```
Note that `return r` is conditional, and is called only when `r` is not `0`. Function returning value now doesn't return anything. It just happens to work as expected since `rax` register is filled with correct return code.

Rather than fixing all places where such macros are used, it's easier to change macros themselves to expand to empty expressions. This also prevents similar issues in the future.