### PR TITLE
tls: fix decryption of a record spanning over multiple skbs

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3103,6 +3103,8 @@ next_msg:
 		tfw_http_req_parse_drop(req, 400, "failed to parse request");
 		return TFW_BLOCK;
 	case TFW_POSTPONE:
+		if (tfw_http_chop_skb((TfwHttpMsg *)req, skb, off, curr_skb_trail))
+			return TFW_BLOCK;
 		r = tfw_gfsm_move(&conn->state, TFW_HTTP_FSM_REQ_CHUNK,
 				  &data_up);
 		TFW_DBG3("TFW_HTTP_FSM_REQ_CHUNK return code %d\n", r);

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -164,6 +164,7 @@ ttls_crypto_req_sglist(TlsCtx *tls, struct crypto_aead *tfm, unsigned int len,
 			n = skb_to_sgvec(skb, sg_i, off, to_read);
 			if (n <= 0)
 				goto err;
+			sg_unmark_end(sg_i + n - 1);
 			T_DBG3_SL("build req sglist", sg_i, n, 0, (size_t)len);
 			len -= to_read;
 			sg_i += n;


### PR DESCRIPTION
There was a couple of issues with parsing medium-sized requests.

First was about missing `sg_unmark_end()` after `skb_to_sgvec()`. Latter calls `sg_mark_end()`, so since we want to pack multiple skb's into a single scatter-list, we must undo the changes.

Second was about cutting TLS-specific data from skb's. We cut them, but only after a whole request is parsed. If a request spans over multiple skb's, information about data offset is lost, so we ended up with passing TLS auxiliary data to a backend. We need to cut data from the head while offset is still known.

Fixes #1299.