### PR TITLE
Fix warning

### DIFF
--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -1535,7 +1535,7 @@ curve_matching_done:
 
 		T_DBG3_BUF("my signature", p, signature_len);
 		n += signature_len;
-		WARN_ON_ONCE(signature_len > 500);
+		WARN_ON_ONCE(signature_len > 512);
 	}
 
 	/* Done with actual work; add handshake header and add the record. */


### PR DESCRIPTION
Fixes #1293

According to the formula (https://github.com/tempesta-tech/tempesta/blob/master/tls/bignum.c#L379) with `ttls_mpi_bitlen (X) == 4096` we get 512. Therefore, we received a warning