### PR TITLE
ASAN-induced fixes

### DIFF
--- a/tempesta_fw/gfsm.c
+++ b/tempesta_fw/gfsm.c
@@ -84,10 +84,6 @@
 				 & TFW_GFSM_PRIO_MASK)
 #define PRIO(s)			__GFSM_PRIO(FSM_STATE(s))
 #define GFSM_HOOK_N		(TFW_GFSM_PRIO_N * TFW_GFSM_STATE_N)
-#define SET_STATE(s, x)						\
-do {								\
-	FSM_STATE(s) = (FSM_STATE(s) & ~TFW_GFSM_STATE_MASK) | (x); \
-} while (0)
 
 #define __BAD_STATE_BYTE	0xff
 #define BAD_STATE		((__BAD_STATE_BYTE << 8) | __BAD_STATE_BYTE)
@@ -223,14 +219,15 @@ tfw_gfsm_move(TfwGState *st, unsigned short state, TfwFsmData *data)
 {
 	int r = TFW_PASS, p, fsm;
 	unsigned int *hooks = fsm_hooks_bm[FSM(st)];
-	unsigned long mask = 1 << state;
+	unsigned long mask = 1 << (state & TFW_GFSM_STATE_MASK);
 	unsigned char curr_st = st->curr;
 
 	T_DBG3("GFSM move %#x -> %#x: skb=%pK req=%pK resp=%pK\n",
 	       FSM_STATE(st), state, data->skb, data->req, data->resp);
 
 	/* Remember current FSM context. */
-	SET_STATE(st, state);
+	FSM_STATE(st) = (FSM_STATE(st) & ~TFW_GFSM_STATE_MASK) |
+			(state & TFW_GFSM_STATE_MASK);
 
 	/* Start from highest priority. */
 	for (p = TFW_GFSM_HOOK_PRIORITY_HIGH;

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1522,9 +1522,10 @@ tfw_vhost_create(const char *name)
 {
 	TfwPool *pool;
 	TfwVhost *vhost;
-	int name_sz = strlen(name) + 1;
+	int name_strlen = strlen(name);
+	int name_mem_sz = ALIGN(name_strlen + 1, sizeof(void *));
 	int size = sizeof(TfwVhost)
-		+ name_sz
+		+ name_mem_sz
 		+ sizeof(TfwLocation) * (TFW_LOCATION_ARRAY_SZ + 1)
 		+ sizeof(FrangGlobCfg)
 		+ tfw_tls_vhost_priv_data_sz();
@@ -1539,8 +1540,8 @@ tfw_vhost_create(const char *name)
 	}
 	INIT_HLIST_NODE(&vhost->hlist);
 	vhost->name.data = (char *)(vhost + 1);
-	vhost->name.len = name_sz - 1;
-	vhost->loc_dflt = (TfwLocation *)(vhost->name.data + name_sz);
+	vhost->name.len = name_strlen;
+	vhost->loc_dflt = (TfwLocation *)(vhost->name.data + name_mem_sz);
 	vhost->loc = (TfwLocation *)(vhost->loc_dflt + 1);
 	vhost->frang_gconf = (FrangGlobCfg *)(vhost->loc + TFW_LOCATION_ARRAY_SZ);
 	vhost->tls_cfg.priv = (vhost->frang_gconf + 1);
@@ -1549,7 +1550,7 @@ tfw_vhost_create(const char *name)
 	BUG_ON((char *)vhost->tls_cfg.priv + tfw_tls_vhost_priv_data_sz() !=
 	       (char *)vhost + size);
 
-	memcpy(vhost->name.data, name, name_sz);
+	memcpy(vhost->name.data, name, name_strlen + 1);
 	vhost->hdrs_pool = pool;
 	atomic64_set(&vhost->refcnt, 1);
 

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -1526,6 +1526,7 @@ tfw_vhost_create(const char *name)
 	int size = sizeof(TfwVhost)
 		+ name_sz
 		+ sizeof(TfwLocation) * (TFW_LOCATION_ARRAY_SZ + 1)
+		+ sizeof(FrangGlobCfg)
 		+ tfw_tls_vhost_priv_data_sz();
 
 	if (!(pool = __tfw_pool_new(0)))
@@ -1543,6 +1544,11 @@ tfw_vhost_create(const char *name)
 	vhost->loc = (TfwLocation *)(vhost->loc_dflt + 1);
 	vhost->frang_gconf = (FrangGlobCfg *)(vhost->loc + TFW_LOCATION_ARRAY_SZ);
 	vhost->tls_cfg.priv = (vhost->frang_gconf + 1);
+
+	/* Must be sure all data fits, to prevent silent data corruption. */
+	BUG_ON((char *)vhost->tls_cfg.priv + tfw_tls_vhost_priv_data_sz() !=
+	       (char *)vhost + size);
+
 	memcpy(vhost->name.data, name, name_sz);
 	vhost->hdrs_pool = pool;
 	atomic64_set(&vhost->refcnt, 1);


### PR DESCRIPTION
Running Tempesta tests with ASAN-enabled builds generates some warnings. Some of them are known, but they are making it hard to spot any new warnings, so let's fix them.

There are three patches. First ensures enough memory is allocated in `tfw_vhost_create()`. It was probably fine the way it was since kmalloc allocated more memory than it was asked. Still, it would be nice to have sizes sharp. Next patch introduces more alignment into the same `tfw_vhost_create()`. Since multiple things are packed one after another into a continuous memory block, a vhost name that can be of any length may cause structures misalignment. Currently I found no atomics there or anything requiring alignment, but even ordinary field accesses may benefit from alignment too, if little. And the third patch fixes state handling in tfw_gfsm_move. As we use only 5 bits for the state number, we need to go defensive and strip other bits if some caller passes them along with the state itself. That actually triggered UBSAN, since shifts were larger than 31. Fortunately, on x86 shift is masked to 5 bits just as we need. Still better to have that in the code explicitly.

Fixes #1246.