### PR TITLE
Some tls fixes

### DIFF
--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -391,6 +391,14 @@ do {									\
 	T_FSM_MOVE(st, {});						\
 } while (0)
 
+/* Unconditional jump to state @st w/o additional logic and/or eating data. */
+#define TTLS_HS_FSM_JMP(st)						\
+do {									\
+	io->rlen = 0;							\
+	state_p = p;							\
+	T_FSM_JMP(st);							\
+} while (0)
+
 /*
  * Size of temporary storage in TlsCtx->hs->tmp.
  * The temporary buffer is used to store 2 types of temporary data: utility

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -953,7 +953,7 @@ ttls_parse_client_hello(TlsCtx *tls, unsigned char *buf, size_t len,
 		if (n)
 			TTLS_HS_FSM_MOVE(TTLS_CH_HS_EX);
 		else
-			T_FSM_JMP(TTLS_CH_HS_EX);
+			TTLS_HS_FSM_JMP(TTLS_CH_HS_EX);
 	}
 
 	/* Parse an extension. */

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -2205,7 +2205,9 @@ next_record:
 		if (io->msgtype == TTLS_MSG_HANDSHAKE
 		    && ttls_hs_checksumable(tls))
 		{
-			if (likely(*read - parsed >= TTLS_HS_HDR_LEN)) {
+			if (likely(*read - parsed >= TTLS_HS_HDR_LEN &&
+			           len > *read - parsed))
+			{
 				/*
 				 * Compute handshake checksum for the message
 				 * body and handshake header in one shot.

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -141,6 +141,9 @@ ttls_crypto_req_sglist(TlsCtx *tls, struct crypto_aead *tfm, unsigned int len,
 	unsigned int sz, aead_sz, to_read, off;
 	int n;
 
+	WARN_ON_ONCE(len == 0); /* nothing to decrypt */
+	WARN_ON_ONCE(!buf && !skb);
+
 	sz = aead_sz = sizeof(*req) + crypto_aead_reqsize(tfm);
 	if (buf) {
 		off = 0;
@@ -149,7 +152,6 @@ ttls_crypto_req_sglist(TlsCtx *tls, struct crypto_aead *tfm, unsigned int len,
 		off = io->off;
 		n = *sgn + io->chunks;
 	}
-	BUG_ON(!buf && (!skb || skb->len <= off)); /* nothing to decrypt */
 	sz += n * sizeof(**sg);
 
 	/* Don't use g_req for better spacial locality. */


### PR DESCRIPTION
fix #1324
- add custom macro of jump into state for handshake with initialization of work in a new state otherwise the crash on `BUG_ON(io->rlen > ext_sz)` in `TTLS_CH_HS_EX` state.
-  In function `ttls_crypto_req_sglist()` `skb->len` is only the length of the first `skb_buff` in `io->skb_list'. `len` is the length of all the data that needs to be decrypted, as in `io->skb_list', as in `buf`.
- if after parsing headers not only handshake header was read, we compute handshake checksum for the message body and handshake header in one shot later

The patch (https://github.com/tempesta-tech/tempesta/pull/1330) is also needed 