### PR TITLE
Improve HTTP parser code layout.

### DIFF
--- a/tempesta_fw/Makefile
+++ b/tempesta_fw/Makefile
@@ -30,6 +30,7 @@ obj-m	= tempesta_fw.o t/
 tfw-srcs = $(wildcard $(obj)/*.c)
 tfw-objs = $(patsubst %.c, %.o, $(tfw-srcs))
 ifdef AVX2
+	EXTRA_CFLAGS += -mno-vzeroupper
 	tfw-objs += str_avx2.o
 endif
 

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -3493,7 +3493,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 	barrier();
 
 	/*
-	 * Process other (imporbable) states here, on slow path.
+	 * Process other (improbable) states here, on slow path.
 	 * We're on state Req_Method.
 	 *
 	 * For most (or at least most frequent) methods @step_inc should be


### PR DESCRIPTION
The most effort was for requests parsing as more performance crucia, but generic macros changes affet responses as well. The overall Tempesta performance is improved for ~3%.

1. Move rare HTTP methods to the end of the parser;
2. Most requests have no bodies, so move body parsing also to the end of the function;
3. Move FSM finishing code and return statement above the improbable states;
4. Use hot and cold label attributes to explicitly say which state transitions are more probable making the optimizer to generate better code layout;
5. Use -mno-vzeroupper since we do not have SSE instructions.

I tested performance with more or less realistic requests, but emphasizing the parser FSM states transition (many headers) instead of performance of particular state parser (e.g. long Cookie):
```
./wrk -t 2 -c 128 -d 30s --header 'Connection: keep-alive' --header 'Upgrade-Insecure-Requests: 1' --header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64)' --header 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' --header 'Accept-Encoding: gzip, deflate, sdch' --header 'Accept-Language: en-US,en;q=0.8,ru;q=0.6' --header 'Cookie: a=sdfasd; sdf=3242u389erfhhs; djcnjhe=sdfsdafsdj' http://192.168.100.4:80/
```
`wrk` was run on my host system with 2 cores (4 HT in total) and Tempesta FW ran in VM with 2 CPUs. Tempesta config:
```
listen 192.168.100.4:80;
srv_group default {
	server 127.0.0.1:8080; # apache
}
vhost default {
	proxy_pass default;
}
cache 1;
cache_fulfill * *;
http_chain {
	-> default;
}
```
The backend returned 3-byte file.