### PR TITLE
Fix crash

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -1152,23 +1152,22 @@ tfw_cache_h2_copy_hdr(TfwCacheEntry *ce, char **p, TdbVRec **trec, TfwStr *hdr,
 		return -ENOMEM;
 	}
 
-	CSTR_MOVE_HDR();
-
 	if (TFW_STR_DUP(hdr)) {
-		CSTR_WRITE_HDR(TFW_STR_DUPLICATE, hdr->nchunks);
 		CSTR_MOVE_HDR();
+		CSTR_WRITE_HDR(TFW_STR_DUPLICATE, hdr->nchunks);
 	}
 
 	TFW_STR_FOR_EACH_DUP(dup, hdr, dup_end) {
-		unsigned int prev_len = ce->hdr_len;
+		unsigned int prev_len;
 
 		if (dupl) {
 			TFW_STR_INIT(&s_nm);
 			TFW_STR_INIT(&s_val);
 			tfw_http_hdr_split(dup, &s_nm, &s_val, true);
 			st_index = dup->hpack_idx;
-			CSTR_MOVE_HDR();
 		}
+		CSTR_MOVE_HDR();
+		prev_len = ce->hdr_len;
 
 		if (st_index) {
 			if (tfw_cache_h2_copy_int(&ce->hdr_len, st_index, 0xF,

--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -723,8 +723,8 @@ tfw_cache_build_resp_hdr(TDB *db, TfwHttpResp *resp, TfwHdrMods *hmods,
 		r = write_actor(db, trec, resp, p, s->len, &dc_iter);
 		if (unlikely(r))
 			break;
-		*acc_len += dc_iter.acc_len;;
 	}
+	*acc_len += dc_iter.acc_len;
 
 	return r;
 }

--- a/tempesta_fw/hpack.c
+++ b/tempesta_fw/hpack.c
@@ -2594,15 +2594,14 @@ tfw_hpack_rbtree_ins_rebalance(TfwHPackETbl *__restrict tbl,
 static void
 tfw_hpack_rbtree_del_rebalance(TfwHPackETbl *__restrict tbl,
 			       TfwHPackNode *__restrict nchild,
-			       TfwHPackNode *__restrict parent,
-			       bool left)
+			       TfwHPackNode *__restrict parent)
 {
 	BUG_ON(!tbl->root);
 
 	while (!nchild || (nchild != tbl->root && HPACK_RB_IS_BLACK(nchild))) {
 		TfwHPackNode *brother, *l_neph, *r_neph;
 
-		if (left) {
+		if (nchild == HPACK_NODE_COND(tbl, parent->left)) {
 			BUG_ON(HPACK_NODE_EMPTY(parent->right));
 			brother = HPACK_NODE(tbl, parent->right);
 			if (HPACK_RB_IS_RED(brother)) {
@@ -2706,12 +2705,11 @@ tfw_hpack_rbtree_min(TfwHPackETbl *__restrict tbl,
 /*
  * Procedure for branches replacement in red-black tree.
  */
-static inline bool
+static inline void
 tfw_hpack_rbtree_replace(TfwHPackETbl *__restrict tbl,
 			 TfwHPackNode *__restrict old,
 			 TfwHPackNode *__restrict new)
 {
-	bool left = true;
 	TfwHPackNode *parent = HPACK_NODE_COND(tbl, old->parent);
 
 	BUG_ON(!old);
@@ -2730,13 +2728,10 @@ tfw_hpack_rbtree_replace(TfwHPackETbl *__restrict tbl,
 		WARN_ON_ONCE(HPACK_NODE_EMPTY(parent->right)
 			     || old != HPACK_NODE(tbl, parent->right));
 		parent->right = HPACK_NODE_COND_OFF(tbl, new);
-		left = false;
 	}
 
 	if (new)
 		new->parent = HPACK_NODE_COND_OFF(tbl, parent);
-
-	return left;
 }
 
 /*
@@ -2834,15 +2829,15 @@ tfw_hpack_rbtree_erase(TfwHPackETbl *__restrict tbl,
 {
 	TfwHPackNode *nchild, *sv = node;
 	TfwHPackNode *parent = HPACK_NODE_COND(tbl, node->parent);
-	bool left_child = false, sv_black = HPACK_RB_IS_BLACK(sv);
+	bool sv_black = HPACK_RB_IS_BLACK(sv);
 
 	if (HPACK_NODE_EMPTY(node->left)) {
 		nchild = HPACK_NODE_COND(tbl, node->right);
-		left_child = tfw_hpack_rbtree_replace(tbl, node, nchild);
+		tfw_hpack_rbtree_replace(tbl, node, nchild);
 	}
 	else if (HPACK_NODE_EMPTY(node->right)) {
 		nchild = HPACK_NODE_COND(tbl, node->left);
-		left_child = tfw_hpack_rbtree_replace(tbl, node, nchild);
+		tfw_hpack_rbtree_replace(tbl, node, nchild);
 	}
 	else {
 		TfwHPackNode *n_left;
@@ -2856,7 +2851,7 @@ tfw_hpack_rbtree_erase(TfwHPackETbl *__restrict tbl,
 			TfwHPackNode *n_right;
 
 			parent = HPACK_NODE(tbl, sv->parent);
-			left_child = tfw_hpack_rbtree_replace(tbl, sv, nchild);
+			tfw_hpack_rbtree_replace(tbl, sv, nchild);
 
 			n_right = HPACK_NODE(tbl, node->right);
 			n_right->parent = HPACK_NODE_OFF(tbl, sv);
@@ -2881,7 +2876,7 @@ tfw_hpack_rbtree_erase(TfwHPackETbl *__restrict tbl,
 	 * the last).
 	 */
 	if (sv_black && tbl->root)
-		tfw_hpack_rbtree_del_rebalance(tbl, nchild, parent, left_child);
+		tfw_hpack_rbtree_del_rebalance(tbl, nchild, parent);
 }
 
 static inline void

--- a/tempesta_fw/hpack.c
+++ b/tempesta_fw/hpack.c
@@ -2538,6 +2538,7 @@ tfw_hpack_rbtree_ins_rebalance(TfwHPackETbl *__restrict tbl,
 				HPACK_RB_SET_BLACK(uncle);
 				HPACK_RB_SET_RED(gparent);
 				parent = HPACK_NODE_COND(tbl, gparent->parent);
+				new = gparent;
 			}
 			else {
 				if (!HPACK_NODE_EMPTY(parent->right)
@@ -2545,6 +2546,11 @@ tfw_hpack_rbtree_ins_rebalance(TfwHPackETbl *__restrict tbl,
 				{
 					tfw_hpack_rbtree_left_rt(tbl, parent);
 					parent = new;
+					/*
+					 * Don't need `new = HPACK_NODE_COND(tbl, parent->left);`.
+					 * This is the last iteration, because the parent will turn
+					 * black below
+					 */
 				}
 				HPACK_RB_SET_BLACK(parent);
 				HPACK_RB_SET_RED(gparent);
@@ -2558,6 +2564,7 @@ tfw_hpack_rbtree_ins_rebalance(TfwHPackETbl *__restrict tbl,
 				HPACK_RB_SET_BLACK(uncle);
 				HPACK_RB_SET_RED(gparent);
 				parent = HPACK_NODE_COND(tbl, gparent->parent);
+				new = gparent;
 			}
 			else {
 				if (!HPACK_NODE_EMPTY(parent->left)
@@ -2565,6 +2572,11 @@ tfw_hpack_rbtree_ins_rebalance(TfwHPackETbl *__restrict tbl,
 				{
 					tfw_hpack_rbtree_right_rt(tbl, parent);
 					parent = new;
+					/*
+					 * Don't need `new = HPACK_NODE_COND(tbl, parent->right);`.
+					 * This is the last iteration, because the parent will turn
+					 * black below
+					 */
 				}
 				HPACK_RB_SET_BLACK(parent);
 				HPACK_RB_SET_RED(gparent);

--- a/tempesta_fw/hpack.c
+++ b/tempesta_fw/hpack.c
@@ -2628,6 +2628,7 @@ tfw_hpack_rbtree_del_rebalance(TfwHPackETbl *__restrict tbl,
 			{
 				HPACK_RB_SET_RED(brother);
 				nchild = parent;
+				parent = HPACK_NODE_COND(tbl, nchild->parent);
 			}
 			else
 			{
@@ -2665,6 +2666,7 @@ tfw_hpack_rbtree_del_rebalance(TfwHPackETbl *__restrict tbl,
 			{
 				HPACK_RB_SET_RED(brother);
 				nchild = parent;
+				parent = HPACK_NODE_COND(tbl, nchild->parent);
 			}
 			else
 			{

--- a/tempesta_fw/t/unit/test_hpack.c
+++ b/tempesta_fw/t/unit/test_hpack.c
@@ -1901,6 +1901,19 @@ TEST(hpack, enc_table_rbtree)
 #undef HDR_VALUE_5
 }
 
+#define ADD_NODE(s, n)								\
+do {										\
+	res = tfw_hpack_rbtree_find(tbl, s, &n, &pl);				\
+	EXPECT_EQ(res, HPACK_IDX_ST_NOT_FOUND);					\
+	EXPECT_NULL(n);								\
+	EXPECT_OK(tfw_hpack_add_node(tbl, s, &pl, TFW_H2_TRANS_INPLACE));	\
+	bzero_fast(&pl, sizeof(pl));						\
+	res = tfw_hpack_rbtree_find(tbl, s, &n, &pl);				\
+	EXPECT_EQ(res, HPACK_IDX_ST_FOUND);					\
+	EXPECT_NULL(pl.parent);							\
+	EXPECT_NOT_NULL(n);							\
+} while (0)
+
 TEST(hpack, rbtree_ins_rebalance)
 {
 	TfwHPackETbl *tbl;
@@ -1954,19 +1967,6 @@ TEST(hpack, rbtree_ins_rebalance)
 	collect_compound_str(s10, s10_value, 0);
 
 	tbl = &ctx.hpack.enc_tbl;
-
-#define ADD_NODE(s, n)								\
-do {										\
-	res = tfw_hpack_rbtree_find(tbl, s, &n, &pl);				\
-	EXPECT_EQ(res, HPACK_IDX_ST_NOT_FOUND);					\
-	EXPECT_NULL(n);								\
-	EXPECT_OK(tfw_hpack_add_node(tbl, s, &pl, TFW_H2_TRANS_INPLACE));	\
-	bzero_fast(&pl, sizeof(pl));						\
-	res = tfw_hpack_rbtree_find(tbl, s, &n, &pl);				\
-	EXPECT_EQ(res, HPACK_IDX_ST_FOUND);					\
-	EXPECT_NULL(pl.parent);							\
-	EXPECT_NOT_NULL(n);							\
-} while (0)
 
 	ADD_NODE(s1, n1);
 	ADD_NODE(s2, n2);
@@ -2068,8 +2068,6 @@ do {										\
 	EXPECT_EQ(HPACK_NODE_COND(tbl, n2->right), n1);
 	EXPECT_NULL(HPACK_NODE_COND(tbl, n1->left));
 	EXPECT_NULL(HPACK_NODE_COND(tbl, n1->right));
-
-#undef ADD_NODE
 }
 
 TEST(hpack, rbtree_del_rebalance)
@@ -2125,19 +2123,6 @@ TEST(hpack, rbtree_del_rebalance)
 	collect_compound_str(s10, s10_value, 0);
 
 	tbl = &ctx.hpack.enc_tbl;
-
-#define ADD_NODE(s, n)								\
-do {										\
-	res = tfw_hpack_rbtree_find(tbl, s, &n, &pl);				\
-	EXPECT_EQ(res, HPACK_IDX_ST_NOT_FOUND);					\
-	EXPECT_NULL(n);								\
-	EXPECT_OK(tfw_hpack_add_node(tbl, s, &pl, TFW_H2_TRANS_INPLACE));	\
-	bzero_fast(&pl, sizeof(pl));						\
-	res = tfw_hpack_rbtree_find(tbl, s, &n, &pl);				\
-	EXPECT_EQ(res, HPACK_IDX_ST_FOUND);					\
-	EXPECT_NULL(pl.parent);							\
-	EXPECT_NOT_NULL(n);							\
-} while (0)
 
 	ADD_NODE(s1, n1);
 	ADD_NODE(s2, n2);
@@ -2240,9 +2225,9 @@ do {										\
 	EXPECT_EQ(HPACK_NODE_COND(tbl, n9->right), n10);
 	EXPECT_NULL(HPACK_NODE_COND(tbl, n10->left));
 	EXPECT_NULL(HPACK_NODE_COND(tbl, n10->right));
+}
 
 #undef ADD_NODE
-}
 
 TEST_SUITE(hpack)
 {

--- a/tempesta_fw/t/unit/test_hpack.c
+++ b/tempesta_fw/t/unit/test_hpack.c
@@ -1901,6 +1901,177 @@ TEST(hpack, enc_table_rbtree)
 #undef HDR_VALUE_5
 }
 
+TEST(hpack, rbtree_ins_rebalance)
+{
+	TfwHPackETbl *tbl;
+	TfwHPackETblRes res;
+	TfwHPackNodeIter pl = {};
+	const TfwHPackNode *n1 = NULL, *n2 = NULL, *n3 = NULL, *n4 = NULL;
+	const TfwHPackNode *n5 = NULL, *n6 = NULL, *n7 = NULL, *n8 = NULL;
+	const TfwHPackNode *n9 = NULL, *n10 = NULL;
+
+	TFW_STR(col, ":");
+	TFW_STR(s1, "80");
+	TFW_STR(s1_value, "80");
+	TFW_STR(s2, "70");
+	TFW_STR(s2_value, "70");
+	TFW_STR(s3, "60");
+	TFW_STR(s3_value, "60");
+	TFW_STR(s4, "50");
+	TFW_STR(s4_value, "50");
+	TFW_STR(s5, "40");
+	TFW_STR(s5_value, "40");
+	TFW_STR(s6, "30");
+	TFW_STR(s6_value, "30");
+	TFW_STR(s7, "20");
+	TFW_STR(s7_value, "20");
+	TFW_STR(s8, "55");
+	TFW_STR(s8_value, "55");
+	TFW_STR(s9, "65");
+	TFW_STR(s9_value, "65");
+	TFW_STR(s10, "67");
+	TFW_STR(s10_value, "67");
+
+	collect_compound_str(s1, col, 0);
+	collect_compound_str(s1, s1_value, 0);
+	collect_compound_str(s2, col, 0);
+	collect_compound_str(s2, s2_value, 0);
+	collect_compound_str(s3, col, 0);
+	collect_compound_str(s3, s3_value, 0);
+	collect_compound_str(s4, col, 0);
+	collect_compound_str(s4, s4_value, 0);
+	collect_compound_str(s5, col, 0);
+	collect_compound_str(s5, s5_value, 0);
+	collect_compound_str(s6, col, 0);
+	collect_compound_str(s6, s6_value, 0);
+	collect_compound_str(s7, col, 0);
+	collect_compound_str(s7, s7_value, 0);
+	collect_compound_str(s8, col, 0);
+	collect_compound_str(s8, s8_value, 0);
+	collect_compound_str(s9, col, 0);
+	collect_compound_str(s9, s9_value, 0);
+	collect_compound_str(s10, col, 0);
+	collect_compound_str(s10, s10_value, 0);
+
+	tbl = &ctx.hpack.enc_tbl;
+
+#define ADD_NODE(s, n)								\
+do {										\
+	res = tfw_hpack_rbtree_find(tbl, s, &n, &pl);				\
+	EXPECT_EQ(res, HPACK_IDX_ST_NOT_FOUND);					\
+	EXPECT_NULL(n);								\
+	EXPECT_OK(tfw_hpack_add_node(tbl, s, &pl, TFW_H2_TRANS_INPLACE));	\
+	bzero_fast(&pl, sizeof(pl));						\
+	res = tfw_hpack_rbtree_find(tbl, s, &n, &pl);				\
+	EXPECT_EQ(res, HPACK_IDX_ST_FOUND);					\
+	EXPECT_NULL(pl.parent);							\
+	EXPECT_NOT_NULL(n);							\
+} while (0)
+
+	ADD_NODE(s1, n1);
+	ADD_NODE(s2, n2);
+	ADD_NODE(s3, n3);
+	ADD_NODE(s4, n4);
+	ADD_NODE(s5, n5);
+	ADD_NODE(s6, n6);
+	ADD_NODE(s7, n7);
+	ADD_NODE(s8, n8);
+	ADD_NODE(s9, n9);
+
+	/*
+	 *                 n2
+	 *              (BLACK)
+	 *               /    \
+	 *              n4     n1
+	 *            (RED)  (BLACK)
+	 *            /    \
+	 *           n6     n3
+	 *        (BLACK) (BLACK)
+	 *         /  \     /  \
+	 *        n7  n5   n8   n9
+	 *     (RED)(RED) (RED)(RED)
+	 */
+
+	ADD_NODE(s10, n10);
+
+	/*
+	 * Add the node n10 as the right child of n9.
+	 * Because parent n9 - red and uncle n8 - red, we make them (n9 and n8)
+	 * black, and grandparent n3 - red.
+	 *                 n2
+	 *              (BLACK)
+	 *               /    \
+	 *              n4     n1
+	 *             (RED)  (BLACK)
+	 *            /     \
+	 *           n6     n3
+	 *        (BLACK)  (RED)
+	 *         /  \     /   \
+	 *        n7  n5   n8    n9
+	 *     (RED)(RED)(BLACK)(BLACK)
+	 *                         \
+	 *                         n10
+	 *                         (RED)
+	 * The grandparent n3 becomes the new current node.
+	 * Then, since the parent n4 of the current node n3 (great-grandparent of
+	 * the original n10) is red, and its uncle n1 is not red, and the node n3 is
+	 * the right child of the left child - we rotate to the left relative to the
+	 * parent n4.
+	 *                 n2
+	 *              (BLACK)
+	 *               /    \
+	 *              n3   n1
+	 *            (RED) (BLACK)
+	 *            /   \
+	 *           n4    n9
+	 *         (RED)  (BLACK)
+	 *        /     \      \
+	 *       n6     n8     n10
+	 *    (BLACK) (BLACK) (RED)
+	 *    /  \
+	 *   n7  n5
+	 *  (RED)(RED)
+	 * The new current node n4 is the left child of the current node n3.
+	 * Because the current node n4 is the left child of the left child, then we
+	 * make the parent n3 black and the grandparent n2 red and rotate to the
+	 * right relative to its grandparent n3.
+	 *                    n3
+	 *                 (BLACK)
+	 *               /         \
+	 *              n4          n2
+	 *            (RED)         (RED)
+	 *            /   \         /   \
+	 *           n6    n8      n9     n1
+	 *        (BLACK)(BLACK) (BLACK) (BLACK)
+	 *         /  \               \
+	 *        n7  n5              n10
+	 *     (RED)(RED)            (RED)
+	 */
+
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n3->left), n4);
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n4->left), n6);
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n6->left), n7);
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n7->left));
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n7->right));
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n6->right), n5);
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n5->left));
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n5->right));
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n4->right), n8);
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n8->left));
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n8->right));
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n3->right), n2);
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n2->left), n9);
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n9->left));
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n9->right), n10);
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n10->left));
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n10->right));
+	EXPECT_EQ(HPACK_NODE_COND(tbl, n2->right), n1);
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n1->left));
+	EXPECT_NULL(HPACK_NODE_COND(tbl, n1->right));
+
+#undef ADD_NODE
+}
+
 TEST_SUITE(hpack)
 {
 	TEST_SETUP(test_h2_setup);
@@ -1917,4 +2088,5 @@ TEST_SUITE(hpack)
 	TEST_RUN(hpack, enc_table_hdr_write);
 	TEST_RUN(hpack, enc_table_index);
 	TEST_RUN(hpack, enc_table_rbtree);
+	TEST_RUN(hpack, rbtree_ins_rebalance);
 }


### PR DESCRIPTION
fix #1408 
- copying each header to the cache, we must leave space for the string header, also, if there are duplicate headers, then we must write the duplicate header.

Earlier in the presence of duplicates, there was a double shift at the beginning of the copying procedure:
CSTR_MOVE_HDR
CSTR_WRITE_HDR
**CSTR_MOVE_HDR
CSTR_MOVE_HDR**
CSTR_WRITE_HDR

- eliminated the progressive accumulation of duplicate lengths

- some fixes for rebalancing procedure

- if hpack rb-tree node was deleted, then we look for a new place to add a node, because the old place may be invalid due to the reducing of the procedure for deleting a node with two children to deleting a node with less than two children


