### PR TITLE
Backport code changes related to #1283 (release-0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+0.6.5 (2019-08-02)
+
+  * Fix parsing of an empty extension if it comes last in ClientHello.
+  * Fix cached data corruption during encryption.
+  * Close the connection on errors during TLS handshake stage.
+  * Fix decryption of large records spanning multiple skb's.
+  * Verify ClientHello extention lengths before trying to read their data.
+  * Fix the deadlock caused by the error reporting during handshake stage.
+  * Handle ciphertexts larger than 16384 bytes.
+
+
 0.6.4 (2019-06-18)
 
   * Fix TCP sequence numbering when working with fast same-host backends.

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -1067,6 +1067,7 @@ ss_skb_process(struct sk_buff *skb, unsigned int off, unsigned int trail,
 			n = frag_size - off;
 			if (trail > frag_len)
 				n -= trail - frag_len;
+			_processed = 0;
 			r = actor(objdata, frag_addr + off, n, &_processed);
 			*processed += _processed;
 			if (r != SS_POSTPONE || trail >= frag_len)

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -321,6 +321,7 @@ __extend_pgfrags(struct sk_buff *skb_head, struct sk_buff *skb, int from, int n)
 			nskb = ss_skb_alloc(0);
 			if (nskb == NULL)
 				return -ENOMEM;
+			skb_shinfo(nskb)->tx_flags = skb_shinfo(skb)->tx_flags;
 			__skb_insert_after(skb, nskb);
 			skb_shinfo(nskb)->nr_frags = n_excess;
 		}

--- a/tempesta_fw/tempesta_fw.h
+++ b/tempesta_fw/tempesta_fw.h
@@ -33,7 +33,7 @@
 
 #define TFW_AUTHOR		"Tempesta Technologies, Inc"
 #define TFW_NAME		"Tempesta FW"
-#define TFW_VERSION		"0.6.4"
+#define TFW_VERSION		"0.6.5"
 
 #define DEF_MAX_PORTS		8
 

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -38,7 +38,7 @@
 
 MODULE_AUTHOR("Tempesta Technologies, Inc");
 MODULE_DESCRIPTION("Tempesta TLS");
-MODULE_VERSION("0.2.4");
+MODULE_VERSION("0.2.5");
 MODULE_LICENSE("GPL");
 
 static DEFINE_PER_CPU(struct aead_request *, g_req) ____cacheline_aligned;


### PR DESCRIPTION
This is the backport of #1322 and #1328 to release-0.6.
Tempesta's version is updated to 0.6.5.