### PR TITLE
Reduce Tempesta logging on start/stop

### DIFF
--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -170,7 +170,7 @@ tfw_classify_tcp(struct sock *sk, struct sk_buff *skb)
 void
 tfw_classifier_register(TfwClassifier *mod)
 {
-	TFW_LOG("Registering new classifier: %s\n", mod->name);
+	T_DBG("Registering new classifier: %s\n", mod->name);
 
 	BUG_ON(classifier);
 	rcu_assign_pointer(classifier, mod);
@@ -179,7 +179,7 @@ tfw_classifier_register(TfwClassifier *mod)
 void
 tfw_classifier_unregister(void)
 {
-	TFW_LOG("Unregistering classifier: %s\n", classifier->name);
+	T_DBG("Un-registering classifier: %s\n", classifier->name);
 
 	rcu_assign_pointer(classifier, NULL);
 	synchronize_rcu();

--- a/tempesta_fw/sched.c
+++ b/tempesta_fw/sched.c
@@ -60,7 +60,7 @@ tfw_sched_lookup(const char *name)
 int
 tfw_sched_register(TfwScheduler *sched)
 {
-	TFW_LOG("Registering new scheduler: %s\n", sched->name);
+	T_DBG("Registering new scheduler: %s\n", sched->name);
 	BUG_ON(!list_empty(&sched->list));
 	list_add_tail(&sched->list, &sched_list);
 
@@ -74,7 +74,7 @@ tfw_sched_register(TfwScheduler *sched)
 void
 tfw_sched_unregister(TfwScheduler *sched)
 {
-	TFW_LOG("Un-registering scheduler: %s\n", sched->name);
+	T_DBG("Un-registering scheduler: %s\n", sched->name);
 	BUG_ON(list_empty(&sched->list));
 	list_del_init(&sched->list);
 }


### PR DESCRIPTION
Tempesta produces too many log records on start & stop operations. This not only is boding, but also makes testing hard since netratelimiting message appears only on next log records, i.e. there is a possibility to loose a log record and learn it only on next start/stop.