### PR TITLE
tls: BUG_ON condition in ttls_parse_client_hello() is redundant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.6.4 (2019-06-18)
+
+  * Fix TCP sequence numbering when working with fast same-host backends.
+  * Handle enormous ciphersuite lists in ClientHello messages.
+  * Fix crashes on server-client ciphersuite mismatch.
+
+
 0.6.3 (2019-05-17)
 
   * Fix crashes on TLS handshakes utilizing SHA384.

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -33,7 +33,7 @@
 
 #define TFW_AUTHOR		"Tempesta Technologies, Inc"
 #define TFW_NAME		"Tempesta FW"
-#define TFW_VERSION		"0.6.3"
+#define TFW_VERSION		"0.6.4"
 
 #define DEF_MAX_PORTS		8
 

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -1038,16 +1038,8 @@ ttls_parse_client_hello(TlsCtx *tls, unsigned char *buf, size_t len,
 	 * preferences over the preference of the client.
 	 */
 	r = ttls_choose_ciphersuite(tls, &tls->hs->tmp[TTLS_HS_TMP_STORE_SZ]);
-	if (r) {
-		/*
-		 * If tls->xfrm.ciphersuite_info contains some valid pointer,
-		 * we'll try to free dhm_ctx or ecdh_ctx later. But since they
-		 * weren't initialized, some unexpected and untrackable bugs
-		 * will appear. Let's crash here and now instead.
-		 */
-		BUG_ON(IS_ERR_OR_NULL(tls->xfrm.ciphersuite_info));
+	if (r)
 		return r;
-	}
 
 	ttls_update_checksum(tls, buf - hh_len, p - buf + hh_len);
 

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -38,7 +38,7 @@
 
 MODULE_AUTHOR("Tempesta Technologies, Inc");
 MODULE_DESCRIPTION("Tempesta TLS");
-MODULE_VERSION("0.2.3");
+MODULE_VERSION("0.2.4");
 MODULE_LICENSE("GPL");
 
 static DEFINE_PER_CPU(struct aead_request *, g_req) ____cacheline_aligned;


### PR DESCRIPTION
There is a BUG_ON statement in `ttls_parse_client_hello()` which was added to ensure `ciphersuite_info` is `NULL` if ciphersuite selection fails. Condition in the statement was inverted, and caused a false-positive (#1270).

One of the solutions was to fix the condition. But it was decided to remove `BUG_ON()` instead, as `ciphersuite_info` is set only in `ttls_choose_ciphersuite()`, and only if the latter succeeds. `BUG_ON()` therefore has no sense, and should be removed.

fixes #1270
backport of #1272