### PR TITLE
Incorporation of HTTP/2 processing into general HTTP logic (#309).

### DIFF
--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -418,7 +418,7 @@
 # Tempesta FW listening address.
 #
 # Syntax:
-#   listen PORT | IPADDR[:PORT] [proto=http|https[:h2|http/1.1]]
+#   listen PORT | IPADDR[:PORT] [proto=http|https|h2]
 #
 # IPADDR may be either an IPv4 or IPv6 address, no host names allowed.
 # IPv6 address must be enclosed in square brackets (e.g. "[::0]" but not "::0").
@@ -426,21 +426,16 @@
 # If only PORT is given, then the address 0.0.0.0 (but not [::1]) is used.
 # If only IPADDR is given, then the default HTTP port 80 is used.
 #
-# It is allowed to specify the type of listening socket via the 'proto'. At
-# the moment HTTP and HTTPS protos are supported. For HTTPS proto (TLS actually)
-# it is allowed the application level protocol (in context of ALPN extension of
-# TLS) to be specified: HTTP/2 or HTTP/1.1 with RFC compliant names 'h2' and
-# 'http/1.1' respectively. It is also possible to specify both protocols
-# separated by comma; in this case, the protocols' order is significant for
-# TLS ALPN: first specified protocol takes precedence over the last one in
-# negotiation procedure. If no application level protocol is given, then
-# HTTP/1.1 is default. If the entire 'proto' option is absent, then plain
-# HTTP protocol (over TCP) is supposed by the default.
+# It is allowed to specify the type of listening socket via the 'proto'. At the
+# moment following values for 'proto' attribute are supported: 'http' (means
+# HTTP/1.1 over TCP), 'https' (means HTTP/1.1 over TLS) and 'h2' (means HTTP/2
+# over TLS). If 'proto' option is absent, then 'proto=http' is supposed by
+# default.
 #
 # Tempesta FW opens one socket for each 'listen' entry, so it may be repeated
 # to listen on multiple addresses/ports. For example:
 #   listen 80;
-#   listen 443 proto=https:h2,http/1.1;
+#   listen 443 proto=h2;
 #   listen [::0]:80;
 #   listen 127.0.0.1:8001;
 #   listen [::1]:8001;

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -660,7 +660,10 @@ tfw_cache_send_304(TfwHttpReq *req, TfwCacheEntry *ce)
 	if (tfw_msg_write(&it, &g_crlf))
 		goto err_setup;
 
-	tfw_http_resp_fwd(resp);
+	if (TFW_CONN_H2(req->conn))
+		tfw_h2_resp_adjust_fwd(resp);
+	else
+		tfw_http_resp_fwd(resp);
 
 	return;
 err_setup:

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -636,7 +636,7 @@ tfw_cache_send_304(TfwHttpReq *req, TfwCacheEntry *ce)
 	WARN_ON_ONCE(!list_empty(&req->fwd_list));
 	WARN_ON_ONCE(!list_empty(&req->nip_list));
 
-	if (TFW_CONN_H2(req->conn)) {
+	if (TFW_MSG_H2(req)) {
 		/*
 		 * TODO: add separate flow for HTTP/2 response preparing
 		 * and sending (HPACK index, encode in HTTP/2 format, add

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -638,9 +638,9 @@ tfw_cache_send_304(TfwHttpReq *req, TfwCacheEntry *ce)
 
 	if (TFW_MSG_H2(req)) {
 		/*
-		 * TODO: add separate flow for HTTP/2 response preparing
-		 * and sending (HPACK index, encode in HTTP/2 format, add
-		 * frame headers and send via @tfw_h2_resp_fwd()).
+		 * TODO #309: add separate flow for HTTP/2 response preparing
+		 * and sending (HPACK index, encode in HTTP/2 format, add frame
+		 * headers and send via @tfw_h2_resp_fwd()).
 		 */
 		return;
 	}

--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -78,7 +78,7 @@ tfw_connection_drop(TfwConn *conn)
 {
 	/* Ask higher levels to free resources at connection close. */
 	TFW_CONN_HOOK_CALL(conn, conn_drop);
-	BUG_ON(conn->msg);
+	BUG_ON(conn->stream.msg);
 }
 
 /*

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -603,8 +603,8 @@ static void
 tfw_h2_send_resp(TfwHttpReq *req, resp_code_t code)
 {
 	/*
-	 * TODO: add separate flow for HTTP/2 response preparing and
-	 * sending (HPACK index, encode in HTTP/2 format, add frame
+	 * TODO #309: add separate flow for HTTP/2 response preparing
+	 * and sending (HPACK index, encode in HTTP/2 format, add frame
 	 * headers and send via @tfw_h2_resp_fwd()).
 	 */
 }
@@ -2696,9 +2696,9 @@ tfw_h2_resp_adjust_fwd(TfwHttpResp *resp)
 		return;
 	}
 	/*
-	 * TODO: transforming response into HTTP/2 format and sending (HPACK
-	 * index, replace headers/names with indexes in HTTP/2 format, add
-	 * lengths in HTTP/2 format for not replaced headers/values, apply
+	 * TODO #309: transforming response into HTTP/2 format and sending
+	 * (HPACK index, replace headers/names with indexes in HTTP/2 format,
+	 * add lengths in HTTP/2 format for not replaced headers/values, apply
 	 * @tfw_http_adjust_resp() optimized for HTTP/2 HPACK, insert frame
 	 * headers for HEADERS and DATA frames and send via @tfw_h2_resp_fwd()).
 	 */

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1085,13 +1085,13 @@ tfw_http_req_evict_dropped(TfwSrvConn *srv_conn, TfwHttpReq *req)
 	if (TFW_MSG_H2(req)) {
 		if (req->stream)
 			return false;
-		TFW_DBG2("%s: Eviction: req=[%p] corresponding stream has been"
-			 " dropped\n", __func__, req);
+		T_DBG2("%s: Eviction: req=[%p] corresponding stream has been"
+		       " dropped\n", __func__, req);
 	} else {
 		if (likely(!test_bit(TFW_HTTP_B_REQ_DROP, req->flags)))
 			return false;
-		TFW_DBG2("%s: Eviction: req=[%p] client disconnected\n",
-			 __func__, req);
+		T_DBG2("%s: Eviction: req=[%p] client disconnected\n", __func__,
+		       req);
 	}
 
 	if (srv_conn)
@@ -1920,7 +1920,7 @@ tfw_http_conn_msg_alloc(TfwConn *conn, TfwStream *stream)
 	hm->stream = stream;
 
 	if (TFW_CONN_H2(conn))
-		__set_bit(TFW_HTTP_B_REQ_H2, hm->flags);
+		__set_bit(TFW_HTTP_B_H2, hm->flags);
 
 	if (type & Conn_Clnt)
 		tfw_http_init_parser_req((TfwHttpReq *)hm);
@@ -2566,7 +2566,7 @@ tfw_h2_resp_fwd(TfwHttpResp *resp)
 	TfwHttpReq *req = resp->req;
 
 	if (tfw_connection_send(req->conn, (TfwMsg *)resp)) {
-		TFW_DBG("Cannot send data to client (%d) via HTTP/2\n", r);
+		T_DBG("%s: cannot send data to client via HTTP/2\n");
 		TFW_INC_STAT_BH(serv.msgs_otherr);
 		tfw_connection_close(req->conn, true);
 	}
@@ -3634,7 +3634,7 @@ next_msg:
  * better to transfer requests to a TDB node to make any adjustments.
  * The other benefit of the scheme is that less work is done in SoftIRQ.
  */
-static inline void
+static void
 tfw_http_resp_cache_cb(TfwHttpMsg *msg)
 {
 	TfwHttpResp *resp = (TfwHttpResp *)msg;

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1068,6 +1068,14 @@ tfw_http_req_zap_error(struct list_head *eq)
 static inline bool
 tfw_http_req_evict_dropped(TfwSrvConn *srv_conn, TfwHttpReq *req)
 {
+	/*
+	 * The special case are the health monitor requests, which have
+	 * not corresponding client connection and, consequently, cannot
+	 * be dropped.
+	 */
+	if (!req->conn)
+		return false;
+
 	if (TFW_CONN_H2(req->conn)) {
 		if (req->stream)
 			return false;

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -238,6 +238,8 @@ enum {
 	TFW_HTTP_B_CT_MULTIPART_HAS_BOUNDARY,
 	/* Singular header presents more than once. */
 	TFW_HTTP_B_FIELD_DUPENTRY,
+	/* Message is fully parsed */
+	TFW_HTTP_B_FULLY_PARSED,
 	/* Message has HTTP/2 format. */
 	TFW_HTTP_B_H2,
 
@@ -257,8 +259,6 @@ enum {
 	TFW_HTTP_B_WHITELIST,
 	/* Client was disconnected, drop the request. */
 	TFW_HTTP_B_REQ_DROP,
-	/* Request is fully assembled (applicable for HTTP/2 mode only). */
-	TFW_HTTP_B_REQ_COMPLETE,
 
 	/* Response flags */
 	TFW_HTTP_FLAGS_RESP,

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -255,6 +255,8 @@ enum {
 	TFW_HTTP_B_WHITELIST,
 	/* Client was disconnected, drop the request. */
 	TFW_HTTP_B_REQ_DROP,
+	/* Request has HTTP/2 format (applicable for HTTP/2 mode only). */
+	TFW_HTTP_B_REQ_H2,
 	/* Request is fully assembled (applicable for HTTP/2 mode only). */
 	TFW_HTTP_B_REQ_COMPLETE,
 
@@ -276,6 +278,9 @@ enum {
 
 #define __TFW_HTTP_MSG_M_CONN						\
 	(BIT(TFW_HTTP_B_CONN_CLOSE) | BIT(TFW_HTTP_B_CONN_KA))
+
+#define TFW_MSG_H2(hmmsg)						\
+	test_bit(TFW_HTTP_B_REQ_H2, ((TfwHttpMsg *)hmmsg)->flags)
 
 /**
  * The structure to hold data for an HTTP error response.

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -238,6 +238,8 @@ enum {
 	TFW_HTTP_B_CT_MULTIPART_HAS_BOUNDARY,
 	/* Singular header presents more than once. */
 	TFW_HTTP_B_FIELD_DUPENTRY,
+	/* Message has HTTP/2 format. */
+	TFW_HTTP_B_H2,
 
 	/* Request flags. */
 	TFW_HTTP_FLAGS_REQ,
@@ -255,8 +257,6 @@ enum {
 	TFW_HTTP_B_WHITELIST,
 	/* Client was disconnected, drop the request. */
 	TFW_HTTP_B_REQ_DROP,
-	/* Request has HTTP/2 format (applicable for HTTP/2 mode only). */
-	TFW_HTTP_B_REQ_H2,
 	/* Request is fully assembled (applicable for HTTP/2 mode only). */
 	TFW_HTTP_B_REQ_COMPLETE,
 
@@ -280,7 +280,7 @@ enum {
 	(BIT(TFW_HTTP_B_CONN_CLOSE) | BIT(TFW_HTTP_B_CONN_KA))
 
 #define TFW_MSG_H2(hmmsg)						\
-	test_bit(TFW_HTTP_B_REQ_H2, ((TfwHttpMsg *)hmmsg)->flags)
+	test_bit(TFW_HTTP_B_H2, ((TfwHttpMsg *)hmmsg)->flags)
 
 /**
  * The structure to hold data for an HTTP error response.

--- a/tempesta_fw/http_frame.c
+++ b/tempesta_fw/http_frame.c
@@ -47,6 +47,8 @@
 #define MAX_WND_SIZE			((1U << 31) - 1)
 #define DEF_WND_SIZE			((1U << 16) - 1)
 
+#define TFW_MAX_CLOSED_STREAMS		5
+
 /**
  * FSM states for HTTP/2 frames processing.
  */
@@ -176,10 +178,10 @@ do {									\
 			tfw_h2_conn_terminate((ctx), err);		\
 			return T_DROP;					\
 		} else if (res == STREAM_FSM_RES_TERM_STREAM) {		\
-			return tfw_h2_stream_terminate((ctx),		\
-							  (hdr)->stream_id, \
-							  &(ctx)->cur_stream, \
-							  err);		\
+			return tfw_h2_stream_close((ctx),		\
+						   (hdr)->stream_id,	\
+						   &(ctx)->cur_stream,	\
+						   err);		\
 		}							\
 		return T_OK;						\
 	}								\
@@ -200,6 +202,7 @@ tfw_h2_cleanup(void)
 void
 tfw_h2_context_init(TfwH2Ctx *ctx)
 {
+	TfwClosedQueue *cl_queue = &ctx->cl_queue;
 	TfwSettings *lset = &ctx->lsettings;
 	TfwSettings *rset = &ctx->rsettings;
 
@@ -207,6 +210,8 @@ tfw_h2_context_init(TfwH2Ctx *ctx)
 
 	ctx->state = HTTP2_RECV_CLI_START_SEQ;
 	ctx->loc_wnd = MAX_WND_SIZE;
+	spin_lock_init(&ctx->lock);
+	INIT_LIST_HEAD(&cl_queue->closed);
 
 	lset->hdr_tbl_sz = rset->hdr_tbl_sz = 1 << 12;
 	lset->push = rset->push = 1;
@@ -223,7 +228,7 @@ tfw_h2_context_init(TfwH2Ctx *ctx)
 void
 tfw_h2_context_clear(TfwH2Ctx *ctx)
 {
-	tfw_h2_streams_cleanup(&ctx->sched);
+	WARN_ON_ONCE(ctx->streams_num);
 }
 
 static inline void
@@ -460,7 +465,7 @@ tfw_h2_send_goaway(TfwH2Ctx *ctx, TfwH2Err err_code)
 	return tfw_h2_send_frame_close(ctx, &hdr, &data);
 }
 
-static inline int
+int
 tfw_h2_send_rst_stream(TfwH2Ctx *ctx, unsigned int id, TfwH2Err err_code)
 {
 	unsigned char buf[ERR_CODE_SIZE];
@@ -484,43 +489,25 @@ tfw_h2_send_rst_stream(TfwH2Ctx *ctx, unsigned int id, TfwH2Err err_code)
 	return tfw_h2_send_frame(ctx, &hdr, &data);
 }
 
-static inline int
-tfw_h2_conn_terminate(TfwH2Ctx *ctx, TfwH2Err err_code)
+void
+tfw_h2_conn_terminate_close(TfwH2Ctx *ctx, TfwH2Err err_code, bool close)
 {
-	return tfw_h2_send_goaway(ctx, err_code);
-}
+	TfwH2Conn *conn = container_of(ctx, TfwH2Conn, h2);
 
-static inline int
-tfw_h2_stream_terminate(TfwH2Ctx *ctx, unsigned int id, TfwStream **stream,
-			TfwH2Err err_code)
-{
-	if (stream && *stream) {
-		--ctx->streams_num;
-		tfw_h2_stop_stream(&ctx->sched, stream);
-	}
-
-	return tfw_h2_send_rst_stream(ctx, id, err_code);
+	if (tfw_h2_send_goaway(ctx, err_code) && close)
+		tfw_connection_close((TfwConn *)conn, true);
 }
 
 static inline void
-tfw_h2_check_closed_stream(TfwH2Ctx *ctx)
+tfw_h2_conn_terminate(TfwH2Ctx *ctx, TfwH2Err err_code)
 {
-	BUG_ON(!ctx->cur_stream);
-
-	T_DBG3("%s: stream->id=%u, stream->state=%d, stream=[%p], streams_num="
-	       "%lu\n", __func__, ctx->cur_stream->id, ctx->cur_stream->state,
-	       ctx->cur_stream, ctx->streams_num);
-
-	if (tfw_h2_stream_is_closed(ctx->cur_stream)) {
-		--ctx->streams_num;
-		tfw_h2_stop_stream(&ctx->sched, &ctx->cur_stream);
-	}
+	tfw_h2_conn_terminate_close(ctx, err_code, false);
 }
 
 #define VERIFY_FRAME_SIZE(ctx)						\
 do {									\
 	if ((ctx)->hdr.length < 0) {					\
-		tfw_h2_conn_terminate(ctx, HTTP2_ECODE_SIZE);	\
+		tfw_h2_conn_terminate(ctx, HTTP2_ECODE_SIZE);		\
 		return T_DROP;						\
 	}								\
 } while (0)
@@ -565,6 +552,12 @@ tfw_h2_headers_pri_process(TfwH2Ctx *ctx)
 	return T_OK;
 }
 
+/*
+ * Create new stream and add it to streams storage and to dependency tree.
+ * Note, that we do not need to protect streams storage in @sched from
+ * concurrent access, since all operations with it (adding, searching and
+ * deletion) are done only in receiving flow of Frame layer.
+ */
 static TfwStream *
 tfw_h2_stream_create(TfwH2Ctx *ctx, unsigned int id)
 {
@@ -592,6 +585,207 @@ tfw_h2_stream_create(TfwH2Ctx *ctx, unsigned int id)
 	return stream;
 }
 
+static inline void
+tfw_h2_stream_clean(TfwH2Ctx *ctx, TfwStream *stream)
+{
+	tfw_h2_stop_stream(&ctx->sched, stream);
+	tfw_h2_delete_stream(stream);
+	--ctx->streams_num;
+}
+
+/*
+ * Unlink stream from corresponding request (if linked) and from special
+ * queue of closed streams (if it is contained there). If request is linked
+ * with stream, but not assembled yet, it must be deleted right here to
+ * avoid leakage, because in this case it is not used anywhere yet.
+ *
+ * NOTE: call to this procedure should be protected by special lock for
+ * Stream linkage protection.
+ */
+static void
+tfw_h2_stream_unlink(TfwH2Ctx *ctx, TfwStream *stream)
+{
+	TfwHttpMsg *hmreq = (TfwHttpMsg *)stream->msg;
+
+	if (!list_empty(&stream->cl_node)) {
+		list_del_init(&stream->cl_node);
+		--ctx->cl_queue.num_closed;
+	}
+
+	if (hmreq) {
+		hmreq->stream = NULL;
+		if (!test_bit(TFW_HTTP_B_REQ_COMPLETE, hmreq->flags))
+			tfw_http_conn_msg_free(hmreq);
+	}
+}
+
+static inline void
+tfw_h2_stream_unlink_locked(TfwH2Ctx *ctx, TfwStream *stream)
+{
+	spin_lock(&ctx->lock);
+
+	tfw_h2_stream_unlink(ctx, stream);
+
+	spin_unlock(&ctx->lock);
+}
+
+static inline void
+tfw_h2_current_stream_remove(TfwH2Ctx *ctx)
+{
+	tfw_h2_stream_unlink_locked(ctx, ctx->cur_stream);
+	tfw_h2_stream_clean(ctx, ctx->cur_stream);
+	ctx->cur_stream = NULL;
+}
+
+void
+tfw_h2_conn_streams_cleanup(TfwH2Ctx *ctx)
+{
+	TfwStream *cur, *next;
+	TfwH2Conn *conn = container_of(ctx, TfwH2Conn, h2);
+	TfwStreamSched *sched = &ctx->sched;
+
+	WARN_ON_ONCE(((TfwConn *)conn)->stream.msg);
+
+	rbtree_postorder_for_each_entry_safe(cur, next, &sched->streams, node) {
+		tfw_h2_stream_unlink_locked(ctx, cur);
+		tfw_h2_stream_clean(ctx, cur);
+	}
+}
+
+/*
+ * Add stream to special queue of closed streams.
+ *
+ * NOTE: call to this procedure should be protected by special lock for
+ * Stream linkage protection.
+ */
+static inline void
+tfw_h2_stream_add_closed(TfwClosedQueue *cl_queue, TfwStream *stream)
+{
+	if (!list_empty(&stream->cl_node))
+		return;
+
+	list_add_tail(&stream->cl_node, &cl_queue->closed);
+	++cl_queue->num_closed;
+}
+
+static inline void
+tfw_h2_stream_add_closed_locked(TfwH2Ctx *ctx, TfwStream *stream)
+{
+	spin_lock(&ctx->lock);
+
+	tfw_h2_stream_add_closed(&ctx->cl_queue, stream);
+
+	spin_unlock(&ctx->lock);
+}
+
+/*
+ * Stream closing procedure: move the stream into special queue of closed
+ * streams and send RST_STREAM frame to peer. This procedure is intended
+ * for usage only in receiving flow of Framing layer, thus the stream is
+ * definitely alive here and we need not any unlinking operations since
+ * all the unlinking and cleaning work will be made later, during shrinking
+ * the queue of closed streams; thus, we just move the stream into the
+ * closed queue here.
+ */
+static int
+tfw_h2_stream_close(TfwH2Ctx *ctx, unsigned int id, TfwStream **stream,
+		    TfwH2Err err_code)
+{
+	if (stream && *stream) {
+		tfw_h2_stream_add_closed_locked(ctx, *stream);
+		*stream = NULL;
+	}
+
+	return tfw_h2_send_rst_stream(ctx, id, err_code);
+}
+
+/*
+ * Unlink request from corresponding stream (if linked) and move the stream
+ * to the queue of closed streams (if it is not contained there yet).
+ */
+unsigned int
+tfw_h2_stream_id_close(TfwHttpReq *req)
+{
+	TfwStream *stream;
+	unsigned int id;
+	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+
+	spin_lock(&ctx->lock);
+
+	stream = req->stream;
+	if (!stream) {
+		spin_unlock(&ctx->lock);
+		return 0;
+	}
+
+	id = stream->id;
+	stream->msg = NULL;
+
+	tfw_h2_stream_add_closed(&ctx->cl_queue, stream);
+
+	spin_unlock(&ctx->lock);
+
+	return id;
+}
+
+/*
+ * Clean the queue of closed streams if its size has exceeded a certain
+ * value.
+ */
+static void
+tfw_h2_closed_streams_shrink(TfwH2Ctx *ctx)
+{
+	TfwStream *cur;
+	unsigned int max_streams = ctx->lsettings.max_streams;
+	TfwClosedQueue *cl_queue = &ctx->cl_queue;
+
+	while (1)
+	{
+		spin_lock(&ctx->lock);
+
+		if (cl_queue->num_closed <= TFW_MAX_CLOSED_STREAMS
+		    || (max_streams == ctx->streams_num
+			&& cl_queue->num_closed))
+		{
+			spin_unlock(&ctx->lock);
+			break;
+		}
+
+		BUG_ON(list_empty(&cl_queue->closed));
+		cur = list_first_entry(&cl_queue->closed, TfwStream, cl_node);
+		tfw_h2_stream_unlink(ctx, cur);
+
+		spin_unlock(&ctx->lock);
+
+		tfw_h2_stream_clean(ctx, cur);
+	}
+}
+
+static inline void
+tfw_h2_check_closed_stream(TfwH2Ctx *ctx)
+{
+	BUG_ON(!ctx->cur_stream);
+
+	T_DBG3("%s: stream->id=%u, stream->state=%d, stream=[%p], streams_num="
+	       "%lu\n", __func__, ctx->cur_stream->id, ctx->cur_stream->state,
+	       ctx->cur_stream, ctx->streams_num);
+
+	if (tfw_h2_stream_is_closed(ctx->cur_stream))
+		tfw_h2_current_stream_remove(ctx);
+}
+
+static inline int
+tfw_h2_stream_state_process(TfwH2Ctx *ctx)
+{
+	TfwFrameHdr *hdr = &ctx->hdr;
+
+	STREAM_RECV_PROCESS(ctx, hdr);
+
+	tfw_h2_check_closed_stream(ctx);
+
+	return T_OK;
+}
+
 static int
 tfw_h2_headers_process(TfwH2Ctx *ctx)
 {
@@ -609,9 +803,9 @@ tfw_h2_headers_process(TfwH2Ctx *ctx)
 
 		ctx->state = HTTP2_IGNORE_FRAME_DATA;
 
-		return tfw_h2_stream_terminate(ctx, hdr->stream_id,
-						  &ctx->cur_stream,
-						  HTTP2_ECODE_PROTO);
+		return tfw_h2_stream_close(ctx, hdr->stream_id,
+					   &ctx->cur_stream,
+					   HTTP2_ECODE_PROTO);
 	}
 
 	if (!ctx->cur_stream) {
@@ -627,11 +821,7 @@ tfw_h2_headers_process(TfwH2Ctx *ctx)
 	 * HEADERS frame), we should process its state here - when frame is
 	 * fully received and new stream is created.
 	 */
-	STREAM_RECV_PROCESS(ctx, hdr);
-
-	tfw_h2_check_closed_stream(ctx);
-
-	return T_OK;
+	return tfw_h2_stream_state_process(ctx);
 }
 
 static int
@@ -643,9 +833,9 @@ tfw_h2_wnd_update_process(TfwH2Ctx *ctx)
 	wnd_incr = ntohl(*(unsigned int *)ctx->rbuf) & ((1U << 31) - 1);
 	if (!wnd_incr) {
 		if (ctx->cur_stream)
-			return tfw_h2_stream_terminate(ctx, hdr->stream_id,
-							  &ctx->cur_stream,
-							  HTTP2_ECODE_PROTO);
+			return tfw_h2_stream_close(ctx, hdr->stream_id,
+						   &ctx->cur_stream,
+						   HTTP2_ECODE_PROTO);
 		tfw_h2_conn_terminate(ctx, HTTP2_ECODE_PROTO);
 		return T_DROP;
 	}
@@ -672,9 +862,9 @@ tfw_h2_priority_process(TfwH2Ctx *ctx)
 		T_DBG("Invalid dependency: new stream with %u depends on"
 		      " itself\n", hdr->stream_id);
 
-		return tfw_h2_stream_terminate(ctx, hdr->stream_id,
-						  &ctx->cur_stream,
-						  HTTP2_ECODE_PROTO);
+		return tfw_h2_stream_close(ctx, hdr->stream_id,
+					   &ctx->cur_stream,
+					   HTTP2_ECODE_PROTO);
 	}
 
 	T_DBG3("%s: parsed, stream_id=%u, dep_stream_id=%u, weight=%hu,"
@@ -686,7 +876,7 @@ tfw_h2_priority_process(TfwH2Ctx *ctx)
 	return T_OK;
 }
 
-static void
+static inline void
 tfw_h2_rst_stream_process(TfwH2Ctx *ctx)
 {
 	BUG_ON(!ctx->cur_stream);
@@ -694,9 +884,7 @@ tfw_h2_rst_stream_process(TfwH2Ctx *ctx)
 	       __func__, ctx->hdr.stream_id, ctx->cur_stream,
 	       ntohl(*(unsigned int *)ctx->rbuf));
 
-	--ctx->streams_num;
-
-	tfw_h2_stop_stream(&ctx->sched, &ctx->cur_stream);
+	tfw_h2_current_stream_remove(ctx);
 }
 
 static int
@@ -838,13 +1026,23 @@ tfw_h2_stream_id_verify(TfwH2Ctx *ctx)
 	if (ctx->cur_stream)
 		return T_OK;
 	/*
-	 * If stream ID is not greater than last processed ID,
-	 * there may be two reasons for that:
-	 * 1. Stream has been created, processed, closed and
-	 *    removed by now;
-	 * 2. Stream was never created and has been moved from
-	 *    idle to closed without processing (see RFC 7540
-	 *    section 5.1.1 for details).
+	 * If stream ID is not greater than last processed ID, there may be
+	 * two reasons for that:
+	 * 1. Stream has been created, processed, closed and removed by now;
+	 * 2. Stream was never created and has been moved from idle to closed
+	 *    without processing (see RFC 7540 section 5.1.1 for details).
+	 *
+	 * NOTE: in cases of sending RST_STREAM frame or END_STREAM flag, stream
+	 * can be switched into special closed states: HTTP2_STREAM_LOC_CLOSED
+	 * or HTTP2_STREAM_REM_CLOSED (which indicates that situation is possible
+	 * when stream had been already closed on server side, but the client
+	 * does not aware about that yet); according to RFC 7540, section 5.1
+	 * ('closed' paragraph) - we should silently discard such stream, i.e.
+	 * continue process entire HTTP/2 connection but ignore HEADERS,
+	 * CONTINUATION and DATA frames from this stream (not pass upstairs);
+	 * to achieve such behavior (to avoid removing of such closed streams
+	 * right away), streams in these states are temporary stored in special
+	 * queue @TfwClosedQueue.
 	 */
 	if (ctx->lstream_id >= hdr->stream_id) {
 		T_DBG("Invalid ID of new stream: %u stream is"
@@ -1002,41 +1200,31 @@ tfw_h2_frame_type_process(TfwH2Ctx *ctx)
 			err_code = HTTP2_ECODE_PROTO;
 			goto conn_term;
 		}
-		/*
-		 * TODO: in cases of sending RST_STREAM frame or END_STREAM
-		 * flag - stream can be switched into the closed state - this
-		 * is the race condition (when stream had been closed on server
-		 * side, but the client does not aware about that yet), and we
-		 * should silently discard such stream, i.e. continue process
-		 * entire HTTP/2 connection but ignore HEADERS, CONTINUATION and
-		 * DATA frames from this stream (not pass upstairs); to achieve
-		 * such behavior (to avoid removing of such closed streams right
-		 * away), we should store closed streams - for some predefined
-		 * period of time or just limiting the amount of closed stored
-		 * streams (see comments for @TfwStreamState enum at the
-		 * beginning of http_stream.c).
-		 */
+
 		ctx->cur_stream = tfw_h2_find_stream(&ctx->sched,
-							hdr->stream_id);
+						     hdr->stream_id);
+		if (tfw_h2_stream_id_verify(ctx)) {
+			err_code = HTTP2_ECODE_PROTO;
+			goto conn_term;
+		}
 		/*
 		 * Endpoints must not exceed the limit set by their peer for
 		 * maximum number of concurrent streams (see RFC 7540 section
 		 * 5.1.2 for details).
 		 */
-		if (!ctx->cur_stream
-		    && ctx->lsettings.max_streams <= ctx->streams_num)
-		{
-			T_DBG("Max streams number exceeded: %lu\n",
-			      ctx->streams_num);
-			SET_TO_READ_VERIFY(ctx, HTTP2_IGNORE_FRAME_DATA);
-			return tfw_h2_stream_terminate(ctx, hdr->stream_id,
-						       NULL,
-						       HTTP2_ECODE_REFUSED);
-		}
+		if (!ctx->cur_stream) {
+			unsigned int max_streams = ctx->lsettings.max_streams;
 
-		if (tfw_h2_stream_id_verify(ctx)) {
-			err_code = HTTP2_ECODE_PROTO;
-			goto conn_term;
+			WARN_ON_ONCE(max_streams < ctx->streams_num);
+			tfw_h2_closed_streams_shrink(ctx);
+
+			if (max_streams == ctx->streams_num) {
+				T_DBG("Max streams number exceeded: %lu\n",
+				      ctx->streams_num);
+				SET_TO_READ_VERIFY(ctx, HTTP2_IGNORE_FRAME_DATA);
+				return tfw_h2_send_rst_stream(ctx, hdr->stream_id,
+							      HTTP2_ECODE_REFUSED);
+			}
 		}
 
 		ctx->data_off = FRAME_HEADER_SIZE;
@@ -1060,9 +1248,9 @@ tfw_h2_frame_type_process(TfwH2Ctx *ctx)
 							hdr->stream_id);
 		if (hdr->length != FRAME_PRIORITY_SIZE) {
 			SET_TO_READ(ctx);
-			return tfw_h2_stream_terminate(ctx, hdr->stream_id,
-							  &ctx->cur_stream,
-							  HTTP2_ECODE_SIZE);
+			return tfw_h2_stream_close(ctx, hdr->stream_id,
+						   &ctx->cur_stream,
+						   HTTP2_ECODE_SIZE);
 		}
 
 		if (ctx->cur_stream)
@@ -1387,7 +1575,8 @@ tfw_h2_frame_recv(void *data, unsigned char *buf, size_t len,
 	T_FSM_STATE(HTTP2_RECV_DATA) {
 		FRAME_FSM_READ(ctx->to_read);
 
-		tfw_h2_check_closed_stream(ctx);
+		if (tfw_h2_stream_state_process(ctx))
+			FRAME_FSM_EXIT(T_DROP);
 
 		FRAME_FSM_EXIT(T_OK);
 	}
@@ -1404,7 +1593,8 @@ tfw_h2_frame_recv(void *data, unsigned char *buf, size_t len,
 	T_FSM_STATE(HTTP2_RECV_CONT) {
 		FRAME_FSM_READ(ctx->to_read);
 
-		tfw_h2_check_closed_stream(ctx);
+		if (tfw_h2_stream_state_process(ctx))
+			FRAME_FSM_EXIT(T_DROP);
 
 		FRAME_FSM_EXIT(T_OK);
 	}
@@ -1457,6 +1647,7 @@ int
 tfw_h2_frame_process(void *c, TfwFsmData *data)
 {
 	int r;
+	bool postponed;
 	unsigned int unused, curr_tail;
 	TfwFsmData data_up = {};
 	TfwH2Ctx *h2 = tfw_h2_context(c);
@@ -1467,6 +1658,7 @@ tfw_h2_frame_process(void *c, TfwFsmData *data)
 	BUG_ON(tail >= skb->len);
 
 next_msg:
+	postponed = false;
 	ss_skb_queue_tail(&h2->skb_head, skb);
 	r = ss_skb_process(skb, off, tail, tfw_h2_frame_recv, h2, &unused,
 			   &parsed);
@@ -1496,10 +1688,12 @@ next_msg:
 		 * all collected skbs are dropped at once when service
 		 * frame fully received, processed and applied.
 		 */
-		if (!APP_FRAME(h2))
-			return T_OK;
+		if (APP_FRAME(h2)) {
+			postponed = true;
+			break;
+		}
 
-		break;
+		return T_OK;
 	case T_OK:
 		T_DBG3("%s: parsed=%d skb->len=%u\n", __func__,
 		       parsed, skb->len);
@@ -1555,8 +1749,8 @@ next_msg:
 		data_up.off = h2->data_off;
 		data_up.skb = h2->skb_head;
 		h2->data_off = 0;
-		h2->skb_head = NULL;
-		r = tfw_http_msg_process_generic(c, &data_up);
+		h2->skb_head = data_up.skb->next = data_up.skb->prev = NULL;
+		r = tfw_http_msg_process_generic(c, h2->cur_stream, &data_up);
 		if (r == T_DROP) {
 			kfree_skb(nskb);
 			goto out;
@@ -1565,7 +1759,7 @@ next_msg:
 		ss_skb_queue_purge(&h2->skb_head);
 	}
 
-	tfw_h2_context_reinit(h2, r == T_POSTPONE);
+	tfw_h2_context_reinit(h2, postponed);
 
 	if (nskb) {
 		skb = nskb;

--- a/tempesta_fw/http_frame.h
+++ b/tempesta_fw/http_frame.h
@@ -59,10 +59,10 @@ typedef enum {
  * 4.1). Reserved bit is not present here since it has no any semantic
  * value for now and should be always ignored.
  *
- * @length	- the frame's payload length;
- * @stream_id	- id of current stream (which frame is processed);
- * @type	- the type of frame being processed;
- * @flags	- frame's flags;
+ * @length		- the frame's payload length;
+ * @stream_id		- id of current stream (which frame is processed);
+ * @type		- the type of frame being processed;
+ * @flags		- frame's flags;
  */
 typedef struct {
 	int		length;
@@ -75,9 +75,9 @@ typedef struct {
  * Unpacked data from priority payload of frames (RFC 7540 section 6.2
  * and section 6.3).
  *
- * @stream_id	- id for the stream that the current stream depends on;
- * @weight	- stream's priority weight;
- * @exclusive	- flag indicating exclusive stream dependency;
+ * @stream_id		- id for the stream that the current stream depends on;
+ * @weight		- stream's priority weight;
+ * @exclusive		- flag indicating exclusive stream dependency;
  */
 typedef struct {
 	unsigned int	stream_id;
@@ -111,51 +111,54 @@ typedef struct {
 } TfwSettings;
 
 /**
- * Limited queue for temporary storage of closed streams. This structure
- * provides the possibility of temporary existing in memory - for streams
- * which are in HTTP2_STREAM_LOC_CLOSED or HTTP2_STREAM_REM_CLOSED states
- * (see RFC 7540, section 5.1, the 'closed' paragraph). Note, that streams
- * in  HTTP2_STREAM_CLOSED state are not stored in this queue and must be
- * removed right away.
+ * Limited queue for temporary storage of half-closed streams. This structure
+ * provides the possibility of temporary existing in memory - for streams which
+ * are in HTTP2_STREAM_LOC_CLOSED or HTTP2_STREAM_REM_CLOSED states (see RFC
+ * 7540, section 5.1, the 'closed' paragraph). Note, that streams in
+ * HTTP2_STREAM_CLOSED state are not stored in this queue and must be removed
+ * right away.
  *
- * @closed	- list of streams which are in closed state;
- * @num_closed	- number of streams in the list;
+ * @list		- list of streams which are in closed state;
+ * @num			- number of streams in the list;
  */
 typedef struct {
-	struct list_head	closed;
-	unsigned long		num_closed;
+	struct list_head	list;
+	unsigned long		num;
 } TfwClosedQueue;
 
 /**
  * Context for HTTP/2 frames processing.
  *
- * @lock	- spinlock to protect stream-request linkage;
- * @lsettings	- local settings for HTTP/2 connection;
- * @rsettings	- settings for HTTP/2 connection received from the remote
- *		  endpoint;
- * @streams_num	- number of the streams initiated by client;
- * @sched	- streams' priority scheduler;
- * @cl_queue	- queue of closed streams (in HTTP2_STREAM_LOC_CLOSED or
- *		  HTTP2_STREAM_REM_CLOSED states), which are waiting for
- *		  removal;
- * @lstream_id	- ID of last stream initiated by client and processed on the
- *		  server side;
- * @loc_wnd	- connection's current flow controlled window;
- * @__off	- offset to reinitialize processing context;
- * @skb_head	- collected list of processed skbs containing HTTP/2 frames;
- * @cur_stream	- found stream for the frame currently being processed;
- * @priority	- unpacked data from priority part of payload of processed
- *		  HEADERS or PRIORITY frames;
- * @hdr		- unpacked data from header of currently processed frame;
- * @state	- current FSM state of HTTP/2 processing context;
- * @to_read	- indicates how much data of HTTP/2 frame should
- *		  be read on next FSM @state;
- * @rlen	- length of accumulated data in @rbuf;
- * @rbuf	- buffer for data accumulation from frames headers and
- *		  payloads (for service frames) during frames processing;
- * @padlen	- length of current frame's padding (if exists);
- * @data_off	- offset of app data in HEADERS, CONTINUATION and DATA
- *		  frames (after all service payloads);
+ * @lock		- spinlock to protect stream-request linkage;
+ * @lsettings		- local settings for HTTP/2 connection;
+ * @rsettings		- settings for HTTP/2 connection received from the
+ *			  remote endpoint;
+ * @streams_num		- number of the streams initiated by client;
+ * @sched		- streams' priority scheduler;
+ * @hclosed_streams	- queue of half-closed streams (in
+ *			  HTTP2_STREAM_LOC_CLOSED or HTTP2_STREAM_REM_CLOSED
+ *			  states), which are waiting for removal;
+ * @lstream_id		- ID of last stream initiated by client and processed on
+ *			  the server side;
+ * @loc_wnd		- connection's current flow controlled window;
+ * @__off		- offset to reinitialize processing context;
+ * @skb_head		- collected list of processed skbs containing HTTP/2
+ *			  frames;
+ * @cur_stream		- found stream for the frame currently being processed;
+ * @priority		- unpacked data from priority part of payload of
+ *			  processed HEADERS or PRIORITY frames;
+ * @hdr			- unpacked data from header of currently processed
+ *			  frame;
+ * @state		- current FSM state of HTTP/2 processing context;
+ * @to_read		- indicates how much data of HTTP/2 frame should
+ *			  be read on next FSM @state;
+ * @rlen		- length of accumulated data in @rbuf;
+ * @rbuf		- buffer for data accumulation from frames headers and
+ *			  payloads (for service frames) during frames
+ *			  processing;
+ * @padlen		- length of current frame's padding (if exists);
+ * @data_off		- offset of app data in HEADERS, CONTINUATION and DATA
+ *			  frames (after all service payloads);
  */
 typedef struct {
 	spinlock_t	lock;
@@ -163,7 +166,7 @@ typedef struct {
 	TfwSettings	rsettings;
 	unsigned long	streams_num;
 	TfwStreamSched	sched;
-	TfwClosedQueue	cl_queue;
+	TfwClosedQueue	hclosed_streams;
 	unsigned int	lstream_id;
 	unsigned int	loc_wnd;
 	char		__off[0];

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -903,7 +903,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, TfwFsmData *data,
 	T_FSM_INIT(Frang_Req_0, "frang");
 
 	BUG_ON(!ra);
-	BUG_ON(req != container_of(conn->msg, TfwHttpReq, msg));
+	BUG_ON(req != container_of(req->stream->msg, TfwHttpReq, msg));
 	frang_dbg("check request for client %s, acc=%p\n",
 		  &FRANG_ACC2CLI(ra)->addr, ra);
 

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -483,7 +483,7 @@ __frang_http_field_len(const TfwHttpReq *req, FrangAcc *ra,
 static int
 frang_http_field_len(const TfwHttpReq *req, FrangAcc *ra, unsigned int field_len)
 {
-	TfwHttpParser *parser = &req->conn->parser;
+	TfwHttpParser *parser = &req->stream->parser;
 
 	if (parser->hdr.len > field_len) {
 		frang_limmsg("HTTP in-progress field length",
@@ -739,7 +739,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, TfwFsmData *data)
 	T_FSM_INIT(Frang_Req_0, "frang");
 
 	BUG_ON(!ra);
-	BUG_ON(req != container_of(conn->msg, TfwHttpReq, msg));
+	BUG_ON(req != container_of(req->stream->msg, TfwHttpReq, msg));
 	frang_dbg("check request for client %s, acc=%p\n",
 		  &FRANG_ACC2CLI(ra)->addr, ra);
 

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -317,7 +317,7 @@ __hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr)
 void
 tfw_http_msg_hdr_open(TfwHttpMsg *hm, unsigned char *hdr_start)
 {
-	TfwStr *hdr = &hm->conn->parser.hdr;
+	TfwStr *hdr = &hm->stream->parser.hdr;
 
 	BUG_ON(!TFW_STR_EMPTY(hdr));
 
@@ -339,7 +339,7 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm, unsigned int id)
 {
 	TfwStr *h;
 	TfwHttpHdrTbl *ht = hm->h_tbl;
-	TfwHttpParser *parser = &hm->conn->parser;
+	TfwHttpParser *parser = &hm->stream->parser;
 
 	BUG_ON(parser->hdr.flags & TFW_STR_DUPLICATE);
 	BUG_ON(id > TFW_HTTP_HDR_RAW);

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -83,7 +83,7 @@ do {									\
 } while (0)
 
 #define __msg_hdr_chunk_fixup(data, len)				\
-	tfw_http_msg_add_str_data(msg, &msg->conn->parser.hdr, data, len)
+	tfw_http_msg_add_str_data(msg, &msg->stream->parser.hdr, data, len)
 
 /**
  * GCC 4.8 (CentOS 7) does a poor work on memory reusage of automatic local
@@ -93,7 +93,7 @@ do {									\
  */
 #define __FSM_DECLARE_VARS(ptr)						\
 	TfwHttpMsg	*msg = (TfwHttpMsg *)(ptr);			\
-	TfwHttpParser	*parser = &msg->conn->parser;			\
+	TfwHttpParser	*parser = &msg->stream->parser;			\
 	unsigned char	*p = data;					\
 	unsigned char	c = *p;						\
 	int		__maybe_unused __fsm_n;				\
@@ -170,10 +170,10 @@ do {									\
 
 #define __FSM_MOVE_nofixup(to)		__FSM_MOVE_nofixup_n(to, 1)
 #define __FSM_MOVE_n(to, n)						\
-	__FSM_MOVE_nf(to, n, &msg->conn->parser.hdr)
+	__FSM_MOVE_nf(to, n, &msg->stream->parser.hdr)
 #define __FSM_MOVE_f(to, field)		__FSM_MOVE_nf(to, 1, field)
 #define __FSM_MOVE(to)							\
-	__FSM_MOVE_nf(to, 1, &msg->conn->parser.hdr)
+	__FSM_MOVE_nf(to, 1, &msg->stream->parser.hdr)
 /* The same as __FSM_MOVE_n(), but exactly for jumps w/o data moving. */
 #define __FSM_JMP(to)			do { goto to; } while (0)
 
@@ -201,7 +201,7 @@ do {									\
 	__FSM_MATCH_MOVE_fixup_pos(alphabet, to, field, true)
 
 #define __FSM_MATCH_MOVE(alphabet, to)					\
-	__FSM_MATCH_MOVE_f(alphabet, to, &msg->conn->parser.hdr)
+	__FSM_MATCH_MOVE_f(alphabet, to, &msg->stream->parser.hdr)
 
 #define __FSM_MATCH_MOVE_nofixup(alphabet, to)				\
 do {									\
@@ -227,7 +227,7 @@ do {									\
 } while (0)
 
 #define __FSM_I_chunk_flags(flag)					\
-	__FSM_I_field_chunk_flags(&msg->conn->parser.hdr, flag)
+	__FSM_I_field_chunk_flags(&msg->stream->parser.hdr, flag)
 
 #define __FSM_I_MOVE_n(to, n)						\
 do {									\
@@ -283,7 +283,7 @@ do {									\
 } while (0)
 
 #define __FSM_I_MOVE_fixup(to, n, flag)					\
-	__FSM_I_MOVE_fixup_f(to, n, &msg->conn->parser.hdr, flag)
+	__FSM_I_MOVE_fixup_f(to, n, &msg->stream->parser.hdr, flag)
 
 #define __FSM_I_MATCH_MOVE_fixup(alphabet, to, flag)			\
 do {									\
@@ -548,7 +548,7 @@ parse_int_hex(unsigned char *data, size_t len, unsigned long *acc, unsigned shor
 static void
 mark_spec_hbh(TfwHttpMsg *hm)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &hm->conn->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &hm->stream->parser.hbh_parser;
 	unsigned int id;
 
 	for (id = 0; id < TFW_HTTP_HDR_RAW; ++id) {
@@ -565,7 +565,7 @@ mark_spec_hbh(TfwHttpMsg *hm)
 static void
 mark_raw_hbh(TfwHttpMsg *hm, TfwStr *hdr)
 {
-	TfwHttpHbhHdrs *hbh = &hm->conn->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh = &hm->stream->parser.hbh_parser;
 	unsigned int i;
 
 	/*
@@ -632,7 +632,7 @@ static int
 __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len, bool last)
 {
 	TfwStr *hdr, *append;
-	TfwHttpHbhHdrs *hbh = &hm->conn->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh = &hm->stream->parser.hbh_parser;
 	static const TfwStr block[] = {
 		/* End-to-end spec and raw headers */
 		TFW_STR_STRING("age:"),
@@ -2606,7 +2606,7 @@ __req_parse_if_msince(TfwHttpMsg *msg, unsigned char *data, size_t len)
 {
 	int r = CSTR_NEQ;
 	TfwHttpReq *req = (TfwHttpReq *)msg;
-	TfwHttpParser *parser = &msg->conn->parser;
+	TfwHttpParser *parser = &msg->stream->parser;
 
 	if (!(req->cond.flags & TFW_HTTP_COND_IF_MSINCE))
 		r = __parse_http_date(msg, data, len);
@@ -2891,10 +2891,10 @@ __parser_init(TfwHttpParser *parser)
 void
 tfw_http_init_parser_req(TfwHttpReq *req)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &req->conn->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &req->stream->parser.hbh_parser;
 
-	__parser_init(&req->conn->parser);
-	req->conn->parser.state = NULL;
+	__parser_init(&req->stream->parser);
+	req->stream->parser.state = NULL;
 
 	/*
 	 * Expected hop-by-hop headers:
@@ -3986,6 +3986,19 @@ match_meth:
 }
 STACK_FRAME_NON_STANDARD(tfw_http_parse_req);
 
+int
+tfw_h2_parse_req(void *req_data, unsigned char *data, size_t len,
+		 unsigned int *parsed)
+{
+	int r = TFW_POSTPONE;
+
+	/*
+	 * TODO: implement parsing of HTTP/2 frame's payload:
+	 * HEADERS/CONTINUATION (through HPACK at first) and DATA.
+	 */
+	return r;
+}
+
 /*
  * ------------------------------------------------------------------------
  *	HTTP response parsing
@@ -4193,7 +4206,7 @@ __resp_parse_expires(TfwHttpMsg *msg, unsigned char *data, size_t len)
 {
 	int r;
 	TfwHttpResp *resp = (TfwHttpResp *)msg;
-	TfwHttpParser *parser = &msg->conn->parser;
+	TfwHttpParser *parser = &msg->stream->parser;
 
 	/*
 	 * A duplicate invalidates the header's value.
@@ -4227,7 +4240,7 @@ __resp_parse_date(TfwHttpMsg *msg, unsigned char *data, size_t len)
 {
 	int r = CSTR_NEQ;
 	TfwHttpResp *resp = (TfwHttpResp *)msg;
-	TfwHttpParser *parser = &msg->conn->parser;
+	TfwHttpParser *parser = &msg->stream->parser;
 
 	if (!test_bit(TFW_HTTP_B_HDR_DATE, resp->flags))
 		r = __parse_http_date(msg, data, len);
@@ -4256,7 +4269,7 @@ __resp_parse_if_modified(TfwHttpMsg *msg, unsigned char *data, size_t len)
 {
 	int r = CSTR_NEQ;
 	TfwHttpResp *resp = (TfwHttpResp *)msg;
-	TfwHttpParser *parser = &msg->conn->parser;
+	TfwHttpParser *parser = &msg->stream->parser;
 
 	if (!test_bit(TFW_HTTP_B_HDR_LMODIFIED, resp->flags))
 		r = __parse_http_date(msg, data, len);
@@ -4334,9 +4347,9 @@ tfw_http_parse_terminate(TfwHttpMsg *hm)
 void
 tfw_http_init_parser_resp(TfwHttpResp *resp)
 {
-	TfwHttpHbhHdrs *hbh_hdrs = &resp->conn->parser.hbh_parser;
+	TfwHttpHbhHdrs *hbh_hdrs = &resp->stream->parser.hbh_parser;
 
-	__parser_init(&resp->conn->parser);
+	__parser_init(&resp->stream->parser);
 
 	/*
 	 * Expected hop-by-hop headers:

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -105,6 +105,8 @@ void tfw_http_init_parser_resp(TfwHttpResp *resp);
 
 int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 		       unsigned int *parsed);
+int tfw_h2_parse_req(void *req_data, unsigned char *data, size_t len,
+		     unsigned int *parsed);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len,
 			unsigned int *parsed);
 int tfw_http_parse_terminate(TfwHttpMsg *hm);

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -226,9 +226,9 @@ tfw_http_sticky_build_redirect(TfwHttpReq *req, StickyVal *sv, RedirMarkVal *mv)
 
 	if (TFW_MSG_H2(req)) {
 		/*
-		 * TODO: add separate flow for HTTP/2 response preparing
-		 * and sending (HPACK index, encode in HTTP/2 format, add
-		 * frame headers and send via @tfw_h2_resp_fwd()).
+		 * TODO #309: add separate flow for HTTP/2 response preparing
+		 * and sending (HPACK index, encode in HTTP/2 format, add frame
+		 * headers and send via @tfw_h2_resp_fwd()).
 		 */
 		return TFW_HTTP_SESS_REDIRECT_NEED;
 	}

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -224,6 +224,15 @@ tfw_http_sticky_build_redirect(TfwHttpReq *req, StickyVal *sv, RedirMarkVal *mv)
 	if (!tfw_http_sticky_redirect_applied(req))
 		return TFW_HTTP_SESS_JS_NOT_SUPPORTED;
 
+	if (TFW_CONN_H2(req->conn)) {
+		/*
+		 * TODO: add separate flow for HTTP/2 response preparing
+		 * and sending (HPACK index, encode in HTTP/2 format, add
+		 * frame headers and send via @tfw_h2_resp_fwd()).
+		 */
+		return TFW_HTTP_SESS_REDIRECT_NEED;
+	}
+
 	if (!(resp = tfw_http_msg_alloc_resp_light(req)))
 		return -ENOMEM;
 

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -224,7 +224,7 @@ tfw_http_sticky_build_redirect(TfwHttpReq *req, StickyVal *sv, RedirMarkVal *mv)
 	if (!tfw_http_sticky_redirect_applied(req))
 		return TFW_HTTP_SESS_JS_NOT_SUPPORTED;
 
-	if (TFW_CONN_H2(req->conn)) {
+	if (TFW_MSG_H2(req)) {
 		/*
 		 * TODO: add separate flow for HTTP/2 response preparing
 		 * and sending (HPACK index, encode in HTTP/2 format, add

--- a/tempesta_fw/http_stream.c
+++ b/tempesta_fw/http_stream.c
@@ -37,15 +37,6 @@
  * of closed state). Besides, there is no explicit 'idle' state here, since
  * in current implementation idle stream is just a stream that has not been
  * created yet.
- *
- * TODO: in HTTP2_STREAM_CLOSED state stream is removed from stream's storage,
- * but for HTTP2_STREAM_LOC_CLOSED and HTTP2_STREAM_REM_CLOSED states stream
- * must be present in memory for some period of time (see RFC 7540, section
- * 5.1, the 'closed' paragraph). Since transitions to these states can occur
- * only during response sending, thus some additional structure for temporary
- * storage of closed streams (e.g. simple limited queue based on linked list -
- * on top of existing storage structure) should be implemented in context of
- * responses' sending functionality of #309.
  */
 typedef enum {
 	HTTP2_STREAM_LOC_RESERVED,
@@ -201,21 +192,19 @@ tfw_h2_stream_fsm(TfwStream *stream, unsigned char type, unsigned char flags,
 		 * will be removed from stream's storage (i.e. moved into final
 		 * 'closed' state).
 		 */
-		if (type == HTTP2_DATA
-		    || type == HTTP2_HEADERS
-		    || type == HTTP2_CONTINUATION)
-		{
-			*err = HTTP2_ECODE_CLOSED;
-			return STREAM_FSM_RES_TERM_STREAM;
-		}
-
 		if (type == HTTP2_CONTINUATION) {
 			*err = HTTP2_ECODE_PROTO;
 			return STREAM_FSM_RES_TERM_CONN;
 		}
 
-		if (type == HTTP2_RST_STREAM)
+		if (type == HTTP2_RST_STREAM) {
 			stream->state = HTTP2_STREAM_CLOSED;
+		}
+		else if (type != HTTP2_PRIORITY || type != HTTP2_WINDOW_UPDATE) {
+			*err = HTTP2_ECODE_CLOSED;
+			return STREAM_FSM_RES_TERM_STREAM;
+		}
+
 		break;
 
 	case HTTP2_STREAM_CONT_HC:
@@ -292,6 +281,12 @@ tfw_h2_stream_fsm(TfwStream *stream, unsigned char type, unsigned char flags,
 }
 
 bool
+tfw_h2_stream_req_complete(TfwStream *stream)
+{
+	return stream->state == HTTP2_STREAM_REM_HALF_CLOSED;
+}
+
+bool
 tfw_h2_stream_is_closed(TfwStream *stream)
 {
 	return stream->state == HTTP2_STREAM_CLOSED;
@@ -302,6 +297,7 @@ tfw_h2_init_stream(TfwStream *stream, unsigned int id, unsigned short weight,
 		   unsigned int wnd)
 {
 	RB_CLEAR_NODE(&stream->node);
+	INIT_LIST_HEAD(&stream->cl_node);
 	stream->id = id;
 	stream->state = HTTP2_STREAM_OPENED;
 	stream->loc_wnd = wnd;
@@ -361,19 +357,10 @@ tfw_h2_add_stream(TfwStreamSched *sched, unsigned int id, unsigned short weight,
 	return new_stream;
 }
 
-static inline void
-tfw_h2_remove_stream(TfwStreamSched *sched, TfwStream *stream)
-{
-	rb_erase(&stream->node, &sched->streams);
-}
-
 void
-tfw_h2_streams_cleanup(TfwStreamSched *sched)
+tfw_h2_delete_stream(TfwStream *stream)
 {
-	TfwStream *cur, *next;
-
-	rbtree_postorder_for_each_entry_safe(cur, next, &sched->streams, node)
-		kmem_cache_free(stream_cache, cur);
+	kmem_cache_free(stream_cache, stream);
 }
 
 int
@@ -417,11 +404,8 @@ tfw_h2_remove_stream_dep(TfwStreamSched *sched, TfwStream *stream)
 }
 
 void
-tfw_h2_stop_stream(TfwStreamSched *sched, TfwStream **stream)
+tfw_h2_stop_stream(TfwStreamSched *sched, TfwStream *stream)
 {
-	tfw_h2_remove_stream_dep(sched, *stream);
-	tfw_h2_remove_stream(sched, *stream);
-
-	kmem_cache_free(stream_cache, *stream);
-	*stream = NULL;
+	tfw_h2_remove_stream_dep(sched, stream);
+	rb_erase(&stream->node, &sched->streams);
 }

--- a/tempesta_fw/http_stream.c
+++ b/tempesta_fw/http_stream.c
@@ -261,7 +261,7 @@ tfw_h2_init_stream(TfwStream *stream, unsigned int id, unsigned short weight,
 		   unsigned int wnd)
 {
 	RB_CLEAR_NODE(&stream->node);
-	INIT_LIST_HEAD(&stream->cl_node);
+	INIT_LIST_HEAD(&stream->hcl_node);
 	stream->id = id;
 	stream->state = HTTP2_STREAM_OPENED;
 	stream->loc_wnd = wnd;

--- a/tempesta_fw/http_stream.c
+++ b/tempesta_fw/http_stream.c
@@ -27,32 +27,6 @@
 
 #define HTTP2_DEF_WEIGHT	16
 
-/**
- * States for HTTP/2 streams processing.
- *
- * NOTE: there is no exact matching between these states and states from
- * RFC 7540 (section 5.1), since several intermediate states were added in
- * current implementation to handle some edge states which are not mentioned
- * explicitly in RFC (e.g. additional continuation states, and special kinds
- * of closed state). Besides, there is no explicit 'idle' state here, since
- * in current implementation idle stream is just a stream that has not been
- * created yet.
- */
-typedef enum {
-	HTTP2_STREAM_LOC_RESERVED,
-	HTTP2_STREAM_REM_RESERVED,
-	HTTP2_STREAM_OPENED,
-	HTTP2_STREAM_CONT,
-	HTTP2_STREAM_CONT_CLOSED,
-	HTTP2_STREAM_CONT_HC,
-	HTTP2_STREAM_CONT_HC_CLOSED,
-	HTTP2_STREAM_LOC_HALF_CLOSED,
-	HTTP2_STREAM_REM_HALF_CLOSED,
-	HTTP2_STREAM_LOC_CLOSED,
-	HTTP2_STREAM_REM_CLOSED,
-	HTTP2_STREAM_CLOSED
-} TfwStreamState;
-
 static struct kmem_cache *stream_cache;
 
 int
@@ -197,10 +171,12 @@ tfw_h2_stream_fsm(TfwStream *stream, unsigned char type, unsigned char flags,
 			return STREAM_FSM_RES_TERM_CONN;
 		}
 
-		if (type == HTTP2_RST_STREAM) {
+		if (type == HTTP2_RST_STREAM)
+		{
 			stream->state = HTTP2_STREAM_CLOSED;
 		}
-		else if (type != HTTP2_PRIORITY || type != HTTP2_WINDOW_UPDATE) {
+		else if (type != HTTP2_PRIORITY || type != HTTP2_WINDOW_UPDATE)
+		{
 			*err = HTTP2_ECODE_CLOSED;
 			return STREAM_FSM_RES_TERM_STREAM;
 		}
@@ -278,18 +254,6 @@ tfw_h2_stream_fsm(TfwStream *stream, unsigned char type, unsigned char flags,
 	T_DBG3("exit %s: stream->state=%d\n", __func__, stream->state);
 
 	return STREAM_FSM_RES_OK;
-}
-
-bool
-tfw_h2_stream_req_complete(TfwStream *stream)
-{
-	return stream->state == HTTP2_STREAM_REM_HALF_CLOSED;
-}
-
-bool
-tfw_h2_stream_is_closed(TfwStream *stream)
-{
-	return stream->state == HTTP2_STREAM_CLOSED;
 }
 
 static inline void

--- a/tempesta_fw/http_stream.h
+++ b/tempesta_fw/http_stream.h
@@ -87,7 +87,7 @@ typedef enum {
  * Representation of HTTP/2 stream entity.
  *
  * @node	- entry in per-connection storage of streams (red-black tree);
- * @cl_node	- entry in queue of closed streams;
+ * @hcl_node	- entry in queue of half-closed streams;
  * @id		- stream ID;
  * @state	- stream's current state;
  * @loc_wnd	- stream's current flow controlled window;
@@ -97,7 +97,7 @@ typedef enum {
  */
 typedef struct {
 	struct rb_node		node;
-	struct list_head	cl_node;
+	struct list_head	hcl_node;
 	unsigned int		id;
 	int			state;
 	unsigned int		loc_wnd;

--- a/tempesta_fw/t/unit/helpers.c
+++ b/tempesta_fw/t/unit/helpers.c
@@ -56,6 +56,7 @@ test_req_alloc(size_t data_len)
 	tfw_connection_init(&conn_req);
 	conn_req.proto.type = Conn_HttpClnt;
 	hmreq->conn = &conn_req;
+	hmreq->stream = &conn_req.stream;
 	tfw_http_init_parser_req((TfwHttpReq *)hmreq);
 
 	return (TfwHttpReq *)hmreq;
@@ -88,6 +89,7 @@ test_resp_alloc(size_t data_len)
 	tfw_connection_init(&conn_req);
 	conn_resp.proto.type = Conn_HttpSrv;
 	hmresp->conn = &conn_resp;
+	hmresp->stream = &conn_resp.stream;
 	tfw_http_init_parser_resp((TfwHttpResp *)hmresp);
 
 	return (TfwHttpResp *)hmresp;

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -358,6 +358,8 @@ http_sticky_suite_setup(void)
 
 	mock.req->conn = (TfwConn *)&mock.conn_req;
 	mock.resp->conn = &mock.conn_resp;
+	mock.req->stream = &mock.conn_req.stream;
+	mock.resp->stream = &mock.conn_resp.stream;
 	tfw_http_init_parser_req(mock.req);
 	tfw_http_init_parser_resp(mock.resp);
 	mock.req->vhost = tfw_vhost_new(TFW_VH_DFT_NAME);
@@ -438,6 +440,7 @@ TEST(http_sticky, sending_302_without_preparing)
 
 	mock.resp = mock.req->resp;
 	mock.resp->conn = &mock.conn_resp;
+	mock.resp->stream = &mock.conn_resp.stream;
 
 	/*
 	 * tfw_http_sticky_build_redirect() uses quick HTTP message allocator,
@@ -496,6 +499,7 @@ TEST(http_sticky, sending_302)
 	/* See test sending_302_without_preparing. */
 	mock.resp = mock.req->resp;
 	mock.resp->conn = &mock.conn_resp;
+	mock.resp->stream = &mock.conn_resp.stream;
 	mock.resp->h_tbl = (TfwHttpHdrTbl *)tfw_pool_alloc(mock.resp->pool,
 							   TFW_HHTBL_SZ(1));
 	EXPECT_NOT_NULL(mock.resp->h_tbl);

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -38,10 +38,6 @@ enum {
 	TFW_TLS_FSM_DONE	= TFW_GFSM_TLS_STATE(TFW_GFSM_STATE_LAST)
 };
 
-#define TFW_CONN_H2(c)							\
-	(tfw_tls_context(c)->alpn_chosen				\
-	 && tfw_tls_context(c)->alpn_chosen->id == TTLS_ALPN_ID_HTTP2)
-
 void tfw_tls_cfg_require(void);
 int tfw_tls_cfg_alpn_protos(const char *cfg_str);
 void tfw_tls_free_alpn_protos(void);

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -251,7 +251,7 @@
 #define TTLS_ALPN_HTTP2				"h2"
 
 /* Number of protocols for negotiation in APLN extension. */
-#define TTLS_ALPN_PROTOS			2
+#define TTLS_ALPN_PROTOS			1
 
 /* The id numbers of supported protocols for APLN extension. */
 typedef enum {


### PR DESCRIPTION
Changes in context of this PR:

1. Introducing `TfwStream` entity in common HTTP logic;
2. Removal of 'seq_queue' from HTTP/2 processing flow;
3. Introducing persistent Stream<->Request linkage and synchronization logic for it;
4. Logic for receiving and assembling of HTTP/2 request;
5. Common logic for HTTP/2 response (server, error or cache) processing.