### PR TITLE
remove "off" and "trail" fields from TfwFsmData

### DIFF
--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -111,12 +111,11 @@ tfw_connection_send(TfwConn *conn, TfwMsg *msg)
 }
 
 int
-tfw_connection_recv(void *cdata, struct sk_buff *skb, unsigned int off)
+tfw_connection_recv(void *cdata, struct sk_buff *skb)
 {
 	TfwConn *conn = cdata;
 	TfwFsmData fsm_data = {
 		.skb = skb,
-		.off = off,
 	};
 
 	return tfw_gfsm_dispatch(&conn->state, conn, &fsm_data);

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -505,6 +505,6 @@ int tfw_connection_close(TfwConn *conn, bool sync);
 void tfw_connection_drop(TfwConn *conn);
 void tfw_connection_release(TfwConn *conn);
 
-int tfw_connection_recv(void *cdata, struct sk_buff *skb, unsigned int off);
+int tfw_connection_recv(void *cdata, struct sk_buff *skb);
 
 #endif /* __TFW_CONNECTION_H__ */

--- a/tempesta_fw/gfsm.c
+++ b/tempesta_fw/gfsm.c
@@ -226,9 +226,8 @@ tfw_gfsm_move(TfwGState *st, unsigned short state, TfwFsmData *data)
 	unsigned long mask = 1 << state;
 	unsigned char curr_st = st->curr;
 
-	T_DBG3("GFSM move %#x -> %#x: skb=%pK off=%u trail=%u"
-	       " req=%pK resp=%pK\n", FSM_STATE(st), state,
-		 data->skb, data->off, data->trail, data->req, data->resp);
+	T_DBG3("GFSM move %#x -> %#x: skb=%pK req=%pK resp=%pK\n",
+	       FSM_STATE(st), state, data->skb, data->req, data->resp);
 
 	/* Remember current FSM context. */
 	SET_STATE(st, state);

--- a/tempesta_fw/gfsm.h
+++ b/tempesta_fw/gfsm.h
@@ -145,19 +145,13 @@ enum {
  *
  * GFSM resides at the top of classes hierarchy, so use generic message classes.
  *
- * @skb		- currently processed skb by the TCP/IP stack, probably preceded
- *		  by skbs from previous GFSM shots;
- * @off		- data offset within the first skb in @skb list;
- * @trail	- data trailer left from the underlying protocol and not to be
- *		  processed by the current protocol;
+ * @skb		- currently processed skb by the TCP/IP stack;
  * @req		- a request associated with current state of an FSM;
  * @resp	- a response associated with the state;
  */
 typedef struct {
 	/* L4 (TCP) members. */
 	struct sk_buff	*skb;
-	unsigned int	off;
-	unsigned int	trail;
 
 	/* L7 members. */
 	TfwMsg		*req;

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -181,9 +181,8 @@ int ss_skb_chop_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,
 int ss_skb_cutoff_data(struct sk_buff *skb_head, const TfwStr *hdr,
 		       int skip, int tail);
 
-int ss_skb_process(struct sk_buff *skb, unsigned int off, unsigned int trail,
-		   ss_skb_actor_t actor, void *objdata, unsigned int *chunks,
-		   unsigned int *processed);
+int ss_skb_process(struct sk_buff *skb, ss_skb_actor_t actor, void *objdata,
+		   unsigned int *chunks, unsigned int *processed);
 
 int ss_skb_unroll(struct sk_buff **skb_head, struct sk_buff *skb);
 void ss_skb_init_for_xmit(struct sk_buff *skb);

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -71,8 +71,7 @@ typedef struct ss_hooks {
 	void (*connection_drop)(struct sock *sk);
 
 	/* Process data received on the socket. */
-	int (*connection_recv)(void *conn, struct sk_buff *skb,
-			       unsigned int off);
+	int (*connection_recv)(void *conn, struct sk_buff *skb);
 } SsHooks;
 
 /**

--- a/tempesta_fw/t/bomber.c
+++ b/tempesta_fw/t/bomber.c
@@ -169,15 +169,14 @@ tfw_bmb_print_msg(void *msg_data, unsigned char *data, size_t len,
 }
 
 static int
-tfw_bmb_conn_recv(void *cdata, struct sk_buff *skb, unsigned int off)
+tfw_bmb_conn_recv(void *cdata, struct sk_buff *skb)
 {
 	if (verbose) {
 		unsigned int parsed = 0, chunks = 0;
 
 		T_LOG("Server response:\n------------------------------\n");
 
-		ss_skb_process(skb, 0, 0, tfw_bmb_print_msg, NULL, &chunks,
-			       &parsed);
+		ss_skb_process(skb, tfw_bmb_print_msg, NULL, &chunks, &parsed);
 
 		printk(KERN_INFO "\n------------------------------\n");
 	}

--- a/tempesta_fw/t/unit/test_http_sticky.c
+++ b/tempesta_fw/t/unit/test_http_sticky.c
@@ -252,8 +252,8 @@ tfw_connection_send(TfwConn *conn, TfwMsg *msg)
 
 	skb = msg->skb_head;
 	do {
-		ss_skb_process(skb, 0, 0, tfw_http_parse_resp, mock.resp,
-			       &chunks, &parsed);
+		ss_skb_process(skb, tfw_http_parse_resp, mock.resp, &chunks,
+			       &parsed);
 		skb = skb->next;
 	} while (skb != msg->skb_head);
 
@@ -570,7 +570,7 @@ http_parse_helper(TfwHttpMsg *hm, ss_skb_actor_t actor)
 	skb = hm->msg.skb_head;
 	BUG_ON(!skb);
 	while (1) {
-		int r = ss_skb_process(skb, 0, 0, actor, hm, &chunks, &parsed);
+		int r = ss_skb_process(skb, actor, hm, &chunks, &parsed);
 		switch (r) {
 		case TFW_POSTPONE:
 			if (skb->next == hm->msg.skb_head)


### PR DESCRIPTION
TLS layer feeds `tfw_http_msg_process()` with multiple skb's at a time. As the smallest possible skb can be as small as one byte, the tail where TLS record tag is located, can span over two or more skb's. Previously we assumed that never happens, but it does depending on network conditions.

It's hard to deal with heading and trailing forbidden parts of an skb or an skb chain. So during the discussion of the PR it was decided to eliminate the notion of heading and trailing parts, so that the consumers of the data could work with skb data without tracking those parts. TLS-related code is now cuts off header and the trailing part that contains TLS tag.

This PR handles the case from #1283 with "kernel BUG at /root/tempesta/tempesta/tempesta_fw/http.c:3058!".