### PR TITLE
propagate tx_flags through the skb chain to honor SKBTX_SHARED_FRAG

### DIFF
--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -321,6 +321,7 @@ __extend_pgfrags(struct sk_buff *skb_head, struct sk_buff *skb, int from, int n)
 			nskb = ss_skb_alloc(0);
 			if (nskb == NULL)
 				return -ENOMEM;
+			skb_shinfo(nskb)->tx_flags = skb_shinfo(skb)->tx_flags;
 			__skb_insert_after(skb, nskb);
 			skb_shinfo(nskb)->nr_frags = n_excess;
 		}


### PR DESCRIPTION
We need to avoid encryption in-place if responses are coming from the cache. Otherwise, data stored in the cache gets mangled, and next time clients get unexpected data. We use `SKBTX_SHARED_FRAG` flags to figure out which skb's data is shared, and set this flag ourselves when serving response from the cache. However there were cases where not all skb's received the flag.

The patch consists of two parts. First ensures all skb's originating from `tfw_http_msg_setup()` receive the flag. It's not very likely scenario, but since `tfw_http_msg_setup()` in theory can generate two or more skb's, it's better be on the safe side. Last part changes `__extend_pgfrags()` to propagate the skb flags. Missing flag propagation causes response corruption if body is only about 64kB in size.

Fixes some tests from #1283.