### PR TITLE
tls: more strict length checks of alerts and change_cipher_spec records

### DIFF
--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1158,8 +1158,9 @@ ttls_parse_record_hdr(TlsCtx *tls, unsigned char *buf, size_t len,
 		/* Alerts are unencrypted during handshake only. */
 		if (!ready) {
 			ivahs_len = 2; /* level & description */
-			if (io->msglen < ivahs_len) {
-				T_DBG("alert message too short: %d\n",
+			if (io->msglen != ivahs_len) {
+				/* TODO: multiple alerts in one record? */
+				T_DBG("unexpected alert message length: %d\n",
 				      io->msglen);
 				return TTLS_ERR_INVALID_RECORD;
 			}
@@ -1179,9 +1180,9 @@ ttls_parse_record_hdr(TlsCtx *tls, unsigned char *buf, size_t len,
 	case TTLS_MSG_CHANGE_CIPHER_SPEC:
 		/* Read 1 byte equal to 0x1. */
 		ivahs_len = 1;
-		if (io->msglen < ivahs_len) {
-			T_DBG("ChangeCipherSpec message too short: %d\n",
-			      io->msglen);
+		if (io->msglen != ivahs_len) {
+			T_DBG("unexpected ChangeCipherSpec message length: "
+			      "%d\n", io->msglen);
 			return TTLS_ERR_INVALID_RECORD;
 		}
 		break;


### PR DESCRIPTION
While the checks `ttls_parse_record_hdr()` ensured we have at least required number of bytes, the skipping code in `ttls_recv()` expected records to contains exactly one instance of an alert or one instance of a change_cipher_spec. Let's make length checking more strict.

However it seems to be possible to send an alert in two records, it's doubtful any implementation will do that. So we'll most probably get away with it.