### PR TITLE
tls: remove redundant BUG_ON condition in ttls_parse_client_hello()

### DIFF
--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -1034,16 +1034,8 @@ ttls_parse_client_hello(TlsCtx *tls, unsigned char *buf, size_t len,
 	 * preferences over the preference of the client.
 	 */
 	r = ttls_choose_ciphersuite(tls, &tls->hs->tmp[TTLS_HS_TMP_STORE_SZ]);
-	if (r) {
-		/*
-		 * If tls->xfrm.ciphersuite_info contains some valid pointer,
-		 * we'll try to free dhm_ctx or ecdh_ctx later. But since they
-		 * weren't initialized, some unexpected and untrackable bugs
-		 * will appear. Let's crash here and now instead.
-		 */
-		BUG_ON(IS_ERR_OR_NULL(tls->xfrm.ciphersuite_info));
+	if (r)
 		return r;
-	}
 
 	ttls_update_checksum(tls, buf - hh_len, p - buf + hh_len);
 


### PR DESCRIPTION
There is a BUG_ON statement in `ttls_parse_client_hello()` which was added to ensure `ciphersuite_info` is `NULL` if ciphersuite selection fails. Condition in the statement was inverted, and caused a false-positive (#1270).

One of the solutions was to fix the condition. But it was decided to remove `BUG_ON()` instead, as `ciphersuite_info` is set only in `ttls_choose_ciphersuite()`, and only if the latter succeeds. `BUG_ON()` therefore has no sense, and should be removed.

fixes #1270