### PR TITLE
tls: change special pointer value to be detectable by IS_ERR_OR_NULL() (backport to 0.6)

### DIFF
--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -378,7 +378,7 @@ ttls_update_checksum(TlsCtx *tls, const unsigned char *buf, size_t len)
 		if (!ci) {
 			if (WARN_ON_ONCE(ttls_sha256_init_start(sha256)))
 				return;
-			tls->xfrm.ciphersuite_info = ERR_PTR(0xdead);
+			tls->xfrm.ciphersuite_info = ERR_PTR(-1);
 		}
 		r = crypto_shash_update((struct shash_desc *)sha256, buf, len);
 		if (WARN_ON_ONCE(r))


### PR DESCRIPTION
The value of `tls->xfrm.ciphersuite_info` may be a regular pointer, or a special value which is then detected by `IS_ERR_OR_NULL()`. To make detection work, pointer value should be inside `[-4095, -1]` interval. Previous value — `0xdead` — wasn't in that interval, was treated as a regular pointer, and caused crashes.

(Backporting of https://github.com/tempesta-tech/tempesta/pull/1242 to release-0.6)