### PR TITLE
fix debug builds

### DIFF
--- a/tls/bignum.h
+++ b/tls/bignum.h
@@ -27,6 +27,10 @@
 
 #include <linux/random.h>
 
+#if DBG_TLS == 0
+#undef DEBUG
+#endif
+
 #define TTLS_MPI_CHK(f)							\
 do {									\
 	if (WARN((ret = (f)), #f " returns %d", ret))			\


### PR DESCRIPTION
bignum.h uses DEBUG macro directly while it's depended from DBG_TLS