### PR TITLE
tls: move io context resetting to tfw_tls_msg_process()

### DIFF
--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -27,6 +27,7 @@
 #include <linux/string.h>
 #include <net/tls.h>
 
+#include "lib/str.h"
 #include "config.h"
 #include "bignum.h"
 #include "ciphersuites.h"
@@ -998,6 +999,12 @@ static inline size_t
 ttls_payload_off(const TlsXfrm *xfrm)
 {
 	return TLS_HEADER_SIZE + ttls_expiv_len(xfrm);
+}
+
+static inline void
+ttls_reset_io_ctx(TlsIOCtx *io)
+{
+	bzero_fast(io->__initoff, sizeof(*io) - offsetof(TlsIOCtx, __initoff));
 }
 
 #endif /* __TTLS_H__ */


### PR DESCRIPTION
Investigation of #1318 revealed an inherent issue with the previous design of the IO context resets. `ttls_recv()` reset the whole IO context, which in turn dropped skb list collected in a IO context so far, and then continued to parse the supplied data. This was an optimization that allowed `ttls_recv()` to greedily parse multiple records at a time. But if during TCP fragmentation a single skb ended up containing both an alert (or a handshake-related record) and a part of application data record, the code could forget a first part of the record. Then, when remaining parts of an application data record arrived, scatterlist was filled incorrectly, and reading uninitialized data could occur. As part of  essential enciphered data were discarded without processing, no further data exchange were possible.

The proposed solution is to move context resets out of `ttls_recv()` to `tfw_tls_msg_process()`. That makes `ttls_recv()` process a single record at a time, but also allows `tfw_tls_msg_process()` to reinitialize `tls->io_in->skb_list` before each record, thus eliminating the issue.

