### PR TITLE
tls: check handshake length earlier

### DIFF
--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -610,16 +610,6 @@ ttls_parse_client_hello(TlsCtx *tls, unsigned char *buf, size_t len,
 		T_DBG("bad type in client hello message\n");
 		return TTLS_ERR_BAD_HS_CLIENT_HELLO;
 	}
-	/*
-	 * Minimal length (with everything empty and extensions
-	 * ommitted) is 2 + 32 + 1 + 2 + 1 = 38 bytes. Check that first,
-	 * so that we can read at least up to session id length without
-	 * worrying.
-	 */
-	if (io->hslen < 38) {
-		T_DBG("too short client handshake message: %u\n", io->hslen);
-		return TTLS_ERR_BAD_HS_CLIENT_HELLO;
-	}
 
 	T_FSM_START(ttls_substate(tls)) {
 

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1218,6 +1218,19 @@ ttls_parse_record_hdr(TlsCtx *tls, unsigned char *buf, size_t len,
 			    | io->hs_hdr[3];
 		T_DBG("handshake message: msglen=%d type=%d hslen=%d read=%u\n",
 		      io->msglen, io->hstype, io->hslen, *read);
+
+		/*
+		 * Minimal length of the ClientHello with everything empty and
+		 * extensions ommitted is 2 + 32 + 1 + 2 + 1 = 38 bytes.
+		 */
+		if (unlikely(io->hstype == TTLS_HS_CLIENT_HELLO &&
+			     io->hslen < 38))
+		{
+			T_DBG("too short client handshake message: %u\n",
+			      io->hslen);
+			return TTLS_ERR_BAD_HS_CLIENT_HELLO;
+		}
+
 		/* With TLS we don't handle fragmentation (for now) */
 		if (io->msglen < io->hslen) {
 			T_DBG("TLS handshake fragmentation not supported\n");


### PR DESCRIPTION
If ClientHello comes in multiple chunks, and last chunk is smaller that 38
bytes, code will emit an error even if there is nothing wrong with the
ClientHello message itself. To avoid that, length check is moved to the
earlier stage.