### PR TITLE
Fix issues when running JS challenge

### DIFF
--- a/etc/js_challenge.tpl
+++ b/etc/js_challenge.tpl
@@ -1,4 +1,5 @@
 <html>
+<link rel="icon" href="data:;base64,iVBORw0KGgo=">
     <body>
         <p></p>&nbsp;<p></p>
         <h2 align='center'>

--- a/scripts/update_template.pl
+++ b/scripts/update_template.pl
@@ -34,6 +34,10 @@ if (!$template || $template !~ '.tpl$' || !$sticky_name
 sub assemble
 {
 	my ($src) = @_;
+	unless (-e $src) {
+		die "JavaScript Challenge template '$src' not found, generation aborted!";
+	}
+
 	my $dir = dirname($src);
 	$src = basename($src);
 	(my $dest = $src) =~ s/.tpl$/.html/;
@@ -42,7 +46,7 @@ sub assemble
 		OUTPUT_PATH	=> "$dir",
 	});
 
-	say "assemble template $src -> $dest";
+	say "Assemble JavaScript Challenge template '$src' -> '$dest'";
 
 	my $html;
 	my $t_vals = {

--- a/scripts/update_template.pl
+++ b/scripts/update_template.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# Copyright (C) 2017-2018 Tempesta Technologies, Inc.
+# Copyright (C) 2017-2020 Tempesta Technologies, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -1978,7 +1978,13 @@ __req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len)
 	}
 
 	__FSM_STATE(Req_I_AfterTextSlash) {
-		TRY_STR("html", Req_I_AfterTextSlash, Req_I_AcceptHtml);
+		if (c == '*')
+			__FSM_I_MOVE(I_EoT);
+		__FSM_I_JMP(Req_I_AfterTextSlashToken);
+	}
+
+	__FSM_STATE(Req_I_AfterTextSlashToken) {
+		TRY_STR("html", Req_I_AfterTextSlashToken, Req_I_AcceptHtml);
 		TRY_STR_INIT();
 		__FSM_I_JMP(Req_I_Subtype);
 	}
@@ -1986,8 +1992,6 @@ __req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len)
 	__FSM_STATE(Req_I_AfterStar) {
 		if (c == '/')
 			__FSM_I_MOVE(Req_I_StarSlashStar);
-		if (IS_TOKEN(c))
-			__FSM_I_JMP(Req_I_Type);
 		return CSTR_NEQ;
 	}
 
@@ -2014,10 +2018,10 @@ __req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len)
 	}
 
 	__FSM_STATE(Req_I_Slash) {
-		if (IS_TOKEN(c))
-			__FSM_I_JMP(Req_I_Subtype);
 		if (c == '*')
 			__FSM_I_MOVE(I_EoT);
+		if (IS_TOKEN(c))
+			__FSM_I_JMP(Req_I_Subtype);
 		return CSTR_NEQ;
 	}
 
@@ -5294,10 +5298,16 @@ __h2_req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len,
 	}
 
 	__FSM_STATE(Req_I_AfterTextSlash) {
+		if (c == '*')
+			__FSM_H2_I_MOVE(I_EoT);
+		__FSM_I_JMP(Req_I_AfterTextSlashToken);
+	}
+
+	__FSM_STATE(Req_I_AfterTextSlashToken) {
 		H2_TRY_STR_LAMBDA("html", {
 			__set_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags);
 			__FSM_EXIT(CSTR_EQ);
-		},  Req_I_AfterTextSlash, Req_I_AcceptHtml);
+		},  Req_I_AfterTextSlashToken, Req_I_AcceptHtml);
 		TRY_STR_INIT();
 		__FSM_I_JMP(Req_I_Subtype);
 	}
@@ -5305,14 +5315,12 @@ __h2_req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len,
 	__FSM_STATE(Req_I_AfterStar) {
 		if (c == '/')
 			__FSM_H2_I_MOVE(Req_I_StarSlashStar);
-		if (IS_TOKEN(c))
-			__FSM_I_JMP(Req_I_Type);
 		return CSTR_NEQ;
 	}
 
 	__FSM_STATE(Req_I_StarSlashStar) {
 		if (c == '*')
-			__FSM_H2_I_MOVE_n(I_EoT, 1);
+			__FSM_H2_I_MOVE(I_EoT);
 		return CSTR_NEQ;
 	}
 
@@ -5335,10 +5343,10 @@ __h2_req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len,
 	}
 
 	__FSM_STATE(Req_I_Slash) {
-		if (IS_TOKEN(c))
-			__FSM_I_JMP(Req_I_Subtype);
 		if (c == '*')
 			__FSM_H2_I_MOVE(I_EoT);
+		if (IS_TOKEN(c))
+			__FSM_I_JMP(Req_I_Subtype);
 		return CSTR_NEQ;
 	}
 

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -1980,7 +1980,7 @@ __req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len)
 	__FSM_STATE(Req_I_AfterTextSlash) {
 		if (c == '*')
 			__FSM_I_MOVE(I_EoT);
-		__FSM_I_JMP(Req_I_AfterTextSlashToken);
+		/* Fall through. */
 	}
 
 	__FSM_STATE(Req_I_AfterTextSlashToken) {
@@ -5300,7 +5300,7 @@ __h2_req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len,
 	__FSM_STATE(Req_I_AfterTextSlash) {
 		if (c == '*')
 			__FSM_H2_I_MOVE(I_EoT);
-		__FSM_I_JMP(Req_I_AfterTextSlashToken);
+		/* Fall through. */
 	}
 
 	__FSM_STATE(Req_I_AfterTextSlashToken) {

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -1993,7 +1993,7 @@ __req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len)
 
 	__FSM_STATE(Req_I_StarSlashStar) {
 		if (c == '*')
-			__FSM_I_MOVE(Req_I_AcceptHtml);
+			__FSM_I_MOVE(I_EoT);
 		return CSTR_NEQ;
 	}
 
@@ -5312,9 +5312,7 @@ __h2_req_parse_accept(TfwHttpReq *req, unsigned char *data, size_t len,
 
 	__FSM_STATE(Req_I_StarSlashStar) {
 		if (c == '*')
-			__FSM_H2_I_MOVE_LAMBDA_n(Req_I_AcceptHtml, 1, {
-				__set_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags);
-			});
+			__FSM_H2_I_MOVE_n(I_EoT, 1);
 		return CSTR_NEQ;
 	}
 

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -17,7 +17,7 @@
  * value can be used to cope the non anonymous forward proxy problem and
  * identify real clients.
  *
- * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -162,7 +162,9 @@ enum {
 	/* Sticky cookie violated, client must be blocked. */
 	TFW_HTTP_SESS_VIOLATE,
 	/* JS challenge enabled, but request is not challengable. */
-	TFW_HTTP_SESS_JS_NOT_SUPPORTED
+	TFW_HTTP_SESS_JS_NOT_SUPPORTED,
+	/* JS challenge restart required. Internal for http_sess module. */
+	TFW_HTTP_SESS_JS_RESTART
 };
 
 int tfw_http_sess_obtain(TfwHttpReq *req);

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -1,7 +1,7 @@
 /*
  *		Tempesta FW
  *
- * Copyright (C) 2017-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2017-2020 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -1537,14 +1537,14 @@ TEST(http_parser, accept)
 		"Accept:  */*  \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
 		"Accept:  invalid/invalid;  q=0.5;    key=val, */* \r\n"
 		"\r\n")
 	{
-		EXPECT_TRUE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
 	FOR_REQ("GET / HTTP/1.1\r\n"
@@ -1582,12 +1582,9 @@ TEST(http_parser, accept)
 		EXPECT_FALSE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
 	}
 
-	FOR_REQ("GET / HTTP/1.1\r\n"
+	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
 		"Accept: */*text\r\n"
-		"\r\n")
-	{
-		EXPECT_FALSE(test_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags));
-	}
+		"\r\n");
 
 	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
 		"Accept: */* text/plain\r\n"


### PR DESCRIPTION
Fix #1393 

Changes: 
- Don't treat `*/*` token in `Accept:` header as allowing to send JS challenge
- Lower pressure on Tempesta by legitimate clients processing JS challenge by eliminating `favicon.ico` request. Empty favicon is integrated into JS challenge template.
-  Don't allow 'unchallengeable' requests to pass the challenge by mistake
- Restart challenge if client has a cookie value from the last run. E.g. If the the challenge is failed, user still can reload the page and try challenge once again.