### PR TITLE
Warn about non-AVX2 build at run time

### DIFF
--- a/tempesta_fw/main.c
+++ b/tempesta_fw/main.c
@@ -426,6 +426,11 @@ tfw_init(void)
 
 	TFW_LOG("Initializing Tempesta FW kernel module...\n");
 
+#ifndef AVX2
+	TFW_LOG("ATTENTION: TEMPESTA IS BUILT WIHTOUT AVX2 SUPPORT, "
+		"PERFORMANCE IS DEGRADED.");
+#endif
+
 	tfw_sysctl_hdr = register_net_sysctl(&init_net, "net/tempesta",
 					     tfw_sysctl_tbl);
 	if (!tfw_sysctl_hdr) {


### PR DESCRIPTION
Required for #1229 