### PR TITLE
tls: release spinlock before invoking gfsm move (release-0.6)

### DIFF
--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -85,8 +85,8 @@ tfw_tls_msg_process(void *conn, TfwFsmData *data)
 	 * in-place by chunks. Add skb to the list to build scatterlist if
 	 * it contains end of current message.
 	 */
-	spin_lock(&tls->lock);
 next_msg:
+	spin_lock(&tls->lock);
 	ss_skb_queue_tail(&tls->io_in.skb_list, skb);
 	/*
 	 * Store skb_list since ttls_recv() reinitializes IO context for each
@@ -153,11 +153,13 @@ next_msg:
 	}
 
 	/* At this point tls->io_in is initialized for the next record. */
-	if ((r = tfw_tls_chop_skb_rec(tls, msg_skb, &data_up)))
-		goto out_err;
+	if ((r = tfw_tls_chop_skb_rec(tls, msg_skb, &data_up))) {
+		spin_unlock(&tls->lock);
+		return r;
+	}
+	spin_unlock(&tls->lock);
 	r = tfw_gfsm_move(&c->state, TFW_TLS_FSM_DATA_READY, &data_up);
 	if (r == TFW_BLOCK) {
-		spin_unlock(&tls->lock);
 		kfree_skb(nskb);
 		return r;
 	}
@@ -168,9 +170,6 @@ next_msg:
 		parsed = 0;
 		goto next_msg;
 	}
-
-out_err:
-	spin_unlock(&tls->lock);
 
 	return r;
 }


### PR DESCRIPTION
Invoking the GFSM may cause other code to execute. If that code tries to send an immediate response, for example, on request parsing error, it will try to acquire `tls->lock` while it's held in `tfw_tls_msg_process()`.

In fact that the way to reproduce the bug: send a malformed HTTPS request. Each such requests causes a deadlock. `N` such requests deadlock whole machine given it has `N` cores.

Backport of #1316.