### PR TITLE
TLS record parsing fixes

### DIFF
--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -2330,7 +2330,8 @@ skip_record:
 	bzero_fast(io->__initoff, sizeof(*io) - offsetof(TlsIOCtx, __initoff));
 
 	delta = *read - parsed;
-	WARN_ON_ONCE(delta > len);
+	if (WARN_ON_ONCE(delta > len))
+		return T_DROP;
 	len -= delta;
 	if (len) {
 		buf += delta;

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1171,6 +1171,8 @@ ttls_parse_record_hdr(TlsCtx *tls, unsigned char *buf, size_t len,
 		 */
 
 	case TTLS_MSG_APPLICATION_DATA:
+		if (unlikely(!ready))
+			return TTLS_ERR_INVALID_RECORD;
 		ivahs_len = ttls_expiv_len(&tls->xfrm);
 		break;
 

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -2282,11 +2282,7 @@ next_record:
 		return r;
 
 	case TTLS_MSG_APPLICATION_DATA:
-		if (!io->msglen) {
-			/* OpenSSL sends empty messages to randomize the IV. */
-			T_DBG("empty application TLS record - skip\n");
-			goto skip_record;
-		}
+		/* Fall through. */
 	}
 
 	if (len == 0)


### PR DESCRIPTION
There are two related fixes here.

First one is what triggered BUG_ON mentioned in #1318: we were parsing application data records even if they appear early. That doesn't make any sense, since cipher is not ready yet. Conforming client will never send such record before handshake is completed, so it's safe to completely reject connections where such record is seen too early.

Second one was not mentioned explicitly in #1318, but was found later. We were postponing record processing despite all required data were already received. The data were processed when next skb arrived and enqueued into `tls->io_in.skb_list`. But since that list is cleared after a record is successfully processed, that next skb was thrown away. Later, that results in out-of-buffer accesses during scatter-gather operations inside a cipher.

(part of #1318-related changes)