### PR TITLE
Process multiple 'Cookie:' header in http2 requests

### DIFF
--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -683,14 +683,15 @@ tfw_http_sticky_challenge_start(TfwHttpReq *req, TfwStickyCookie *sticky,
 				StickyVal *sv)
 {
 	int r;
-	RedirMarkVal mv = {};
+	RedirMarkVal mv = {}, *mvp = NULL;
 
 	/*
 	 * If configured, ensure that limit for requests without
 	 * cookie and timeout for redirections are not exhausted.
 	 */
 	if (sticky->max_misses) {
-		if ((r = tfw_http_sess_check_redir_mark(req, &mv)))
+		mvp = &mv;
+		if ((r = tfw_http_sess_check_redir_mark(req, mvp)))
 			return r;
 	}
 	if (!sv->ts) {
@@ -698,7 +699,7 @@ tfw_http_sticky_challenge_start(TfwHttpReq *req, TfwStickyCookie *sticky,
 			return TFW_HTTP_SESS_FAILURE;
 	}
 
-	return tfw_http_sticky_build_redirect(req, sv, &mv);
+	return tfw_http_sticky_build_redirect(req, sv, mvp);
 }
 
 /*

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -318,22 +318,33 @@ search_cookie(TfwStickyCookie *sticky, const TfwStr *cookie, TfwStr *val,
 static int
 tfw_http_sticky_get_req(TfwHttpReq *req, TfwStr *cookie_val)
 {
-	TfwStr value = { 0 };
-	TfwStr *hdr;
+	TfwStr *hdr, *end, *dup;
 
 	/*
 	 * Find a 'Cookie:' header field in the request. Then search for
-	 * Tempesta sticky cookie within the field. Note that there can
-	 * be only one "Cookie:" header field. See RFC 6265 section 5.4.
+	 * Tempesta sticky cookie within the field. In HTTP/1.x requests
+	 * all cookies are stored in the only "Cookie:" header (RFC 6265
+	 * section 5.4), HTTP/2 requests may use either a single header
+	 * or multiple headers (RFC 7540 Section 8.1.2.5).
+	 * Don't need to worry about multiple headers over HTTP/1.x connections
+	 * here, parser blocks such requests.
 	 * NOTE: Irrelevant here, but there can be multiple 'Set-Cookie"
 	 * header fields as an exception. See RFC 7230 section 3.2.2.
 	 */
 	hdr = &req->h_tbl->tbl[TFW_HTTP_HDR_COOKIE];
 	if (TFW_STR_EMPTY(hdr))
 		return 0;
-	tfw_http_msg_clnthdr_val(req, hdr, TFW_HTTP_HDR_COOKIE, &value);
+	TFW_STR_FOR_EACH_DUP(dup, hdr, end) {
+		TfwStr value = { 0 };
+		int r;
 
-	return search_cookie(req->vhost->cookie, &value, cookie_val, false);
+		tfw_http_msg_clnthdr_val(req, dup, TFW_HTTP_HDR_COOKIE, &value);
+		r = search_cookie(req->vhost->cookie, &value, cookie_val, false);
+		if (r)
+			return r;
+	}
+
+	return 0;
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
Fix #1396. 

A degradation was found in sticky module, introduced in 0937fed631a1b1b954bcd47c52e0873ddff6eaf5 : a redirection mark is always added to 302 redirect even if disabled. Functional tests doesn't validate redirect uri, thus the degradation passed through CI tests. Functional tests are to be updated shortly. Fixed that.

The PR doesn't fix  https://github.com/tempesta-tech/tempesta/issues/1396#issuecomment-611550309 yet. 