### PR TITLE
tls: check union field accesses in TlsHandshake

### DIFF
--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -135,6 +135,7 @@ typedef struct tls_handshake_t {
 	ttls_sig_hash_set_t		hash_algs;
 	int				sni_authmode;
 
+	unsigned char			ecdh_point_format;
 	unsigned char			point_form		: 1,
 					extended_ms		: 1,
 					new_session_ticket	: 1,

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -227,7 +227,7 @@ ttls_parse_supported_point_formats(TlsCtx *tls, const unsigned char *buf,
 		if (p[0] == TTLS_ECP_PF_UNCOMPRESSED
 		    || p[0] == TTLS_ECP_PF_COMPRESSED)
 		{
-			tls->hs->ecdh_ctx.point_format = p[0];
+			tls->hs->ecdh_point_format = p[0];
 			T_DBG("ClientHello: point format selected: %d\n", p[0]);
 			return 0;
 		}
@@ -1287,8 +1287,13 @@ ttls_write_server_key_exchange(TlsCtx *tls, struct sg_table *sgt,
 	 * For suites involving ECDH, extract DH parameters from certificate at
 	 * this point.
 	 */
-	if (ttls_ciphersuite_uses_ecdh(ci))
+	if (ttls_ciphersuite_uses_ecdh(ci)) {
+		tls->hs->ecdh_ctx.point_format = tls->hs->ecdh_point_format;
 		ttls_get_ecdh_params_from_cert(tls);
+	} else if (ttls_ciphersuite_uses_ecdhe(ci)) {
+		tls->hs->ecdh_ctx.point_format = tls->hs->ecdh_point_format;
+	}
+
 	/*
 	 * Key exchanges not involving ephemeral keys don't use
 	 * ServerKeyExchange, so end here.

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -355,7 +355,6 @@ ttls_update_checksum(TlsCtx *tls, const unsigned char *buf, size_t len)
 	int r;
 	TlsHandshake *hs = tls->hs;
 	const TlsCiphersuite *ci = tls->xfrm.ciphersuite_info;
-	ttls_sha256_context *sha256 = (ttls_sha256_context *)&hs->ecdh_ctx;
 	ttls_md_type_t mac;
 
 	if (unlikely(!len))
@@ -371,6 +370,7 @@ ttls_update_checksum(TlsCtx *tls, const unsigned char *buf, size_t len)
 	 * hs->ecdh_ctx to store SHA256 checksum data.
 	 */
 	if (unlikely(IS_ERR_OR_NULL(ci))) {
+		ttls_sha256_context *sha256 = &TTLS_HS_tmp_sha256(hs);
 		WARN_ON_ONCE(tls->state >= TTLS_SERVER_HELLO);
 		BUILD_BUG_ON(sizeof(ttls_ecdh_context)
 			     < sizeof(ttls_sha256_context));
@@ -396,10 +396,10 @@ ttls_update_checksum(TlsCtx *tls, const unsigned char *buf, size_t len)
 		if (unlikely(tls->state < TTLS_SERVER_HELLO && hs->desc.tfm
 			     && mac == TTLS_MD_SHA256))
 		{
+			ttls_sha256_context *sha256 = &TTLS_HS_tmp_sha256(hs);
 			crypto_free_shash(hs->desc.tfm);
 			memcpy_fast(&tls->hs->fin_sha256, sha256,
 				    sizeof(*sha256));
-			bzero_fast(&hs->ecdh_ctx, sizeof(ttls_ecdh_context));
 		}
 	}
 	if (unlikely(!hs->desc.tfm)) {
@@ -1242,7 +1242,7 @@ ttls_parse_record_hdr(TlsCtx *tls, unsigned char *buf, size_t len,
 }
 
 static void
-ttls_handshake_free(TlsHandshake *hs)
+ttls_handshake_free(TlsHandshake *hs, const TlsCiphersuite *ci)
 {
 	if (!hs)
 		return;
@@ -1262,10 +1262,16 @@ ttls_handshake_free(TlsHandshake *hs)
 
 	crypto_free_shash(hs->desc.tfm);
 
+	if (!IS_ERR_OR_NULL(ci)) {
+		if (ttls_ciphersuite_uses_ecdh(ci) ||
+		    ttls_ciphersuite_uses_ecdhe(ci))
+			ttls_ecdh_free(&TTLS_HS_ecdh_ctx(hs));
+
 #if defined(TTLS_DHM_C)
-	ttls_dhm_free(&hs->dhm_ctx);
+		if (ttls_ciphersuite_uses_dhe(ci))
+			ttls_dhm_free(&TTLS_HS_dhm_ctx(hs));
 #endif
-	ttls_ecdh_free(&hs->ecdh_ctx);
+	}
 
 	bzero_fast(hs, sizeof(TlsHandshake));
 	kmem_cache_free(ttls_hs_cache, hs);
@@ -1282,7 +1288,7 @@ ttls_handshake_wrapup(TlsCtx *tls)
 		T_DBG("cache did not store session\n");
 
 	/* Free our hs params. */
-	ttls_handshake_free(tls->hs);
+	ttls_handshake_free(tls->hs, tls->xfrm.ciphersuite_info);
 	tls->hs = NULL;
 }
 
@@ -1853,10 +1859,6 @@ ttls_handshake_params_init(TlsHandshake *hs)
 
 	ttls_sig_hash_set_const_hash(&hs->hash_algs, TTLS_MD_NONE);
 
-#if defined(TTLS_DHM_C)
-	ttls_dhm_init(&hs->dhm_ctx);
-#endif
-	ttls_ecdh_init(&hs->ecdh_ctx);
 	hs->sni_authmode = TTLS_VERIFY_UNSET;
 }
 
@@ -2420,7 +2422,7 @@ ttls_ctx_clear(TlsCtx *tls)
 	if (!tls)
 		return;
 
-	ttls_handshake_free(tls->hs);
+	ttls_handshake_free(tls->hs, tls->xfrm.ciphersuite_info);
 
 	if (tls->hostname) {
 		bzero_fast(tls->hostname, strlen(tls->hostname));


### PR DESCRIPTION
~~During early stages of handshake process code calculates both sha384 and sha256 sums. Context for the latter is stored where `ecdh_ctx` is located. It turned out that there are access clashes in the code, and `ecdh_ctx` may be changed while sha256 sum is still in the process of calculation.~~

~~The patchset has a patch for fixing the clash,~~ and another patch, that adds a way to determine such clashes at runtime in debug builds.

**Upd.** During PR discussion it was found that although there were accesses to `edch_ctx` while its storage is used for sha256 context, there is no possibility of sha256 context corruption. So it's safe, and this PR doesn't fix anything, but only adds a framework of union field access tracking.