### PR TITLE
tls: close connection if handshake is not done (release-0.6)

### DIFF
--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -582,14 +582,14 @@ tfw_tls_conn_close(TfwConn *c, bool sync)
 	/*
 	 * ttls_close_notify() calls ss_send() with SS_F_CONN_CLOSE flag, so
 	 * if the call succeeded, then we'll close the socket with the alert
-	 * transmission. Otherwise if we have to close the socket synchronously
+	 * transmission. Otherwise if we have to close the socket
 	 * and can not write to the socket, then there is no other way than
 	 * skip the alert and just close the socket.
 	 */
-	if (r && sync) {
+	if (r) {
 		TFW_WARN_ADDR("Close TCP socket w/o sending alert to the peer",
 			      &c->peer->addr, TFW_WITH_PORT);
-		r = ss_close(c->sk, SS_F_SYNC);
+		r = ss_close(c->sk, sync ? SS_F_SYNC : 0);
 	}
 
 	return r;

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -2400,7 +2400,7 @@ ttls_close_notify(TlsCtx *tls)
 	T_DBG("write close notify\n");
 
 	if (tls->state != TTLS_HANDSHAKE_OVER)
-		return 0;
+		return -EINVAL;
 	return ttls_send_alert(tls, TTLS_ALERT_LEVEL_WARNING,
 			       TTLS_ALERT_MSG_CLOSE_NOTIFY);
 }


### PR DESCRIPTION
`tfw_tls_conn_close()` is expected to close connection somehow. It either sends an alert via `ttls_close_notify()` which closes connection after data departure, or calls `ss_close()` explicitly if alert cannot be sent. However, `ttls_close_notify()` may return 0 if TLS handshake wasn't finished yet. In that case connection remains not closed, with keepalive timers armed. Unloading Tempesta from memory makes these timers to crash the kernel.

The patch ensures that connections are closed in all cases.

Backport of #1292.