### PR TITLE
guard against NULL deref in tfw_client_for_each

### DIFF
--- a/tempesta_fw/client.c
+++ b/tempesta_fw/client.c
@@ -253,6 +253,8 @@ EXPORT_SYMBOL(tfw_client_obtain);
 int
 tfw_client_for_each(int (*fn)(void *))
 {
+	if (!client_db)
+		return 0;
 	return tdb_entry_walk(client_db, fn);
 }
 

--- a/tempesta_fw/main.c
+++ b/tempesta_fw/main.c
@@ -141,8 +141,10 @@ tfw_mods_stop(struct list_head *mod_list)
 	TFW_LOG("Stopping all modules...\n");
 	MOD_FOR_EACH_REVERSE(mod, mod_list) {
 		TFW_DBG2("mod_stop(): %s\n", mod->name);
-		if (mod->stop)
+		if (mod->stop && mod->started) {
 			mod->stop();
+			mod->started = 0;
+		}
 	}
 
 	TFW_LOG("modules are stopped\n");
@@ -193,6 +195,7 @@ tfw_mods_start(struct list_head *mod_list)
 				   mod->name, ret);
 			return ret;
 		}
+		mod->started = 1;
 	}
 	TFW_LOG("modules are started\n");
 

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -88,6 +88,7 @@ typedef struct {
 	int			(*start)(void);
 	void			(*stop)(void);
 	TfwCfgSpec		*specs;
+	unsigned int		started:1;
 } TfwMod;
 
 #define MOD_FOR_EACH(pos, head)		\


### PR DESCRIPTION
May happen after initialization failure. To reproduce, add `return -EINVAL` to `tfw_filter_start()` before `tdb_open()` call.

Upd. During offline discussion it was decided to add guards to `tfw_mods_start()` and `tfw_mods_end()` too.