### PR TITLE
Fix possible memory corruption.

### DIFF
--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -38,7 +38,7 @@
 
 MODULE_AUTHOR("Tempesta Technologies, Inc");
 MODULE_DESCRIPTION("Tempesta TLS");
-MODULE_VERSION("0.2.5");
+MODULE_VERSION("0.2.6");
 MODULE_LICENSE("GPL");
 
 static DEFINE_PER_CPU(struct aead_request *, g_req) ____cacheline_aligned;
@@ -414,6 +414,7 @@ ttls_update_checksum(TlsCtx *tls, const unsigned char *buf, size_t len)
 			crypto_free_shash(hs->desc.tfm);
 			memcpy_fast(&tls->hs->fin_sha256, sha256,
 				    sizeof(*sha256));
+			bzero_fast(sha256, sizeof(*sha256));
 		}
 	}
 	if (unlikely(!hs->desc.tfm)) {


### PR DESCRIPTION
TlsHandshake->tmp_sha256 resides in the same union with ecdh_ctx, so
ttls_write_server_key_exchange() -> ttls_ecp_group_load() may find
dirty memory in tls->hs->ecdh_ctx.grp and ttls_ecp_group_free() calls
kfree on bad pointers.

Fix for current 0.7 will be done in context of #1064.