### PR TITLE
#1181: GCOV compilation option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,13 @@ ifdef DEBUG
 	TFW_CFLAGS += -DDEBUG=$(DEBUG)
 endif
 
+# Use `$ TFW_GCOV=y make` to compile Tempesta modules with GCOV.
+# The kernel should be built with:
+#	CONFIG_GCOV_KERNEL=y
+#	CONFIG_GCOV_PROFILE_ALL=y
+#	CONFIG_GCOV_FORMAT_AUTODETECT=y
+TFW_GCOV ?= n
+
 # Specify the defines below if you need to build Tempesta FW with
 # debugging of the subsystem, e.g. for Tempesta TLS:
 #
@@ -55,7 +62,7 @@ TFW_CFLAGS += -mmmx -msse4.2
 
 KERNEL = /lib/modules/$(shell uname -r)/build
 
-export KERNEL TFW_CFLAGS AVX2
+export KERNEL TFW_CFLAGS AVX2 TFW_GCOV
 
 obj-m	+= lib/ tempesta_db/core/ tempesta_fw/ tls/
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,6 @@
 #		Tempesta DB
 #
-# Copyright (C) 2018 Tempesta Technologies, Inc.
+# Copyright (C) 2018-2019 Tempesta Technologies, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -20,7 +20,9 @@ EXTRA_CFLAGS += $(TFW_CFLAGS)
 
 obj-m	= tempesta_lib.o
 
+GCOV_PROFILE := $(TFW_GCOV)
+
 tempesta_lib-objs = hash.o main.o
 ifdef AVX2
-tempesta_lib-objs += str_simd.o
+	tempesta_lib-objs += str_simd.o
 endif

--- a/scripts/gcov_gather.sh
+++ b/scripts/gcov_gather.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Gcov gather script for Tempesta FW data.
+# Mainly bothered from linux/Documentation/dev-tools/gcov.rst
+#
+# Copyright (C) 2019 Tempesta Technologies, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License,
+# or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59
+# Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+DEST=$1
+GCDA=/sys/kernel/debug/gcov
+
+if [ -z "$DEST" ]; then
+	echo "Usage: $0 <output.tar.gz>" >&2
+	exit 1
+fi
+
+TEMPDIR=$(mktemp -d)
+echo Collecting data..
+find $GCDA -type d -exec mkdir -p $TEMPDIR/\{\} \;
+find $GCDA -name '*.gcda' -exec sh -c 'cat < $0 > '$TEMPDIR'/$0' {} \;
+find $GCDA -name '*.gcno' -exec sh -c 'cp -d $0 '$TEMPDIR'/$0' {} \;
+tar czf $DEST -C $TEMPDIR sys
+rm -rf $TEMPDIR
+
+echo "$DEST successfully created, copy to build system and unpack with:"
+echo "  tar xfz $DEST"

--- a/scripts/gcov_gather.sh
+++ b/scripts/gcov_gather.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Gcov gather script for Tempesta FW data.
-# Mainly bothered from linux/Documentation/dev-tools/gcov.rst
+# Mainly borrowed from linux/Documentation/dev-tools/gcov.rst
 #
 # Copyright (C) 2019 Tempesta Technologies, Inc.
 #

--- a/tempesta_db/core/Makefile
+++ b/tempesta_db/core/Makefile
@@ -19,5 +19,7 @@
 
 EXTRA_CFLAGS += $(TFW_CFLAGS) -I$(src)/../../
 
+GCOV_PROFILE := $(TFW_GCOV)
+
 obj-m	= tempesta_db.o
 tempesta_db-objs = file.o htrie.o if.o main.o table.o

--- a/tempesta_fw/Makefile
+++ b/tempesta_fw/Makefile
@@ -1,7 +1,7 @@
 #		Tempesta FW
 #
 # Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-# Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+# Copyright (C) 2015-2019 Tempesta Technologies, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -22,6 +22,8 @@ export TTLS_CFLAGS TFW_CFLAGS
 
 EXTRA_CFLAGS += $(TFW_CFLAGS) $(TTLS_CFLAGS)
 EXTRA_CFLAGS += -I$(src)/../tempesta_db/core -I$(src)/../
+
+GCOV_PROFILE := $(TFW_GCOV)
 
 obj-m	= tempesta_fw.o t/
 

--- a/tls/Makefile
+++ b/tls/Makefile
@@ -1,6 +1,6 @@
 #		Tempesta FW
 #
-# Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+# Copyright (C) 2015-2019 Tempesta Technologies, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -17,6 +17,8 @@
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 EXTRA_CFLAGS += $(TFW_CFLAGS) -I$(src)/../ -I$(src)/../tls/dummy_headers
+
+GCOV_PROFILE := $(TFW_GCOV)
 
 obj-m = tempesta_tls.o
 


### PR DESCRIPTION
The option is useful for profile guided optimization (PGO). I tried to build
http_parser.c with "profile-use=/root/tempesta/http_parser.c.gcov" in #pragma
GCC optimize. http_parser.c.gcov is generated by

$ cd ~/tempesta
$ ./scripts/gcov_gather.sh /tmp/gcov.tgz
$ cd /tmp && tar -zxf gcov.tgz && cd -
$ gcov -o /tmp/sys/kernel/debug/gcov/root/tempesta/tempesta_fw http_parser.c

perf(1) also can be used for the profile generation, see -fauto-profile GCC
command line option.

PGO generates slightly better code layout, but the profile counts total
samples and doesn't record sequence of called code. E.g. for a normal HTTP
request the parser spends more time in URI processing than in method
processing, so PGO moves URI before method processing which is completely
wrong.

The second drawback of PGO is that each code update requires regeneration of
the profile. Moreover, in general it's tricky to correctly choose the right
workload for the profile, so it looks more like workload programming than the
parser programming.

All in all, I leave the GCOV compilation option only for the test coverage and
we need to use more flexible way to generate proper code layout.