### PR TITLE
HTTP/2: remove chunked encoding during h1 -> h2 response transformation

### DIFF
--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -191,6 +191,7 @@ int tfw_h2_msg_rewrite_data(TfwHttpTransIter *mit, const TfwStr *str,
 			    const char *stop);
 
 int tfw_http_msg_insert(TfwMsgIter *it, char *off, const TfwStr *data);
+int tfw_http_msg_evict_data(TfwHttpMsg *hm, TfwStr *it);
 
 #define TFW_H2_MSG_HDR_ADD(hm, name, val, idx)				\
 	tfw_h2_msg_hdr_add(hm, name, sizeof(name) - 1, val,		\

--- a/tempesta_fw/http_parser.h
+++ b/tempesta_fw/http_parser.h
@@ -126,15 +126,15 @@ void tfw_http_init_parser_req(TfwHttpReq *req);
 void tfw_http_init_parser_resp(TfwHttpResp *resp);
 
 int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
-		       unsigned int *parsed);
+		       unsigned int *parsed, unsigned char **evict_ptr);
 
 int tfw_h2_parse_req_hdr(unsigned char *data, unsigned long len, TfwHttpReq *req,
 			 bool fin, bool value_stage);
 int tfw_h2_parse_req(void *req_data, unsigned char *data, size_t len,
-		     unsigned int *parsed);
+		     unsigned int *parsed, unsigned char **evict_ptr);
 int tfw_h2_parse_req_finish(TfwHttpReq *req);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len,
-			unsigned int *parsed);
+			unsigned int *parsed, unsigned char **evict_ptr);
 int tfw_http_parse_terminate(TfwHttpMsg *hm);
 bool tfw_http_parse_is_done(TfwHttpMsg *hm);
 

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -47,7 +47,7 @@ enum {
 };
 
 typedef int ss_skb_actor_t(void *conn, unsigned char *data, size_t len,
-			   unsigned int *read);
+			   unsigned int *read, unsigned char **evict_ptr);
 
 /**
  * Add new _single_ @skb to the queue in FIFO order.
@@ -207,7 +207,8 @@ char *ss_skb_fmt_src_addr(const struct sk_buff *skb, char *out_buf);
 
 int ss_skb_alloc_data(struct sk_buff **skb_head, size_t len,
 		      unsigned int tx_flags);
-struct sk_buff *ss_skb_split(struct sk_buff *skb, int len);
+struct sk_buff *ss_skb_split(struct sk_buff *skb_head, struct sk_buff *skb,
+			     int len);
 int skb_fragment(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
 		 int len, TfwStr *it);
 int ss_skb_get_room(struct sk_buff *skb_head, struct sk_buff *skb,
@@ -220,8 +221,9 @@ int ss_skb_cutoff_data(struct sk_buff *skb_head, const TfwStr *hdr,
 		       int skip, int tail);
 int skb_next_data(struct sk_buff *skb, char *last_ptr, TfwStr *it);
 
-int ss_skb_process(struct sk_buff *skb, ss_skb_actor_t actor, void *objdata,
-		   unsigned int *chunks, unsigned int *processed);
+int ss_skb_process(struct sk_buff *skb_head, struct sk_buff **skb,
+		   ss_skb_actor_t actor, void *objdata, unsigned int *chunks,
+		   unsigned int *acc_last, size_t *acc);
 
 int ss_skb_unroll(struct sk_buff **skb_head, struct sk_buff *skb);
 void ss_skb_init_for_xmit(struct sk_buff *skb);

--- a/tempesta_fw/t/bomber.c
+++ b/tempesta_fw/t/bomber.c
@@ -160,7 +160,7 @@ tfw_bmb_conn_drop(struct sock *sk)
 
 static int
 tfw_bmb_print_msg(void *msg_data, unsigned char *data, size_t len,
-		  unsigned int *read)
+		  unsigned int *read, unsigned char **evict_ptr)
 {
 	printk(KERN_INFO "%.*s\n", (int)len, data);
 	*read = len;
@@ -172,11 +172,13 @@ static int
 tfw_bmb_conn_recv(void *cdata, struct sk_buff *skb)
 {
 	if (verbose) {
+		size_t acc = 0;
 		unsigned int parsed = 0, chunks = 0;
 
 		T_LOG("Server response:\n------------------------------\n");
 
-		ss_skb_process(skb, tfw_bmb_print_msg, NULL, &chunks, &parsed);
+		ss_skb_process(NULL, &skb, tfw_bmb_print_msg, NULL, &chunks,
+			       &parsed, &acc);
 
 		printk(KERN_INFO "\n------------------------------\n");
 	}

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -50,6 +50,7 @@ split_and_parse_n(unsigned char *str, int type, size_t len, size_t chunks)
 	size_t chlen = len / chunks, rem = len % chunks, pos = 0, step;
 	unsigned int parsed;
 	int r = 0;
+	unsigned char *eptr = NULL;
 	TfwHttpMsg *hm = (type == FUZZ_REQ)
 			? (TfwHttpMsg *)req
 			: (TfwHttpMsg *)resp;
@@ -64,10 +65,11 @@ split_and_parse_n(unsigned char *str, int type, size_t len, size_t chunks)
 		TEST_DBG3("split: len=%zu pos=%zu, chunks=%zu step=%zu\n",
 			  len, pos, chunks, step);
 		if (type == FUZZ_REQ)
-			r = tfw_http_parse_req(req, str + pos, step, &parsed);
+			r = tfw_http_parse_req(req, str + pos, step,
+					       &parsed, &eptr);
 		else
-			r = tfw_http_parse_resp(resp, str + pos, step, &parsed);
-
+			r = tfw_http_parse_resp(resp, str + pos, step,
+						&parsed, &eptr);
 		pos += step;
 		hm->msg.len += parsed;
 
@@ -86,6 +88,7 @@ static int
 set_sample_req(unsigned char *str)
 {
 	size_t len = strlen(str);
+	unsigned char *eptr = NULL;
 	int r;
 	unsigned int parsed;
 
@@ -93,7 +96,7 @@ set_sample_req(unsigned char *str)
 		test_req_free(sample_req);
 	sample_req = test_req_alloc(len);
 
-	r = tfw_http_parse_req(sample_req, str, len, &parsed);
+	r = tfw_http_parse_req(sample_req, str, len, &parsed, &eptr);
 
 	return r;
 }

--- a/tempesta_fw/t/unit/test_http_tbl.c
+++ b/tempesta_fw/t/unit/test_http_tbl.c
@@ -105,10 +105,12 @@ test_req(char *req_str, TfwSrvConn *expect_conn)
 	if (req_str) {
 		static char req_str_copy[PAGE_SIZE];
 		const size_t req_str_len = strlen(req_str);
+		unsigned char *eptr = NULL;
 
 		BUG_ON(req_str_len + 1 > sizeof(req_str_copy));
 		strcpy(req_str_copy, req_str);
-		tfw_http_parse_req(req, req_str_copy, req_str_len, &parsed);
+		tfw_http_parse_req(req, req_str_copy, req_str_len,
+				   &parsed, &eptr);
 	}
 
 	req->vhost = tfw_http_tbl_vhost((TfwMsg *)req, &block);

--- a/tempesta_fw/t/unit/test_sched_hash.c
+++ b/tempesta_fw/t/unit/test_sched_hash.c
@@ -66,13 +66,14 @@ static TfwMsg *
 sched_hash_get_arg(size_t conn_type)
 {
 	TfwHttpReq *req = NULL;
+	unsigned char *eptr = NULL;
 	unsigned int parsed;
 
 	BUG_ON(conn_type >= sched_helper_hash.conn_types);
 
 	req = test_req_alloc(strlen(req_strs[conn_type]));
 	tfw_http_parse_req(req, (unsigned char *)req_strs[conn_type],
-			   strlen(req_strs[conn_type]), &parsed);
+			   strlen(req_strs[conn_type]), &parsed, &eptr);
 
 	return (TfwMsg *) req;
 }

--- a/tempesta_fw/t/unit/test_sched_ratio.c
+++ b/tempesta_fw/t/unit/test_sched_ratio.c
@@ -55,12 +55,13 @@ sched_ratio_get_arg(size_t conn_type)
 {
 	static char *str = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
 	TfwHttpReq *req = NULL;
+	unsigned char *eptr = NULL;
 	unsigned int parsed;
 
 	BUG_ON(conn_type >= sched_helper_ratio.conn_types);
 
 	req = test_req_alloc(strlen(str));
-	tfw_http_parse_req(req, str, strlen(str), &parsed);
+	tfw_http_parse_req(req, str, strlen(str), &parsed, &eptr);
 
 	return (TfwMsg *)req;
 }

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -2105,7 +2105,8 @@ ttls_handshake_step(TlsCtx *tls, unsigned char *buf, size_t len, size_t hh_len,
  * The function adds the number of bytes parsed in @buf to @read.
  */
 int
-ttls_recv(void *tls_data, unsigned char *buf, size_t len, unsigned int *read)
+ttls_recv(void *tls_data, unsigned char *buf, size_t len, unsigned int *read,
+	  unsigned char **evict_ptr)
 {
 	int r;
 	unsigned int hh_len = 0, parsed = *read;

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -561,7 +561,7 @@ void ttls_conf_version(TlsCfg *conf, int min_minor, int max_minor);
 int ttls_get_session(const TlsCtx *ssl, TlsSess *session);
 
 int ttls_recv(void *tls_data, unsigned char *buf, size_t len,
-	      unsigned int *read);
+	      unsigned int *read, unsigned char **evict_ptr);
 int ttls_encrypt(TlsCtx *tls, struct sg_table *sgt, struct sg_table *out_sgt);
 
 int ttls_send_alert(TlsCtx *tls, unsigned char lvl, unsigned char msg);


### PR DESCRIPTION
#1379

TODO:

1. While forwarding chunked encoded response to the client: a) in case of H2 client the body of the response is not needed to be edited, since all unnecessary chunked descriptors had been cut on the parsing stage; if response contains headers in trailer-part, they need to be placed after the DATA frame in the resulting H2 response - into the HEADERS/CONTINUATION frames; this can be done in `tfw_h2_resp_adjust_fwd()` - via iterating in `tfw_h2_resp_next_hdr()` only until the first header with TFW_STR_TRAILER flag, and applying the `tfw_h2_resp_next_hdr()` one more time - after the DATA frame(s) assembled - continuing from the first trailer header (with subsequent insertion of frame headers for trailer HEADERS/CONTINUATION frames); b) in the case of H1 client the new chunked descriptors should inserted (at least one - to define one chunk for entire body), but if the response does not have the trailer-part - perhaps it will be enough just to add `Content-Length` header with appropriate length of the body;
2. When saving the response into the cache, only H2 form of the response is written; thus, if chunked encoded response contains headers in trailer-part - it is better to save these headers after the body (to avoid double iteration over headers list during H2/H1 response generation from cache); it seems that this goal can be achieved via iteration through `resp->mit.map` (instead of iteration through `resp->h_tbl`, as now) in `tfw_cache_copy_resp()`, since in the map the headers are located in the order of their appearance in the message, and it makes possible sequentially storing into the cache the main headers, then body, and in the end - the headers of trailer-part. In the same time, the response body is not needed to be adjusted, since this work is already done during HTTP-parsing stage.
3. While generating H2 response from the cache (considering p.2) no any additional work should be done - it is needed only to read and send unchanged H2 response to the client. For the H1 case - the chunked-encoded response should be re-created similarly as described in p.1 (b).