### PR TITLE
typo fixes (release-0.6)

### DIFF
--- a/CodingStyle
+++ b/CodingStyle
@@ -364,7 +364,7 @@ Let's consider following *bad* example of C++ function definition:
 
 In this example function type occupies almost full line, so there is no space
 for name of the function and its arguments. To make function declarations more
-convinient we place template argumenta at first line, function return type at
+convenient we place template arguments at first line, function return type at
 the second one and the function name with its arguments at the last line:
 
 	template<typename T>
@@ -376,7 +376,7 @@ the second one and the function name with its arguments at the last line:
 	}
 
 Please note that if some function arguments ("c" at the example above) don't
-fit one line, they are placed at the next line with identation by tabs and
+fit one line, they are placed at the next line with indentation by tabs and
 spaces to the first argument.
 
 
@@ -846,7 +846,7 @@ headers from other standard libraries and lastly the project's internal headers:
 
 It is also good idea to sort includes alhpabetically.
 
-By the way, C++ is very powerfull tool which in many cases uses TIMTOWTDI (There
+By the way, C++ is very powerful tool which in many cases uses TIMTOWTDI (There
 Is More Than One Way To Do It) concept. For example in some cases you can use
 simple C-array, STL vector or Boost array. In such cases keep you code as simple
 as possibly. It means that if there is no difference, then you should prefer
@@ -867,7 +867,7 @@ of the type as <some_prefix>_<type_name> or <type_name>_<some_suffix>. E.g.:
 	some_func_t some_func_var2 = yyy_some_func;
 
 This way it is pretty simple to grep whole code for all functions which can be
-refered by "var1_some_func". Exception of the rule could be variable names
+referred by "var1_some_func". Exception of the rule could be variable names
 defined and used in one function scope.
 
 In Linux kernel pointer specifier "*" is placed near to the argument name.
@@ -897,7 +897,7 @@ specify it with noexcept statement:
 Yes, it makes risk to get unexpected exception. But such exceptions must be
 tested and fixed during test phase. And, yes, each time when you need to modify
 source code of a function you have to check that your changes don't affect
-the function exception specification. However, it is much simplier to analyze
+the function exception specification. However, it is much simpler to analyze
 which work flow could lead to and to which exceptions.
 
 Do not use following stupid safe programming for conditions:

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -833,7 +833,7 @@
 
 # TAG: sticky_sessions
 #
-# Load balancing method. Forward all requests from client to the the same
+# Load balancing method. Forward all requests from client to the same
 # upstream server. Applied to a server group.
 #
 # Syntax:

--- a/pkg/scripts/tempesta_installer.sh
+++ b/pkg/scripts/tempesta_installer.sh
@@ -53,7 +53,7 @@ usage()
 # Use github API to get information about latest release.
 #
 # `latest` release shows ONLY releases which are not marked as `prereleases`.
-# Github restricts 60 API requests per hour without autorisation. Enough for
+# Github restricts 60 API requests per hour without authorisation. Enough for
 # our needs.
 tfw_download()
 {

--- a/tempesta_db/README.md
+++ b/tempesta_db/README.md
@@ -10,7 +10,7 @@ Meantime, the database has much lower overhead for data transport in comparison
 with client-server databases. The library should be considered as an embedded
 database.
 
-The database is designed to work in deffered interrupt context, so it doesn't
+The database is designed to work in deferred interrupt context, so it doesn't
 sleep on read or write operations.
 
 Fixed and variable length records can be stored. However, fixed size records

--- a/tempesta_db/core/htrie.c
+++ b/tempesta_db/core/htrie.c
@@ -538,7 +538,7 @@ err_cleanup:
 }
 
 /**
- * Descend the the tree starting at @node.
+ * Descend the tree starting at @node.
  *
  * @return byte offset of data (w/o TDB_HTRIE_DBIT bit) on success
  * or 0 if key @key was not found.

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -1636,7 +1636,7 @@ tfw_apm_cfgclean(void)
 }
 
 /**
- * Cleanup the configuration values when when all server groups are stopped
+ * Cleanup the configuration values when all server groups are stopped
  * and the APM timers are deleted.
  */
 static void

--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -102,7 +102,7 @@ tfw_connection_release(TfwConn *conn)
  *   0		- @msg had been sent successfully;
  *   -EBADF	- connection is broken;
  *   -EBUSY	- transmission work queue is full;
- *   -ENOMEM	- out-of-memory error occured.
+ *   -ENOMEM	- out-of-memory error occurred.
  */
 int
 tfw_connection_send(TfwConn *conn, TfwMsg *msg)

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3823,7 +3823,7 @@ next_msg:
 	}
 
 	/*
-	 * If a non critical error occured in further GFSM processing,
+	 * If a non critical error occurred in further GFSM processing,
 	 * then the response and the paired request had been handled.
 	 * Keep the server connection open for data exchange.
 	 */

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -170,7 +170,7 @@ tfw_http_sticky_redirect_applied(TfwHttpReq *req)
  *	<attempt_no> | <timestamp> | HMAC(Secret, attempt_no, timestamp)
  *
  * Field <attempt_no> is required to track redirection limit, and <timestamp> is
- * needed to detect bots, who repeat inital redirect mark in all subsequent
+ * needed to detect bots, who repeat initial redirect mark in all subsequent
  * requests.
  */
 static void

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -1020,7 +1020,7 @@ ss_skb_cutoff_data(struct sk_buff *skb_head, const TfwStr *str, int skip,
  *
  * @return SS_OK, SS_DROP, SS_POSTPONE, or a negative value of error code.
  * @processed and @chunks are incremented by number of effectively processed
- * bytes and contigous data chunks correspondingly. A caller must properly
+ * bytes and contiguous data chunks correspondingly. A caller must properly
  * initialize them. @actor sees @chunks including current chunk of data.
  */
 int

--- a/tempesta_fw/str_simd.c
+++ b/tempesta_fw/str_simd.c
@@ -47,7 +47,7 @@
  * @_token	- ASCII table column bitmaps for HTTP token, e.g. header name
  *		  (RFC 7230 3.2.6);
  * @_qetoken	- `token` with double quotes and equal sign;
- * @_nctl	- ASCII VCHAR (RFC RFC 5234, Appendix B.1.) plus SP and HTAB,
+ * @_nctl	- ASCII VCHAR (RFC 5234, Appendix B.1.) plus SP and HTAB,
  *		  used to accept HTTP header values;
  * @_xff	- ASCII characters for HTTP X-Forwarded-For header (RFC 7239);
  * @_cookie	- cookie-octet as defined in RFC 6265 4.1.1 plus DQUOTE;

--- a/tempesta_fw/t/README.md
+++ b/tempesta_fw/t/README.md
@@ -22,7 +22,7 @@ The implementation is done as simple as possible:
 
 - Test functions are organized into suites, one suite per file, for example: `test_http_parser.c`, `test_str.c`. Usually for each suite there is a corresponding unit in the Tempesta code (i.e. `test_http_parser.c` -> `http_parser.c`, `test_str.c` -> `str.c`, etc).
 
-- There is a tiny testing framework located at `unit/test.h` which is just a bunch of macros mimicing Google Test API. We hope to run tests in the user-space in future.
+- There is a tiny testing framework located at `unit/test.h` which is just a bunch of macros mimicking Google Test API. We hope to run tests in the user-space in future.
 
 - The `tfw_test` module are compiled together with the main Tempesta FW module, there is no separate build system or configuration for them. The process is controlled by the root `Makefile`. When you compile Tempesta Fw, you get tests compiled for free. That allows to keep `Makefile`s simple and ensure that you always run recent tests for the recent main module.
 

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -353,7 +353,7 @@ test_sched_srv_one_srv_zero_conn(struct TestSchedHelper *sched_helper)
 
 /**
  * Unit test. Message cannot be scheduled to any server of server group if
- * there is no no live connections across all server.
+ * there are no live connections across all server.
  */
 void
 test_sched_srv_max_srv_zero_conn(struct TestSchedHelper *sched_helper)

--- a/tempesta_fw/t/unit/test.c
+++ b/tempesta_fw/t/unit/test.c
@@ -50,7 +50,7 @@ test_fixture_fn_t test_teardown_fn;
  * thus avoid all this noise in the test log.
  *
  * Currently the Tempesta FW logger module interface is not established
- * yet, so here is just a BUG() that terminates the the testing process.
+ * yet, so here is just a BUG() that terminates the testing process.
  * It doesn't prevent flooding, but at least it makes interesting
  * messages appear at the end of the log where they can be found easily.
  */

--- a/tempesta_fw/t/unit/test_tls.c
+++ b/tempesta_fw/t/unit/test_tls.c
@@ -76,7 +76,7 @@ ttls_md_update(TlsMdCtx *ctx, const unsigned char *input, size_t ilen)
  *	Tests for Tempesta TLS low-level basic math/crypto operations.
  *
  * Note that some of the routines are designed to be called in process
- * context during Tempesta FW intialization and some of them are for
+ * context during Tempesta FW initialization and some of them are for
  * run-time softirq context, so the testing routines must enable/disable
  * FPU for them on its own.
  * ------------------------------------------------------------------------

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -36,8 +36,8 @@ static struct {
 
 /**
  * Chop skb list with begin at @skb by TLS extra data at the begin and end of
- * the the list after decryption and write the right pointer at the first skb
- * and offset to @data for upper layers processing.
+ * the list after decryption and write the right pointer at the first skb and
+ * offset to @data for upper layers processing.
  */
 static int
 tfw_tls_chop_skb_rec(TlsCtx *tls, struct sk_buff *skb, TfwFsmData *data)

--- a/tls/asn1write.h
+++ b/tls/asn1write.h
@@ -222,7 +222,7 @@ int ttls_asn1_write_octet_string(unsigned char **p, unsigned char *start,
  * \param val	   Data to store (can be NULL if you want to fill it by hand)
  * \param val_len   Minimum length of the data buffer needed
  *
- * \return	  NULL if if there was a memory allocation error, or a pointer
+ * \return	  NULL if there was a memory allocation error, or a pointer
  *			  to the new / existing entry.
  */
 ttls_asn1_named_data *ttls_asn1_store_named_data(ttls_asn1_named_data **list,

--- a/tls/bignum.h
+++ b/tls/bignum.h
@@ -170,7 +170,7 @@ int ttls_mpi_copy(ttls_mpi *X, const ttls_mpi *Y);
 void ttls_mpi_swap(ttls_mpi *X, ttls_mpi *Y);
 
 /**
- * \brief		  Safe conditional assignement X = Y if assign is 1
+ * \brief		  Safe conditional assignment X = Y if assign is 1
  *
  * \param X		MPI to conditionally assign to
  * \param Y		Value to be assigned

--- a/tls/config.h
+++ b/tls/config.h
@@ -65,10 +65,10 @@
  * \note Because of a signature change, the core AES encryption and decryption routines are
  *	   currently named ttls_aes_internal_encrypt and ttls_aes_internal_decrypt,
  *	   respectively. When setting up alternative implementations, these functions should
- *	   be overriden, but the wrapper functions ttls_aes_decrypt and ttls_aes_encrypt
+ *	   be overridden, but the wrapper functions ttls_aes_decrypt and ttls_aes_encrypt
  *	   must stay untouched.
  *
- * \note If you use the AES_xxx_ALT macros, then is is recommended to also set
+ * \note If you use the AES_xxx_ALT macros, then it is recommended to also set
  *	   TTLS_AES_ROM_TABLES in order to help the linker garbage-collect the AES
  *	   tables.
  *

--- a/tls/ecdh.h
+++ b/tls/ecdh.h
@@ -166,7 +166,7 @@ int ttls_ecdh_read_params(ttls_ecdh_context *ctx,
  * \brief		   This function sets up an ECDH context from an EC key.
  *
  *				  It is used by clients and servers in place of the
- *				  ServerKeyEchange for static ECDH, and imports ECDH
+ *				  ServerKeyExchange for static ECDH, and imports ECDH
  *				  parameters from the EC key information of a certificate.
  *
  * \param ctx	   The ECDH context to set up.

--- a/tls/ecp.c
+++ b/tls/ecp.c
@@ -1090,8 +1090,8 @@ cleanup:
  * representation uses one more K_i, due to carries.
  *
  * Also, for the sake of compactness, only the seven low-order bits of x[i]
- * are used to represent K_i, and the msb of x[i] encodes the the sign (s_i in
- * the paper): it is set if and only if if s_i == -1;
+ * are used to represent K_i, and the msb of x[i] encodes the sign (s_i in
+ * the paper): it is set if and only if s_i == -1;
  *
  * Calling conventions:
  * - x is an array of size d + 1

--- a/tls/error.c
+++ b/tls/error.c
@@ -273,7 +273,7 @@ void ttls_strerror(int ret, char *buf, size_t buflen)
 		if (use_ret == -(TTLS_ERR_X509_BUFFER_TOO_SMALL))
 			snprintf(buf, buflen, "X509 - Destination buffer is too small");
 		if (use_ret == -(TTLS_ERR_X509_FATAL_ERROR))
-			snprintf(buf, buflen, "X509 - A fatal error occured, eg the chain is too long or the vrfy callback failed");
+			snprintf(buf, buflen, "X509 - A fatal error occurred, eg the chain is too long or the vrfy callback failed");
 		// END generated code
 
 		if (strlen(buf) == 0)

--- a/tls/pk.h
+++ b/tls/pk.h
@@ -106,7 +106,7 @@ typedef struct ttls_pk_info_t ttls_pk_info_t;
 /**
  * Public key container.
  *
- * @pk_info	- Public key informations;
+ * @pk_info	- Public key information;
  * @pk_ctx	- Underlying public key context.
  */
 typedef struct {

--- a/tls/rsa.c
+++ b/tls/rsa.c
@@ -5,7 +5,7 @@
  *
  * TODO #1064: The Linux crypt API already has RSA implementation, so probably
  * the stuff below should be just thrown out. Fallback to GPU is necessary
- * however, so maybe not... A careful rethinking is requiered.
+ * however, so maybe not... A careful rethinking is required.
  *
  * The following sources were referenced in the design of this implementation
  * of the RSA algorithm:
@@ -436,12 +436,12 @@ int ttls_rsa_export_crt(const ttls_rsa_context *ctx,
  * scheme and the RSASSA-PSS signature scheme. The choice of padding mode is
  * strictly enforced for private key operations, since there might be security
  * concerns in mixing padding modes. For public key operations it is a default
- * value, which can be overriden by calling specific rsa_rsaes_xxx or
+ * value, which can be overridden by calling specific rsa_rsaes_xxx or
  * rsa_rsassa_xxx functions.
  *
  * The hash selected in hash_id is always used for OEAP encryption. For PSS
- * signatures, it is always used for making signatures, but can be overriden
- * for verifying them. If set to TTLS_MD_NONE, it is always overriden.
+ * signatures, it is always used for making signatures, but can be overridden
+ * for verifying them. If set to TTLS_MD_NONE, it is always overridden.
  */
 void
 ttls_rsa_init(ttls_rsa_context *ctx, int padding, int hash_id)

--- a/tls/rsa.h
+++ b/tls/rsa.h
@@ -61,7 +61,7 @@
 
 /*
  * The above constants may be used even if the RSA module is compile out,
- * eg for alternative (PKCS#11) RSA implemenations in the PK layers.
+ * eg for alternative (PKCS#11) RSA implementations in the PK layers.
  */
 
 /**

--- a/tls/ssl_ticket.c
+++ b/tls/ssl_ticket.c
@@ -28,7 +28,7 @@
 #include "ssl_ticket.h"
 
 /*
- * Initialze context
+ * Initialize context
  */
 void ttls_ticket_init(ttls_ticket_context *ctx)
 {

--- a/tls/ssl_ticket.h
+++ b/tls/ssl_ticket.h
@@ -75,11 +75,11 @@ void ttls_ticket_init(ttls_ticket_context *ctx);
  *				  Recommended value: 86400 (one day).
  *
  * \note			It is highly recommended to select a cipher that is at
- *				  least as strong as the the strongest ciphersuite
+ *				  least as strong as the strongest ciphersuite
  *				  supported. Usually that means a 256-bit key.
  *
  * \note			The lifetime of the keys is twice the lifetime of tickets.
- *				  It is recommended to pick a reasonnable lifetime so as not
+ *				  It is recommended to pick a reasonable lifetime so as not
  *				  to negate the benefits of forward secrecy.
  *
  * \return		  0 if successful,

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -228,7 +228,7 @@ void ttls_update_checksum(TlsCtx *tls, const unsigned char *buf, size_t len);
 
 /**
  * Implementation that should never be optimized out by the compiler.
- * Use this only for preemptable contexts and prefer bzero_fast() for siftirq.
+ * Use this only for preemptable contexts and prefer bzero_fast() for softirq.
  */
 static inline void
 ttls_zeroize(void *v, size_t n)
@@ -308,7 +308,7 @@ ttls_write_version(const TlsCtx *tls, unsigned char ver[2])
 #if defined(DEBUG) && (DEBUG >= 3)
 /*
  * Make the things repeatable, simple and INSECURE on largest debug level -
- * this helps to debug TLS (thanks to reproducable records payload), but
+ * this helps to debug TLS (thanks to reproducible records payload), but
  * must not be used in any security sensitive installations.
  */
 static inline void

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -925,9 +925,10 @@ ttls_parse_client_hello(TlsCtx *tls, unsigned char *buf, size_t len,
 		/*
 		 * Copy the extension to the temporary buffer for further
 		 * parsing. We have to copy the data since the extension parsers
-		 * call external functions and callbacks with contigous buffers.
+		 * call external functions and callbacks with contiguous
+		 * buffers.
 		 * It's too time consumptive to rework the whole API to work w/
-		 * chunked data and it's doubtful how much perfromance we get if
+		 * chunked data and it's doubtful how much performance we get if
 		 * we avoid the copies - the extensions are small after all.
 		 */
 		unsigned short off, ciph_len = 2;
@@ -1779,7 +1780,7 @@ ttls_parse_client_key_exchange(TlsCtx *tls, unsigned char *buf, size_t len,
 	 */
 	if (io->rlen + len < io->hslen) {
 		T_WARN("chunked key - fall back to copy (total length"
-		       " %u, shunk length %lu, max copy %lu)\n",
+		       " %u, chunk length %lu, max copy %lu)\n",
 		       io->hslen, len, TTLS_HS_RBUF_SZ);
 		if (io->hslen > TTLS_HS_RBUF_SZ)
 			return TTLS_ERR_BAD_HS_CLIENT_KEY_EXCHANGE;

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -139,7 +139,7 @@ ttls_crypto_req_sglist(TlsCtx *tls, struct crypto_aead *tfm, unsigned int len,
 	BUG_ON(!buf && (!skb || skb->len <= off)); /* nothing to decrypt */
 	sz += n * sizeof(**sg);
 
-	/* Dont' use g_req for better spacial locality. */
+	/* Don't use g_req for better spacial locality. */
 	req = kmalloc(sz, GFP_ATOMIC);
 	if (!req)
 		return NULL;
@@ -757,10 +757,10 @@ ttls_aead_req_free(struct crypto_aead *tfm, struct aead_request *req)
 }
 
 /**
- * This TLS records encryption function can be called syncronously, on handshake
- * finished, or asynchrnously, on callback from the TCP/IP stack. We can use TLS
- * context very carefully - many records can be processed before a record is
- * encrypted on TCP transmission.
+ * This TLS records encryption function can be called synchronously, on
+ * handshake finished, or asynchronously, on callback from the TCP/IP stack. We
+ * can use TLS context very carefully - many records can be processed before a
+ * record is encrypted on TCP transmission.
  *
  * @sgt must have enough room for AAD header and a TAG.
  *
@@ -1221,7 +1221,7 @@ ttls_parse_record_hdr(TlsCtx *tls, unsigned char *buf, size_t len,
 
 		/*
 		 * Minimal length of the ClientHello with everything empty and
-		 * extensions ommitted is 2 + 32 + 1 + 2 + 1 = 38 bytes.
+		 * extensions omitted is 2 + 32 + 1 + 2 + 1 = 38 bytes.
 		 */
 		if (unlikely(io->hstype == TTLS_HS_CLIENT_HELLO &&
 			     io->hslen < 38))
@@ -2288,7 +2288,7 @@ next_record:
 		 * before Hello message we have no idea which hash algorithm
 		 * we should use, but key derieval on KeyExchange phase may
 		 * require complete checksum for all the messages including
-		 * the KeyEchange one.
+		 * the KeyExchange one.
 		 */
 		r = ttls_handshake_step(tls, buf, len, hh_len, read);
 		if (!r)
@@ -2480,7 +2480,7 @@ static ttls_ecp_group_id ssl_preset_suiteb_curves[] = {
 };
 
 /**
- * Load reasonnable default TLS configuration values.
+ * Load reasonable default TLS configuration values.
  * Use NSA Suite B as a preset-specific defaults.
  */
 int

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -421,7 +421,7 @@ struct ttls_config
  * @rlen	- read bytes of the message body so far;
  * @skb_list	- list of skbs attached to the current I/O context;
  * @off		- data offset within @skb_list, can be after the 1st skb;
- * @chunks	- number of contigious memory chunks in all skbs in @skb_list;
+ * @chunks	- number of contiguous memory chunks in all skbs in @skb_list;
  */
 typedef struct {
 	unsigned long	ctr;
@@ -679,7 +679,7 @@ void ttls_conf_ca_chain(ttls_config *conf,
  *		provision more than one cert/key pair (eg one ECDSA, one
  *		RSA with SHA-256, one RSA with SHA-1). An adequate
  *		certificate will be selected according to the client's
- *		advertised capabilities. In case mutliple certificates are
+ *		advertised capabilities. In case multiple certificates are
  *		adequate, preference is given to the one set by the first
  *		call to this function, then second, etc.
  *

--- a/tls/x509.c
+++ b/tls/x509.c
@@ -87,7 +87,7 @@ int ttls_x509_get_alg_null(unsigned char **p, const unsigned char *end,
 }
 
 /*
- * Parse an algorithm identifier with (optional) paramaters
+ * Parse an algorithm identifier with (optional) parameters
  */
 int ttls_x509_get_alg(unsigned char **p, const unsigned char *end,
 				  ttls_x509_buf *alg, ttls_x509_buf *params)

--- a/tls/x509.h
+++ b/tls/x509.h
@@ -80,7 +80,7 @@
 /* Destination buffer is too small. */
 #define TTLS_ERR_X509_BUFFER_TOO_SMALL			-0x2980
 /*
- * A fatal error occured, eg the chain is too long or the vrfy callback
+ * A fatal error occurred, eg the chain is too long or the vrfy callback
  * failed.
  */
 #define TTLS_ERR_X509_FATAL_ERROR			-0x3000
@@ -246,7 +246,7 @@ int ttls_x509_serial_gets(char *buf, size_t size, const ttls_x509_buf *serial);
  *
  * \param to	   ttls_x509_time to check
  *
- * \return		 1 if the given time is in the past or an error occured,
+ * \return		 1 if the given time is in the past or an error occurred,
  *				 0 otherwise.
  */
 int ttls_x509_time_is_past(const ttls_x509_time *to);
@@ -260,8 +260,8 @@ int ttls_x509_time_is_past(const ttls_x509_time *to);
  *
  * \param from	 ttls_x509_time to check
  *
- * \return		 1 if the given time is in the future or an error occured,
- *				 0 otherwise.
+ * \return		 1 if the given time is in the future or an error
+ *			 occurred, 0 otherwise.
  */
 int ttls_x509_time_is_future(const ttls_x509_time *from);
 

--- a/tls/x509_crl.h
+++ b/tls/x509_crl.h
@@ -96,7 +96,7 @@ int ttls_x509_crl_parse_der(ttls_x509_crl *chain,
 /**
  * \brief		  Parse one or more CRLs and append them to the chained list
  *
- * \note		   Mutliple CRLs are accepted only if using PEM format
+ * \note		   Multiple CRLs are accepted only if using PEM format
  *
  * \param chain	points to the start of the chain
  * \param buf	  buffer holding the CRL data in PEM or DER format


### PR DESCRIPTION
Fix some typos in the comments and strings.

(backport of #1247)