### PR TITLE
Close the connection after sending tls alerts in the queue

### DIFF
--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -2,7 +2,7 @@
  *		Synchronous Socket API.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -876,9 +876,8 @@ ss_tcp_data_ready(struct sock *sk)
 			 * The callback will free all SKBs linked with
 			 * the message that is currently being processed.
 			 *
-			 * On receiving FIN we have to reply ACK and move to
-			 * TCP_CLOSE WAIT state where we send all required data
-			 * to the peer and only after than send our FIN.
+			 * Closing a socket should go through the queue and
+			 * should be done after all pending data has been sent.
 			 *
 			 * TODO #861. ss_tcp_process_data() returns true/false
 			 * on all kind of problems: e.g. inability to unroll an
@@ -1001,9 +1000,8 @@ ss_tcp_state_change(struct sock *sk)
 			ss_tcp_process_data(sk);
 		T_DBG2("[%d]: Peer connection closing\n", smp_processor_id());
 		/*
-		 * On receiving FIN we have to reply ACK and more to
-		 * TCP_CLOSE WAIT state where we send all required data
-		 * to the peer and only after than send our FIN.
+		 * Closing a socket should go through the queue and should be
+		 * done after all pending data has been sent.
 		 */
 		ss_close(sk, SS_F_SYNC);
 	}
@@ -1384,8 +1382,8 @@ ss_tx_action(void)
 			/*
 			 * We were asked to close the socket. If current state
 			 * is either ESTABLISHED or SYN_SENT, we initiate the
-			 * closure process. If for some reason other side sent
-			 * us FIN, we are at CLOSE_WAIT, so the socket closure
+			 * closing process. If for some reason other side sent
+			 * us FIN, we are at CLOSE_WAIT, so the socket closing
 			 * is in progress, but still need to cleanup on our
 			 * side. If we get here while the socket in any other
 			 * state, resources were either already freed or were

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -222,17 +222,18 @@ err_client:
 	return r;
 }
 
-/**
- * Do the same stuff for intentional client connection closing and due to some
- * error on TCP socket or application layers.
+/*
+ * The hook is executed when a client connection is closed by either
+ * side of the connection or client connection is terminated due to
+ * an error of any kind.
  */
 static void
-tfw_sock_clnt_do_drop(struct sock *sk, const char *msg)
+tfw_sock_clnt_drop(struct sock *sk)
 {
 	TfwConn *conn = sk->sk_user_data;
 
-	T_DBG3("%s: close client socket: sk=%p, conn=%p, client=%p\n",
-	       msg, sk, conn, conn->peer);
+	T_DBG3("connection lost: close client socket: sk=%p, conn=%p, "
+	       "client=%p\n", sk, conn, conn->peer);
 	/*
 	 * Withdraw from socket activity. Connection is now closed,
 	 * and Tempesta is not called anymore on events in the socket.
@@ -251,30 +252,9 @@ tfw_sock_clnt_do_drop(struct sock *sk, const char *msg)
 	tfw_connection_put(conn);
 }
 
-/*
- * The hook is executed when a client connection is closed by either
- * side of the connection.
- */
-static void
-tfw_sock_clnt_drop(struct sock *sk)
-{
-	tfw_sock_clnt_do_drop(sk, "connection lost");
-}
-
-/*
- * The hook is executed when a client connection is terminated due to
- * an error of any kind.
- */
-static void
-tfw_sock_clnt_error(struct sock *sk)
-{
-	tfw_sock_clnt_do_drop(sk, "connection error");
-}
-
 static const SsHooks tfw_sock_clnt_ss_hooks = {
 	.connection_new		= tfw_sock_clnt_new,
 	.connection_drop	= tfw_sock_clnt_drop,
-	.connection_error	= tfw_sock_clnt_error,
 	.connection_recv	= tfw_connection_recv,
 };
 

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -368,9 +368,10 @@ tfw_sock_srv_connect_drop(struct sock *sk)
 
 	if (test_bit(TFW_CONN_B_DEL, &((TfwSrvConn *)conn)->flags)) {
 		/**
-		 * This is executed when we intentionally close a server connection during
-		 * shutdown process. Now @sk is closed (but still alive) and we release all
-		 * associated resources before SS put()'s the socket.
+		 * This is executed when we intentionally close a server
+		 * connection during shutdown process. Now @sk is closed (but
+		 * still alive) and we release all associated resources before
+		 * SS put()'s the socket.
 		 */
 		TFW_INC_STAT_BH(serv.conn_disconnects);
 		tfw_connection_drop(conn);
@@ -381,9 +382,10 @@ tfw_sock_srv_connect_drop(struct sock *sk)
 	/**
 	 * This is executed when there's unrecoverable error in a connection
 	 * (and not executed when an established connection is closed as usual).
-	 * An error may occur in any TCP state including data processing on application
-	 * layer. All Tempesta resources associated with the socket must be released in
-	 * case they were allocated before. Server socket must be recovered.
+	 * An error may occur in any TCP state including data processing on
+	 * application layer. All Tempesta resources associated with the socket
+	 * must be released in case they were allocated before. Server socket
+	 * must be recovered.
 	 */
 	T_DBG_ADDR("connection error", &srv->addr, TFW_WITH_PORT);
 

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -59,21 +59,16 @@ typedef struct ss_hooks {
 	int (*connection_new)(struct sock *sk);
 
 	/*
-	 * Drop TCP connection associated with the socket.
-	 * The callback is called on intentional socket closing when the socket
-	 * is already closed (i.e. there could not be ingress data on it) and we
-	 * can safely do some clenup stuff. We need the callback sine socket
-	 * closing always has chance to run asynchronously on other CPU and a
-	 * caller doesn't know the it completes.
+	 * Intentional socket closing when the socket is already closed (i.e. there
+	 * could not be ingress data on it) and we can safely do some clenup stuff
+	 * or error on TCP connection (on Linux TCP socket layer) associated with
+	 * the socket or at application (data processing) layer, i.e. unintentional
+	 * connection closing.
+	 * We need the callback since socket closing always has a chance to run
+	 * asynchronously on another CPU and a caller doesn't know when it
+	 * completes.
 	 */
 	void (*connection_drop)(struct sock *sk);
-
-	/*
-	 * Error on TCP connection (on Linux TCP socket layer) associated
-	 * with the socket or at application (data processing) layer,
-	 * i.e. unintentional connection closing.
-	 */
-	void (*connection_error)(struct sock *sk);
 
 	/* Process data received on the socket. */
 	int (*connection_recv)(void *conn, struct sk_buff *skb,

--- a/tempesta_fw/t/bomber.c
+++ b/tempesta_fw/t/bomber.c
@@ -189,7 +189,6 @@ tfw_bmb_conn_recv(void *cdata, struct sk_buff *skb, unsigned int off)
 static SsHooks bmb_hooks = {
 	.connection_new		= tfw_bmb_conn_compl,
 	.connection_drop	= tfw_bmb_conn_drop,
-	.connection_error	= tfw_bmb_conn_drop,
 	.connection_recv	= tfw_bmb_conn_recv,
 };
 

--- a/tempesta_fw/t/sync_sockets/kernel/sync_kclient.c
+++ b/tempesta_fw/t/sync_sockets/kernel/sync_kclient.c
@@ -176,34 +176,9 @@ kclient_connection_close(struct sock *sk)
 	return 0;
 }
 
-static int
-kclient_connection_error(struct sock *sk)
-{
-	int descidx;
-	kclient_desc_t *desc;
-	SsProto *proto = sk->sk_user_data;
-
-	BUG_ON(proto == NULL);
-
-	descidx = proto->type;
-	desc = *(kclient_desc + descidx / KCLIENT_NCONNECTS)
-			      + descidx % KCLIENT_NCONNECTS;
-	BUG_ON(desc->proto.type != descidx);
-	BUG_ON(desc->proto.listener != NULL);
-	BUG_ON(desc->proto.hooks != &kclient_hooks);
-	BUG_ON(desc->sk && (desc->sk != sk));
-
-	desc->sk = NULL;
-	desc->flags |= KCLIENT_CONNECT_ERROR;
-	atomic_inc(&kclient_connect_nerror);
-	wake_up(&kclient_finish_wq);
-	return 0;
-}
-
 static SsHooks kclient_hooks = {
 	.connection_new		= kclient_connect_complete,
 	.connection_drop	= kclient_connection_close,
-	.connection_error	= kclient_connection_error,
 };
 
 static void

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -530,9 +530,10 @@ tfw_tls_send(TlsCtx *tls, struct sg_table *sgt, bool close)
 			       skb, skb->len);
 		}
 	}
-
-	if (close)
+	if (close) {
 		flags |= SS_F_CONN_CLOSE;
+		TFW_CONN_TYPE(&conn->cli_conn) |= Conn_Stop;
+	}
 	if (ttls_xfrm_ready(tls))
 		flags |= SS_F_ENCRYPT;
 

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -534,8 +534,8 @@ tfw_tls_send(TlsCtx *tls, struct sg_table *sgt, bool close)
 		flags |= SS_F_CONN_CLOSE;
 		TFW_CONN_TYPE(&conn->cli_conn) |= Conn_Stop;
 	}
-	if (ttls_xfrm_ready(tls))
-		flags |= SS_F_ENCRYPT;
+	if (ttls_xfrm_need_encript(tls))
+		flags |= SS_SKB_TYPE2F(io->msgtype) | SS_F_ENCRYPT;
 
 	return ss_send(conn->cli_conn.sk, &io->skb_list, flags);
 }

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -534,7 +534,7 @@ tfw_tls_send(TlsCtx *tls, struct sg_table *sgt, bool close)
 		flags |= SS_F_CONN_CLOSE;
 		TFW_CONN_TYPE(&conn->cli_conn) |= Conn_Stop;
 	}
-	if (ttls_xfrm_need_encript(tls))
+	if (ttls_xfrm_need_encrypt(tls))
 		flags |= SS_SKB_TYPE2F(io->msgtype) | SS_F_ENCRYPT;
 
 	return ss_send(conn->cli_conn.sk, &io->skb_list, flags);

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -2264,6 +2264,8 @@ ttls_handshake_finished(TlsCtx *tls)
 		if ((r = ttls_write_finished(tls, &sgt, &p)))
 			return r;
 		CHECK_STATE(TLS_HEADER_SIZE + TTLS_HS_FINISHED_BODY_LEN);
+		sg_mark_end(&sgt.sgl[sgt.nents - 1]);
+		r = __ttls_send_record(tls, &sgt, false);
 		/*
 		 * In case of session resuming, invert the client and server
 		 * ChangeCipherSpec messages order.
@@ -2272,7 +2274,7 @@ ttls_handshake_finished(TlsCtx *tls)
 			     ? TTLS_CLIENT_CHANGE_CIPHER_SPEC
 			     : TTLS_HANDSHAKE_WRAPUP;
 		sg_mark_end(&sgt.sgl[sgt.nents - 1]);
-		return __ttls_send_record(tls, &sgt, false);
+		return r;
 	}
 	}
 	T_FSM_FINISH(r, tls->state);

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -2273,7 +2273,6 @@ ttls_handshake_finished(TlsCtx *tls)
 		tls->state = tls->hs->resume
 			     ? TTLS_CLIENT_CHANGE_CIPHER_SPEC
 			     : TTLS_HANDSHAKE_WRAPUP;
-		sg_mark_end(&sgt.sgl[sgt.nents - 1]);
 		return r;
 	}
 	}

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1334,7 +1334,7 @@ ttls_send_alert(TlsCtx *tls, unsigned char lvl, unsigned char msg)
 	io->alert[0] = lvl;
 	io->alert[1] = msg;
 
-	if (msg == TTLS_ALERT_MSG_CLOSE_NOTIFY)
+	if (msg == TTLS_ALERT_MSG_CLOSE_NOTIFY || lvl == TTLS_ALERT_LEVEL_FATAL)
 		close = true;
 
 	return ttls_write_record(tls, NULL, close);
@@ -2227,7 +2227,7 @@ next_record:
 	case TTLS_MSG_HANDSHAKE:
 		if (unlikely(tls->state == TTLS_HANDSHAKE_OVER)) {
 			T_DBG("refusing renegotiation, sending alert\n");
-			ttls_send_alert(tls, TTLS_ALERT_LEVEL_WARNING,
+			ttls_send_alert(tls, TTLS_ALERT_LEVEL_FATAL,
 					TTLS_ALERT_MSG_NO_RENEGOTIATION);
 			return TTLS_ERR_UNEXPECTED_MESSAGE;
 		}

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -248,6 +248,19 @@ ttls_xfrm_ready(TlsCtx *tls)
 }
 EXPORT_SYMBOL(ttls_xfrm_ready);
 
+/*
+ * There are states in which encryption is not used or performed in advance, as
+ * with TTLS_SERVER_FINISHED
+ */
+bool
+ttls_xfrm_need_encript(TlsCtx *tls)
+{
+	return tls->state >= TTLS_CLIENT_FINISHED
+	       && tls->state != TTLS_SERVER_CHANGE_CIPHER_SPEC
+	       && tls->state != TTLS_SERVER_FINISHED;
+}
+EXPORT_SYMBOL(ttls_xfrm_need_encript);
+
 #if defined(TTLS_CLI_C)
 static int
 ssl_session_copy(TlsSess *dst, const TlsSess *src)

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -2231,6 +2231,11 @@ next_record:
 		if (unlikely(!ttls_xfrm_ready(tls))) {
 			if (!(r = ttls_handle_alert(io)))
 				goto skip_record;
+			if (io->alert[0] == TTLS_ALERT_LEVEL_WARNING
+			    && io->alert[1] == TTLS_ALERT_MSG_CLOSE_NOTIFY)
+			{
+				ttls_close_notify(tls);
+			}
 			return T_DROP;
 		}
 		break;
@@ -2309,6 +2314,11 @@ next_record:
 	if (io->msgtype == TTLS_MSG_ALERT) {
 		if (!(r = ttls_handle_alert(io)))
 			goto skip_record;
+		if (io->alert[0] == TTLS_ALERT_LEVEL_WARNING
+		    && io->alert[1] == TTLS_ALERT_MSG_CLOSE_NOTIFY)
+		{
+			ttls_close_notify(tls);
+		}
 		return T_DROP;
 	}
 

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -567,6 +567,7 @@ typedef struct ttls_context {
 typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt, bool close);
 
 bool ttls_xfrm_ready(TlsCtx *tls);
+bool ttls_xfrm_need_encript(TlsCtx *tls);
 void ttls_write_hshdr(unsigned char type, unsigned char *buf,
 		      unsigned short len);
 void *ttls_alloc_crypto_req(unsigned int extra_size, unsigned int *rsz);

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -567,7 +567,7 @@ typedef struct ttls_context {
 typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt, bool close);
 
 bool ttls_xfrm_ready(TlsCtx *tls);
-bool ttls_xfrm_need_encript(TlsCtx *tls);
+bool ttls_xfrm_need_encrypt(TlsCtx *tls);
 void ttls_write_hshdr(unsigned char type, unsigned char *buf,
 		      unsigned short len);
 void *ttls_alloc_crypto_req(unsigned int extra_size, unsigned int *rsz);


### PR DESCRIPTION
#1308

- Close the socket after sending all pending data on TCP_CLOSE_WAIT and internal errors.

- Close the connection after sending fatal tls alerts and close_notify alert in the queue

- Not encryption for TTLS_SERVER_FINISHED, because encryption is done in `ttls_write_finished()`.

- Sending close_notify alert on close_notify alert.