### PR TITLE
backport tls encrypting in new sk_buff pages, if `sendfile()` is used or response from cache, from #1264 to release 0.6 branch

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1451,7 +1451,7 @@ tfw_cache_build_resp_body(TDB *db, TfwHttpResp *resp, TdbVRec *trec,
 	 * If headers perfectly fit allocated skbs, then
 	 * it->skb == it->skb_head, see tfw_msg_iter_next_data_frag().
 	 * Normally all the headers fit single skb, but these two situations
-	 * can't be distingueshed. Start after last fragment of last skb in list.
+	 * can't be distinguished. Start after last fragment of last skb in list.
 	 */
 	if ((it->skb == it->skb_head) || (it->frag == -1)) {
 		it->skb = ss_skb_peek_tail(&it->skb_head);

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1444,19 +1444,33 @@ tfw_cache_build_resp_body(TDB *db, TfwHttpResp *resp, TdbVRec *trec,
 			  TfwMsgIter *it, char *p)
 {
 	int off, f_size, r;
-	skb_frag_t *frag;
 
-	BUG_ON(!it->skb);
-	frag = &skb_shinfo(it->skb)->frags[it->frag];
-	if (skb_frag_size(frag))
-		++it->frag;
+	if (WARN_ON_ONCE(!it->skb))
+		return -EINVAL;
+	/*
+	 * If headers perfectly fit allocated skbs, then
+	 * it->skb == it->skb_head, see tfw_msg_iter_next_data_frag().
+	 * Normally all the headers fit single skb, but these two situations
+	 * can't be distingueshed. Start after last fragment of last skb in list.
+	 */
+	if ((it->skb == it->skb_head) || (it->frag == -1)) {
+		it->skb = ss_skb_peek_tail(&it->skb_head);
+		it->frag = skb_shinfo(it->skb)->nr_frags;
+	}
+	else {
+		skb_frag_t *frag = &skb_shinfo(it->skb)->frags[it->frag];
+		if (skb_frag_size(frag))
+			++it->frag;
+	}
+	BUG_ON(it->frag < 0);
+
 	if (it->frag >= MAX_SKB_FRAGS - 1
-	    && (r = tfw_http_msg_setup((TfwHttpMsg *)resp, it, 0)))
+	    && (r = tfw_msg_iter_append_skb(it)))
 		return r;
 
 	while (1) {
 		if (it->frag == MAX_SKB_FRAGS
-		    && (r = tfw_http_msg_setup((TfwHttpMsg *)resp, it, 0)))
+		    && (r = tfw_msg_iter_append_skb(it)))
 			return r;
 
 		/* TDB keeps data by pages and we can reuse the pages. */

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1539,6 +1539,13 @@ tfw_cache_build_resp(TfwHttpReq *req, TfwCacheEntry *ce)
 		goto free;
 
 	/*
+	 * Mark skb as SKBTX_SHARED_FRAG so that when sending it to the client
+	 * via https, encryption routines do not change data in-place.
+	 */
+	if (TFW_CONN_TLS(req->conn))
+		skb_shinfo(it.skb)->tx_flags |= SKBTX_SHARED_FRAG;
+
+	/*
 	 * Allocate HTTP headers table of proper size.
 	 * There were no other allocations since the table is allocated,
 	 * so realloc() just grows the table and returns the same pointer.

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -110,6 +110,7 @@ typedef struct {
 
 #define TFW_CONN_TYPE(c)	((c)->proto.type)
 #define TFW_CONN_PROTO(c)	TFW_CONN_TYPE2IDX(TFW_CONN_TYPE(c))
+#define TFW_CONN_TLS(c)		(TFW_CONN_TYPE(c) & TFW_FSM_HTTPS)
 
 /*
  * Queues in client and server connections provide support for correct

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -889,42 +889,6 @@ tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len)
 }
 EXPORT_SYMBOL(tfw_http_msg_setup);
 
-static int
-__http_msg_add_data_frag(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,
-			 const TfwStr *data, unsigned int off)
-{
-	char *p;
-	skb_frag_t *frag = &skb_shinfo(it->skb)->frags[it->frag];
-	unsigned int f_size, d_size, f_room, n_copy;
-
-next_frag:
-	if (!frag)
-		return -E2BIG;
-
-	d_size = data->len - off;
-	f_size = skb_frag_size(frag);
-	f_room = PAGE_SIZE - frag->page_offset - f_size;
-	n_copy = min(d_size, f_room);
-	if (!n_copy)
-		return 0;
-
-	p = (char *)skb_frag_address(frag) + f_size;
-	memcpy_fast(p, data->data + off, n_copy);
-	skb_frag_size_add(frag, n_copy);
-	ss_skb_adjust_data_len(it->skb, n_copy);
-
-	if (__tfw_http_msg_add_str_data(hm, field, p, n_copy, it->skb))
-		return -ENOMEM;
-
-	if (d_size > f_room) {
-		frag = ss_skb_frag_next(&it->skb, it->skb_head, &it->frag);
-		off += n_copy;
-		goto next_frag;
-	}
-
-	return 0;
-}
-
 /**
  * Similar to tfw_msg_write(), but properly maintain @hm header
  * fields, so that @hm can be used in regular transformations. However,
@@ -935,34 +899,48 @@ int
 tfw_http_msg_add_data(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,
 		      const TfwStr *data)
 {
-	char *p;
-	unsigned int n_copy;
+	unsigned int c_off = 0, c_size;
 
-	WARN_ON_ONCE(TFW_STR_DUP(data));
-	WARN_ON_ONCE(!TFW_STR_PLAIN(data));
+	if (WARN_ON_ONCE(TFW_STR_DUP(data) || !TFW_STR_PLAIN(data)))
+		return -EINVAL;
+	if (WARN_ON_ONCE(it->frag >= skb_shinfo(it->skb)->nr_frags))
+		return -E2BIG;
 
-	n_copy = min(data->len, (unsigned long)skb_tailroom(it->skb));
-	if (!n_copy)
-		return 0;
+	while ((c_size = data->len - c_off)) {
+		char *p;
+		unsigned int n_copy, f_room;
 
-	if (it->frag >= 0)
-		goto add_frag;
+		if (it->frag >= 0) {
+			unsigned int f_size;
+			skb_frag_t *frag = &skb_shinfo(it->skb)->frags[it->frag];
 
-	p = skb_put(it->skb, n_copy);
-	memcpy_fast(p, data->data, n_copy);
+			f_size = skb_frag_size(frag);
+			f_room = PAGE_SIZE - frag->page_offset - f_size;
+			p = (char *)skb_frag_address(frag) + f_size;
+			n_copy = min(c_size, f_room);
+			skb_frag_size_add(frag, n_copy);
+			ss_skb_adjust_data_len(it->skb, n_copy);
+		} else {
+			f_room = skb_tailroom(it->skb);
+			n_copy = min(c_size, f_room);
+			p = skb_put(it->skb, n_copy);
+		}
 
-	if (__tfw_http_msg_add_str_data(hm, field, p, n_copy, it->skb))
-		return -ENOMEM;
+		memcpy_fast(p, data->data, n_copy);
+		if (__tfw_http_msg_add_str_data(hm, field, p, n_copy, it->skb))
+			return -ENOMEM;
+		c_off += n_copy;
 
-	if (data->len == n_copy) {
-		if (!skb_tailroom(it->skb))
-			it->frag = 0;
-		return 0;
+		if (c_size >= f_room) {
+			if (WARN_ON_ONCE(tfw_msg_iter_next_data_frag(it)
+					 && (c_size != f_room)))
+			{
+				return -E2BIG;
+			}
+		}
 	}
 
-add_frag:
-	it->frag = 0;
-	return __http_msg_add_data_frag(it, hm, field, data, n_copy);
+	return 0;
 }
 
 void

--- a/tempesta_fw/msg.c
+++ b/tempesta_fw/msg.c
@@ -19,6 +19,7 @@
  */
 #include "lib/str.h"
 #include "msg.h"
+#include "http_msg.h"
 
 /**
  * Fill up an HTTP message by iterator @it with data from string @data.
@@ -34,60 +35,7 @@
 int
 tfw_msg_write(TfwMsgIter *it, const TfwStr *data)
 {
-	const TfwStr *c, *end;
-
-	BUG_ON(TFW_STR_DUP(data));
-	if (WARN_ON_ONCE(it->frag >= skb_shinfo(it->skb)->nr_frags))
-		return -E2BIG;
-
-	TFW_STR_FOR_EACH_CHUNK(c, data, end) {
-		char *p;
-		unsigned int c_off = 0, c_size, f_room, n_copy;
-this_chunk:
-
-		c_size = c->len - c_off;
-		if (it->frag >= 0) {
-			unsigned int f_size;
-			skb_frag_t *frag = &skb_shinfo(it->skb)->frags[it->frag];
-
-			f_size = skb_frag_size(frag);
-			f_room = PAGE_SIZE - frag->page_offset - f_size;
-			p = (char *)skb_frag_address(frag) + f_size;
-			n_copy = min(c_size, f_room);
-			skb_frag_size_add(frag, n_copy);
-			ss_skb_adjust_data_len(it->skb, n_copy);
-		} else {
-			f_room = skb_tailroom(it->skb);
-			n_copy = min(c_size, f_room);
-			p = skb_put(it->skb, n_copy);
-		}
-
-		memcpy_fast(p, c->data + c_off, n_copy);
-
-		/*
-		 * The chunk occupied all the spare space in the SKB fragment,
-		 * switch to the next fragment.
-		 */
-		if (c_size >= f_room) {
-			if (WARN_ON_ONCE(tfw_msg_iter_next_data_frag(it)
-					 && ((c_size != f_room)
-					     || (c + 1 < end))))
-			{
-				return -E2BIG;
-			}
-			/*
-			 * Not all data from the chunk has been copied,
-			 * stay in the current chunk and copy the rest to the
-			 * next fragment.
-			 */
-			if (c_size != f_room) {
-				c_off += n_copy;
-				goto this_chunk;
-			}
-		}
-	}
-
-	return 0;
+	return tfw_http_msg_add_data(it, NULL, NULL, data);
 }
 EXPORT_SYMBOL(tfw_msg_write);
 

--- a/tempesta_fw/msg.c
+++ b/tempesta_fw/msg.c
@@ -74,5 +74,7 @@ tfw_msg_iter_append_skb(TfwMsgIter *it)
 	it->skb = ss_skb_peek_tail(&it->skb_head);
 	it->frag = 0;
 
+	skb_shinfo(it->skb)->tx_flags = skb_shinfo(it->skb->prev)->tx_flags;
+
 	return 0;
 }

--- a/tempesta_fw/msg.c
+++ b/tempesta_fw/msg.c
@@ -69,10 +69,7 @@ this_chunk:
 		 * switch to the next fragment.
 		 */
 		if (c_size >= f_room) {
-			skb_frag_t *frag = ss_skb_frag_next(&it->skb,
-							    it->skb_head,
-							    &it->frag);
-			if (WARN_ON_ONCE(!frag
+			if (WARN_ON_ONCE(tfw_msg_iter_next_data_frag(it)
 					 && ((c_size != f_room)
 					     || (c + 1 < end))))
 			{

--- a/tempesta_fw/msg.h
+++ b/tempesta_fw/msg.h
@@ -64,6 +64,7 @@ typedef struct {
 int tfw_msg_write(TfwMsgIter *it, const TfwStr *data);
 int tfw_msg_iter_setup(TfwMsgIter *it, struct sk_buff **skb_head,
 		       size_t data_len);
+int tfw_msg_iter_append_skb(TfwMsgIter *it);
 
 static inline int
 tfw_msg_iter_next_data_frag(TfwMsgIter *it)
@@ -79,6 +80,7 @@ tfw_msg_iter_next_data_frag(TfwMsgIter *it)
 		return -EINVAL;
 	}
 	it->frag = -1;
+
 	return 0;
 }
 

--- a/tempesta_fw/msg.h
+++ b/tempesta_fw/msg.h
@@ -65,4 +65,21 @@ int tfw_msg_write(TfwMsgIter *it, const TfwStr *data);
 int tfw_msg_iter_setup(TfwMsgIter *it, struct sk_buff **skb_head,
 		       size_t data_len);
 
+static inline int
+tfw_msg_iter_next_data_frag(TfwMsgIter *it)
+{
+	if (skb_shinfo(it->skb)->nr_frags > it->frag + 1) {
+		++it->frag;
+		return 0;
+	}
+
+	it->skb = it->skb->next;
+	if (it->skb == it->skb_head || !skb_shinfo(it->skb)->nr_frags) {
+		it->frag = MAX_SKB_FRAGS;
+		return -EINVAL;
+	}
+	it->frag = -1;
+	return 0;
+}
+
 #endif /* __TFW_MSG_H__ */

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -193,7 +193,7 @@ tfw_sock_clnt_new(struct sock *sk)
 	tfw_connection_link_peer(conn, (TfwPeer *)cli);
 
 	ss_set_callbacks(sk);
-	if (TFW_CONN_TYPE(conn) & TFW_FSM_HTTPS)
+	if (TFW_CONN_TLS(conn))
 		/*
 		 * Probably, that's not beautiful to introduce an alternate
 		 * upcall beside GFSM and SS, but that's efficient and I didn't

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -1217,6 +1217,7 @@ __coalesce_frag(struct sk_buff **skb_head, skb_frag_t *frag,
 		skb = ss_skb_alloc(0);
 		if (!skb)
 			return -ENOMEM;
+		skb_shinfo(skb)->tx_flags = skb_shinfo(orig_skb)->tx_flags;
 		ss_skb_queue_tail(skb_head, skb);
 		skb->mark = orig_skb->mark;
 	}
@@ -1396,3 +1397,63 @@ ss_skb_dump(struct sk_buff *skb)
 		ss_skb_dump(f_skb);
 }
 EXPORT_SYMBOL(ss_skb_dump);
+
+/*
+ * Replace the skb fragments with new pages and add them to the scatter list.
+ */
+int
+ss_skb_to_sgvec_with_new_pages(struct sk_buff *skb, struct scatterlist *sgl,
+                               struct page ***old_pages)
+{
+	unsigned int head_data_len = skb_headlen(skb);
+	unsigned int out_frags = 0;
+	int remain = 0, offset = 0;
+	int i;
+
+	/* TODO: process of SKBTX_ZEROCOPY_FRAG for MSG_ZEROCOPY */
+	if (skb_shinfo(skb)->tx_flags & SKBTX_SHARED_FRAG) {
+		if (head_data_len) {
+			sg_set_buf(sgl + out_frags, skb->data, head_data_len);
+			out_frags++;
+		}
+
+		for (i = 0; i < skb_shinfo(skb)->nr_frags; i++) {
+			skb_frag_t *f = &skb_shinfo(skb)->frags[i];
+			unsigned int size;
+			struct page *p;
+
+			size = skb_frag_size(f);
+			if (remain < size) {
+				int order = get_order(size);
+				p = alloc_pages(GFP_ATOMIC, order);
+				if (!p)
+					return -ENOMEM;
+				remain = (1 << order) * PAGE_SIZE;
+				offset = 0;
+			} else {
+				skb_frag_t *prev_f;
+
+				prev_f = &skb_shinfo(skb)->frags[i - 1];
+				p = skb_frag_page(prev_f);
+				get_page(p);
+			}
+			**old_pages = skb_frag_page(f);
+			(*old_pages)++;
+			sg_set_page(sgl + out_frags, p, size, offset);
+			__skb_fill_page_desc(skb, i, p, offset, size);
+			remain -= size;
+			offset += size;
+			out_frags++;
+		}
+		if (out_frags > 0)
+			sg_mark_end(&sgl[out_frags - 1]);
+		skb_shinfo(skb)->tx_flags &= ~SKBTX_SHARED_FRAG;
+	} else {
+		int r = skb_to_sgvec(skb, sgl + out_frags, 0, skb->len);
+		if (r <= 0)
+			return r;
+		out_frags += r;
+	}
+
+	return out_frags;
+}

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -120,21 +120,6 @@ ss_skb_adjust_data_len(struct sk_buff *skb, int delta)
 	skb->truesize += delta;
 }
 
-static inline skb_frag_t *
-ss_skb_frag_next(struct sk_buff **skb, const struct sk_buff *skb_head, int *f)
-{
-	if (skb_shinfo(*skb)->nr_frags > *f + 1) {
-		++*f;
-		return &skb_shinfo(*skb)->frags[*f];
-	}
-
-	*skb = (*skb)->next;
-	*f = 0;
-	if (*skb == skb_head || !skb_shinfo(*skb)->nr_frags)
-		return NULL;
-	return &skb_shinfo(*skb)->frags[0];
-}
-
 /*
  * skb_tailroom - number of bytes at buffer end
  *

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -187,5 +187,7 @@ int ss_skb_process(struct sk_buff *skb, unsigned int off, unsigned int trail,
 int ss_skb_unroll(struct sk_buff **skb_head, struct sk_buff *skb);
 void ss_skb_init_for_xmit(struct sk_buff *skb);
 void ss_skb_dump(struct sk_buff *skb);
+int ss_skb_to_sgvec_with_new_pages(struct sk_buff *skb, struct scatterlist *sgl,
+                                   struct page ***old_pages);
 
 #endif /* __TFW_SS_SKB_H__ */

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -932,7 +932,7 @@ int ttls_get_session(const ttls_context *ssl, TlsSess *session);
 
 int ttls_recv(void *tls_data, unsigned char *buf, size_t len,
 	      unsigned int *read);
-int ttls_encrypt(TlsCtx *tls, struct sg_table *sgt);
+int ttls_encrypt(TlsCtx *tls, struct sg_table *sgt, struct sg_table *out_sgt);
 
 int ttls_send_alert(TlsCtx *tls, unsigned char lvl, unsigned char msg);
 


### PR DESCRIPTION
#1209 #1264 #1286 #1288