### PR TITLE
Trivial fixes to logging messages

### DIFF
--- a/tempesta_fw/addr.c
+++ b/tempesta_fw/addr.c
@@ -377,7 +377,7 @@ int
 tfw_addr_ifmatch(const TfwAddr *server, const TfwAddr *listener)
 {
 	if (unlikely(server->sin6_family != AF_INET6)) {
-		TFW_ERR("Unexpected protocol family\n");
+		T_ERR("Unexpected protocol family\n");
 		BUG();
 		return 0;
 	}

--- a/tempesta_fw/apm.c
+++ b/tempesta_fw/apm.c
@@ -125,8 +125,8 @@ __range_grow_right(TfwPcntRanges *rng, TfwPcntCtl *pc, int r)
 	++pc->order;
 	pc->end = pc->begin + TFW_STATS_RSPAN(pc->order);
 
-	TFW_DBG3("  -- extend right bound of range %d to begin=%u order=%u"
-		 " end=%u\n", r, pc->begin, pc->order, pc->end);
+	T_DBG3("  -- extend right bound of range %d to begin=%u order=%u"
+	       " end=%u\n", r, pc->begin, pc->order, pc->end);
 
 	/* Coalesce counters to buckets on the left half of the range. */
 	for (i = 0; i < TFW_STATS_BCKTS / 2; ++i)
@@ -142,8 +142,8 @@ __range_shrink_left(TfwPcntRanges *rng, TfwPcntCtl *pc, int r)
 	--pc->order;
 	pc->begin = pc->end - TFW_STATS_RSPAN(pc->order);
 
-	TFW_DBG3("  -- shrink left bound of range %d to begin=%u order=%u"
-		 " end=%u\n", r, pc->begin, pc->order, pc->end);
+	T_DBG3("  -- shrink left bound of range %d to begin=%u order=%u"
+	       " end=%u\n", r, pc->begin, pc->order, pc->end);
 	/*
 	 * Write sum of the left half counters to the first bucket and equally
 	 * split counters of the right half among the rest of the buckets.
@@ -197,8 +197,8 @@ tfw_stats_extend(TfwPcntRanges *rng, unsigned int r_time)
 
 	pc->order = order;
 
-	TFW_DBG3("  -- extend last range to begin=%u order=%u end=%u\n",
-		 pc->begin, pc->order, pc->end);
+	T_DBG3("  -- extend last range to begin=%u order=%u end=%u\n",
+	       pc->begin, pc->order, pc->end);
 
 	/*
 	 * Coalesce counters to buckets on the left side of the range.
@@ -265,8 +265,8 @@ tfw_stats_adjust(TfwPcntRanges *rng, int r)
 	if (likely(max <= sum * 2 / cnt))
 		return;
 
-	TFW_DBG3("  -- range %d has an outlier %lu (avg=%lu total=%lu) at"
-		 " bucket %lu\n", r, max, sum / cnt, sum, i_max);
+	T_DBG3("  -- range %d has an outlier %lu (avg=%lu total=%lu) at"
+	       " bucket %lu\n", r, max, sum / cnt, sum, i_max);
 
 	/*
 	 * If too many hits fall in the gap between r'th and (r - 1)'th
@@ -848,8 +848,8 @@ tfw_apm_rbctl_update(TfwApmData *data)
 		rbctl->total_cnt = total_cnt;
 		rbctl->jtmwstamp = jtmwstart;
 
-		TFW_DBG3("%s: New time window: centry [%d] total_cnt [%lu]\n",
-			 __func__, centry, rbctl->total_cnt);
+		T_DBG3("%s: New time window: centry [%d] total_cnt [%lu]\n",
+		       __func__, centry, rbctl->total_cnt);
 
 		return true;
 	}
@@ -869,8 +869,8 @@ tfw_apm_rbctl_update(TfwApmData *data)
 	rbctl->total_cnt += entry_cnt - rbctl->entry_cnt;
 	rbctl->entry_cnt = entry_cnt;
 
-	TFW_DBG3("%s: Old time window: centry [%d] total_cnt [%lu]\n",
-		 __func__, centry, rbctl->total_cnt);
+	T_DBG3("%s: Old time window: centry [%d] total_cnt [%lu]\n",
+	       __func__, centry, rbctl->total_cnt);
 
 	return true;
 }
@@ -897,7 +897,7 @@ tfw_apm_calc(TfwApmData *data)
 		return;
 	tfw_apm_prnctl_calc(&data->rbuf, &data->rbctl, &pstats);
 
-	TFW_DBG3("%s: Percentile values may have changed.\n", __func__);
+	T_DBG3("%s: Percentile values may have changed.\n", __func__);
 	write_lock(&asent->rwlock);
 	memcpy_fast(asent->pstats.val, pstats.val,
 		    asent->pstats.psz * sizeof(asent->pstats.val[0]));
@@ -1102,7 +1102,7 @@ tfw_apm_create(void)
 
 	might_sleep();
 	if (!tfw_apm_tmwscale) {
-		TFW_ERR("Late initialization of 'apm_stats' option\n");
+		T_ERR("Late initialization of 'apm_stats' option\n");
 		return NULL;
 	}
 
@@ -1245,8 +1245,8 @@ tfw_apm_hm_srv_alive(int status, TfwStr *body, void *apmref)
 
 	BUG_ON(!hm);
 	if (hm->codes && !test_bit(HTTP_CODE_BIT_NUM(status), hm->codes)) {
-		TFW_WARN_NL("Response for health monitor '%s': status"
-			 " '%d' mismatched\n", hm->name, status);
+		T_WARN_NL("Response for health monitor '%s': status '%d' "
+			  "mismatched\n", hm->name, status);
 		return false;
 	}
 
@@ -1270,8 +1270,8 @@ tfw_apm_hm_srv_alive(int status, TfwStr *body, void *apmref)
 
 	return true;
 crc_err:
-	TFW_WARN_NL("Response for health monitor '%s': crc32"
-		 " value '%u' mismatched (expected value:"
+	T_WARN_NL("Response for health monitor '%s': crc32"
+		  " value '%u' mismatched (expected value:"
 		 " '%u')\n", hm->name, crc32, hm->crc32);
 	return false;
 }
@@ -1445,16 +1445,15 @@ bool
 tfw_apm_check_hm(const char *name)
 {
 	if (!tfw_hm_codes_cnt) {
-		TFW_ERR_NL("No response codes specified for"
-			   " server's health monitoring\n");
+		T_ERR_NL("No response codes specified for server's health "
+			 "monitoring\n");
 		return false;
 	}
 
 	if (!strcasecmp(name, TFW_APM_HM_AUTO) || tfw_apm_get_hm(name))
 		return true;
 
-	TFW_ERR_NL("health monitor with name"
-		   " '%s' does not exist\n", name);
+	T_ERR_NL("health monitor with name '%s' does not exist\n", name);
 
 	return false;
 }
@@ -1466,7 +1465,7 @@ tfw_cfgop_apm_add_hm(const char *name)
 	BUG_ON(tfw_hm_entry);
 	tfw_hm_entry = kzalloc(sizeof(TfwApmHM) + size, GFP_KERNEL);
 	if (!tfw_hm_entry) {
-		TFW_ERR_NL("Can't allocate health check entry '%s'\n", name);
+		T_ERR_NL("Can't allocate health check entry '%s'\n", name);
 		return -ENOMEM;
 	}
 	INIT_LIST_HEAD(&tfw_hm_entry->list);
@@ -1486,8 +1485,8 @@ tfw_cfgop_apm_add_hm_req(const char *req_cstr, TfwApmHM *hm_entry)
 	hm_entry->req = (char *)__get_free_pages(GFP_KERNEL,
 						     get_order(size));
 	if (!hm_entry->req) {
-		TFW_ERR_NL("Can't allocate memory for health"
-			   " monitoring request\n");
+		T_ERR_NL("Can't allocate memory for health monitoring request"
+			 "\n");
 		return -ENOMEM;
 	}
 	memcpy(hm_entry->req, req_cstr, size);
@@ -1505,7 +1504,7 @@ tfw_cfgop_apm_add_hm_url(const char *url, TfwApmHM *hm_entry)
 	size = strlen(url);
 	mptr = kzalloc(size, GFP_KERNEL);
 	if (!mptr) {
-		TFW_ERR_NL("Can't allocate memory for '%s'\n", url);
+		T_ERR_NL("Can't allocate memory for '%s'\n", url);
 		return -ENOMEM;
 	}
 	memcpy(mptr, url, size);
@@ -1521,9 +1520,9 @@ tfw_cfgop_apm_alloc_hm_codes(TfwApmHM *hm_entry)
 	tfw_hm_entry->codes = kzalloc(BITS_TO_LONGS(512) * sizeof(long),
 				      GFP_KERNEL);
 	if (!tfw_hm_entry->codes) {
-		TFW_ERR_NL("Can't allocate memory for HTTP codes"
-			   " field for '%s' health check entry\n",
-			   tfw_hm_entry->name);
+		T_ERR_NL("Can't allocate memory for HTTP codes field for '%s' "
+			 "health check entry\n",
+			 tfw_hm_entry->name);
 		return -ENOMEM;
 	}
 	return 0;
@@ -1566,15 +1565,15 @@ tfw_apm_cfgend(void)
 	if ((tfw_apm_jtmwindow < TFW_APM_MIN_TMWINDOW)
 	    || (tfw_apm_jtmwindow > TFW_APM_MAX_TMWINDOW))
 	{
-		TFW_ERR_NL("apm_stats: window: value '%d' is out of limits.\n",
-			   tfw_apm_jtmwindow);
+		T_ERR_NL("apm_stats: window: value '%d' is out of limits.\n",
+			 tfw_apm_jtmwindow);
 		return -EINVAL;
 	}
 	if ((tfw_apm_tmwscale < TFW_APM_MIN_TMWSCALE)
 	    || (tfw_apm_tmwscale > TFW_APM_MAX_TMWSCALE))
 	{
-		TFW_ERR_NL("apm_stats: scale: value '%d' is out of limits.\n",
-			   tfw_apm_tmwscale);
+		T_ERR_NL("apm_stats: scale: value '%d' is out of limits.\n",
+			 tfw_apm_tmwscale);
 		return -EINVAL;
 	}
 
@@ -1587,8 +1586,8 @@ tfw_apm_cfgend(void)
 			    + !!(jtmwindow % tfw_apm_tmwscale);
 
 	if (tfw_apm_jtmintrvl < TFW_APM_MIN_TMINTRVL) {
-		TFW_ERR_NL("apm_stats window=%d scale=%d: scale is too long.\n",
-			   tfw_apm_jtmwindow, tfw_apm_tmwscale);
+		T_ERR_NL("apm_stats window=%d scale=%d: scale is too long.\n",
+			 tfw_apm_jtmwindow, tfw_apm_tmwscale);
 		return -EINVAL;
 	}
 	tfw_apm_jtmwindow = tfw_apm_jtmintrvl * tfw_apm_tmwscale;
@@ -1652,13 +1651,12 @@ tfw_cfgop_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	const char *key, *val;
 
 	if (ce->val_n) {
-		TFW_ERR_NL("%s: Arguments must be a key=value pair.\n",
-			   cs->name);
+		T_ERR_NL("%s: Arguments must be a key=value pair.\n", cs->name);
 		return -EINVAL;
 	}
 	if (!ce->attr_n) {
-		TFW_WARN_NL("%s: arguments missing, using default values.\n",
-			    cs->name);
+		T_WARN_NL("%s: arguments missing, using default values.\n",
+			  cs->name);
 		return 0;
 	}
 
@@ -1670,8 +1668,8 @@ tfw_cfgop_apm_stats(TfwCfgSpec *cs, TfwCfgEntry *ce)
 			if ((r = tfw_cfg_parse_int(val, &tfw_apm_tmwscale)))
 				return r;
 		} else {
-			TFW_ERR_NL("%s: unsupported argument: '%s=%s'.\n",
-				   cs->name, key, val);
+			T_ERR_NL("%s: unsupported argument: '%s=%s'.\n",
+				 cs->name, key, val);
 			return -EINVAL;
 		}
 	}
@@ -1688,26 +1686,26 @@ tfw_cfgop_apm_server_failover(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (tfw_cfg_check_val_n(ce, 3))
 		return -EINVAL;
 	if (ce->attr_n) {
-		TFW_ERR_NL("Unexpected attributes\n");
+		T_ERR_NL("Unexpected attributes\n");
 		return -EINVAL;
 	}
 
 	if (tfw_cfgop_parse_http_status(ce->vals[0], &code)) {
-		TFW_ERR_NL("Unable to parse http code value: '%s'\n",
-			   ce->vals[0]);
+		T_ERR_NL("Unable to parse http code value: '%s'\n",
+			 ce->vals[0]);
 		return -EINVAL;
 	}
 	if (tfw_cfg_parse_int(ce->vals[1], &limit)) {
-		TFW_ERR_NL("Unable to parse http limit value: '%s'\n",
-			   ce->vals[1]);
+		T_ERR_NL("Unable to parse http limit value: '%s'\n",
+			 ce->vals[1]);
 		return -EINVAL;
 	}
 	if (tfw_cfg_check_range(limit, 1, USHRT_MAX))
 		return -EINVAL;
 
 	if (tfw_cfg_parse_int(ce->vals[2], &tframe)) {
-		TFW_ERR_NL("Unable to parse http tframe value: '%s'\n",
-			   ce->vals[2]);
+		T_ERR_NL("Unable to parse http tframe value: '%s'\n",
+			 ce->vals[2]);
 		return -EINVAL;
 	}
 	if (tfw_cfg_check_range(tframe, 1, USHRT_MAX))
@@ -1749,14 +1747,14 @@ tfw_cfgop_begin_apm_hm(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (tfw_cfg_check_val_n(ce, 1))
 		return -EINVAL;
 	if (ce->attr_n) {
-		TFW_ERR_NL("Unexpected attributes\n");
+		T_ERR_NL("Unexpected attributes\n");
 		return -EINVAL;
 	}
 
 	list_for_each_entry(hm, &tfw_hm_list, list) {
 		if (!strcasecmp(hm->name, ce->vals[0])) {
-			TFW_ERR_NL("Duplicate health check entry: '%s'\n",
-				   ce->vals[0]);
+			T_ERR_NL("Duplicate health check entry: '%s'\n",
+				 ce->vals[0]);
 			return -EINVAL;
 		}
 	}
@@ -1778,9 +1776,9 @@ tfw_cfgop_finish_apm_hm(TfwCfgSpec *cs)
 	BUG_ON(!tfw_hm_entry);
 	BUG_ON(list_empty(&tfw_hm_list));
 	if (!tfw_hm_entry->codes && !tfw_hm_entry->crc32) {
-		TFW_ERR_NL("At least one of 'resp_code' or 'resp_crc32'"
-			   " explicit (not 'auto') values must be"
-			   " configured for '%s'\n", cs->name);
+		T_ERR_NL("At least one of 'resp_code' or 'resp_crc32' explicit "
+			 "(not 'auto') values must be configured for '%s'\n",
+			 cs->name);
 		return -EINVAL;
 	}
 	tfw_hm_entry = NULL;
@@ -1816,11 +1814,11 @@ tfw_cfgop_apm_hm_resp_code(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	const char *val;
 
 	if (!ce->val_n) {
-		TFW_ERR_NL("No arguments found.\n");
+		T_ERR_NL("No arguments found.\n");
 		return -EINVAL;
 	}
 	if (ce->attr_n) {
-		TFW_ERR_NL("Unexpected attributes\n");
+		T_ERR_NL("Unexpected attributes\n");
 		return -EINVAL;
 	}
 
@@ -1831,8 +1829,8 @@ tfw_cfgop_apm_hm_resp_code(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		if (tfw_cfgop_parse_http_status(val, &code)
 		    || tfw_cfg_check_range(code, HTTP_CODE_MIN, HTTP_CODE_MAX))
 		{
-			TFW_ERR_NL("Unable to parse http code value: '%s'\n",
-				   val);
+			T_ERR_NL("Unable to parse http code value: '%s'\n",
+				 val);
 			kfree(tfw_hm_entry->codes);
 			return -EINVAL;
 		}
@@ -1856,7 +1854,7 @@ tfw_cfgop_apm_hm_resp_crc32(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	}
 
 	if (tfw_cfg_parse_uint(ce->vals[0], &crc32)) {
-		TFW_ERR_NL("Unable to parse crc32 value: '%s'\n", ce->vals[0]);
+		T_ERR_NL("Unable to parse crc32 value: '%s'\n", ce->vals[0]);
 		return -EINVAL;
 	}
 
@@ -1873,8 +1871,8 @@ tfw_cfgop_apm_hm_timeout(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (tfw_cfg_check_single_val(ce))
 		return -EINVAL;
 	if (tfw_cfg_parse_int(ce->vals[0], &timeout)) {
-		TFW_ERR_NL("Unable to parse http timeout value: '%s'\n",
-			   ce->vals[0]);
+		T_ERR_NL("Unable to parse http timeout value: '%s'\n",
+			 ce->vals[0]);
 		return -EINVAL;
 	}
 	if (tfw_cfg_check_range(timeout, 1, USHRT_MAX))

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -120,7 +120,7 @@ __alloc_and_copy_literal(const char *src, size_t len, bool keep_bs)
 
 	dst = kmalloc(len + 1, GFP_KERNEL);
 	if (!dst) {
-		TFW_ERR_NL("can't allocate memory\n");
+		T_ERR_NL("can't allocate memory\n");
 		return NULL;
 	}
 
@@ -174,7 +174,7 @@ check_identifier(const char *buf, size_t len)
 	size_t i;
 
 	if (!len) {
-		TFW_ERR_NL("the string is empty\n");
+		T_ERR_NL("the string is empty\n");
 		return false;
 	}
 
@@ -182,15 +182,14 @@ check_identifier(const char *buf, size_t len)
 		return true;
 
 	if (!isalpha(buf[0])) {
-		TFW_ERR_NL("the first character is not a letter: '%c'\n",
-			   buf[0]);
+		T_ERR_NL("the first character is not a letter: '%c'\n", buf[0]);
 		return false;
 	}
 
 	for (i = 0; i < len; ++i) {
 		if (!isalnum(buf[i]) && buf[i] != '_') {
-			TFW_ERR_NL("invalid character: '%c' in '%.*s'\n",
-				   buf[i], (int)len, buf);
+			T_ERR_NL("invalid character: '%c' in '%.*s'\n",
+				 buf[i], (int)len, buf);
 			return false;
 		}
 	}
@@ -250,7 +249,7 @@ entry_set_name(TfwCfgEntry *e)
 		len = sizeof(TFW_CFG_RULE_NAME) - 1;
 	}
 
-	TFW_DBG3("set name: %.*s\n", len, name);
+	T_DBG3("set name: %.*s\n", len, name);
 
 	if (!check_identifier(name, len))
 		return -EINVAL;
@@ -273,7 +272,7 @@ entry_set_first_token(TfwCfgEntry *e, const char *src, int len)
 	BUG_ON(!e);
 	BUG_ON(e->ftoken);
 
-	TFW_DBG3("set first token: %.*s\n", len, src);
+	T_DBG3("set first token: %.*s\n", len, src);
 
 	if (!src || !len)
 		return -EINVAL;
@@ -297,7 +296,7 @@ entry_add_val(TfwCfgEntry *e, const char *val_src, size_t val_len)
 		return -EINVAL;
 
 	if (e->val_n == ARRAY_SIZE(e->vals)) {
-		TFW_ERR_NL("maximum number of values per entry reached\n");
+		T_ERR_NL("maximum number of values per entry reached\n");
 		return -ENOBUFS;
 	}
 
@@ -327,7 +326,7 @@ entry_add_attr(TfwCfgEntry *e, const char *key_src, size_t key_len,
 		return -EINVAL;
 
 	if (e->attr_n == ARRAY_SIZE(e->attrs)) {
-		TFW_ERR_NL("maximum number of attributes per entry reached\n");
+		T_ERR_NL("maximum number of attributes per entry reached\n");
 		return -ENOBUFS;
 	}
 
@@ -442,11 +441,11 @@ typedef struct {
 /* Macros common for both TFSM and PFSM. */
 
 #define FSM_STATE(name) 		\
-	TFW_DBG3("fsm: implicit exit from: %s\n", ps->fsm_ss); \
+	T_DBG3("fsm: implicit exit from: %s\n", ps->fsm_ss); \
 	BUG();				\
 name:					\
 	if (ps->fsm_s != &&name) {	\
-		TFW_DBG3("fsm turn: %s -> %s\n", ps->fsm_ss, #name); \
+		T_DBG3("fsm turn: %s -> %s\n", ps->fsm_ss, #name); \
 		ps->fsm_s = &&name;	\
 		ps->fsm_ss = #name;	\
 	}
@@ -469,7 +468,7 @@ do {					\
 do {					\
 	ps->prev_c = ps->c;		\
 	ps->c = *(++ps->pos);		\
-	TFW_DBG3("tfsm move: '%c' -> '%c'\n", ps->prev_c, ps->c); \
+	T_DBG3("tfsm move: '%c' -> '%c'\n", ps->prev_c, ps->c); \
 	if (ps->prev_c == '\n') {	\
 		++ps->line_no;		\
 		ps->line = ps->pos;	\
@@ -508,7 +507,7 @@ do {					\
 #define PFSM_MOVE(to_state)					\
 do {								\
 	read_next_token(ps);					\
-	TFW_DBG3("pfsm move: %d (\"%.*s\") -> %d (\"%.*s\")", 	\
+	T_DBG3("pfsm move: %d (\"%.*s\") -> %d (\"%.*s\")", 	\
 		ps->prev_t, ps->prev_lit_len, ps->prev_lit,  	\
 		ps->t, ps->lit_len, ps->lit); 			\
 	if(!ps->t) {						\
@@ -524,7 +523,7 @@ do {								\
 #define PFSM_COND_JMP_EXIT_ERROR(cond)				\
 do {								\
 	if (cond) {						\
-		TFW_DBG3("pfsm: rule error, %d -> %d", ps->prev_t, ps->t); \
+		T_DBG3("pfsm: rule error, %d -> %d", ps->prev_t, ps->t); \
 		ps->err = -EINVAL;				\
 		FSM_JMP(PS_EXIT);				\
 	}							\
@@ -550,7 +549,7 @@ read_next_token(TfwCfgParserState *ps)
 	ps->t = TOKEN_NA;
 	ps->c = *ps->pos;
 
-	TFW_DBG3("tfsm start, char: '%c', pos: %.20s\n", ps->c, ps->pos);
+	T_DBG3("tfsm start, char: '%c', pos: %.20s\n", ps->c, ps->pos);
 
 	FSM_JMP(TS_START_NEW_TOKEN);
 
@@ -701,8 +700,8 @@ read_next_token(TfwCfgParserState *ps)
 	}
 
 	FSM_STATE(TS_EXIT) {
-		TFW_DBG3("tfsm exit: t: %d, lit: %.*s\n",
-			 ps->t, ps->lit_len, ps->lit);
+		T_DBG3("tfsm exit: t: %d, lit: %.*s\n",
+		       ps->t, ps->lit_len, ps->lit);
 	}
 }
 STACK_FRAME_NON_STANDARD(read_next_token);
@@ -717,9 +716,9 @@ entry_set_cond(TfwCfgEntry *e, token_t cond_type, const char *src, int len)
 	BUG_ON(!e->ftoken);
 	BUG_ON(e->name);
 
-	TFW_DBG3("set entry rule name '%.*s', 1st operand '%.*s', 2nd operand"
-		 " '%.*s', and condition type '%d'\n", name_len, name,
-		 (int)strlen(e->ftoken), e->ftoken, len, src, cond_type);
+	T_DBG3("set entry rule name '%.*s', 1st operand '%.*s', 2nd operand"
+	       " '%.*s', and condition type '%d'\n", name_len, name,
+	       (int)strlen(e->ftoken), e->ftoken, len, src, cond_type);
 
 	if (!src || !len)
 		return -EINVAL;
@@ -758,7 +757,7 @@ entry_set_cond(TfwCfgEntry *e, token_t cond_type, const char *src, int len)
 static void
 parse_cfg_entry(TfwCfgParserState *ps)
 {
-	TFW_DBG3("pfsm: start\n");
+	T_DBG3("pfsm: start\n");
 	BUG_ON(ps->err);
 
 	/* Start of the input? Read the first token and start a new entry. */
@@ -919,7 +918,7 @@ parse_cfg_entry(TfwCfgParserState *ps)
 		/* name val1 val2;
 		 *           ^
 		 *           We are here (but still need to store val1). */
-		TFW_DBG3("add value: %.*s\n", ps->prev_lit_len, ps->prev_lit);
+		T_DBG3("add value: %.*s\n", ps->prev_lit_len, ps->prev_lit);
 
 		ps->err = entry_add_val(&ps->e, ps->prev_lit, ps->prev_lit_len);
 		FSM_COND_JMP(ps->err, PS_EXIT);
@@ -940,7 +939,7 @@ parse_cfg_entry(TfwCfgParserState *ps)
 		val = ps->lit;
 		val_len = ps->lit_len;
 
-		TFW_DBG3("add attr: %.*s = %.*s\n", key_len, key, val_len, val);
+		T_DBG3("add attr: %.*s = %.*s\n", key_len, key, val_len, val);
 
 		ps->err = entry_add_attr(&ps->e, key, key_len, val, val_len);
 		FSM_COND_JMP(ps->err, PS_EXIT);
@@ -966,7 +965,7 @@ parse_cfg_entry(TfwCfgParserState *ps)
 
 	FSM_STATE(PS_EXIT) {
 		/* Cleanup of entry is done in tfw_cfg_parse_mods() */
-		TFW_DBG3("pfsm: exit\n");
+		T_DBG3("pfsm: exit\n");
 	}
 }
 
@@ -1009,10 +1008,10 @@ __spec_start_handling(TfwCfgSpec *parent, TfwCfgSpec specs[])
 		if (spec->handler == &tfw_cfg_handle_children)
 			BUG_ON(!spec->cleanup);
 		if (parent && !parent->allow_reconfig && spec->allow_reconfig) {
-			TFW_WARN_NL("Directive '%s' doesn't allow "
-				    "reconfiguration required for directive '%s'"
-				    "\n",
-				    parent->name, spec->name);
+			T_WARN_NL("Directive '%s' doesn't allow "
+				  "reconfiguration required for directive '%s'"
+				  "\n",
+				  parent->name, spec->name);
 			return -EINVAL;
 		}
 		spec->__called_now = false;
@@ -1034,8 +1033,8 @@ spec_handle_entry(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry)
 	bool dont_reconfig = tfw_runstate_is_reconfig() && !spec->allow_reconfig;
 
 	if (!spec->allow_repeat && spec->__called_now) {
-		TFW_ERR_NL("duplicate entry: '%s', only one such entry is"
-			   " allowed.\n", parsed_entry->name);
+		T_ERR_NL("duplicate entry: '%s', only one such entry is "
+			 "allowed.\n", parsed_entry->name);
 		return -EINVAL;
 	}
 	spec->__called_now = true;
@@ -1046,19 +1045,19 @@ spec_handle_entry(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry)
 	 * will handle it.
 	 */
 	if (dont_reconfig && (spec->handler != &tfw_cfg_handle_children)) {
-		TFW_DBG2("skip spec '%s': reconfig not allowed\n", spec->name);
+		T_DBG2("skip spec '%s': reconfig not allowed\n", spec->name);
 		return 0;
 	}
-	TFW_DBG2("spec handle: '%s'\n", spec->name);
+	T_DBG2("spec handle: '%s'\n", spec->name);
 	r = spec->handler(spec, parsed_entry);
 	if (dont_reconfig) {
-		TFW_DBG2("spec '%s' skipped: reconfig not allowed\n", spec->name);
+		T_DBG2("spec '%s' skipped: reconfig not allowed\n", spec->name);
 		return r;
 	}
 
 	spec->__called_cfg = true;
 	if (r)
-		TFW_DBG("configuration handler returned error: %d\n", r);
+		T_DBG("configuration handler returned error: %d\n", r);
 
 	return r;
 }
@@ -1081,7 +1080,7 @@ spec_handle_default(TfwCfgSpec *spec)
 		 spec->name, spec->deflt);
 	BUG_ON(len >= sizeof(fake_entry_buf));
 
-	TFW_DBG2("use default entry: '%s'\n", fake_entry_buf);
+	T_DBG2("use default entry: '%s'\n", fake_entry_buf);
 
 	memset(&ps, 0, sizeof(ps));
 	ps.line = ps.in = ps.pos = fake_entry_buf;
@@ -1103,7 +1102,7 @@ spec_handle_default_section(TfwCfgSpec *spec)
 {
 	if (spec->handler != tfw_cfg_handle_children)
 		return 0;
-	TFW_DBG2("use default values for section '%s'\n", spec->name);
+	T_DBG2("use default values for section '%s'\n", spec->name);
 	if (spec->dest == NULL)
 		return 0;
 	return spec_finish_handling(spec->dest);
@@ -1138,7 +1137,7 @@ spec_finish_handling(TfwCfgSpec specs[])
 			if ((r = spec_handle_default(spec)))
 				goto err_dflt_val;
 		} else if (!spec->allow_none) {
-			/* Jump just because TFW_ERR() is ugly here. */
+			/* Jump just because T_ERR() is ugly here. */
 			goto err_no_entry;
 		}
 	}
@@ -1146,11 +1145,11 @@ spec_finish_handling(TfwCfgSpec specs[])
 	return 0;
 
 err_no_entry:
-	TFW_ERR_NL("the required entry is not found: '%s'\n", spec->name);
+	T_ERR_NL("the required entry is not found: '%s'\n", spec->name);
 	return -EINVAL;
 
 err_dflt_val:
-	TFW_ERR_NL("Error handling default value for: '%s'\n", spec->name);
+	T_ERR_NL("Error handling default value for: '%s'\n", spec->name);
 	return r;
 }
 
@@ -1168,7 +1167,7 @@ spec_cleanup(TfwCfgSpec specs[])
 			spec->__called_ever = false;
 		}
 		if (called && spec->cleanup) {
-			TFW_DBG2("%s: '%s'\n", __func__, spec->name);
+			T_DBG2("%s: '%s'\n", __func__, spec->name);
 			spec->cleanup(spec);
 		}
 	}
@@ -1241,8 +1240,8 @@ int
 tfw_cfg_check_range(long value, long min, long max)
 {
 	if (min != max && (value < min || value > max)) {
-		TFW_ERR_NL("the value %ld is out of range: [%ld, %ld]\n",
-			   value, min, max);
+		T_ERR_NL("the value %ld is out of range: [%ld, %ld]\n",
+			 value, min, max);
 		return -EINVAL;
 	}
 	return 0;
@@ -1257,8 +1256,8 @@ int
 tfw_cfg_check_multiple_of(long value, int divisor)
 {
 	if (divisor && (value % divisor)) {
-		TFW_ERR_NL("the value of %ld is not a multiple of %d\n",
-			   value, divisor);
+		T_ERR_NL("the value of %ld is not a multiple of %d\n",
+			 value, divisor);
 		return -EINVAL;
 	}
 	return 0;
@@ -1272,8 +1271,8 @@ int
 tfw_cfg_check_val_n(const TfwCfgEntry *e, int val_n)
 {
 	if (e->val_n != val_n) {
-		TFW_ERR_NL("invalid number of values; expected: %d, got: %zu\n",
-			   val_n, e->val_n);
+		T_ERR_NL("invalid number of values; expected: %d, got: %zu\n",
+			 val_n, e->val_n);
 		return -EINVAL;
 	}
 	return 0;
@@ -1295,13 +1294,13 @@ tfw_cfg_check_single_val(const TfwCfgEntry *e)
 	int r = -EINVAL;
 
 	if (e->val_n == 0)
-		TFW_ERR_NL("no value specified\n");
+		T_ERR_NL("no value specified\n");
 	else if (e->val_n > 1)
-		TFW_ERR_NL("more than one value specified\n");
+		T_ERR_NL("more than one value specified\n");
 	else if (e->attr_n)
-		TFW_ERR_NL("unexpected attributes\n");
+		T_ERR_NL("unexpected attributes\n");
 	else if (e->have_children)
-		TFW_ERR_NL("unexpected children entries\n");
+		T_ERR_NL("unexpected children entries\n");
 	else
 		r = 0;
 
@@ -1431,7 +1430,7 @@ tfw_cfg_parse_intvl(const char *str, unsigned long *i0, unsigned long *i1)
 	while (*s) {
 		if (*s == '-') {
 			if (v == i1) {
-				TFW_ERR_NL("Bad interval delimiter\n");
+				T_ERR_NL("Bad interval delimiter\n");
 				return -EINVAL;
 			}
 			v = i1;
@@ -1444,18 +1443,18 @@ tfw_cfg_parse_intvl(const char *str, unsigned long *i0, unsigned long *i1)
 			return -EINVAL;
 		r = _parse_integer(s, base, v);
 		if (!r || r & KSTRTOX_OVERFLOW) {
-			TFW_ERR_NL("Bad integer\n");
+			T_ERR_NL("Bad integer\n");
 			return -EINVAL;
 		}
 		if (v == i1 && *i0 >= *i1) {
-			TFW_ERR("Interval bound crossing\n");
+			T_ERR("Interval bound crossing\n");
 			return -EINVAL;
 		}
 
 		s += r;
 	}
 	if (v == i1 && !*v) {
-		TFW_ERR_NL("Zero interval left bound in '%s'\n", str);
+		T_ERR_NL("Zero interval left bound in '%s'\n", str);
 		return -EINVAL;
 	}
 
@@ -1507,7 +1506,7 @@ tfw_cfg_handle_children(TfwCfgSpec *cs, TfwCfgEntry *e)
 	BUG_ON(!cs->cleanup);
 
 	if (!e->have_children) {
-		TFW_ERR_NL("the entry has no nested children entries\n");
+		T_ERR_NL("the entry has no nested children entries\n");
 		return -EINVAL;
 	}
 
@@ -1534,13 +1533,13 @@ tfw_cfg_handle_children(TfwCfgSpec *cs, TfwCfgEntry *e)
 	while (ps->t && (ps->t != TOKEN_RBRACE)) {
 		parse_cfg_entry(ps);
 		if (ps->err) {
-			TFW_ERR_NL("parser error\n");
+			T_ERR_NL("parser error\n");
 			return ps->err;
 		}
 
 		matching_spec = spec_find(nested_specs, ps->e.name);
 		if (!matching_spec) {
-			TFW_ERR_NL("don't know how to handle: %s\n", ps->e.name);
+			T_ERR_NL("don't know how to handle: %s\n", ps->e.name);
 			return -EINVAL;
 		}
 
@@ -1556,7 +1555,7 @@ tfw_cfg_handle_children(TfwCfgSpec *cs, TfwCfgEntry *e)
 	 * Check that we have a '}' here.
 	 */
 	if (ps->t != TOKEN_RBRACE) {
-		TFW_ERR_NL("%s: Missing closing brace.\n", cs->name);
+		T_ERR_NL("%s: Missing closing brace.\n", cs->name);
 		return -EINVAL;
 	}
 
@@ -1617,7 +1616,7 @@ tfw_cfg_set_bool(TfwCfgSpec *cs, TfwCfgEntry *e)
 
 	BUG_ON(is_true && is_false);
 	if (!is_true && !is_false) {
-		TFW_ERR_NL("invalid boolean value: '%s'\n", in_str);
+		T_ERR_NL("invalid boolean value: '%s'\n", in_str);
 		return -EINVAL;
 	}
 
@@ -1666,7 +1665,7 @@ val_is_parsed:
 	return 0;
 
 err:
-	TFW_ERR_NL("can't parse integer");
+	T_ERR_NL("can't parse integer");
 	return -EINVAL;
 }
 EXPORT_SYMBOL(tfw_cfg_set_int);
@@ -1701,7 +1700,7 @@ tfw_cfg_set_long(TfwCfgSpec *cs, TfwCfgEntry *e)
 	return 0;
 
 err:
-	TFW_ERR_NL("can't parse long integer");
+	T_ERR_NL("can't parse long integer");
 	return -EINVAL;
 }
 EXPORT_SYMBOL(tfw_cfg_set_long);
@@ -1755,15 +1754,15 @@ tfw_cfg_set_str(TfwCfgSpec *cs, TfwCfgEntry *e)
 		min = cse->len_range.min;
 		max = cse->len_range.max;
 		if (min != max && (len < min || len > max)) {
-			TFW_ERR_NL("the string length (%d) is out of valid "
-				   "range (%d, %d): '%s'\n", len, min, max,
-				   str);
+			T_ERR_NL("the string length (%d) is out of valid range "
+				 "(%d, %d): '%s'\n",
+				 len, min, max, str);
 			return -EINVAL;
 		}
 
 		cset = cse->cset;
 		if (cset && !is_matching_to_cset(str, cset)) {
-			TFW_ERR_NL("invalid characters found: '%s'\n", str);
+			T_ERR_NL("invalid characters found: '%s'\n", str);
 			return -EINVAL;
 		}
 	}
@@ -1806,16 +1805,16 @@ print_parse_error(const TfwCfgParserState *ps)
 	 * by @spec_finish_handling() function.
 	 */
 	if (!ps->e.line) {
-		TFW_ERR_NL("configuration parsing error\n");
+		T_ERR_NL("configuration parsing error\n");
 		return;
 	}
 
 	eos = strchrnul(ps->e.line, '\n');
 	len = min(80, (int)(eos - ps->e.line));
-	TFW_ERR_NL("configuration parsing error:\n"
-		   "%4zu: %.*s\n"
-		   "      %.*s\n",
-		   ps->e.line_no + 1, len, ps->e.line, len, ticks);
+	T_ERR_NL("configuration parsing error:\n"
+		 "%4zu: %.*s\n"
+		 "      %.*s\n",
+		 ps->e.line_no + 1, len, ps->e.line, len, ticks);
 }
 
 /*
@@ -1856,7 +1855,7 @@ tfw_cfg_parse_mods(const char *cfg_text, struct list_head *mod_list)
 	do {
 		parse_cfg_entry(&ps);
 		if (ps.err) {
-			TFW_ERR_NL("syntax error\n");
+			T_ERR_NL("syntax error\n");
 			goto err;
 		}
 		if (!ps.e.name)
@@ -1868,7 +1867,7 @@ tfw_cfg_parse_mods(const char *cfg_text, struct list_head *mod_list)
 				break;
 		}
 		if (!matching_spec) {
-			TFW_ERR_NL("don't know how to handle: '%s'\n", ps.e.name);
+			T_ERR_NL("don't know how to handle: '%s'\n", ps.e.name);
 			goto err;
 		}
 
@@ -1902,7 +1901,7 @@ tfw_cfg_cleanup(struct list_head *mod_list)
 {
 	TfwMod *mod;
 
-	TFW_DBG3("Configuration cleanup...\n");
+	T_DBG3("Configuration cleanup...\n");
 	MOD_FOR_EACH_REVERSE(mod, mod_list) {
 		spec_cleanup(mod->specs);
 		if (mod->cfgclean)
@@ -1918,13 +1917,13 @@ tfw_cfg_parse(struct list_head *mod_list)
 	size_t file_size = 0;
 	char *cfg_text_buf;
 
-	TFW_DBG3("reading configuration file...\n");
+	T_DBG3("reading configuration file...\n");
 	if (!(cfg_text_buf = tfw_cfg_read_file(tfw_cfg_path, &file_size)))
 		return -ENOENT;
 
-	TFW_DBG2("parsing configuration and pushing it to modules...\n");
+	T_DBG2("parsing configuration and pushing it to modules...\n");
 	if ((ret = tfw_cfg_parse_mods(cfg_text_buf, mod_list)))
-		TFW_DBG("Error parsing configuration data\n");
+		T_DBG("Error parsing configuration data\n");
 
 	free_pages((unsigned long)cfg_text_buf, get_order(file_size));
 
@@ -1974,47 +1973,47 @@ tfw_cfg_read_file(const char *path, size_t *file_size)
 	mm_segment_t oldfs;
 
 	if (!path || !*path) {
-		TFW_ERR_NL("can't open file with empty name\n");
+		T_ERR_NL("can't open file with empty name\n");
 		return NULL;
 	}
 
-	TFW_DBG2("reading file: %s\n", path);
+	T_DBG2("reading file: %s\n", path);
 
 	oldfs = get_fs();
 	set_fs(get_ds());
 
 	fp = filp_open(path, O_RDONLY, 0);
 	if (IS_ERR_OR_NULL(fp)) {
-		TFW_ERR_NL("can't open file: %s (err: %ld)\n",
-			   path, PTR_ERR(fp));
+		T_ERR_NL("can't open file: %s (err: %ld)\n",
+			 path, PTR_ERR(fp));
 		goto err_open;
 	}
 
 	buf_size = fp->f_inode->i_size;
-	TFW_DBG2("file size: %zu bytes\n", buf_size);
+	T_DBG2("file size: %zu bytes\n", buf_size);
 	buf_size += 1; /* for '\0' */
 	*file_size = buf_size;
 
 	out_buf = (char *)__get_free_pages(GFP_KERNEL, get_order(buf_size));
 	if (!out_buf) {
-		TFW_ERR_NL("can't allocate memory\n");
+		T_ERR_NL("can't allocate memory\n");
 		goto err_alloc;
 	}
 
 	do {
-		TFW_DBG3("read by offset: %d\n", (int)off);
+		T_DBG3("read by offset: %d\n", (int)off);
 		read_size = min((size_t)(buf_size - off), PAGE_SIZE);
 		bytes_read = kernel_read(fp, out_buf + off, read_size, &off);
 		if (bytes_read < 0) {
-			TFW_ERR_NL("can't read file: %s (err: %zu)\n", path,
-				bytes_read);
+			T_ERR_NL("can't read file: %s (err: %zu)\n", path,
+				 bytes_read);
 			goto err_read;
 		}
 	} while (bytes_read);
 
 	/* Exactly one byte (reserved for '\0') should remain. */
 	if (buf_size - off - 1) {
-		TFW_ERR_NL("file size changed during the read: '%s'\n,", path);
+		T_ERR_NL("file size changed during the read: '%s'\n,", path);
 		goto err_read;
 	}
 

--- a/tempesta_fw/client.c
+++ b/tempesta_fw/client.c
@@ -76,8 +76,8 @@ tfw_client_put(TfwClient *cli)
 {
 	TfwClientEntry *ent = (TfwClientEntry *)cli;
 
-	TFW_DBG2("put client %p, users=%d\n",
-		 cli, atomic_read(&ent->users));
+	T_DBG2("put client %p, users=%d\n",
+	       cli, atomic_read(&ent->users));
 
 	if (!atomic_dec_and_test(&ent->users))
 		return;
@@ -94,7 +94,7 @@ tfw_client_put(TfwClient *cli)
 
 	spin_unlock(&ent->lock);
 
-	TFW_DBG("put client: cli=%p\n", cli);
+	T_DBG("put client: cli=%p\n", cli);
 	TFW_DEC_STAT_BH(clnt.online);
 }
 
@@ -149,8 +149,8 @@ tfw_client_addr_eq(TdbRec *rec, void (*init)(void *), void *data)
 
 	spin_unlock(&ent->lock);
 
-	TFW_DBG("client was found in tdb\n");
-	TFW_DBG2("client %p, users=%d\n", cli, users);
+	T_DBG("client was found in tdb\n");
+	T_DBG2("client %p, users=%d\n", cli, users);
 
 	return true;
 }
@@ -178,9 +178,9 @@ tfw_client_ent_init(TdbRec *rec, void (*init)(void *), void *data)
 			sizeof(ent->user_agent));
 	ent->user_agent_len = min(ctx->user_agent.len, sizeof(ent->user_agent));
 
-	TFW_DBG("new client: cli=%p\n", cli);
-	TFW_DBG_ADDR("client address", &cli->addr, TFW_NO_PORT);
-	TFW_DBG2("client %p, users=%d\n", cli, 1);
+	T_DBG("new client: cli=%p\n", cli);
+	T_DBG_ADDR("client address", &cli->addr, TFW_NO_PORT);
+	T_DBG2("client %p, users=%d\n", cli, 1);
 }
 
 /**
@@ -228,7 +228,7 @@ tfw_client_obtain(TfwAddr addr, TfwAddr *xff_addr, TfwStr *user_agent,
 				&tfw_client_ent_init, init, &ctx, &is_new);
 	BUG_ON(len < sizeof(TfwClientEntry));
 	if (!rec) {
-		TFW_WARN("cannot allocate TDB space for client\n");
+		T_WARN("cannot allocate TDB space for client\n");
 		return NULL;
 	}
 

--- a/tempesta_fw/filter.c
+++ b/tempesta_fw/filter.c
@@ -81,13 +81,13 @@ tfw_filter_block_ip(const TfwAddr *addr)
 	unsigned long key = tfw_ipv6_hash(&addr->sin6_addr);
 	size_t len = sizeof(rule);
 
-	TFW_DBG_ADDR("filter: block", addr, TFW_NO_PORT);
+	T_DBG_ADDR("filter: block", addr, TFW_NO_PORT);
 
 	/* TODO create records on all NUMA nodes. */
 	if (!tdb_entry_create(ip_filter_db, key, &rule, &len)) {
-		TFW_WARN_ADDR("cannot create blocking rule", addr, TFW_NO_PORT);
+		T_WARN_ADDR("cannot create blocking rule", addr, TFW_NO_PORT);
 	} else {
-		TFW_DBG_ADDR("block client", addr, TFW_NO_PORT);
+		T_DBG_ADDR("block client", addr, TFW_NO_PORT);
 	}
 }
 EXPORT_SYMBOL(tfw_filter_block_ip);
@@ -302,7 +302,7 @@ tfw_filter_start(void)
 		return -EINVAL;
 
 	if ((r = register_pernet_subsys(&tfw_net_ops)))	{
-		TFW_ERR_NL("can't register netfilter hooks\n");
+		T_ERR_NL("can't register netfilter hooks\n");
 		tdb_close(ip_filter_db);
 		return r;
 	}

--- a/tempesta_fw/gfsm.c
+++ b/tempesta_fw/gfsm.c
@@ -154,8 +154,8 @@ tfw_gfsm_switch(TfwGState *st, int state, int prio)
 		FSM_STATE(st) = fsm_hooks[fsm_curr][shift].st0;
 	}
 
-	TFW_DBG3("GFSM switch from fsm %d at state %d to fsm %d at state %#x\n",
-		 fsm_curr, state, fsm_next, TFW_GFSM_STATE(st));
+	T_DBG3("GFSM switch from fsm %d at state %d to fsm %d at state %#x\n",
+	       fsm_curr, state, fsm_next, TFW_GFSM_STATE(st));
 
 	return fsm_next;
 }
@@ -182,7 +182,7 @@ __gfsm_fsm_exec(TfwGState *st, int fsm_id, TfwFsmData *data)
 
 	FSM_STATE(st) |= TFW_GFSM_ONSTACK;
 
-	TFW_DBG3("GFSM exec fsm %d, state %#x\n", fsm_id, st->states[slot]);
+	T_DBG3("GFSM exec fsm %d, state %#x\n", fsm_id, st->states[slot]);
 
 	r = fsm_htbl[fsm_id](st->obj, data);
 
@@ -226,8 +226,8 @@ tfw_gfsm_move(TfwGState *st, unsigned short state, TfwFsmData *data)
 	unsigned long mask = 1 << state;
 	unsigned char curr_st = st->curr;
 
-	TFW_DBG3("GFSM move %#x -> %#x: skb=%pK off=%u trail=%u"
-		 " req=%pK resp=%pK\n", FSM_STATE(st), state,
+	T_DBG3("GFSM move %#x -> %#x: skb=%pK off=%u trail=%u"
+	       " req=%pK resp=%pK\n", FSM_STATE(st), state,
 		 data->skb, data->off, data->trail, data->req, data->resp);
 
 	/* Remember current FSM context. */
@@ -282,8 +282,8 @@ EXPORT_SYMBOL(tfw_gfsm_move);
 void
 tfw_gfsm_debug_state(TfwGState *st, const char *msg)
 {
-	TFW_DBG("%s: curr=%d: on_stack=%d fsm_id=%d prio=%d state=%d\n",
-		msg, st->curr, !!(FSM_STATE(st) & TFW_GFSM_ONSTACK), FSM(st),
+	T_DBG("%s: curr=%d: on_stack=%d fsm_id=%d prio=%d state=%d\n",
+	      msg, st->curr, !!(FSM_STATE(st) & TFW_GFSM_ONSTACK), FSM(st),
 		PRIO(st), TFW_GFSM_STATE(st));
 }
 EXPORT_SYMBOL(tfw_gfsm_debug_state);
@@ -320,7 +320,7 @@ tfw_gfsm_register_hook(int fsm_id, int prio, int state,
 			if (!(fsm_hooks_bm[fsm_id][prio] & st_bit))
 				break;
 		if (prio == TFW_GFSM_HOOK_PRIORITY_NUM) {
-			TFW_ERR_NL("All hook slots for FSM %d are acquired\n",
+			T_ERR_NL("All hook slots for FSM %d are acquired\n",
 				   fsm_id);
 			return -EBUSY;
 		}
@@ -330,7 +330,7 @@ tfw_gfsm_register_hook(int fsm_id, int prio, int state,
 	if (fsm_hooks[fsm_id][shift].fsm_id)
 		return -EBUSY;
 	if (!fsm_htbl[fsm_id]) {
-		TFW_ERR_NL("gfsm: fsm %d is not registered\n", fsm_id);
+		T_ERR_NL("gfsm: fsm %d is not registered\n", fsm_id);
 		return -ENOENT;
 	}
 

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -238,7 +238,7 @@ typedef struct {
 					     TfwClient, class_prvt)
 
 #define frang_msg(check, addr, fmt, ...)				\
-	TFW_WARN_MOD_ADDR(frang, check, addr, TFW_NO_PORT, fmt, ##__VA_ARGS__)
+	T_WARN_MOD_ADDR(frang, check, addr, TFW_NO_PORT, fmt, ##__VA_ARGS__)
 
 /*
  * Client actions has triggered a security event. Log the client addr and

--- a/tempesta_fw/http_match.c
+++ b/tempesta_fw/http_match.c
@@ -393,9 +393,9 @@ do_eval(const TfwHttpReq *req, const TfwHttpMatchRule *rule)
 	match_fn match_fn;
 	tfw_http_match_fld_t field;
 
-	TFW_DBG2("rule: %p, field: %#x, op: %#x, arg:%d:%d'%.*s'\n",
-		 rule, rule->field, rule->op, rule->arg.type, rule->arg.len,
-		 rule->arg.len, rule->arg.str);
+	T_DBG2("rule: %p, field: %#x, op: %#x, arg:%d:%d'%.*s'\n",
+	       rule, rule->field, rule->op, rule->arg.type, rule->arg.len,
+	       rule->arg.len, rule->arg.str);
 
 	BUG_ON(!req || !rule);
 	BUG_ON(rule->field <= 0 || rule->field >= _TFW_HTTP_MATCH_F_COUNT);
@@ -450,7 +450,7 @@ tfw_http_match_req(const TfwHttpReq *req, struct list_head *mlst)
 {
 	TfwHttpMatchRule *rule;
 
-	TFW_DBG2("Matching request: %p, list: %p\n", req, mlst);
+	T_DBG2("Matching request: %p, list: %p\n", req, mlst);
 
 	list_for_each_entry(rule, mlst, list) {
 		if (do_eval(req, rule))
@@ -472,7 +472,7 @@ tfw_http_chain_add(const char *name, TfwHttpTable *table)
 	int size = sizeof(TfwHttpChain) + name_sz;
 
 	if (!(chain = tfw_pool_alloc(table->pool, size))) {
-		TFW_ERR("Can't allocate memory for HTTP chain\n");
+		T_ERR("Can't allocate memory for HTTP chain\n");
 		return NULL;
 	}
 
@@ -520,8 +520,8 @@ tfw_http_rule_new(TfwHttpChain *chain, tfw_http_match_arg_t type,
 
 	BUG_ON(!chain || !chain->pool);
 	if (!(rule = tfw_pool_alloc(chain->pool, size))) {
-		TFW_ERR_NL("Can't allocate a rule for http chain: %p\n",
-			   chain->name);
+		T_ERR_NL("Can't allocate a rule for http chain: %p\n",
+			 chain->name);
 		return NULL;
 	}
 
@@ -545,8 +545,8 @@ tfw_http_rule_arg_init(TfwHttpMatchRule *rule, const char *arg, size_t arg_len)
 
 	if (rule->arg.type == TFW_HTTP_MATCH_A_NUM) {
 		if (tfw_cfg_parse_uint(arg, &rule->arg.num) || !rule->arg.num) {
-			TFW_ERR_NL("http_match: invalid 'mark' condition:"
-				   " '%s'\n", arg);
+			T_ERR_NL("http_match: invalid 'mark' condition: '%s'\n",
+				 arg);
 			return -EINVAL;
 		}
 		rule->op = TFW_HTTP_MATCH_O_EQ;
@@ -555,8 +555,8 @@ tfw_http_rule_arg_init(TfwHttpMatchRule *rule, const char *arg, size_t arg_len)
 
 	if (rule->arg.type == TFW_HTTP_MATCH_A_METHOD) {
 		if (tfw_http_tbl_method(arg, &rule->arg.method)) {
-			TFW_ERR_NL("http_tbl: invalid 'method' condition:"
-				   " '%s'\n", arg);
+			T_ERR_NL("http_tbl: invalid 'method' condition: '%s'\n",
+				 arg);
 			return -EINVAL;
 		}
 		rule->op = TFW_HTTP_MATCH_O_EQ;
@@ -605,8 +605,7 @@ tfw_http_arg_adjust(const char *arg, tfw_http_match_fld_t field,
 	}
 
 	if (!(arg_out = kzalloc(full_name_len + len + 1, GFP_KERNEL))) {
-		TFW_ERR_NL("http_match: unable to allocate rule"
-			   " argument.\n");
+		T_ERR_NL("http_match: unable to allocate rule argument.\n");
 		return ERR_PTR(-ENOMEM);
 	}
 
@@ -631,15 +630,15 @@ tfw_http_arg_adjust(const char *arg, tfw_http_match_fld_t field,
 	 */
 	if (!wc_arg && arg[0] == '*') {
 		if (*op_out == TFW_HTTP_MATCH_O_PREFIX)
-			TFW_WARN_NL("http_match: unable to match"
-				    " double-wildcard patterns '%s', so"
-				    " prefix pattern will be applied\n", arg);
+			T_WARN_NL("http_match: unable to match"
+				  " double-wildcard patterns '%s', so"
+				  " prefix pattern will be applied\n", arg);
 
 		else if (raw_hdr_name)
-			TFW_WARN_NL("http_match: unable to match suffix"
-				    " pattern '%s' in case of raw header"
-				    " specification: '%s', so wildcard pattern"
-				    " will not be applied\n", arg, raw_hdr_name);
+			T_WARN_NL("http_match: unable to match suffix"
+				  " pattern '%s' in case of raw header"
+				  " specification: '%s', so wildcard pattern"
+				  " will not be applied\n", arg, raw_hdr_name);
 
 		else
 			*op_out = TFW_HTTP_MATCH_O_SUFFIX;
@@ -674,11 +673,11 @@ tfw_http_verify_hdr_field(tfw_http_match_fld_t field, const char **hdr_name,
 	const char *h_name = *hdr_name;
 
 	if (field != TFW_HTTP_MATCH_F_HDR && h_name) {
-		TFW_ERR_NL("http_tbl: unnecessary extra field is specified:"
-			   " '%s'\n", h_name);
+		T_ERR_NL("http_tbl: unnecessary extra field is specified: "
+			 "'%s'\n", h_name);
 		return -EINVAL;
 	} else if (field == TFW_HTTP_MATCH_F_HDR && !h_name) {
-		TFW_ERR_NL("http_tbl: header name missed\n");
+		T_ERR_NL("http_tbl: header name missed\n");
 		return -EINVAL;
 	} else if (h_name) {
 		size_t h_len = strlen(h_name);

--- a/tempesta_fw/http_sched_hash.c
+++ b/tempesta_fw/http_sched_hash.c
@@ -451,13 +451,13 @@ static TfwScheduler tfw_sched_hash = {
 int
 tfw_sched_hash_init(void)
 {
-	TFW_DBG("sched_hash: init\n");
+	T_DBG("sched_hash: init\n");
 	return tfw_sched_register(&tfw_sched_hash);
 }
 
 void
 tfw_sched_hash_exit(void)
 {
-	TFW_DBG("sched_hash: exit\n");
+	T_DBG("sched_hash: exit\n");
 	tfw_sched_unregister(&tfw_sched_hash);
 }

--- a/tempesta_fw/http_sched_ratio.c
+++ b/tempesta_fw/http_sched_ratio.c
@@ -653,7 +653,7 @@ tfw_sched_ratio_calc_tmfn(TfwRatio *ratio,
 	 * is a critical issue in itself.
 	 */
 	if (!(nrtodata = tfw_sched_ratio_rtodata_get(ratio))) {
-		TFW_ERR("Sched ratio: Insufficient memory\n");
+		T_ERR("Sched ratio: Insufficient memory\n");
 		goto rearm;
 	}
 
@@ -1103,7 +1103,7 @@ tfw_sched_ratio_add_grp_common(TfwSrvGroup *sg)
 	TfwRatio *ratio;
 	TfwRatioData *rtodata;
 
-	TFW_DBG2("%s: SG=[%s]\n", __func__, sg->name);
+	T_DBG2("%s: SG=[%s]\n", __func__, sg->name);
 
 	size = sizeof(TfwRatio) + sizeof(TfwRatioSrvDesc) * sg->srv_n;
 	if (!(ratio = kzalloc(size, GFP_KERNEL)))
@@ -1147,7 +1147,7 @@ tfw_sched_ratio_add_grp_dynamic(TfwSrvGroup *sg, void *arg)
 	TfwRatio *ratio;
 	TfwSchrefPredict *schref = arg;
 
-	TFW_DBG2("%s: SG=[%s]\n", __func__, sg->name);
+	T_DBG2("%s: SG=[%s]\n", __func__, sg->name);
 
 	if (!(ratio = tfw_sched_ratio_add_grp_common(sg)))
 		return ratio;
@@ -1305,13 +1305,13 @@ static TfwScheduler tfw_sched_ratio = {
 int
 tfw_sched_ratio_init(void)
 {
-	TFW_DBG("%s: init\n", tfw_sched_ratio.name);
+	T_DBG("%s: init\n", tfw_sched_ratio.name);
 	return tfw_sched_register(&tfw_sched_ratio);
 }
 
 void
 tfw_sched_ratio_exit(void)
 {
-	TFW_DBG("%s: exit\n", tfw_sched_ratio.name);
+	T_DBG("%s: exit\n", tfw_sched_ratio.name);
 	tfw_sched_unregister(&tfw_sched_ratio);
 }

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -1187,14 +1187,14 @@ tfw_http_sess_get_srv_conn(TfwMsg *msg)
 				tfw_http_sess_set_expired(sess);
 				goto err;
 			}
-			TFW_ERR("sticky sched: pinned server %s in group '%s'"
-				" is down\n",
-				addr_str, srv->sg->name);
+			T_WARN("sticky sched: pinned server %s in group '%s'"
+			       " is down\n",
+			       addr_str, srv->sg->name);
 			goto err;
 		}
-		TFW_WARN("sticky sched: pinned server %s in group '%s'"
-			 " is down, try find other server\n",
-			 addr_str, srv->sg->name);
+		T_LOG("sticky sched: pinned server %s in group '%s'"
+		      " is down, try find other server\n",
+		      addr_str, srv->sg->name);
 	}
 
 	srv_conn = tfw_vhost_get_srv_conn(msg);

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -350,19 +350,19 @@ tfw_http_sticky_get(TfwHttpReq *req, TfwStr *cookie_val)
 }
 
 #ifdef DEBUG
-#define TFW_DBG_PRINT_STICKY_COOKIE(addr, ua, sv)			\
+#define T_DBG_PRINT_STICKY_COOKIE(addr, ua, sv)				\
 do {									\
 	char abuf[TFW_ADDR_STR_BUF_SIZE] = {0};				\
 	char hbuf[STICKY_KEY_MAXLEN * 2] = {0};				\
 	tfw_addr_fmt(addr, TFW_NO_PORT, abuf);				\
 	bin2hex(hbuf, tfw_sticky_key, STICKY_KEY_MAXLEN);		\
-	TFW_DBG("http_sess: calculate sticky cookie for %s,"		\
-		" ts=%#lx(now=%#lx)...\n", abuf, (sv)->ts, jiffies);	\
-	TFW_DBG("\t...secret: %.*s\n", (int)STICKY_KEY_MAXLEN * 2, hbuf);\
+	T_DBG("http_sess: calculate sticky cookie for %s,"		\
+	      " ts=%#lx(now=%#lx)...\n", abuf, (sv)->ts, jiffies);	\
+	T_DBG("\t...secret: %.*s\n", (int)STICKY_KEY_MAXLEN * 2, hbuf);	\
 	tfw_str_dprint(ua, "\t...User-Agent");				\
 } while (0)
 #else
-#define TFW_DBG_PRINT_STICKY_COOKIE(addr, ua, sv)
+#define T_DBG_PRINT_STICKY_COOKIE(addr, ua, sv)
 #endif
 
 /*
@@ -392,7 +392,7 @@ __sticky_calc(TfwHttpReq *req, StickyVal *sv)
 	shash_desc->tfm = tfw_sticky_shash;
 	shash_desc->flags = 0;
 
-	TFW_DBG_PRINT_STICKY_COOKIE(addr, &ua_value, sv);
+	T_DBG_PRINT_STICKY_COOKIE(addr, &ua_value, sv);
 
 	if ((r = crypto_shash_init(shash_desc)))
 		return r;
@@ -450,13 +450,13 @@ tfw_http_sticky_add(TfwHttpResp *resp)
 	bin2hex(buf, &ts_be64, sizeof(ts_be64));
 	bin2hex(&buf[sizeof(ts_be64) * 2], sess->hmac, sizeof(sess->hmac));
 
-	TFW_DBG("%s: \"" S_F_SET_COOKIE "%.*s=%.*s\"\n", __func__,
-		PR_TFW_STR(&tfw_cfg_sticky.name), len, buf);
+	T_DBG("%s: \"" S_F_SET_COOKIE "%.*s=%.*s\"\n", __func__,
+	      PR_TFW_STR(&tfw_cfg_sticky.name), len, buf);
 
 	r = tfw_http_msg_hdr_add((TfwHttpMsg *)resp, &set_cookie);
 	if (r)
-		TFW_WARN("Cannot add \"" S_F_SET_COOKIE "%.*s=%.*s\"\n",
-			 PR_TFW_STR(&tfw_cfg_sticky.name), len, buf);
+		T_WARN("Cannot add \"" S_F_SET_COOKIE "%.*s=%.*s\"\n",
+		       PR_TFW_STR(&tfw_cfg_sticky.name), len, buf);
 	return r;
 }
 
@@ -477,8 +477,8 @@ __redir_hmac_calc(RedirMarkVal *mv)
 	shash_desc->tfm = tfw_sticky_shash;
 	shash_desc->flags = 0;
 
-	TFW_DBG("http_sess: calculate redirection mark: ts=%#lx(now=%#lx),"
-		" att_no=%#x\n", mv->ts, jiffies, mv->att_no);
+	T_DBG("http_sess: calculate redirection mark: ts=%#lx(now=%#lx),"
+	      " att_no=%#x\n", mv->ts, jiffies, mv->att_no);
 
 	if ((r = crypto_shash_init(shash_desc)))
 		return r;
@@ -512,7 +512,7 @@ tfw_http_redir_mark_get(TfwHttpReq *req, TfwStr *out_val)
 }
 
 #define sess_warn(check, addr, fmt, ...)				\
-	TFW_WARN_MOD_ADDR(http_sess, check, addr, TFW_NO_PORT, fmt,	\
+	T_WARN_MOD_ADDR(http_sess, check, addr, TFW_NO_PORT, fmt,	\
 	                  ##__VA_ARGS__)
 
 /* The set of macros for parsing hex strings of following format:
@@ -593,14 +593,14 @@ tfw_http_redir_mark_verify(TfwHttpReq *req, TfwStr *mark_val, RedirMarkVal *mv)
 	TfwAddr *addr = &req->conn->peer->addr;
 	TfwStr *c, *end;
 
-	TFW_DBG("Redirection mark found%s: \"%.*s\"\n",
-		TFW_STR_PLAIN(mark_val) ? "" : ", starts with",
-		TFW_STR_PLAIN(mark_val) ?
-			(int)mark_val->len :
-			(int)mark_val->chunks->len,
-		TFW_STR_PLAIN(mark_val) ?
-			mark_val->data :
-			mark_val->chunks->data);
+	T_DBG("Redirection mark found%s: \"%.*s\"\n",
+	      TFW_STR_PLAIN(mark_val) ? "" : ", starts with",
+	      TFW_STR_PLAIN(mark_val) ?
+		      (int)mark_val->len :
+		      (int)mark_val->chunks->len,
+	      TFW_STR_PLAIN(mark_val) ?
+		      mark_val->data :
+		      mark_val->chunks->data);
 
 	if (mark_val->len != sizeof(RedirMarkVal) * 2) {
 		sess_warn("bad length of redirection mark", addr,
@@ -710,14 +710,14 @@ tfw_http_sticky_verify(TfwHttpReq *req, TfwStr *value, StickyVal *sv)
 	TfwAddr *addr = &req->conn->peer->addr;
 	TfwStr *c, *end;
 
-	TFW_DBG("Sticky cookie found%s: \"%.*s\"\n",
-		TFW_STR_PLAIN(value) ? "" : ", starts with",
-		TFW_STR_PLAIN(value) ?
-			(int)value->len :
-			(int)value->chunks->len,
-		TFW_STR_PLAIN(value) ?
-			value->data :
-			value->chunks->data);
+	T_DBG("Sticky cookie found%s: \"%.*s\"\n",
+	      TFW_STR_PLAIN(value) ? "" : ", starts with",
+	      TFW_STR_PLAIN(value) ?
+		      (int)value->len :
+		      (int)value->chunks->len,
+	      TFW_STR_PLAIN(value) ?
+		      value->data :
+		      value->chunks->data);
 
 	if (value->len != sizeof(StickyVal) * 2) {
 		sess_warn("bad sticky cookie length", addr, ": %lu(%lu)\n",
@@ -779,7 +779,7 @@ tfw_http_sticky_req_process(TfwHttpReq *req, StickyVal *sv)
 		}
 		return TFW_HTTP_SESS_SUCCESS;
 	}
-	TFW_WARN("Multiple Tempesta sticky cookies found: %d\n", r);
+	T_WARN("Multiple Tempesta sticky cookies found: %d\n", r);
 
 	return TFW_HTTP_SESS_FAILURE;
 }
@@ -905,13 +905,13 @@ tfw_http_sess_check_jsch(StickyVal *sv, TfwHttpReq* req)
 		return 0;
 
 	if (tfw_http_sticky_redirect_applied(req)) {
-		TFW_DBG("sess: jsch block: request received outside allowed "
-			"time range.\n");
+		T_DBG("sess: jsch block: request received outside allowed "
+		      "time range.\n");
 		return TFW_HTTP_SESS_VIOLATE;
 	}
 	else {
-		TFW_DBG("sess: jsch drop: non-challegeable resource was "
-			"requested outside allowed time range.\n");
+		T_DBG("sess: jsch drop: non-challegeable resource was "
+		      "requested outside allowed time range.\n");
 		return TFW_HTTP_SESS_JS_NOT_SUPPORTED;
 	}
 }
@@ -1027,7 +1027,7 @@ tfw_http_sess_obtain(TfwHttpReq *req)
 	sess->vhost = NULL;
 	rwlock_init(&sess->lock);
 
-	TFW_DBG("new session %p\n", sess);
+	T_DBG("new session %p\n", sess);
 
 found:
 	atomic_inc(&sess->users);
@@ -1181,9 +1181,9 @@ tfw_http_sess_get_srv_conn(TfwMsg *msg)
 			 * session destructor (tfw_http_sess_put()).
 			 */
 			if (unlikely(test_bit(TFW_CFG_B_DEL, &srv->flags))) {
-				TFW_LOG("sticky sched: server %s"
-					" was removed, set session expired\n",
-					addr_str);
+				T_LOG("sticky sched: server %s"
+				      " was removed, set session expired\n",
+				      addr_str);
 				tfw_http_sess_set_expired(sess);
 				goto err;
 			}
@@ -1217,20 +1217,20 @@ tfw_cfgop_sticky(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		} else if (!strcasecmp(key, "max_misses")) {
 			if (tfw_cfg_parse_uint(val, &tfw_cfg_sticky.max_misses))
 			{
-				TFW_ERR_NL("%s: invalid value for 'max_misses'"
-					   " attribute: '%s'\n", cs->name, val);
+				T_ERR_NL("%s: invalid value for 'max_misses'"
+					 " attribute: '%s'\n", cs->name, val);
 				return -EINVAL;
 			}
 		} else if (!strcasecmp(key, "timeout")) {
 			if (tfw_cfg_parse_uint(val, &tfw_cfg_sticky.tmt_sec))
 			{
-				TFW_ERR_NL("%s: invalid value for 'timeout'"
-					   " attribute: '%s'\n", cs->name, val);
+				T_ERR_NL("%s: invalid value for 'timeout'"
+					 " attribute: '%s'\n", cs->name, val);
 				return -EINVAL;
 			}
 		} else {
-			TFW_ERR_NL("%s: unsupported argument: '%s=%s'.\n",
-				   cs->name, key, val);
+			T_ERR_NL("%s: unsupported argument: '%s=%s'.\n",
+				 cs->name, key, val);
 			return -EINVAL;
 		}
 	}
@@ -1247,20 +1247,20 @@ tfw_cfgop_sticky(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		if (!strcasecmp(val, "enforce")) {
 			tfw_cfg_sticky.enforce = 1;
 		} else {
-			TFW_ERR_NL("%s: unsupported argument: '%s'\n",
-				   cs->name, val);
+			T_ERR_NL("%s: unsupported argument: '%s'\n",
+				 cs->name, val);
 			return -EINVAL;
 		}
 	}
 
 	if (tfw_cfg_sticky.max_misses && !tfw_cfg_sticky.enforce) {
-		TFW_ERR_NL("%s: 'max_misses' can be enabled only in"
-			   " 'enforce' mode\n", cs->name);
+		T_ERR_NL("%s: 'max_misses' can be enabled only in 'enforce' "
+			 "mode\n", cs->name);
 		return -EINVAL;
 	}
 	if (tfw_cfg_sticky.tmt_sec && !tfw_cfg_sticky.max_misses) {
-		TFW_ERR_NL("%s: 'timeout' can be specified only with"
-			   " 'max_misses' attribute\n", cs->name);
+		T_ERR_NL("%s: 'timeout' can be specified only with"
+			 " 'max_misses' attribute\n", cs->name);
 		return -EINVAL;
 	}
 
@@ -1337,7 +1337,7 @@ tfw_cfgop_jsch_parse(TfwCfgSpec *cs, const char *key, const char *val,
 	int r;
 
 	if ((r = tfw_cfg_parse_uint(val, uint_val))) {
-		TFW_ERR_NL("%s: can't parse key '%s'\n", cs->name, key);
+		T_ERR_NL("%s: can't parse key '%s'\n", cs->name, key);
 		return r;
 	}
 
@@ -1350,7 +1350,7 @@ tfw_cfg_op_jsch_parse_resp_code(TfwCfgSpec *cs, const char *val)
 	int r, int_val;
 
 	if ((r = tfw_cfg_parse_int(val, &int_val))) {
-		TFW_ERR_NL("%s: can't parse key 'resp_code'\n", cs->name);
+		T_ERR_NL("%s: can't parse key 'resp_code'\n", cs->name);
 		return r;
 	}
 	if ((r = tfw_cfg_check_range(int_val, 100, 599)))
@@ -1373,8 +1373,8 @@ tfw_cfgop_jsch_set_delay_limit(TfwCfgSpec *cs)
 		tfw_cfg_js_ch->delay_limit = max_limit;
 	}
 	if (tfw_cfg_js_ch->delay_limit < min_limit) {
-		TFW_WARN_NL("%s: 'delay_limit' is too low, many slow/distant "
-			    "clients will be blocked. "
+		T_WARN_NL("%s: 'delay_limit' is too low, many slow/distant "
+			  "clients will be blocked. "
 			    "Minimum recommended value is %u, "
 			    "but %u is provided\n",
 			    cs->name,
@@ -1384,10 +1384,10 @@ tfw_cfgop_jsch_set_delay_limit(TfwCfgSpec *cs)
 	hc_prob = tfw_cfg_js_ch->delay_limit * 100
 			/ msecs_to_jiffies(tfw_cfg_js_ch->delay_range);
 	if (hc_prob > max_hc_p) {
-		TFW_WARN_NL("%s: 'delay_limit' is too big, attacker may "
-			    "hardcode bots and breach the JavaScript challenge "
-			    "with %lu%% success probability\n",
-			    cs->name, hc_prob);
+		T_WARN_NL("%s: 'delay_limit' is too big, attacker may "
+			  "hardcode bots and breach the JavaScript challenge "
+			  "with %lu%% success probability\n",
+			  cs->name, hc_prob);
 	}
 }
 
@@ -1418,13 +1418,13 @@ tfw_cfgop_js_challenge(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	tfw_cfg_js_ch = kzalloc(sizeof(TfwCfgJsCh), GFP_KERNEL);
 	if (!tfw_cfg_js_ch) {
-		TFW_ERR_NL("%s: can't alloc memory\n", cs->name);
+		T_ERR_NL("%s: can't alloc memory\n", cs->name);
 		return -ENOMEM;
 	}
 
 	if (ce->val_n > 1) {
-		TFW_ERR_NL("invalid number of values; 1 possible, got: %zu\n",
-			   ce->val_n);
+		T_ERR_NL("invalid number of values; 1 possible, got: %zu\n",
+			 ce->val_n);
 		return -EINVAL;
 	}
 	TFW_CFG_ENTRY_FOR_EACH_ATTR(ce, i, key, val) {
@@ -1444,19 +1444,19 @@ tfw_cfgop_js_challenge(TfwCfgSpec *cs, TfwCfgEntry *ce)
 			if ((r = tfw_cfg_op_jsch_parse_resp_code(cs, val)))
 				return r;
 		} else {
-			TFW_ERR_NL("%s: unsupported argument: '%s=%s'.\n",
-				   cs->name, key, val);
+			T_ERR_NL("%s: unsupported argument: '%s=%s'.\n",
+				 cs->name, key, val);
 			return -EINVAL;
 		}
 	}
 	if (!tfw_cfg_js_ch->delay_min) {
-		TFW_ERR_NL("%s: required argument 'delay_min' not set.\n",
-			   cs->name);
+		T_ERR_NL("%s: required argument 'delay_min' not set.\n",
+			 cs->name);
 		return -EINVAL;
 	}
 	if (!tfw_cfg_js_ch->delay_range) {
-		TFW_ERR_NL("%s: required argument 'delay_range' not set.\n",
-			   cs->name);
+		T_ERR_NL("%s: required argument 'delay_range' not set.\n",
+			 cs->name);
 		return -EINVAL;
 	}
 	if (!tfw_cfg_js_ch->st_code)
@@ -1485,8 +1485,8 @@ static int
 tfw_http_sess_cfgend(void)
 {
 	if (tfw_cfg_js_ch && TFW_STR_EMPTY(&tfw_cfg_sticky.name)) {
-		TFW_ERR_NL("JavaScript challenge requires sticky cookies "
-			   "enabled\r\n");
+		T_ERR_NL("JavaScript challenge requires sticky cookies "
+			 "enabled\r\n");
 		return -EINVAL;
 	}
 	if (tfw_cfg_js_ch) {

--- a/tempesta_fw/http_tbl.c
+++ b/tempesta_fw/http_tbl.c
@@ -134,8 +134,8 @@ tfw_http_tbl_scan(TfwMsg *msg, TfwHttpTable *table, bool *block)
 			rule = tfw_http_match_req((TfwHttpReq *)msg,
 						  &chain->match_list);
 		if (unlikely(!rule)) {
-			TFW_DBG("http_tbl: No rule found in HTTP"
-				" chain '%s'\n", chain->name);
+			T_DBG("http_tbl: No rule found in HTTP chain '%s'\n",
+			      chain->name);
 			return NULL;
 		}
 		chain = (rule->act.type == TFW_HTTP_MATCH_ACT_CHAIN)
@@ -222,8 +222,7 @@ tfw_http_tbl_method(const char *arg, tfw_http_meth_t *method)
 {
 	if (tfw_cfg_map_enum(tfw_http_tbl_cfg_method_enum, arg, method))
 	{
-		TFW_ERR_NL("http_tbl: invalid 'method' condition:"
-			   " '%s'\n", arg);
+		T_ERR_NL("http_tbl: invalid 'method' condition: '%s'\n", arg);
 		return -EINVAL;
 	}
 	return 0;
@@ -266,7 +265,7 @@ tfw_http_tbl_cfgstart(void)
 
 	tfw_table_reconfig = tfw_pool_new(TfwHttpTable, TFW_POOL_ZERO);
 	if (!tfw_table_reconfig) {
-		TFW_ERR_NL("Can't create a memory pool\n");
+		T_ERR_NL("Can't create a memory pool\n");
 		return -ENOMEM;
 	}
 
@@ -288,29 +287,29 @@ tfw_cfgop_http_tbl_chain_begin(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	BUG_ON(!tfw_table_reconfig);
 	BUG_ON(tfw_chain_entry);
 
-	TFW_DBG("http_tbl: begin http_chain\n");
+	T_DBG("http_tbl: begin http_chain\n");
 
 	if (ce->val_n > 1) {
-		TFW_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
+		T_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
 		return -EINVAL;
 	}
 	if (ce->attr_n) {
-		TFW_ERR_NL("Unexpected attributes\n");
+		T_ERR_NL("Unexpected attributes\n");
 		return -EINVAL;
 	}
 
 	chain = list_first_entry_or_null(&tfw_table_reconfig->head,
 					 TfwHttpChain, list);
 	if (chain && !chain->name) {
-		TFW_ERR_NL("Main HTTP chain must be only one and last\n");
+		T_ERR_NL("Main HTTP chain must be only one and last\n");
 		return -EINVAL;
 	}
 	if (ce->val_n) {
 		name = ce->vals[0];
 		list_for_each_entry(chain, &tfw_table_reconfig->head, list) {
 			if (!strcasecmp(chain->name, name)) {
-				TFW_ERR_NL("Duplicate http chain"
-					   " entry: '%s'\n", name);
+				T_ERR_NL("Duplicate http chain entry: '%s'\n",
+					 name);
 				return -EINVAL;
 			}
 		}
@@ -326,7 +325,7 @@ tfw_cfgop_http_tbl_chain_begin(TfwCfgSpec *cs, TfwCfgEntry *ce)
 static int
 tfw_cfgop_http_tbl_chain_finish(TfwCfgSpec *cs)
 {
-	TFW_DBG("http_tbl: finish http_chain\n");
+	T_DBG("http_tbl: finish http_chain\n");
 	BUG_ON(!tfw_chain_entry);
 	tfw_chain_entry = NULL;
 	return 0;
@@ -378,7 +377,7 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 	if ((r = tfw_cfg_check_val_n(e, 0)))
 		return r;
 	if (e->attr_n) {
-		TFW_ERR_NL("Attributes count must be zero\n");
+		T_ERR_NL("Attributes count must be zero\n");
 		return -EINVAL;
 	}
 
@@ -393,9 +392,9 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 	BUG_ON(!action);
 
 	if (tfw_http_rule_default_exist(&tfw_chain_entry->match_list)) {
-		TFW_ERR_NL("http_tbl: default HTTP rule must be"
-			   " only one and last; chain '%s'\n",
-			   tfw_chain_entry->name ? : "main" );
+		T_ERR_NL("http_tbl: default HTTP rule must be only one and "
+			 "last; chain '%s'\n",
+			 tfw_chain_entry->name ? : "main" );
 		return -EINVAL;
 	}
 
@@ -405,8 +404,8 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 		r = tfw_cfg_map_enum(tfw_http_tbl_cfg_field_enum,
 				     in_field, &field);
 		if (r) {
-			TFW_ERR_NL("http_tbl: invalid rule field: '%s'\n",
-				   in_field);
+			T_ERR_NL("http_tbl: invalid rule field: '%s'\n",
+				 in_field);
 			return r;
 		}
 		if ((r = tfw_http_verify_hdr_field(field, &hdr, &hid)))
@@ -420,7 +419,7 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 
 	rule = tfw_http_rule_new(tfw_chain_entry, type, arg_size);
 	if (!rule) {
-		TFW_ERR_NL("http_tbl: can't allocate memory for rule\n");
+		T_ERR_NL("http_tbl: can't allocate memory for rule\n");
 		r = -ENOMEM;
 		goto err;
 	} else {
@@ -443,15 +442,15 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 		if (!action_val ||
 		    tfw_cfg_parse_uint(action_val,&rule->act.mark))
 		{
-			TFW_ERR_NL("http_tbl: 'mark' action must have"
-				   " unsigned integer value: '%s'\n",
-				   action_val);
+			T_ERR_NL("http_tbl: 'mark' action must have unsigned "
+				 "integer value: '%s'\n",
+				 action_val);
 			return -EINVAL;
 		}
 		rule->act.type = TFW_HTTP_MATCH_ACT_MARK;
 	} else if (action_val) {
-		TFW_ERR_NL("http_tbl: not 'mark' actions must not have"
-			   " any value: '%s'\n", action_val);
+		T_ERR_NL("http_tbl: not 'mark' actions must not have any value:"
+			 " '%s'\n", action_val);
 		return -EINVAL;
 	} else if (!strcasecmp(action, "block")) {
 		rule->act.type = TFW_HTTP_MATCH_ACT_BLOCK;
@@ -462,14 +461,14 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 		rule->act.type = TFW_HTTP_MATCH_ACT_VHOST;
 		rule->act.vhost = vhost;
 	} else {
-		TFW_ERR_NL("http_tbl: neither http_chain nor vhost with"
-			   " specified name were found: '%s'\n", action);
+		T_ERR_NL("http_tbl: neither http_chain nor vhost with specified"
+			 " name were found: '%s'\n", action);
 		return -EINVAL;
 	}
 
 	if (chain == tfw_chain_entry) {
-		TFW_ERR_NL("http_tbl: cyclic reference of http_chain to"
-			   " itself: '%s'\n", tfw_chain_entry->name);
+		T_ERR_NL("http_tbl: cyclic reference of http_chain to itself:"
+			 " '%s'\n", tfw_chain_entry->name);
 		return -EINVAL;
 	}
 
@@ -556,8 +555,8 @@ tfw_http_tbl_cfgend(void)
 
 	rule = tfw_http_rule_new(chain, TFW_HTTP_MATCH_A_WILDCARD, 0);
 	if (!rule) {
-		TFW_ERR_NL("http_tbl: can't allocate memory for"
-			   " default rule of main HTTP chain\n");
+		T_ERR_NL("http_tbl: can't allocate memory for default rule of "
+			 "main HTTP chain\n");
 		r = -ENOMEM;
 		goto err;
 	}

--- a/tempesta_fw/log.h
+++ b/tempesta_fw/log.h
@@ -25,16 +25,6 @@
 
 #define BANNER	"fw"
 #include "lib/log.h"
-/* TODO remove the definitions after moving to unified logging. */
-#define TFW_ERR(...)		T_ERR(__VA_ARGS__)
-#define TFW_ERR_NL(...)		T_ERR_NL(__VA_ARGS__)
-#define TFW_WARN(...)		T_WARN(__VA_ARGS__)
-#define TFW_WARN_NL(...)	T_WARN_NL(__VA_ARGS__)
-#define TFW_LOG(...)		T_LOG(__VA_ARGS__)
-#define TFW_LOG_NL(...)		T_LOG_NL(__VA_ARGS__)
-#define TFW_DBG(...)		T_DBG(__VA_ARGS__)
-#define TFW_DBG2(...)		T_DBG2(__VA_ARGS__)
-#define TFW_DBG3(...)		T_DBG3(__VA_ARGS__)
 
 /*
  * Print an IP address into a buffer (allocated on stack) and then evaluate
@@ -52,26 +42,26 @@ do {									\
 } while (0)
 
 /* Log a debug message and append an IP address to it.*/
-#define TFW_DBG_ADDR(msg, addr_ptr, print_port)				\
+#define T_DBG_ADDR(msg, addr_ptr, print_port)				\
 	TFW_WITH_ADDR_FMT(addr_ptr, print_port, addr_str,		\
 	                  T_DBG("%s: %s\n", msg, addr_str))
 
 /* Log an info message and append an IP address to it.*/
-#define TFW_LOG_ADDR(msg, addr_ptr, print_port)				\
+#define T_LOG_ADDR(msg, addr_ptr, print_port)				\
 	TFW_WITH_ADDR_FMT(addr_ptr, print_port, addr_str,		\
 	                  T_LOG("%s: %s\n", msg, addr_str))
 
 /* Log a warning message and append an IP address to it.*/
-#define TFW_WARN_ADDR(msg, addr_ptr, print_port)			\
+#define T_WARN_ADDR(msg, addr_ptr, print_port)				\
 	TFW_WITH_ADDR_FMT(addr_ptr, print_port, addr_str,		\
 	                  T_WARN("%s: %s\n", msg, addr_str))
 
 /* Log an error message and append an IP address to it. */
-#define TFW_ERR_ADDR(msg, addr_ptr, print_port)				\
+#define T_ERR_ADDR(msg, addr_ptr, print_port)				\
 	TFW_WITH_ADDR_FMT(addr_ptr, print_port, addr_str,		\
 	                  T_ERR("%s: %s\n", msg, addr_str))
 
-#define TFW_WARN_MOD_ADDR(mod, check, addr, print_port, fmt, ...)	\
+#define T_WARN_MOD_ADDR(mod, check, addr, print_port, fmt, ...)		\
 do {									\
 	char abuf[TFW_ADDR_STR_BUF_SIZE] = {0};				\
 	tfw_addr_fmt(addr, print_port, abuf);				\

--- a/tempesta_fw/pool.h
+++ b/tempesta_fw/pool.h
@@ -64,7 +64,7 @@ typedef struct {
 			memset(s, 0, sizeof(struct_name));		\
  		s->pool = p;						\
  	} else {							\
- 		TFW_ERR("Can't alloc new " #struct_name);		\
+		T_ERR("Can't alloc new " #struct_name);			\
  	}								\
  	s;								\
  })

--- a/tempesta_fw/procfs.c
+++ b/tempesta_fw/procfs.c
@@ -92,7 +92,7 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	SsStat *ss_stat = kmalloc(sizeof(SsStat) * num_online_cpus(),
 				  GFP_KERNEL);
 	if (!ss_stat)
-		TFW_WARN("Cannot allocate sync sockets statistics\n");
+		T_WARN("Cannot allocate sync sockets statistics\n");
 
 	memset(&stat, 0, sizeof(stat));
 	tfw_perfstat_collect(&stat);

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -126,7 +126,7 @@ tfw_server_lookup(TfwSrvGroup *sg, TfwAddr *addr)
 int
 tfw_server_start_sched(TfwServer *srv)
 {
-	TFW_DBG_ADDR("Start scheduler for server", &srv->addr, TFW_WITH_PORT);
+	T_DBG_ADDR("Start scheduler for server", &srv->addr, TFW_WITH_PORT);
 	if (srv->sg->sched->add_srv)
 		return srv->sg->sched->add_srv(srv);
 
@@ -136,7 +136,7 @@ tfw_server_start_sched(TfwServer *srv)
 void
 tfw_server_stop_sched(TfwServer *srv)
 {
-	TFW_DBG_ADDR("Stop scheduler for server", &srv->addr, TFW_WITH_PORT);
+	T_DBG_ADDR("Stop scheduler for server", &srv->addr, TFW_WITH_PORT);
 	if (srv->sg->sched && srv->sg->sched->del_srv)
 		srv->sg->sched->del_srv(srv);
 }
@@ -205,7 +205,7 @@ tfw_sg_new(const char *name, unsigned int len, gfp_t flags)
 	TfwSrvGroup *sg;
 	size_t name_size = strlen(name) + 1;
 
-	TFW_DBG("Create new server group: '%s'\n", name);
+	T_DBG("Create new server group: '%s'\n", name);
 
 	sg = kzalloc(sizeof(*sg) + name_size, flags);
 	if (!sg)
@@ -233,10 +233,10 @@ tfw_sg_add_reconfig(TfwSrvGroup *sg)
 {
 	unsigned long key;
 
-	TFW_DBG("Add new server group: '%s'\n", sg->name);
+	T_DBG("Add new server group: '%s'\n", sg->name);
 
 	if (tfw_sg_lookup_reconfig(sg->name, sg->nlen)) {
-		TFW_ERR("duplicate server group: '%s'\n", sg->name);
+		T_ERR_NL("duplicate server group: '%s'\n", sg->name);
 		return -EINVAL;
 	}
 
@@ -266,7 +266,7 @@ tfw_sg_apply_reconfig(struct hlist_head *del_sg)
 	struct hlist_node *tmp;
 	TfwSrvGroup *sg;
 
-	TFW_DBG("Apply reconfig groups\n");
+	T_DBG("Apply reconfig groups\n");
 
 	down_write(&sg_sem);
 
@@ -326,7 +326,7 @@ tfw_sg_add_srv(TfwSrvGroup *sg, TfwServer *srv)
 	tfw_sg_get(sg);
 	srv->sg = sg;
 
-	TFW_DBG2("Add new backend server to group '%s'\n", sg->name);
+	T_DBG2("Add new backend server to group '%s'\n", sg->name);
 	down_write(&sg_sem);
 	list_add(&srv->list, &sg->srv_list);
 	++sg->srv_n;
@@ -346,7 +346,7 @@ __tfw_sg_del_srv(TfwSrvGroup *sg, TfwServer *srv, bool lock)
 	 * change it's group on the fly.
 	 */
 
-	TFW_DBG2("Remove backend server from group '%s'\n", sg->name);
+	T_DBG2("Remove backend server from group '%s'\n", sg->name);
 
 	if (lock)
 		down_write(&sg_sem);
@@ -360,8 +360,7 @@ __tfw_sg_del_srv(TfwSrvGroup *sg, TfwServer *srv, bool lock)
 int
 tfw_sg_start_sched(TfwSrvGroup *sg, TfwScheduler *sched, void *arg)
 {
-	TFW_DBG2("Start scheduler '%s' for group '%s'\n",
-		 sched->name, sg->name);
+	T_DBG2("Start scheduler '%s' for group '%s'\n", sched->name, sg->name);
 	sg->sched = sched;
 	if (sched->add_grp)
 		return sched->add_grp(sg, arg);
@@ -372,8 +371,8 @@ tfw_sg_start_sched(TfwSrvGroup *sg, TfwScheduler *sched, void *arg)
 void
 tfw_sg_stop_sched(TfwSrvGroup *sg)
 {
-	TFW_DBG2("Stop scheduler '%s' for group '%s'\n",
-		 (sg->sched ? sg->sched->name : ""), sg->name);
+	T_DBG2("Stop scheduler '%s' for group '%s'\n",
+	       (sg->sched ? sg->sched->name : ""), sg->name);
 	if (sg->sched && sg->sched->del_grp)
 		sg->sched->del_grp(sg);
 }
@@ -462,7 +461,7 @@ end:
 void
 tfw_sg_destroy(TfwSrvGroup *sg)
 {
-	TFW_DBG2("release group: '%s'\n", sg->name);
+	T_DBG2("release group: '%s'\n", sg->name);
 	WARN_ON(!list_empty(&sg->srv_list));
 
 	kfree(sg);

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -94,8 +94,8 @@ ss_skb_alloc_pages(size_t len)
 			return NULL;
 		}
 		skb_fill_page_desc(skb, i, page, 0, 0);
-		TFW_DBG3("Created new frag %d,%p for skb %p\n",
-			 i, page_address(page), skb);
+		T_DBG3("Created new frag %d,%p for skb %p\n",
+		       i, page_address(page), skb);
 	}
 
 	return skb;
@@ -434,8 +434,8 @@ __split_linear_data(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
 	int tail_len = (char *)skb_tail_pointer(skb) - pspt;
 	int tail_off = pspt - (char *)page_address(page);
 
-	TFW_DBG3("[%d]: %s: skb [%p] pspt [%p] len [%d] tail_len [%d]\n",
-		 smp_processor_id(), __func__, skb, pspt, len, tail_len);
+	T_DBG3("[%d]: %s: skb [%p] pspt [%p] len [%d] tail_len [%d]\n",
+	       smp_processor_id(), __func__, skb, pspt, len, tail_len);
 	BUG_ON(!skb->head_frag);
 	BUG_ON(tail_len <= 0);
 	BUG_ON(!(alloc | tail_len));
@@ -539,8 +539,8 @@ __split_pgfrag_add(struct sk_buff *skb_head, struct sk_buff *skb, int i, int off
 	struct sk_buff *skb_dst, *skb_new;
 	skb_frag_t *frag_dst, *frag = &skb_shinfo(skb)->frags[i];
 
-	TFW_DBG3("[%d]: %s: skb [%p] i [%d] off [%d] len [%d] fragsize [%d]\n",
-		 smp_processor_id(), __func__,
+	T_DBG3("[%d]: %s: skb [%p] i [%d] off [%d] len [%d] fragsize [%d]\n",
+	       smp_processor_id(), __func__,
 		 skb, i, off, len, skb_frag_size(frag));
 
 	/*
@@ -624,12 +624,12 @@ __split_pgfrag_del(struct sk_buff *skb_head, struct sk_buff *skb, int i, int off
 	skb_frag_t *frag = &skb_shinfo(skb)->frags[i];
 	struct skb_shared_info *si = skb_shinfo(skb);
 
-	TFW_DBG3("[%d]: %s: skb [%p] i [%d] off [%d] len [%d] fragsize [%d]\n",
-		 smp_processor_id(), __func__,
+	T_DBG3("[%d]: %s: skb [%p] i [%d] off [%d] len [%d] fragsize [%d]\n",
+	       smp_processor_id(), __func__,
 		 skb, i, off, len, skb_frag_size(frag));
 
 	if (unlikely(off + len > skb_frag_size(frag))) {
-		TFW_WARN("Attempt to delete too much\n");
+		T_WARN("Attempt to delete too much\n");
 		return -EFAULT;
 	}
 
@@ -737,11 +737,11 @@ __skb_fragment(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
 	unsigned int d_size;
 	struct skb_shared_info *si = skb_shinfo(skb);
 
-	TFW_DBG3("[%d]: %s: len=%d pspt=%pK skb=%pK head=%pK data=%pK tail=%pK"
-		 " end=%pK len=%u data_len=%u truesize=%u nr_frags=%u\n",
-		 smp_processor_id(), __func__, len, pspt, skb, skb->head,
-		 skb->data, skb_tail_pointer(skb), skb_end_pointer(skb),
-		 skb->len, skb->data_len, skb->truesize, si->nr_frags);
+	T_DBG3("[%d]: %s: len=%d pspt=%pK skb=%pK head=%pK data=%pK tail=%pK"
+	       " end=%pK len=%u data_len=%u truesize=%u nr_frags=%u\n",
+	       smp_processor_id(), __func__, len, pspt, skb, skb->head,
+	       skb->data, skb_tail_pointer(skb), skb_end_pointer(skb),
+	       skb->len, skb->data_len, skb->truesize, si->nr_frags);
 	BUG_ON(!len);
 
 	/*
@@ -814,12 +814,12 @@ append:
 	__it_next_data(skb, i + 1, it);
 
 done:
-	TFW_DBG3("[%d]: %s: out: res [%p], skb [%p]: head [%p] data [%p]"
-		 " tail [%p] end [%p] len [%u] data_len [%u]"
-		 " truesize [%u] nr_frags [%u]\n",
-		 smp_processor_id(), __func__, it->data, skb, skb->head,
-		 skb->data, skb_tail_pointer(skb), skb_end_pointer(skb),
-		 skb->len, skb->data_len, skb->truesize, si->nr_frags);
+	T_DBG3("[%d]: %s: out: res [%p], skb [%p]: head [%p] data [%p]"
+	       " tail [%p] end [%p] len [%u] data_len [%u]"
+	       " truesize [%u] nr_frags [%u]\n",
+	       smp_processor_id(), __func__, it->data, skb, skb->head,
+	       skb->data, skb_tail_pointer(skb), skb_end_pointer(skb),
+	       skb->len, skb->data_len, skb->truesize, si->nr_frags);
 
 	if (ret < 0)
 		return ret;
@@ -836,7 +836,7 @@ skb_fragment(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
 	     int len, TfwStr *it)
 {
 	if (unlikely(abs(len) > PAGE_SIZE)) {
-		TFW_WARN("Attempt to add or delete too much data: %u\n", len);
+		T_WARN("Attempt to add or delete too much data: %u\n", len);
 		return -EINVAL;
 	}
 	/* skbs with skb fragments are not expected. */
@@ -918,10 +918,10 @@ ss_skb_chop_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,
 	skb_frag_t *frag;
 	TfwStr it;
 
-	TFW_DBG3("%s: head=%#lx trail=%#lx skb=%pK (head=%pK data=%pK tail=%pK"
-		 " end=%pK len=%u data_len=%u nr_frags=%u)\n", __func__,
-		 head, trail, skb, skb->head, skb->data, skb_tail_pointer(skb),
-		 skb_end_pointer(skb), skb->len, skb->data_len, si->nr_frags);
+	T_DBG3("%s: head=%#lx trail=%#lx skb=%pK (head=%pK data=%pK tail=%pK"
+	       " end=%pK len=%u data_len=%u nr_frags=%u)\n", __func__,
+	       head, trail, skb, skb->head, skb->data, skb_tail_pointer(skb),
+	       skb_end_pointer(skb), skb->len, skb->data_len, si->nr_frags);
 	if (WARN_ON_ONCE(skb->len <= head + trail))
 		return -EINVAL;
 
@@ -995,7 +995,7 @@ ss_skb_cutoff_data(struct sk_buff *skb_head, const TfwStr *str, int skip,
 		bzero_fast(&it, sizeof(TfwStr));
 		r = skb_fragment(skb_head, t_skb, t_ptr, -tail, &it);
 		if (r < 0) {
-			TFW_WARN("Cannot delete tail\n");
+			T_WARN("Cannot delete tail\n");
 			return r;
 		}
 		BUG_ON(r > tail);
@@ -1374,23 +1374,23 @@ ss_skb_dump(struct sk_buff *skb)
 	struct sk_buff *f_skb;
 	struct skb_shared_info *si = skb_shinfo(skb);
 
-	TFW_LOG_NL("SKB (%p) DUMP: len=%u data_len=%u truesize=%u users=%u\n",
-		   skb, skb->len, skb->data_len, skb->truesize,
-		   refcount_read(&skb->users));
-	TFW_LOG_NL("  head=%p data=%p tail=%x end=%x\n",
-		   skb->head, skb->data, skb->tail, skb->end);
-	TFW_LOG_NL("  nr_frags=%u frag_list=%p next=%p prev=%p\n",
-		   si->nr_frags, skb_shinfo(skb)->frag_list,
-		   skb->next, skb->prev);
-	TFW_LOG_NL("  head data (%u):\n", skb_headlen(skb));
+	T_LOG_NL("SKB (%p) DUMP: len=%u data_len=%u truesize=%u users=%u\n",
+		 skb, skb->len, skb->data_len, skb->truesize,
+		 refcount_read(&skb->users));
+	T_LOG_NL("  head=%p data=%p tail=%x end=%x\n",
+		 skb->head, skb->data, skb->tail, skb->end);
+	T_LOG_NL("  nr_frags=%u frag_list=%p next=%p prev=%p\n",
+		 si->nr_frags, skb_shinfo(skb)->frag_list,
+		 skb->next, skb->prev);
+	T_LOG_NL("  head data (%u):\n", skb_headlen(skb));
 	print_hex_dump(KERN_INFO, "    ", DUMP_PREFIX_OFFSET, 16, 1,
 		       skb->data, skb_headlen(skb), true);
 
 	for (i = 0; i < si->nr_frags; ++i) {
 		const skb_frag_t *f = &si->frags[i];
-		TFW_LOG_NL("  frag %d (addr=%p pg_off=%u size=%u pg_ref=%d):\n",
-			   i, skb_frag_address(f), f->page_offset,
-			   skb_frag_size(f), page_ref_count(skb_frag_page(f)));
+		T_LOG_NL("  frag %d (addr=%p pg_off=%u size=%u pg_ref=%d):\n",
+			 i, skb_frag_address(f), f->page_offset,
+			 skb_frag_size(f), page_ref_count(skb_frag_page(f)));
 		print_hex_dump(KERN_INFO, "    ", DUMP_PREFIX_OFFSET, 16, 1,
 			       skb_frag_address(f), skb_frag_size(f), true);
 	}

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -111,7 +111,7 @@ tfw_match_ctext_vchar(const char *str, size_t len)
 	else
 		r = __tfw_match_ctext_vchar(str, len);
 
-	TFW_DBG3("%s: str[0]=%#x len=%lu r=%lu\n", __func__, str[0], len, r);
+	T_DBG3("%s: str[0]=%#x len=%lu r=%lu\n", __func__, str[0], len, r);
 
 	return r;
 }
@@ -346,7 +346,7 @@ size_t tfw_match_##a_name(const char *str, size_t len)			\
 	size_t r;							\
 	r = __tfw_match_slow(str, len, custom_##a_name##_enabled	\
 					? custom_##a_name : a_name);	\
-	TFW_DBG3("%s: str[0]=%#x len=%lu r=%lu\n",			\
+	T_DBG3("%s: str[0]=%#x len=%lu r=%lu\n",			\
 		 __func__, str[0], len, r);				\
 	return r;							\
 }									\
@@ -569,7 +569,7 @@ __str_grow_tree(TfwPool *pool, TfwStr *str, unsigned int flag, int n)
 		void *p;
 
 		if (unlikely(str->nchunks >= __TFW_STR_CN_MAX)) {
-			TFW_WARN("Reaching chunks hard limit\n");
+			T_WARN("Reaching chunks hard limit\n");
 			return NULL;
 		}
 
@@ -1234,15 +1234,15 @@ tfw_str_dprint(const TfwStr *str, const char *msg)
 {
 	const TfwStr *dup, *dup_end, *c, *chunk_end;
 
-	TFW_DBG("%s: addr=%p skb=%p len=%lu flags=%x eolen=%u:\n", msg,
-		str, str->skb, str->len, str->flags, str->eolen);
+	T_DBG("%s: addr=%p skb=%p len=%lu flags=%x eolen=%u:\n", msg,
+	      str, str->skb, str->len, str->flags, str->eolen);
 	TFW_STR_FOR_EACH_DUP(dup, str, dup_end) {
-		TFW_DBG("  duplicate %p, len=%lu, flags=%x eolen=%u:\n",
-			dup, dup->len, dup->flags, dup->eolen);
+		T_DBG("  duplicate %p, len=%lu, flags=%x eolen=%u:\n",
+		      dup, dup->len, dup->flags, dup->eolen);
 		TFW_STR_FOR_EACH_CHUNK(c, dup, chunk_end)
-			TFW_DBG("   len=%lu, eolen=%u ptr=%p flags=%x '%.*s'\n",
-				c->len, c->eolen, c->data, c->flags,
-				(int)c->len, c->data);
+			T_DBG("   len=%lu, eolen=%u ptr=%p flags=%x '%.*s'\n",
+			      c->len, c->eolen, c->data, c->flags,
+			      (int)c->len, c->data);
 	}
 }
 

--- a/tempesta_fw/t/fuzzer.c
+++ b/tempesta_fw/t/fuzzer.c
@@ -406,8 +406,8 @@ __add_field(TfwFuzzContext *ctx, int type, char **p, char *end, int t, int n)
 			r = fmsg.flags;
 
 		if (r & FUZZ_MSG_F_INVAL) {
-			TFW_DBG("generate invalid field %d for header %d\n",
-				 n, t);
+			T_DBG("generate invalid field %d for header %d\n",
+			      n, t);
 			r |= FUZZ_INVALID;
 		}
 
@@ -437,8 +437,8 @@ __add_field(TfwFuzzContext *ctx, int type, char **p, char *end, int t, int n)
 		}
 
 		if (r == FUZZ_INVALID)
-			TFW_DBG("generate invalid random field for header %d\n",
-				t);
+			T_DBG("generate invalid random field for header %d\n",
+			      t);
 
 		return r;
 	}
@@ -473,7 +473,7 @@ __add_header(TfwFuzzContext *ctx, int type, char **p, char *end, int t, int n)
 	add_string(p, end, "\r\n");
 
 	if (v & FUZZ_INVALID)
-		TFW_DBG("generate invalid header %d\n", t);
+		T_DBG("generate invalid header %d\n", t);
 
 	ctx->hdr_flags |= 1 << t;
 
@@ -513,8 +513,8 @@ add_body(TfwFuzzContext *ctx, char **p, char *end, int type)
 
 	err = kstrtoul(len_str, 10, &len);
 	if (err) {
-		TFW_ERR("error %d on getting content length from \"%s\""
-			"(%lu)\n", err, len_str, i);
+		T_ERR("error %d on getting content length from \"%s\" (%lu)\n",
+		      err, len_str, i);
 		return FUZZ_INVALID;
 	}
 
@@ -522,7 +522,7 @@ add_body(TfwFuzzContext *ctx, char **p, char *end, int type)
 		if (!ctx->is_only_valid && len && !(i % INVALID_BODY_PERIOD)) {
 			len /= 2;
 			ret = FUZZ_INVALID;
-			TFW_DBG("1/2 invalid body %lu\n", len);
+			T_DBG("1/2 invalid body %lu\n", len);
 		}
 
 		add_rand_string(p, end, len, A_BODY);
@@ -555,8 +555,8 @@ add_body(TfwFuzzContext *ctx, char **p, char *end, int type)
 				{
 					step /= 2;
 					ret = FUZZ_INVALID;
-					TFW_DBG("1/2 invalid chunked body %lu,"
-						" chunks %d\n", len, chunks);
+					T_DBG("1/2 invalid chunked body %lu,"
+					      " chunks %d\n", len, chunks);
 				}
 
 				add_rand_string(p, end, step, A_BODY);
@@ -596,7 +596,7 @@ __add_duplicates(TfwFuzzContext *ctx, int type,
 	}
 
 	if (gen_vector[t].singular && i > 0) {
-		TFW_DBG("generate duplicate for singular header %d\n", t);
+		T_DBG("generate duplicate for singular header %d\n", t);
 		return FUZZ_INVALID;
 	}
 

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -44,7 +44,7 @@ test_spec_cleanup(TfwCfgSpec specs[])
 	TFW_CFG_FOR_EACH_SPEC(spec, specs) {
 		bool called = spec->__called_cfg | spec->__called_ever;
 		if (called && spec->cleanup) {
-			TFW_DBG2("%s: '%s'\n", __func__, spec->name);
+			T_DBG2("%s: '%s'\n", __func__, spec->name);
 			spec->cleanup(spec);
 		}
 		spec->__called_cfg = false;

--- a/tempesta_fw/t/unit/test.c
+++ b/tempesta_fw/t/unit/test.c
@@ -39,7 +39,7 @@ test_fixture_fn_t test_teardown_fn;
  * message among all logs generated during a test run.
  * That happens because:
  *  - Some tests intentionally make calls with invalid input data.
- *    The code generates TFW_ERR() messages indistinguishable from
+ *    The code generates T_ERR() messages indistinguishable from
  *    real errors.
  *  - Overall, there is a lot of debugging output, and usually you
  *    don't need it unless the test is failed.

--- a/tempesta_fw/t/unit/test_http_match.c
+++ b/tempesta_fw/t/unit/test_http_match.c
@@ -57,7 +57,7 @@ TfwHttpReq *test_req;
 		  : sizeof(container);					\
 	container *_c = tfw_pool_alloc((chain)->pool, _s);		\
 	if (!_c) {							\
-		TFW_ERR("Can't allocate memory from pool\n");		\
+		T_ERR("Can't allocate memory from pool\n");		\
 	} else { 							\
 		struct list_head *head = (type == TFW_HTTP_MATCH_A_NUM)	\
 				       ? &(chain)->mark_list		\

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -572,7 +572,7 @@ tfw_tls_conn_init(TfwConn *c)
 	T_DBG2("%s: conn=[%p]\n", __func__, c);
 
 	if ((r = ttls_ctx_init(tls, &tfw_tls.cfg))) {
-		TFW_ERR("TLS (%pK) setup failed (%x)\n", tls, -r);
+		T_ERR("TLS (%pK) setup failed (%x)\n", tls, -r);
 		return -EINVAL;
 	}
 
@@ -606,8 +606,8 @@ tfw_tls_conn_close(TfwConn *c, bool sync)
 	 * skip the alert and just close the socket.
 	 */
 	if (r) {
-		TFW_WARN_ADDR("Close TCP socket w/o sending alert to the peer",
-			      &c->peer->addr, TFW_WITH_PORT);
+		T_WARN_ADDR("Close TCP socket w/o sending alert to the peer",
+			    &c->peer->addr, TFW_WITH_PORT);
 		r = ss_close(c->sk, sync ? SS_F_SYNC : 0);
 	}
 
@@ -770,7 +770,7 @@ tfw_tls_do_init(void)
 	/* Use cute ECDHE-ECDSA-AES128-GCM-SHA256 by default. */
 	r = ttls_config_defaults(&tfw_tls.cfg, TTLS_IS_SERVER);
 	if (r) {
-		TFW_ERR_NL("TLS: can't set config defaults (%x)\n", -r);
+		T_ERR_NL("TLS: can't set config defaults (%x)\n", -r);
 		return -EINVAL;
 	}
 	ttls_conf_sni(&tfw_tls.cfg, tfw_tls_sni, NULL);
@@ -874,20 +874,20 @@ tfw_tls_cfgend(void)
 {
 	if (!(tfw_tls_cgf & TFW_TLS_CFG_F_REQUIRED)) {
 		if (tfw_tls_cgf)
-			TFW_WARN_NL("TLS: no HTTPS listener set, configuration "
-				    "is ignored.\n");
+			T_WARN_NL("TLS: no HTTPS listener set, configuration "
+				  "is ignored.\n");
 		return 0;
 	}
 	else if (!(tfw_tls_cgf & TFW_TLS_CFG_F_CERTS)) {
-		TFW_ERR_NL("TLS: HTTPS listener set but no TLS certificates "
+		T_ERR_NL("TLS: HTTPS listener set but no TLS certificates "
 			    "provided. At least one vhost must have TLS "
 			   "certificates configured.\n");
 		return -EINVAL;
 	}
 
 	if (!(tfw_tls_cgf & TFW_TLS_CFG_F_CERTS_GLOBAL)) {
-		TFW_WARN_NL("TLS: no global TLS certificates provided. "
-			    "Client TLS connections with unknown "
+		T_WARN_NL("TLS: no global TLS certificates provided. "
+			  "Client TLS connections with unknown "
 			    "server name values or with no server name "
 			    "specified will be dropped.\n");
 	}

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -131,15 +131,15 @@ tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 	ttls_x509_crt_init(&conf->crt);
 	crt_data = tfw_cfg_read_file(ce->vals[0], &crt_size);
 	if (!crt_data) {
-		TFW_ERR_NL("%s: Can't read certificate file '%s'\n",
-			   ce->name, ce->vals[0]);
+		T_ERR_NL("%s: Can't read certificate file '%s'\n",
+			 ce->name, ce->vals[0]);
 		return -EINVAL;
 	}
 
 	r = ttls_x509_crt_parse(&conf->crt, crt_data, crt_size);
 	if (r) {
-		TFW_ERR_NL("%s: Invalid certificate specified (%x)\n",
-			   cs->name, -r);
+		T_ERR_NL("%s: Invalid certificate specified (%x)\n",
+			 cs->name, -r);
 		free_pages((unsigned long)crt_data, get_order(crt_size));
 		return -EINVAL;
 	}
@@ -159,7 +159,7 @@ tfw_tls_cert_cfg_finish_cert(TfwVhost *vhost)
 	r = ttls_conf_own_cert(&vhost->tls_cfg, &conf->crt, &conf->key,
 			       conf->crt.next, NULL);
 	if (r) {
-		TFW_ERR_NL("TLS: can't set own certificate (%x)\n", r);
+		T_ERR_NL("TLS: can't set own certificate (%x)\n", r);
 		return -EINVAL;
 	}
 	conf_entry->certs_num++;
@@ -188,8 +188,8 @@ tfw_tls_set_cert_key(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	key_data = tfw_cfg_read_file(ce->vals[0], &key_size);
 	if (!key_data) {
-		TFW_ERR_NL("%s: Can't read certificate file '%s'\n",
-			   ce->name, ce->vals[0]);
+		T_ERR_NL("%s: Can't read certificate file '%s'\n",
+			 ce->name, ce->vals[0]);
 		return -EINVAL;
 	}
 
@@ -197,8 +197,8 @@ tfw_tls_set_cert_key(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 	/* The key is copied, so free the paged data. */
 	free_pages((unsigned long)key_data, get_order(key_size));
 	if (r) {
-		TFW_ERR_NL("%s: Invalid private key specified (%x)\n",
-			   cs->name, -r);
+		T_ERR_NL("%s: Invalid private key specified (%x)\n",
+			 cs->name, -r);
 		return -EINVAL;
 	}
 
@@ -221,8 +221,8 @@ tfw_tls_cert_cfg_finish(TfwVhost *vhost)
 		return 0;
 	curr_cert_conf = &conf->certs[conf->certs_num];
 	if (curr_cert_conf->conf_stage) {
-		TFW_ERR_NL("TLS: certificate configuration is not done, "
-			   "directive 'tls_certificate_key' is missing. \n");
+		T_ERR_NL("TLS: certificate configuration is not done, "
+			 "directive 'tls_certificate_key' is missing. \n");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Changes:
- Decrease log levels for sticky sessions, related to tempesta-tech/tempesta-test#127
- replace deprecated `TFW_ERR|TFW_WARN|TFW_LOG` macroses with newer `T_ERR|T_WARN|T_LOG`

This PR fix #1152 