### PR TITLE
tls tickets: don't fail configuration if tls_tickets value is not needed

### DIFF
--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -2081,7 +2081,9 @@ static int
 tfw_cfgop_out_tls_tickets(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	if (tfw_vhosts_reconfig->expl_dflt) {
-		T_ERR_NL("%s: global tls tickets are to be configured "
+		if (ce->dflt_value)
+			return 0;
+		T_ERR_NL("%s: global tls_tickets are to be configured "
 			 "outside of explicit '%s' vhost.\n",
 			 cs->name, TFW_VH_DFT_NAME);
 		return -EINVAL;


### PR DESCRIPTION
Even if explicit `default` vhost is created, an attempt to add an implicit `tls_tickets` directive with default value still happens. Since global-level  `tls_tickets`  directive is not allowed after explicit `default` vhost block configuration error is raised. But it's default implicit value, not configured by user, ignore it and continue configuration process.