### PR TITLE
make tfw_http_msg_setup() accept skb flags

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -433,7 +433,7 @@ tfw_http_prep_redirect(TfwHttpMsg *resp, unsigned short status, TfwStr *rmark,
 	data_len += req->uri_path.len + h_common_2.len + cookie->len;
 	data_len += cookie_crlf->len + r_end->len;
 
-	if (tfw_http_msg_setup(resp, &it, data_len))
+	if (tfw_http_msg_setup(resp, &it, data_len, 0))
 		return TFW_BLOCK;
 
 	tfw_http_prep_date(__TFW_STR_CH(&h_common_1, 1)->data);
@@ -492,7 +492,7 @@ tfw_http_prep_304(TfwHttpMsg *resp, TfwHttpReq *req, TfwMsgIter *it,
 	if (end)
 		data_len += end->len;
 
-	if (tfw_http_msg_setup(resp, it, data_len))
+	if (tfw_http_msg_setup(resp, it, data_len, 0))
 		return TFW_BLOCK;
 
 	ret = tfw_msg_write(it, &rh);
@@ -651,7 +651,7 @@ tfw_h1_send_resp(TfwHttpReq *req, resp_code_t code)
 
 	if (!(resp = tfw_http_msg_alloc_resp_light(req)))
 		goto err;
-	if (tfw_http_msg_setup((TfwHttpMsg *)resp, &it, msg.len))
+	if (tfw_http_msg_setup((TfwHttpMsg *)resp, &it, msg.len, 0))
 		goto err_setup;
 
 	body = TFW_STR_BODY_CH(&msg);
@@ -4184,7 +4184,7 @@ tfw_http_hm_srv_send(TfwServer *srv, char *data, unsigned long len)
 	if (!(req = tfw_http_msg_alloc_req_light()))
 		return;
 	hmreq = (TfwHttpMsg *)req;
-	if (tfw_http_msg_setup(hmreq, &it, msg.len))
+	if (tfw_http_msg_setup(hmreq, &it, msg.len, 0))
 		goto cleanup;
 	if (tfw_msg_write(&it, &msg))
 		goto cleanup;

--- a/tempesta_fw/http_frame.c
+++ b/tempesta_fw/http_frame.c
@@ -298,7 +298,7 @@ __tfw_h2_send_frame(TfwH2Ctx *ctx, TfwFrameHdr *hdr, TfwStr *data, bool close)
 	T_DBG2("Preparing HTTP/2 message with %lu bytes data\n", data->len);
 
 	msg.len = data->len;
-	if ((r = tfw_msg_iter_setup(&it, &msg.skb_head, msg.len)))
+	if ((r = tfw_msg_iter_setup(&it, &msg.skb_head, msg.len, 0)))
 		goto err;
 
 	if ((r = tfw_msg_write(&it, data)))

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -877,11 +877,12 @@ tfw_http_msg_hdr_add(TfwHttpMsg *hm, const TfwStr *hdr)
  * may be used. (See __tfw_http_msg_alloc(full=False)).
  */
 int
-tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len)
+tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len,
+		   unsigned int tx_flags)
 {
 	int r;
 
-	if ((r = tfw_msg_iter_setup(it, &hm->msg.skb_head, data_len)))
+	if ((r = tfw_msg_iter_setup(it, &hm->msg.skb_head, data_len, tx_flags)))
 		return r;
 	T_DBG2("Set up HTTP message %pK with %lu bytes data\n", hm, data_len);
 

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -117,7 +117,8 @@ int tfw_http_msg_del_str(TfwHttpMsg *hm, TfwStr *str);
 int tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm);
 int tfw_http_msg_to_chunked(TfwHttpMsg *hm);
 
-int tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len);
+int tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len,
+		       unsigned int tx_flags);
 int tfw_http_msg_add_data(TfwMsgIter *it, TfwHttpMsg *hm, TfwStr *field,
 			  const TfwStr *data);
 

--- a/tempesta_fw/msg.c
+++ b/tempesta_fw/msg.c
@@ -45,11 +45,12 @@ EXPORT_SYMBOL(tfw_msg_write);
  * iterator, since its current state is to be rewritten.
  */
 int
-tfw_msg_iter_setup(TfwMsgIter *it, struct sk_buff **skb_head, size_t data_len)
+tfw_msg_iter_setup(TfwMsgIter *it, struct sk_buff **skb_head, size_t data_len,
+		   unsigned int tx_flags)
 {
 	int r;
 
-	if ((r = ss_skb_alloc_data(skb_head, data_len)))
+	if ((r = ss_skb_alloc_data(skb_head, data_len, tx_flags)))
 		return r;
 	it->skb = it->skb_head = *skb_head;
 	it->frag = data_len ? -1 /* first 'frag' is the skb head */ : 0;
@@ -69,7 +70,7 @@ tfw_msg_iter_append_skb(TfwMsgIter *it)
 {
 	int r;
 
-	if ((r = ss_skb_alloc_data(&it->skb_head, 0)))
+	if ((r = ss_skb_alloc_data(&it->skb_head, 0, 0)))
 		return r;
 	it->skb = ss_skb_peek_tail(&it->skb_head);
 	it->frag = 0;

--- a/tempesta_fw/msg.h
+++ b/tempesta_fw/msg.h
@@ -63,7 +63,7 @@ typedef struct {
 
 int tfw_msg_write(TfwMsgIter *it, const TfwStr *data);
 int tfw_msg_iter_setup(TfwMsgIter *it, struct sk_buff **skb_head,
-		       size_t data_len);
+		       size_t data_len, unsigned int tx_flags);
 int tfw_msg_iter_append_skb(TfwMsgIter *it);
 
 static inline int

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -108,7 +108,7 @@ ss_skb_alloc_pages(size_t len)
  * segmentation. The allocated payload space will be filled with data.
  */
 int
-ss_skb_alloc_data(struct sk_buff **skb_head, size_t len)
+ss_skb_alloc_data(struct sk_buff **skb_head, size_t len, unsigned int tx_flags)
 {
 	int i_skb, nr_skbs = len ? DIV_ROUND_UP(len, SS_SKB_MAX_DATA_LEN) : 1;
 	size_t n = 0;
@@ -119,6 +119,7 @@ ss_skb_alloc_data(struct sk_buff **skb_head, size_t len)
 		skb = ss_skb_alloc_pages(n);
 		if (!skb)
 			return -ENOMEM;
+		skb_shinfo(skb)->tx_flags |= tx_flags;
 		ss_skb_queue_tail(skb_head, skb);
 	}
 

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -169,7 +169,8 @@ ss_skb_alloc(size_t n)
 
 char *ss_skb_fmt_src_addr(const struct sk_buff *skb, char *out_buf);
 
-int ss_skb_alloc_data(struct sk_buff **skb_head, size_t len);
+int ss_skb_alloc_data(struct sk_buff **skb_head, size_t len,
+		      unsigned int tx_flags);
 struct sk_buff *ss_skb_split(struct sk_buff *skb, int len);
 int ss_skb_get_room(struct sk_buff *skb_head, struct sk_buff *skb,
 		    char *pspt, unsigned int len, TfwStr *it);

--- a/tempesta_fw/t/bomber.c
+++ b/tempesta_fw/t/bomber.c
@@ -270,7 +270,7 @@ tfw_bmb_msg_send(TfwBmbTask *task, int cn)
 	memset(&hmreq, 0, sizeof(hmreq));
 	hmreq.msg.skb_head = NULL;
 
-	if (!tfw_http_msg_setup(&hmreq, &it, msg.len)) {
+	if (!tfw_http_msg_setup(&hmreq, &it, msg.len, 0)) {
 		T_WARN("Cannot create HTTP request.\n");
 		return;
 	}

--- a/tempesta_fw/t/unit/helpers.c
+++ b/tempesta_fw/t/unit/helpers.c
@@ -49,7 +49,7 @@ test_req_alloc(size_t data_len)
 	hmreq = __tfw_http_msg_alloc(Conn_HttpClnt, true);
 	BUG_ON(!hmreq);
 
-	ret = tfw_http_msg_setup(hmreq, &it, data_len);
+	ret = tfw_http_msg_setup(hmreq, &it, data_len, 0);
 	BUG_ON(ret);
 
 	memset(&conn_req, 0, sizeof(TfwConn));
@@ -82,7 +82,7 @@ test_resp_alloc(size_t data_len)
 	hmresp = __tfw_http_msg_alloc(Conn_HttpSrv, true);
 	BUG_ON(!hmresp);
 
-	ret = tfw_http_msg_setup(hmresp, &it, data_len);
+	ret = tfw_http_msg_setup(hmresp, &it, data_len, 0);
 	BUG_ON(ret);
 
 	memset(&conn_resp, 0, sizeof(TfwConn));

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -502,7 +502,7 @@ tfw_tls_send(TlsCtx *tls, struct sg_table *sgt, bool close)
 	      str.len, sgt ? sgt->nents : 0, io->msglen, io->msgtype, conn,
 	      conn->cli_conn.sk->sk_write_xmit, ttls_xfrm_ready(tls));
 
-	if ((r = tfw_msg_iter_setup(&it, &io->skb_list, str.len)))
+	if ((r = tfw_msg_iter_setup(&it, &io->skb_list, str.len, 0)))
 		return r;
 	if ((r = tfw_msg_write(&it, &str)))
 		return r;


### PR DESCRIPTION
When serving responses from the cache, we need to mark generated skbs with the `SKBTX_SHARED_FRAG` flag to avoid cache pages corruption. Rather than traversing the skb chain, let's set skb flags right after skb allocation.

This patch removes the loop mentioned in https://github.com/tempesta-tech/tempesta/pull/1330#discussion_r311292965.