### PR TITLE
cleanup tfw_addr_ifmatch() tfw_addr_eq()

### DIFF
--- a/tempesta_fw/addr.c
+++ b/tempesta_fw/addr.c
@@ -406,8 +406,6 @@ tfw_addr_ifmatch(const TfwAddr *server, const TfwAddr *listener)
 			/* backend = [::1] */
 			return 1;
 		}
-
-		/* TODO: same as in v4 case */
 	}
 
 	return tfw_addr_eq(server, listener);


### PR DESCRIPTION
Remove misleading TODO: v6 case is alredy the same as v4 one.

Replace direct sockaddr_in::sin6_port access with accessor
function tfw_addr_port().