### PR TITLE
Mock timer for TLS tests

### DIFF
--- a/ktest/linux/timer.h
+++ b/ktest/linux/timer.h
@@ -1,0 +1,25 @@
+/**
+ *	Tempesta kernel emulation unit testing framework.
+ *
+ * Copyright (C) 2020 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TIMER_H__
+#define __TIMER_H__
+
+struct timer_list { /* dummy struct */ };
+
+#endif /* __TIMER_H__ */

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -27,6 +27,7 @@
 #include <linux/skbuff.h>
 #include <linux/slab.h>
 #include <linux/string.h>
+#include <linux/timer.h>
 #include <net/tls.h>
 
 #include "lib/str.h"


### PR DESCRIPTION
Fixes after merge of NIST p256 optimizations and TLS session resumption branches.