### PR TITLE
Backport TLS FSM fixes to release-0.6

### DIFF
--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -368,7 +368,11 @@ do {									\
 	WARN_ON_ONCE(p - buf > len);					\
 	io->rlen = 0;							\
 	state_p = p;							\
-	T_FSM_MOVE(st, if (unlikely(p - buf >= len)) T_FSM_EXIT(); );	\
+	if (unlikely(p - buf >= len)) {					\
+		__fsm_const_state = ttls_state(tls) + st;		\
+		T_FSM_EXIT();						\
+	}								\
+	T_FSM_MOVE(st, {});						\
 } while (0)
 
 /*

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -670,7 +670,7 @@ ttls_parse_client_hello(TlsCtx *tls, unsigned char *buf, size_t len,
 		/* Save client random (inc. Unix time). */
 		memcpy_fast(tls->hs->randbytes + io->rlen, p, n);
 		p += n;
-		io->hslen -= 32;
+		io->hslen -= n;
 		if (unlikely(io->rlen + n < 32))
 			T_FSM_EXIT();
 		T_DBG3_BUF("ClientHello: random bytes ",


### PR DESCRIPTION
Couple of fixes for fragmented TLS handshakes. See #1220 for the original PR.