### PR TITLE
fix errors found by static analysers

### DIFF
--- a/tempesta_fw/addr.c
+++ b/tempesta_fw/addr.c
@@ -121,11 +121,9 @@ tfw_addr_pton_v6(const TfwStr *s, TfwAddr *addr)
 					 */
 					if (k < c->len - 1) {
 						++k;
-						++p;
 					} else {
 						++c;
 						k = 0;
-						p = c->data;
 					}
 					hole = (words[i] != -1) ? ++i : i;
 				} else if (words[i] == -1)

--- a/tempesta_fw/addr.c
+++ b/tempesta_fw/addr.c
@@ -252,6 +252,7 @@ tfw_addr_pton(const TfwStr *str, TfwAddr *addr)
 					goto delim;
 			}
 		}
+		return ret;
 delim:
 		if (*pos == ':') {
 			mode = 6;

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -3404,7 +3404,6 @@ tfw_http_req_process(TfwConn *conn, TfwStream *stream, const TfwFsmData *data)
 	struct sk_buff *skb = data->skb;
 	TfwHttpReq *req;
 	TfwHttpMsg *hmsib;
-	TfwHttpParser *parser;
 	TfwFsmData data_up;
 	int r = TFW_BLOCK;
 
@@ -3422,7 +3421,6 @@ next_msg:
 	parsed = 0;
 	hmsib = NULL;
 	req = (TfwHttpReq *)stream->msg;
-	parser = &stream->parser;
 	actor = TFW_MSG_H2(req) ? tfw_h2_parse_req : tfw_http_parse_req;
 
 	r = ss_skb_process(skb, actor, req, &req->chunk_cnt, &parsed);
@@ -3927,7 +3925,6 @@ tfw_http_resp_process(TfwConn *conn, TfwStream *stream, const TfwFsmData *data)
 	struct sk_buff *skb = data->skb;
 	TfwHttpReq *bad_req;
 	TfwHttpMsg *hmresp, *hmsib;
-	TfwHttpParser *parser;
 	TfwFsmData data_up;
 	bool conn_stop, filtout = false;
 
@@ -3950,7 +3947,6 @@ next_msg:
 	parsed = 0;
 	hmsib = NULL;
 	hmresp = (TfwHttpMsg *)stream->msg;
-	parser = &stream->parser;
 
 	r = ss_skb_process(skb, tfw_http_parse_resp, hmresp, &chunks_unused,
 			   &parsed);

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -1934,7 +1934,6 @@ __req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len)
 
 	__FSM_STATE(Req_I_Subtype) {
 		__FSM_I_MATCH_MOVE(token, Req_I_Subtype);
-		c = *(p + __fsm_sz);
 		__FSM_I_MOVE_n(I_EoT, __fsm_sz);
 	}
 
@@ -1967,7 +1966,6 @@ __req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len)
 		if (c == '\"')
 			__FSM_I_MOVE(Req_I_QuotedString);
 		__FSM_I_MATCH_MOVE(token, Req_I_ParamValue);
-		c = *(p + __fsm_sz);
 		__FSM_I_MOVE_n(I_EoT, __fsm_sz);
 	}
 

--- a/tempesta_fw/http_tbl.c
+++ b/tempesta_fw/http_tbl.c
@@ -369,7 +369,7 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 	tfw_http_match_fld_t field = TFW_HTTP_MATCH_F_WILDCARD;
 	tfw_http_match_arg_t type = TFW_HTTP_MATCH_A_WILDCARD;
 	TfwCfgRule *cfg_rule = &e->rule;
-	size_t len = 0, arg_size = 0;
+	size_t arg_size = 0;
 	TfwHttpChain *chain = NULL;
 	TfwVhost *vhost = NULL;
 
@@ -385,8 +385,6 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 	in_field = cfg_rule->fst;
 	hdr = cfg_rule->fst_ext;
 	in_arg = cfg_rule->snd;
-	if (in_arg)
-		len = strlen(in_arg);
 	action = cfg_rule->act;
 	action_val = cfg_rule->val;
 	BUG_ON(!action);

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -380,51 +380,51 @@ TFW_INIT_CUSTOM_A(cookie);
 #endif /* AVX2 */
 
 /**
- * Quickly get number of digits - 1, e.g. returns '0' for '7' and '2' for '333'.
+ * Quickly get number of digits, e.g. returns '1' for '7' and '3' for '333'.
  * It's assumed that small numbers are likely.
  */
 static inline unsigned int
 __dig_num_dec(unsigned long a)
 {
 	if (a < 10)
-		return 0;
-	if (a < 100)
 		return 1;
-	if (a < 1000)
+	if (a < 100)
 		return 2;
-	if (a < 10000)
+	if (a < 1000)
 		return 3;
-	if (a < 100000)
+	if (a < 10000)
 		return 4;
-	if (a < 1000000)
+	if (a < 100000)
 		return 5;
-	if (a < 10000000)
+	if (a < 1000000)
 		return 6;
-	if (a < 100000000)
+	if (a < 10000000)
 		return 7;
-	if (a < 1000000000)
+	if (a < 100000000)
 		return 8;
-	if (a < 10000000000)
+	if (a < 1000000000)
 		return 9;
-	if (a < 100000000000UL)
+	if (a < 10000000000)
 		return 10;
-	if (a < 1000000000000UL)
+	if (a < 100000000000UL)
 		return 11;
-	if (a < 10000000000000UL)
+	if (a < 1000000000000UL)
 		return 12;
-	if (a < 100000000000000UL)
+	if (a < 10000000000000UL)
 		return 13;
-	if (a < 1000000000000000UL)
+	if (a < 100000000000000UL)
 		return 14;
-	if (a < 10000000000000000UL)
+	if (a < 1000000000000000UL)
 		return 15;
-	if (a < 100000000000000000UL)
+	if (a < 10000000000000000UL)
 		return 16;
-	if (a < 1000000000000000000UL)
+	if (a < 100000000000000000UL)
 		return 17;
-	if (a < 10000000000000000000UL)
+	if (a < 1000000000000000000UL)
 		return 18;
-	return 19;
+	if (a < 10000000000000000000UL)
+		return 19;
+	return 20;
 }
 
 /**
@@ -434,8 +434,8 @@ static inline unsigned int
 __dig_num_hex(unsigned long a)
 {
 	if (a == 0)
-		return 0;
-	return __fls(a) / 4;
+		return 1;
+	return __fls(a) / 4 + 1;
 }
 
 /**
@@ -449,16 +449,16 @@ tfw_ultoa(unsigned long ai, char *buf, unsigned int len)
 	size_t n = __dig_num_dec(ai);
 	char *p = buf + n;
 
-	if (unlikely(n + 1 > len))
+	if (unlikely(n > len))
 		return 0;
 
 	do {
 		/* Compiled to only one MUL instruction with -O2. */
-		*p-- = "0123456789"[ai % 10];
+		*--p = "0123456789"[ai % 10];
 		ai /= 10;
 	} while (ai);
 
-	return n + 1;
+	return n;
 }
 EXPORT_SYMBOL(tfw_ultoa);
 
@@ -471,16 +471,16 @@ tfw_ultohex(unsigned long ai, char *buf, unsigned int len)
 	size_t n = __dig_num_hex(ai);
 	char *p = buf + n;
 
-	if (unlikely(n + 1 > len))
+	if (unlikely(n > len))
 		return 0;
 
 	do {
 		/* Compiled to only one MUL instruction with -O2. */
-		*p-- = "0123456789abcdef"[ai % 16];
+		*--p = "0123456789abcdef"[ai % 16];
 		ai /= 16;
 	} while (ai);
 
-	return n + 1;
+	return n;
 }
 EXPORT_SYMBOL(tfw_ultohex);
 

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -630,7 +630,7 @@ tfw_str_add_duplicate(TfwPool *pool, TfwStr *str)
 int
 tfw_strcpy(TfwStr *dst, const TfwStr *src)
 {
-	int n1, n2, o1 = 0, o2 = 0, chunks = 0;
+	int n1, o1 = 0, o2 = 0, chunks = 0;
 	int mode = (TFW_STR_PLAIN(src) << 1) | TFW_STR_PLAIN(dst);
 	TfwStr *c1, *c2, *end;
 
@@ -665,7 +665,6 @@ tfw_strcpy(TfwStr *dst, const TfwStr *src)
 		break;
 	case 0: /* The both are compound. */
 		n1 = src->nchunks;
-		n2 = dst->nchunks;
 		c1 = src->chunks;
 		c2 = dst->chunks;
 		end = c1 + n1 - 1;

--- a/tempesta_fw/t/unit/test_hpack.c
+++ b/tempesta_fw/t/unit/test_hpack.c
@@ -277,7 +277,7 @@ TEST(hpack, dec_table_mixed)
 
 	entry = tfw_hpack_find_index(&hp->dec_tbl, 64);
 	EXPECT_NOT_NULL(entry);
-	if (entry) {
+	if (entry && entry_1) {
 		/*
 		 * Check that entries with 66 and 64 indexes use the same
 		 * dynamic @name instance.
@@ -289,7 +289,7 @@ TEST(hpack, dec_table_mixed)
 
 	entry = tfw_hpack_find_index(&hp->dec_tbl, 63);
 	EXPECT_NOT_NULL(entry);
-	if (entry) {
+	if (entry && entry_2) {
 		/*
 		 * Check that entries with 65 and 63 indexes use the same
 		 * dynamic @name instance.
@@ -301,7 +301,7 @@ TEST(hpack, dec_table_mixed)
 
 	entry = tfw_hpack_find_index(&hp->dec_tbl, 62);
 	EXPECT_NOT_NULL(entry);
-	if (entry) {
+	if (entry && entry_3) {
 		/*
 		 * Check that entries with 62 and 24(static) indexes use the
 		 * same static @name instance.
@@ -344,6 +344,8 @@ TEST(hpack, dec_table_wrap)
 
 			entry = tfw_hpack_find_index(&hp->dec_tbl, i);
 			EXPECT_NOT_NULL(entry);
+			if (!entry)
+				continue;
 
 			if (i >= end_idx - shift)
 				last_entries[i - (end_idx - shift)] = *entry;
@@ -361,7 +363,7 @@ TEST(hpack, dec_table_wrap)
 
 		}
 
-		if (i < end_idx) {
+		if (i < end_idx && s) {
 			/*
 			 * Evict first @shift entries, i.e shrink table to only
 			 * one existing entry.
@@ -1143,6 +1145,8 @@ TEST(hpack, enc_table_rbtree)
 	EXPECT_EQ(res, HPACK_IDX_ST_FOUND);
 	EXPECT_NULL(pl.parent);
 	EXPECT_NOT_NULL(n3);
+	if (!n3)
+		return;
 
 	/*
 	 * After re-balancing (which includes one right and one left rotations)
@@ -1207,6 +1211,8 @@ TEST(hpack, enc_table_rbtree)
 	EXPECT_EQ(res, HPACK_IDX_ST_FOUND);
 	EXPECT_NULL(pl.parent);
 	EXPECT_NOT_NULL(n4);
+	if (!n4)
+		return;
 
 	/*
 	 * After re-balancing (which should not include any rotations, only
@@ -1256,6 +1262,8 @@ TEST(hpack, enc_table_rbtree)
 	EXPECT_EQ(res, HPACK_IDX_ST_FOUND);
 	EXPECT_NULL(pl.parent);
 	EXPECT_NOT_NULL(n5);
+	if (!n5)
+		return;
 
 	/* Check the structure and nodes' color of the entire tree. */
 	EXPECT_NULL(HPACK_NODE_COND(tbl, n3->parent));

--- a/tempesta_fw/t/unit/test_hpack.c
+++ b/tempesta_fw/t/unit/test_hpack.c
@@ -224,7 +224,6 @@ TEST(hpack, dec_table_mixed)
 {
 	TfwHPack *hp;
 	TfwMsgParseIter it;
-	TfwHPackStr *name, *value;
 	TfwStr *s1, *s2, *s3, *s4, *s5;
 	const TfwHPackEntry *entry, *entry_1, *entry_2, *entry_3;
 	TFW_STR(s1_name, "custom-header-1");
@@ -255,8 +254,6 @@ TEST(hpack, dec_table_mixed)
 	entry_1 = tfw_hpack_find_index(&hp->dec_tbl, 63);
 	EXPECT_NOT_NULL(entry_1);
 	if (entry_1) {
-		name = entry_1->name;
-		value = entry_1->value;
 		it.hdr = s4;
 		it.nm_len = s1_name->len;
 		EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, entry_1, &it));
@@ -265,8 +262,6 @@ TEST(hpack, dec_table_mixed)
 	entry_2 = tfw_hpack_find_index(&hp->dec_tbl, 63);
 	EXPECT_NOT_NULL(entry_2);
 	if (entry_2) {
-		name = entry_2->name;
-		value = entry_2->value;
 		it.hdr = s5;
 		it.nm_len = s2_name->len;
 		EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, entry_2, &it));

--- a/tempesta_fw/t/unit/test_http_match.c
+++ b/tempesta_fw/t/unit/test_http_match.c
@@ -121,9 +121,15 @@ test_chain_add_rule_str(int test_id, tfw_http_match_fld_t field,
 
 	tfw_http_verify_hdr_field(field, &hdr, &hid);
 	arg = tfw_http_arg_adjust(in_arg, field, hdr, &arg_size, &type, &op);
+	EXPECT_NOT_NULL(arg);
+	if (!arg)
+		return;
 
 	e = test_rule_container_new(test_chain, MatchEntry, rule,
 				    type, arg_size);
+	EXPECT_NOT_NULL(e);
+	if (!e)
+		goto err;
 	e->rule.hid = hid;
 	e->rule.field = field;
 	e->rule.op = op;
@@ -132,6 +138,7 @@ test_chain_add_rule_str(int test_id, tfw_http_match_fld_t field,
 	/* Just dummy action type to avoid BUG_ON in 'do_eval()'. */
 	e->rule.act.type = TFW_HTTP_MATCH_ACT_CHAIN;
 	e->test_id = test_id;
+err:
 	kfree(arg);
 }
 
@@ -461,6 +468,9 @@ TEST(http_match, method_eq)
 
 	e1 = test_rule_container_new(test_chain, MatchEntry, rule,
 				     TFW_HTTP_MATCH_A_METHOD, 0);
+	EXPECT_NOT_NULL(e1);
+	if (!e1)
+		return;
 	e1->test_id = 42,
 	e1->rule.field = TFW_HTTP_MATCH_F_METHOD;
 	e1->rule.op = TFW_HTTP_MATCH_O_EQ;
@@ -470,6 +480,9 @@ TEST(http_match, method_eq)
 
 	e2 = test_rule_container_new(test_chain, MatchEntry, rule,
 				     TFW_HTTP_MATCH_A_METHOD, 0);
+	EXPECT_NOT_NULL(e2);
+	if (!e2)
+		return;
 	e2->test_id = 43,
 	e2->rule.field = TFW_HTTP_MATCH_F_METHOD;
 	e2->rule.op = TFW_HTTP_MATCH_O_EQ;

--- a/tempesta_fw/t/unit/test_tfw_str.c
+++ b/tempesta_fw/t/unit/test_tfw_str.c
@@ -1323,6 +1323,8 @@ TEST(tfw_str_add_compound, plain)
 
 	s = tfw_str_add_compound(str_pool, s1);
 	EXPECT_NOT_NULL(s);
+	if (!s)
+		return;
 	*s = *s2;
 	EXPECT_TRUE(s1->nchunks == 2);
 	EXPECT_TRUE(tfw_str_eq_cstr(s1, "abcdefghijklmnopqrstuvwxyz",
@@ -1341,6 +1343,8 @@ TEST(tfw_str_add_compound, compound)
 
 	s = tfw_str_add_compound(str_pool, s1);
 	EXPECT_NOT_NULL(s);
+	if (!s)
+		return;
 	*s = *s2;
 	EXPECT_TRUE(s1->nchunks == chunks + 1);
 	EXPECT_TRUE(tfw_str_eq_cstr(s1, "abcdefghijklmnopqrstuvwxyz",
@@ -1356,6 +1360,8 @@ TEST(tfw_str_add_duplicate, both_plain)
 
 	s = tfw_str_add_duplicate(str_pool, s1);
 	EXPECT_NOT_NULL(s);
+	if (!s)
+		return;
 	*s = *s2;
 	EXPECT_TRUE(TFW_STR_DUP(s1));
 	EXPECT_TRUE(s1->nchunks == 2);
@@ -1377,6 +1383,8 @@ TEST(tfw_str_add_duplicate, first_plain)
 
 	s = tfw_str_add_duplicate(str_pool, s1);
 	EXPECT_NOT_NULL(s);
+	if (!s)
+		return;
 	*s = *s2;
 	EXPECT_TRUE(TFW_STR_DUP(s1));
 	EXPECT_TRUE(s1->nchunks == 2);
@@ -1398,6 +1406,8 @@ TEST(tfw_str_add_duplicate, second_plain)
 
 	s = tfw_str_add_duplicate(str_pool, s1);
 	EXPECT_NOT_NULL(s);
+	if (!s)
+		return;
 	*s = *s2;
 	EXPECT_TRUE(TFW_STR_DUP(s1));
 	EXPECT_TRUE(s1->nchunks == 2);
@@ -1419,6 +1429,8 @@ TEST(tfw_str_add_duplicate, both_compound)
 
 	s = tfw_str_add_duplicate(str_pool, s1);
 	EXPECT_NOT_NULL(s);
+	if (!s)
+		return;
 	*s = *s2;
 	EXPECT_TRUE(TFW_STR_DUP(s1));
 	EXPECT_TRUE(s1->nchunks == 2);

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -90,12 +90,14 @@ tfw_tls_get_cert_conf(TfwVhost *vhost, unsigned int directive)
 			T_WARN_NL("'tls_certificate_key' directive was found"
 				  "before 'tls_certificate' has encountered.\n");
 			curr_cert_conf = NULL;
+			break;
 		}
 		if (curr_cert_conf->conf_stage & TFW_TLS_CFG_F_CKEY) {
 			T_WARN_NL("'tls_certificate_key' directive was found"
 				  "twice for the same 'tls_certificate' "
 				  "directive.\n");
 			curr_cert_conf = NULL;
+			break;
 		}
 		break;
 

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -2100,8 +2100,6 @@ tfw_cfgop_in_tls_any_sni(TfwCfgSpec *cs, TfwCfgEntry *ce)
 static int
 tfw_cfgop_out_tls_any_sni(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
-	if (tfw_vhosts_reconfig->expl_dflt && ce->dflt_value)
-		return 0;
 	if (tfw_vhosts_reconfig->expl_dflt) {
 		if (ce->dflt_value) {
 			return 0;

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -2235,7 +2235,7 @@ ttls_handshake_server_hello(TlsCtx *tls)
 static int
 ttls_handshake_finished(TlsCtx *tls)
 {
-	int r;
+	int r = 0;
 	unsigned char *p, *begin;
 	struct page *pg;
 	struct scatterlist sg[MAX_SKB_FRAGS];


### PR DESCRIPTION
Fix #1185 
- Fix dead assignments.
- Fix dereference of null pointer (`curr_cert_conf`).
- Fix dereference of null pointer (`pos`).
- Fix use uninitialized argument value.
- Add check on NULL in tests.
