### PR TITLE
vhost selection by sticky sessions

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3171,9 +3171,6 @@ next_msg:
 	 * client may use just a few cookie variants. Even if different
 	 * sticky cookies are used for each vhost, the sticky module should
 	 * be faster than tfw_http_tbl_vhost().
-	 *
-	 * TODO: #1043 sticky cookie module must assign correct vhost when it
-	 * returns TFW_HTTP_SESS_SUCCESS or TFW_HTTP_SESS_REDIRECT_NEED;
 	 */
 	switch (tfw_http_sess_obtain(req))
 	{
@@ -3216,8 +3213,10 @@ next_msg:
 	 * In the same time location may differ between requests, so the
 	 * sticky module can't fill it.
 	 */
-	if (!req->vhost)
+	if (!req->vhost) {
 		req->vhost = tfw_http_tbl_vhost((TfwMsg *)req, &block);
+		tfw_http_sess_pin_vhost(req->sess, req->vhost);
+	}
 	if (req->vhost)
 		req->location = tfw_location_match(req->vhost,
 						   &req->uri_path);

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -50,14 +50,7 @@
  * HTTP match rules sessions must be pinned to completely other server groups.
  * This cases cannot be deduced during live reconfiguration, manual session
  * removing is required. End user should avoid such configurations.
- *
- * @srv_conn	- last used connection;
- * @lock	- protects whole @TfwStickyConn;
  */
-typedef struct {
-	TfwSrvConn		*srv_conn;
-	rwlock_t		lock;
-} TfwStickyConn;
 
 /**
  * HTTP session descriptor.
@@ -67,7 +60,8 @@ typedef struct {
  * @users	- the session use counter;
  * @ts		- timestamp for the client's session;
  * @expire	- expiration time for the session;
- * @st_conn	- upstream server connection servicing the session;
+ * @srv_conn	- upstream server connection for the session;
+ * @lock	- protects @srv_conn;
  */
 struct tfw_http_sess_t {
 	unsigned char		hmac[SHA1_DIGEST_SIZE];
@@ -75,7 +69,8 @@ struct tfw_http_sess_t {
 	atomic_t		users;
 	unsigned long		ts;
 	unsigned long		expires;
-	TfwStickyConn		st_conn;
+	TfwSrvConn		*srv_conn;
+	rwlock_t		lock;
 };
 
 enum {

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -60,8 +60,9 @@
  * @users	- the session use counter;
  * @ts		- timestamp for the client's session;
  * @expire	- expiration time for the session;
+ * @vhost	- vhost for the session if known;
  * @srv_conn	- upstream server connection for the session;
- * @lock	- protects @srv_conn;
+ * @lock	- protects @vhost and @srv_conn;
  */
 struct tfw_http_sess_t {
 	unsigned char		hmac[SHA1_DIGEST_SIZE];
@@ -69,6 +70,7 @@ struct tfw_http_sess_t {
 	atomic_t		users;
 	unsigned long		ts;
 	unsigned long		expires;
+	TfwVhost		*vhost;
 	TfwSrvConn		*srv_conn;
 	rwlock_t		lock;
 };
@@ -90,6 +92,7 @@ int tfw_http_sess_obtain(TfwHttpReq *req);
 int tfw_http_sess_req_process(TfwHttpReq *req);
 int tfw_http_sess_resp_process(TfwHttpResp *resp);
 void tfw_http_sess_put(TfwHttpSess *sess);
+void tfw_http_sess_pin_vhost(TfwHttpSess *sess, TfwVhost *vhost);
 
 bool tfw_http_sess_max_misses(void);
 unsigned int tfw_http_sess_mark_size(void);

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -375,8 +375,8 @@ http_sticky_suite_teardown(void)
 		INIT_LIST_HEAD(&mock.req->fwd_list);
 		INIT_LIST_HEAD(&mock.req->nip_list);
 		/* We have no server, so don't try to unpin a server session. */
-		if (mock.req->sess && mock.req->sess->st_conn.srv_conn)
-			mock.req->sess->st_conn.srv_conn = NULL;
+		if (mock.req->sess && mock.req->sess->srv_conn)
+			mock.req->sess->srv_conn = NULL;
 		tfw_http_msg_free((TfwHttpMsg *)mock.req);
 	}
 	if (mock.resp)

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1928,8 +1928,10 @@ tfw_cfgop_vhosts_list_free(TfwVhostList *vhosts)
 
 	list_for_each_entry_safe(vhost, tmp, &vhosts->head, list) {
 		list_del(&vhost->list);
+		set_bit(TFW_VHOST_B_REMOVED, &vhost->flags);
 		tfw_vhost_put(vhost);
 	}
+	set_bit(TFW_VHOST_B_REMOVED, &vhosts->vhost_dflt->flags);
 	tfw_vhost_put(vhosts->vhost_dflt);
 	kfree(vhosts);
 }

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -128,6 +128,11 @@ enum {
 	TFW_D_CACHE_PURGE_INVALIDATE,
 };
 
+enum {
+	/* Vhost was removed during reconfiguration. */
+	TFW_VHOST_B_REMOVED = 0,
+};
+
 typedef struct tfw_vhost_t TfwVhost;
 
 /**
@@ -141,6 +146,7 @@ typedef struct tfw_vhost_t TfwVhost;
  * @hdrs_pool	- Modification headers allocation pool for vhost's policies.
  * @refcnt	- Number of users of the virtual host object.
  * @loc_sz	- Count of elements in @loc array.
+ * @flags	- flags.
  */
 struct  tfw_vhost_t {
 	struct list_head	list;
@@ -151,6 +157,7 @@ struct  tfw_vhost_t {
 	TfwPool			*hdrs_pool;
 	atomic64_t		refcnt;
 	size_t			loc_sz;
+	unsigned long		flags;
 };
 
 #define TFW_VH_DFT_NAME		"default"


### PR DESCRIPTION
The patchset adds `vhost` caching in HTTP sessions. We now save `vhost` after the first request in a session is processed, and then reuse it for other requests in the session, thus avoiding the selection procedure which may be quite costly.

(fixes https://github.com/tempesta-tech/tempesta/issues/1043)