### PR TITLE
tls: merge dhm_ctx, ecdh_ctx, and tmp_sha256 fields into a union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.6.3 (2019-05-17)
+
+  * Fix crashes on TLS handshakes utilizing SHA384.
+  * Fix crashes on heavily fragmented TLS handshakes.
+  * Fix crashes on premature handshake termination from a client.
+  * Decrease TLS handshake context a bit.
+
+
 0.6.2 (2019-03-30)
 
   * Fix TLS FSM jumps on exiting out of FSM.

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -33,7 +33,7 @@
 
 #define TFW_AUTHOR		"Tempesta Technologies, Inc"
 #define TFW_NAME		"Tempesta FW"
-#define TFW_VERSION		"0.6.2"
+#define TFW_VERSION		"0.6.3"
 
 #define DEF_MAX_PORTS		8
 

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -148,10 +148,14 @@ typedef struct tls_handshake_t {
 	int  (*tls_prf)(const unsigned char *, size_t, const char *, size_t,
 			const unsigned char *, size_t, unsigned char *, size_t);
 
+	union {
 #if defined(TTLS_DHM_C)
-	ttls_dhm_context		dhm_ctx;
+		ttls_dhm_context	dhm_ctx;
 #endif
-	ttls_ecdh_context		ecdh_ctx;
+		ttls_ecdh_context	ecdh_ctx;
+		ttls_sha256_context	tmp_sha256;
+	};
+
 	union {
 		struct shash_desc	desc; /* common for both the contexts */
 		ttls_sha256_context	fin_sha256;


### PR DESCRIPTION
As ecdh_ctx and dhm_ctx share same storage space, their constructors and
destructors are now called in a more precise way.

(Backporting https://github.com/tempesta-tech/tempesta/pull/1254, because it's not solely an optimization, but also a bugfix. Crashes were possible if client were to disconnect during initial stages of handshake processing. In that case `ttls_ecdh_free()` could be called on incorrect data.)