### PR TITLE
tls: TlsMdCtx requires 16 bytes more of storage (backport to 0.6)

### DIFF
--- a/tls/crypto.h
+++ b/tls/crypto.h
@@ -70,7 +70,8 @@ typedef enum {
 /** Maximum length of any IV, in Bytes. */
 #define TTLS_MAX_IV_LENGTH		16
 #define TTLS_MD_MAX_SIZE		64  /* longest known is SHA512 */
-#define __MD_MAX_CTX_SZ			sizeof(struct sha512_state)
+#define __MD_MAX_CTX_SZ			(sizeof(struct sha512_state) + \
+					 sizeof(struct shash_desc))
 
 /**
  * Cipher information. Allows calling cipher functions in a generic way.


### PR DESCRIPTION
HMAC algorithm "hmac(sha384)" uses `sizeof(struct sha512_state)` bytes of storage for its "sha384" inner part and additional `sizeof(struct shash_desc)` for the "hmac" wrapper. See `hmac_init_tfm()` implementation for details (`/crypto/hmac.c` in the kernel).

(Backporting https://github.com/tempesta-tech/tempesta/pull/1243 to release-0.6)