### PR TITLE
hide BUILD_BUG_ON in __parse_ulong in KASAN builds

### DIFF
--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -457,11 +457,13 @@ __parse_ulong(unsigned char *__restrict data, size_t len,
 		*acc = *acc * 10 + *p - '0';
 	}
 
+#if !defined(CONFIG_KASAN)
 	/*
 	 * We are expecting the compiler to deduce this expression to
 	 * a constant, to avoid division at run time.
 	 */
 	BUILD_BUG_ON(!__builtin_constant_p((limit - 10) / 10));
+#endif
 
 	return CSTR_POSTPONE;
 }


### PR DESCRIPTION
Looks like optimizer doesn't eliminate integer divisions when address sanitizer is active. But the potential slowdown we care about doesn't really matter in KASAN builds anyway.

Since the patch `BUILD_BUG_ON(!__builtin_constant_p((limit - 10) / 10));` was added in, one needs to comment that line if they try to build the code with KASAN enabled. That's a bit inconvenient.