### PR TITLE
Resetting the counter of redirected requests after a timeout during which the client must block

### DIFF
--- a/etc/js_challenge.js.tpl
+++ b/etc/js_challenge.js.tpl
@@ -1,6 +1,11 @@
 var c_name = "[% STICKY_NAME %]";
 var delay_min = [% DELAY_MIN %];
 var delay_range = [% DELAY_RANGE %];
+/*
+ * If JS challenge are enabled, then Location header cannot be used to add
+ * rmark to the url. We pass rmark through the response body.
+ */
+var TFW_DONT_CHANGE_NAME = "";
 
 function cookieVal(input, c_name) {
     var re = new RegExp("(.*;)?\s*" + c_name + "=([0-9a-f]+)")
@@ -15,7 +20,15 @@ var c_val = cookieVal(document.cookie, c_name)
 if (navigator.cookieEnabled && !!c_val) {
     var ts = "0x" + c_val.substr(0, 16);
     setTimeout(function() {
-        location.reload();
+        var url = location.pathname;
+        /* If there is rmark */
+        if (TFW_DONT_CHANGE_NAME) {
+            url = TFW_DONT_CHANGE_NAME + location.pathname;
+            const regex = /\/__tfw=[0-9a-z]+/;
+            if (location.pathname.search(regex) != -1)
+                url = location.pathname.replace(regex, TFW_DONT_CHANGE_NAME);
+        }
+        location.replace(url);
     }, delay_min + Number(ts) % delay_range);
 } else {
     document.write("<h3 align='center' style='color:red'>"

--- a/etc/js_challenge.tpl
+++ b/etc/js_challenge.tpl
@@ -8,6 +8,10 @@
         </h2>
         <p></p>&nbsp;<p></p>
 
+        <h3 align='center'>
+            Please check that you browser supports JavaScript.
+        </h3>
+
         <script>[% INCLUDE js_challenge.js.tpl %]</script>
     </body>
 </html>

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -35,8 +35,6 @@
 #define S_VERSION11		"HTTP/1.1"
 #define S_0			S_VERSION11 " "
 
-#define SLEN(s)			(sizeof(s) - 1)
-
 /*
  * The size of the buffer to store the value for ':status' pseudo-header
  * of HTTP/2-response.

--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -47,6 +47,7 @@
 #include "hash.h"
 #include "http_msg.h"
 #include "http_sess.h"
+#include "http_sess_conf.h"
 #include "vhost.h"
 #include "filter.h"
 #include "tdb.h"
@@ -174,7 +175,8 @@ tfw_http_redir_mark_prepare(RedirMarkVal *mv, char *buf, unsigned int buf_len,
 }
 
 static int
-tfw_http_sticky_build_redirect(TfwHttpReq *req, StickyVal *sv, RedirMarkVal *mv)
+tfw_http_sticky_build_redirect(TfwHttpReq *req, StickyVal *sv, RedirMarkVal *mv,
+                               bool jsch_allow)
 {
 	unsigned long ts_be64 = cpu_to_be64(sv->ts);
 	TfwStr c_chunks[3], m_chunks[3], r_chunks[5], cookie = { 0 }, rmark = { 0 };
@@ -182,7 +184,7 @@ tfw_http_sticky_build_redirect(TfwHttpReq *req, StickyVal *sv, RedirMarkVal *mv)
 	char c_buf[sizeof(*sv) * 2], m_buf[sizeof(*mv) * 2];
 	TfwStr body = { 0 };
 	TfwStickyCookie *sticky;
-	int r;
+	int r, code;
 
 	WARN_ON_ONCE(!list_empty(&req->fwd_list));
 	WARN_ON_ONCE(!list_empty(&req->nip_list));
@@ -205,7 +207,7 @@ tfw_http_sticky_build_redirect(TfwHttpReq *req, StickyVal *sv, RedirMarkVal *mv)
 					    sizeof(m_chunks), &rmark);
 
 	sticky = req->vhost->cookie;
-	if (sticky->js_challenge) {
+	if (sticky->js_challenge && jsch_allow) {
 		if (mv) {
 			if (sticky->js_challenge->body.nchunks != 2)
 				return TFW_HTTP_SESS_FAILURE;
@@ -250,11 +252,10 @@ tfw_http_sticky_build_redirect(TfwHttpReq *req, StickyVal *sv, RedirMarkVal *mv)
 		cookie.nchunks++;
 	}
 
+	code = jsch_allow ? sticky->redirect_code: TFW_REDIR_STATUS_CODE_DFLT;
 	r = TFW_MSG_H2(req)
-		? tfw_h2_prep_redirect(resp, sticky->redirect_code, &rmark,
-				       &cookie, &body)
-		: tfw_h1_prep_redirect(resp, sticky->redirect_code, &rmark,
-				       &cookie, &body);
+		? tfw_h2_prep_redirect(resp, code, &rmark, &cookie, &body)
+		: tfw_h1_prep_redirect(resp, code, &rmark, &cookie, &body);
 	if (r) {
 		tfw_http_msg_free((TfwHttpMsg *)resp);
 		return TFW_HTTP_SESS_FAILURE;
@@ -719,7 +720,7 @@ tfw_http_sticky_challenge_start(TfwHttpReq *req, TfwStickyCookie *sticky,
 			return TFW_HTTP_SESS_FAILURE;
 	}
 
-	return tfw_http_sticky_build_redirect(req, sv, mvp);
+	return tfw_http_sticky_build_redirect(req, sv, mvp, true);
 }
 
 /*
@@ -1145,6 +1146,7 @@ tfw_http_sess_obtain(TfwHttpReq *req)
 	TfwStr *c_val = &ctx.cookie_val;
 	TdbRec *rec;
 	TdbGetAllocCtx tdb_ctx = { 0 };
+	TfwStr mark_val = {};
 
 	/*
 	 * If vhost is not known, then request is to be dropped. Don't save the
@@ -1212,6 +1214,9 @@ tfw_http_sess_obtain(TfwHttpReq *req)
 		 * bucket with the session as soon as possible.
 		 */
 		tdb_rec_put(rec);
+
+	if (tfw_http_redir_mark_get(req, &mark_val))
+		return tfw_http_sticky_build_redirect(req, sv, NULL, false);
 
 	return TFW_HTTP_SESS_SUCCESS;
 }

--- a/tempesta_fw/http_sess_conf.c
+++ b/tempesta_fw/http_sess_conf.c
@@ -597,6 +597,7 @@ TfwCfgSpec tfw_http_sess_specs[] = {
 		.name = "js_challenge",
 		.handler = tfw_cfgop_js_challenge,
 		.allow_none = true,
+		.allow_reconfig = true,
 	},
 	{ 0 }
 };

--- a/tempesta_fw/http_sess_conf.c
+++ b/tempesta_fw/http_sess_conf.c
@@ -30,7 +30,6 @@ static TfwVhost *cur_vhost;
 #define STICKY_NAME_DEFAULT	"__tfw"
 
 static const unsigned int tfw_cfg_jsch_code_dflt = 503;
-static const unsigned short tfw_cfg_redirect_st_code_dflt = 302;
 #define TFW_CFG_JS_PATH "/etc/tempesta/js_challenge.html"
 
 void
@@ -116,7 +115,7 @@ tfw_http_sess_cfgop_finish(TfwVhost *vhost, TfwCfgSpec *cs)
 		sticky->enforce = true;
 		sticky->redirect_code = sticky->js_challenge->st_code;
 	} else {
-		sticky->redirect_code = tfw_cfg_redirect_st_code_dflt;
+		sticky->redirect_code = TFW_REDIR_STATUS_CODE_DFLT;
 	}
 
 	cur_vhost = NULL;

--- a/tempesta_fw/http_sess_conf.h
+++ b/tempesta_fw/http_sess_conf.h
@@ -24,6 +24,8 @@
 #include "cfg.h"
 #include "http_types.h"
 
+#define TFW_REDIR_STATUS_CODE_DFLT 302
+
 extern TfwCfgSpec tfw_http_sess_specs[];
 
 int tfw_http_sess_cfgop_begin(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce);

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -218,6 +218,8 @@ size_t tfw_ultohex(unsigned long ai, char *buf, unsigned int len);
 /* The chunk contains only WS characters. */
 #define TFW_STR_OWS		0x100
 
+#define SLEN(s)			(sizeof(s) - 1)
+
 /*
  * @ptr		- pointer to string data or array of nested strings;
  * @skb		- socket buffer containing the string data;


### PR DESCRIPTION
#1398 
- counting the timeout as a time interval after which the counter of redirected requests is reset
- adding the ability to set the path directive for cookies
- adding reconfiguration capability for `js_challenge` 