### PR TITLE
tls: ciphertexts larger than 16384 bytes

### DIFF
--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -1067,6 +1067,7 @@ ss_skb_process(struct sk_buff *skb, unsigned int off, unsigned int trail,
 			n = frag_size - off;
 			if (trail > frag_len)
 				n -= trail - frag_len;
+			_processed = 0;
 			r = actor(objdata, frag_addr + off, n, &_processed);
 			*processed += _processed;
 			if (r != SS_POSTPONE || trail >= frag_len)


### PR DESCRIPTION
TLS records have plaintext size limitation, they cannot be larger than 2^14 bytes. However, ciphertext may be as large as 2^14 + 2048 bytes. But the plaintext obtained from that ciphertext should still be 2^14 bytes or smaller. We need to respect that limits precisely.

The patchset consists of two patches. One changes the limits, and other fixes a defect in the parsed bytes calculation.

Related to #1283, but doesn't fix it entirely yet.