### PR TITLE
fix #1420

### DIFF
--- a/pkg/debian/tempesta-fw.service
+++ b/pkg/debian/tempesta-fw.service
@@ -10,10 +10,12 @@ Environment="TDB_PATH=/lib/modules/%v/updates/dkms/"
 Environment="TLS_PATH=/lib/modules/%v/updates/dkms/"
 Environment="LIB_PATH=/lib/modules/%v/updates/dkms/"
 Environment=TFW_CFG_PATH=/etc/tempesta/tempesta_fw.conf
+Environment="TFW_SYSTEMD=1"
 RemainAfterExit=yes
 ExecStart=/lib/tempesta/scripts/tempesta.sh --start
-ExecStop=/lib/tempesta/scripts/tempesta.sh --stop
+ExecStopPost=/lib/tempesta/scripts/tempesta.sh --stop
 ExecReload=/lib/tempesta/scripts/tempesta.sh --reload
+TimeoutSec=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -19,13 +19,15 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-if [ "${TEMPESTA_LCK}" != "$0" ]; then
-	env TEMPESTA_LCK="$0" flock -n -E 254 "/tmp/tempesta-lock-file" "$0" "$@"
-	if [ $? -eq 254 ]; then
-		echo "Cannot operate with Tempesta FW: locked by another process"
-		exit 3
+if [ -z "$TFW_SYSTEMD" ]; then
+	if [ "${TEMPESTA_LCK}" != "$0" ]; then
+		env TEMPESTA_LCK="$0" flock -n -E 254 "/tmp/tempesta-lock-file" "$0" "$@"
+		if [ $? -eq 254 ]; then
+			echo "Cannot operate with Tempesta FW: locked by another process"
+			exit 3
+		fi
+		exit
 	fi
-	exit
 fi
 
 . "$(dirname $0)/tfw_lib.sh"


### PR DESCRIPTION
When the Tempesta is started using systemd daemon, service management
in tempesta.sh conflicts with systemd unit management. This happens
because `flock` daemonizes and immediately exits. Systemd unit was
configured to run `oneshot` command thus tempesta-fw.service immediately
switches  to state `started`. It's highly likely that Tempesta is
not started by that moment.

Situation may became worse if concurrent start and stop happens:
flock process may be killed and lock file may become forever locked.

To fix all the issues:
- don't manage concurrent starts manually, it's systemd job
- use  ExecStopPost instead of ExecStop to call stop functions even on
unclean start
- set TimeoutSec to handle cases with really long commands processings,
i.e. reconfiguration under heavy load.