### PR TITLE
Fix framing on long msg

### DIFF
--- a/tempesta_fw/cache.c
+++ b/tempesta_fw/cache.c
@@ -2112,7 +2112,7 @@ tfw_cache_build_resp(TfwHttpReq *req, TfwCacheEntry *ce, time_t lifetime,
 		 */
 		if (tfw_http_expand_hbh(resp, ce->resp_status)
 		    || tfw_http_expand_hdr_via(resp)
-		    || tfw_http_set_loc_hdrs((TfwHttpMsg *)resp, req, true)
+		    || tfw_h1_set_loc_hdrs((TfwHttpMsg *)resp, true, true)
 		    || (lifetime > ce->lifetime
 			&& tfw_http_expand_stale_warn(resp))
 		    || (!test_bit(TFW_HTTP_B_HDR_DATE, resp->flags)

--- a/tempesta_fw/hpack.c
+++ b/tempesta_fw/hpack.c
@@ -1834,7 +1834,7 @@ check_name_text:
 			/* All duplicate headers must be skipped by caller. */
 			WARN_ON_ONCE(test_bit(i, mit->found));
 			__set_bit(i, mit->found);
-			if (!TFW_STR_CHUNK(dc_iter->desc->hdr, 2)) {
+			if (!TFW_STR_CHUNK(dc_iter->desc->hdr, 1)) {
 				dc_iter->skip = true;
 				goto out;
 			}
@@ -1915,10 +1915,10 @@ get_value_text:
 			TfwStr n_val = {
 				.chunks = (TfwStr []){
 					{ .data = ", ", .len = 2 },
-					{ .data = __TFW_STR_CH(h, 2)->data,
-					  .len = __TFW_STR_CH(h, 2)->len }
+					{ .data = __TFW_STR_CH(h, 1)->data,
+					  .len = __TFW_STR_CH(h, 1)->len }
 				},
-				.len = __TFW_STR_CH(h, 2)->len + 2,
+				.len = __TFW_STR_CH(h, 1)->len + 2,
 				.nchunks = 2
 			};
 

--- a/tempesta_fw/hpack.c
+++ b/tempesta_fw/hpack.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2020 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -1834,6 +1834,12 @@ check_name_text:
 			/* All duplicate headers must be skipped by caller. */
 			WARN_ON_ONCE(test_bit(i, mit->found));
 			__set_bit(i, mit->found);
+			/*
+			 * Header modifications format: 0 chunk - header name,
+			 * optional 1st chunk - header value. If the value is
+			 * empty, then the header is about to be removed,
+			 * don't write it.
+			 */
 			if (!TFW_STR_CHUNK(dc_iter->desc->hdr, 1)) {
 				dc_iter->skip = true;
 				goto out;
@@ -1912,6 +1918,10 @@ get_value_text:
 
 		if (dc_iter->desc) {
 			TfwStr *val, *h = dc_iter->desc->hdr;
+			/*
+			 * Header value is stored in chunk 1, see
+			 * tfw_cfgop_mod_hdr_add().
+			 */
 			TfwStr n_val = {
 				.chunks = (TfwStr []){
 					{ .data = ", ", .len = 2 },

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -4160,7 +4160,7 @@ do {									\
 	frame_hdr.flags = (len) ?  0 : (hdr_flags);			\
 	tfw_h2_pack_frame_header(buf, &frame_hdr);			\
 									\
-	r = tfw_http_msg_insert(iter, data, &frame_hdr_str);		\
+	r = tfw_http_msg_insert(iter, &data, &frame_hdr_str);		\
 	if (unlikely(r)) 						\
 		return r;						\
 } while ((len));

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2936,6 +2936,7 @@ tfw_http_set_loc_hdrs(TfwHttpMsg *hm, TfwHttpReq *req, bool cache)
 			TfwHttpResp *resp = (TfwHttpResp *)hm;
 			struct sk_buff **skb_head = &resp->msg.skb_head;
 			TfwHttpTransIter *mit = &resp->mit;
+			TfwStr crlf = { .data = S_CRLF, .len = SLEN(S_CRLF) };
 			/*
 			 * Skip the configured header if we have already
 			 * processed it during cache reading, or if the header
@@ -2946,6 +2947,8 @@ tfw_http_set_loc_hdrs(TfwHttpMsg *hm, TfwHttpReq *req, bool cache)
 
 			r = tfw_http_msg_expand_data(&mit->iter, skb_head,
 						     &h_mdf, NULL);
+			r |= tfw_http_msg_expand_data(&mit->iter, skb_head,
+						     &crlf, NULL);
 		} else {
 			r = tfw_http_msg_hdr_xfrm_str(hm, &h_mdf, d->hid,
 						      d->append);

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -2893,15 +2893,25 @@ tfw_http_should_validate_post_req(TfwHttpReq *req)
 	return false;
 }
 
+/**
+ * Add local headers (defined by administrator in configuration file) to http/1
+ * message.
+ *
+ * @hm		- Message to be updated;
+ * @is_resp	- Message represents response, not request;
+ * @from_cache	- The response is created from cache, not applied to requests.
+ */
 int
-tfw_http_set_loc_hdrs(TfwHttpMsg *hm, TfwHttpReq *req, bool cache)
+tfw_h1_set_loc_hdrs(TfwHttpMsg *hm, bool is_resp, bool from_cache)
 {
 	size_t i;
-	bool hm_req = (hm == (TfwHttpMsg *)req);
-	int mod_type = hm_req ? TFW_VHOST_HDRMOD_REQ : TFW_VHOST_HDRMOD_RESP;
+	int mod_type = is_resp ? TFW_VHOST_HDRMOD_RESP : TFW_VHOST_HDRMOD_REQ;
+	TfwHttpReq *req = is_resp ? hm->req : (TfwHttpReq *)hm;
 	TfwHdrMods *h_mods = tfw_vhost_get_hdr_mods(req->location, req->vhost,
 						    mod_type);
-	BUG_ON(hm_req && cache);
+
+	if(WARN_ON_ONCE(!is_resp && from_cache))
+		return -EINVAL;
 	if (!h_mods)
 		return 0;
 
@@ -2932,7 +2942,12 @@ tfw_http_set_loc_hdrs(TfwHttpMsg *hm, TfwHttpReq *req, bool cache)
 		h_mdf.flags = d->hdr->flags;
 		h_mdf.eolen += d->hdr->eolen;
 
-		if (!hm_req && cache) {
+		/*
+		 * A response is built from cache. Response is stored in
+		 * cache optimised for h2 and it's being created
+		 * header-by-header right away.
+		 */
+		if (from_cache) {
 			TfwHttpResp *resp = (TfwHttpResp *)hm;
 			struct sk_buff **skb_head = &resp->msg.skb_head;
 			TfwHttpTransIter *mit = &resp->mit;
@@ -2944,7 +2959,7 @@ tfw_http_set_loc_hdrs(TfwHttpMsg *hm, TfwHttpReq *req, bool cache)
 			 */
 			if (test_bit(i, mit->found) || h_mdf.nchunks < 3)
 				continue;
-
+			/* h_mdf->eolen is ignored, add explicit CRLF. */
 			r = tfw_http_msg_expand_data(&mit->iter, skb_head,
 						     &h_mdf, NULL);
 			r |= tfw_http_msg_expand_data(&mit->iter, skb_head,
@@ -2991,7 +3006,7 @@ tfw_h1_adjust_req(TfwHttpReq *req)
 	if (r < 0)
 		return r;
 
-	r = tfw_http_set_loc_hdrs(hm, req, false);
+	r = tfw_h1_set_loc_hdrs(hm, false, false);
 	if (r < 0)
 		return r;
 
@@ -3537,7 +3552,7 @@ tfw_http_adjust_resp(TfwHttpResp *resp)
 	if (r < 0)
 		return r;
 
-	r = tfw_http_set_loc_hdrs(hm, req, false);
+	r = tfw_h1_set_loc_hdrs(hm, true, false);
 	if (r < 0)
 		return r;
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -654,7 +654,7 @@ void tfw_http_resp_fwd(TfwHttpResp *resp);
 void tfw_http_resp_build_error(TfwHttpReq *req);
 int tfw_cfgop_parse_http_status(const char *status, int *out);
 void tfw_http_hm_srv_send(TfwServer *srv, char *data, unsigned long len);
-int tfw_http_set_loc_hdrs(TfwHttpMsg *hm, TfwHttpReq *req, bool cache);
+int tfw_h1_set_loc_hdrs(TfwHttpMsg *hm, bool is_resp, bool from_cache);
 int tfw_http_expand_stale_warn(TfwHttpResp *resp);
 int tfw_http_expand_hdr_date(TfwHttpResp *resp);
 int tfw_http_expand_hbh(TfwHttpResp *resp, unsigned short status);

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -1448,6 +1448,7 @@ tfw_http_msg_insert(TfwMsgIter *it, char **off, const TfwStr *data)
 	}
 
 	*off = dst.data;
+	it->skb = dst.skb;
 
 	return tfw_strcpy(&dst, data);
 }

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -1443,7 +1443,9 @@ tfw_http_msg_insert(TfwMsgIter *it, char **off, const TfwStr *data)
 	int r;
 	TfwStr dst = {};
 
-	if ((r = ss_skb_get_room_w_frag(it->skb_head, it->skb, *off, data->len, &dst, &it->frag))) {
+	if ((r = ss_skb_get_room_w_frag(it->skb_head, it->skb, *off, data->len,
+					&dst, &it->frag)))
+	{
 		return r;
 	}
 

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -952,34 +952,6 @@ tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm)
 	return 0;
 }
 
-int
-tfw_http_msg_del_eol(struct sk_buff *skb_head, TfwStr *hdr)
-{
-	int r;
-	TfwStr it = {};
-	int eolen = tfw_str_eolen(hdr);
-	TfwStr *last = TFW_STR_LAST(hdr);
-
-	if ((r = skb_next_data(last->skb, last->data + last->len - 1, &it)))
-		return r;
-
-	while (eolen) {
-		char *ptr = it.data;
-		struct sk_buff *skb = it.skb;
-
-		bzero_fast(&it, sizeof(TfwStr));
-		if ((r = skb_fragment(skb_head, skb, ptr, -eolen, &it)))
-			return r;
-
-		if (WARN_ON_ONCE(r > eolen))
-			return -EINVAL;
-
-		eolen -= r;
-	}
-
-	return 0;
-}
-
 /**
  * Modify message body, add string @data to the end of the body (if @append) or
  * to its beginning.

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -188,7 +188,7 @@ int __http_hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr);
 int tfw_h2_msg_rewrite_data(TfwHttpTransIter *mit, const TfwStr *str,
 			    const char *stop);
 
-int tfw_http_msg_insert(TfwMsgIter *it, char *off, const TfwStr *data);
+int tfw_http_msg_insert(TfwMsgIter *it, char **off, const TfwStr *data);
 
 #define TFW_H2_MSG_HDR_ADD(hm, name, val, idx)				\
 	tfw_h2_msg_hdr_add(hm, name, sizeof(name) - 1, val,		\

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -170,7 +170,6 @@ int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 
 int tfw_http_msg_del_str(TfwHttpMsg *hm, TfwStr *str);
 int tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm);
-int tfw_http_msg_del_eol(struct sk_buff *skb_head, TfwStr *hdr);
 int tfw_http_msg_to_chunked(TfwHttpMsg *hm);
 
 int tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len,

--- a/tempesta_fw/msg.c
+++ b/tempesta_fw/msg.c
@@ -132,10 +132,18 @@ tfw_msg_iter_move(TfwMsgIter *it, unsigned char **data, unsigned long sz)
 
 		/* Linear skb part. */
 		if (it->frag < 0) {
+			unsigned char *begin = it->skb->data;
+			unsigned char *end = begin + skb_headlen(it->skb);
+			if (unlikely(addr < begin || addr > end))
+				addr = begin;
 			f_sz_rem = skb_headlen(it->skb) + it->skb->data - addr;
 		}
 		else {
 			skb_frag_t *f = &skb_shinfo(it->skb)->frags[it->frag];
+			unsigned char *begin = skb_frag_address(f);
+			unsigned char *end = begin + skb_frag_size(f);
+			if (unlikely(addr < begin || addr > end))
+				addr = begin;
 			f_sz_rem = skb_frag_size(f) +
 				(unsigned char *)skb_frag_address(f) - addr;
 		}

--- a/tempesta_fw/msg.c
+++ b/tempesta_fw/msg.c
@@ -132,18 +132,10 @@ tfw_msg_iter_move(TfwMsgIter *it, unsigned char **data, unsigned long sz)
 
 		/* Linear skb part. */
 		if (it->frag < 0) {
-			unsigned char *begin = it->skb->data;
-			unsigned char *end = begin + skb_headlen(it->skb);
-			if (unlikely(addr < begin || addr > end))
-				addr = begin;
 			f_sz_rem = skb_headlen(it->skb) + it->skb->data - addr;
 		}
 		else {
 			skb_frag_t *f = &skb_shinfo(it->skb)->frags[it->frag];
-			unsigned char *begin = skb_frag_address(f);
-			unsigned char *end = begin + skb_frag_size(f);
-			if (unlikely(addr < begin || addr > end))
-				addr = begin;
 			f_sz_rem = skb_frag_size(f) +
 				(unsigned char *)skb_frag_address(f) - addr;
 		}

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -228,15 +228,18 @@ success:
  * expected to have SKB fragments.
  */
 static inline void *
-__skb_data_address(struct sk_buff *skb)
+__skb_data_address(struct sk_buff *skb, int *fragn)
 {
+	*fragn = -1;
 	if (skb == NULL)
 		return NULL;
 	if (skb_headlen(skb))
 		return skb->data;
 	WARN_ON_ONCE(!skb_is_nonlinear(skb));
-	if (skb_shinfo(skb)->nr_frags)
+	if (skb_shinfo(skb)->nr_frags) {
+		*fragn = 0;
 		return skb_frag_address(&skb_shinfo(skb)->frags[0]);
+	}
 	WARN_ON_ONCE(skb_has_frag_list(skb));
 	return NULL;
 }
@@ -256,8 +259,7 @@ __it_next_data(struct sk_buff *skb, int i, TfwStr *it, int *fragn)
 		*fragn = i;
 	} else {
 		it->skb = skb->next;
-		it->data = __skb_data_address(it->skb);
-		*fragn = -1;
+		it->data = __skb_data_address(it->skb, fragn);
 	}
 }
 

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -858,7 +858,14 @@ ss_skb_get_room(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
 	int r = skb_fragment(skb_head, skb, pspt, len, it);
 	if (r == len)
 		return 0;
-	return r;
+	/*
+	 * TODO: skb_fragment() returns a number of processed data, which can
+	 * differ from the requested one: inserted or removed part of data is
+	 * less than requested and the caller has to handle it. Currently
+	 * none of the callers support that, just raise -ENOMEM in that case,
+	 * since the error is passed further.
+	 */
+	return r <= 0 ? r : -ENOMEM;
 }
 
 /**

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -788,18 +788,13 @@ __skb_fragment(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
 		d_size = skb_frag_size(frag);
 		offset = pspt - (char *)skb_frag_address(frag);
 
-		if (offset >= 0 && offset <= d_size) {
+		/*
+		 * @pspt can be the end of a frag, but it can also be a start of
+		 * another fragment. Not necessary, that both frags are
+		 * neighbours.
+		 */
+		if (offset >= 0 && offset < d_size) {
 			int t_size = d_size - offset;
-			if (!t_size) {
-				/*
-				 * @pspt is at the end of the frag (zero tail
-				 * length): append if @len > 0 or move to the
-				 * next frag for deletion.
-				 */
-				if (len > 0)
-					goto append;
-				continue;
-			}
 			len = max(len, -t_size);
 			ret = __split_pgfrag(skb_head, skb, i, offset, len, it);
 			goto done;

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -1426,7 +1426,7 @@ ss_skb_dump(struct sk_buff *skb)
 
 	for (i = 0; i < si->nr_frags; ++i) {
 		const skb_frag_t *f = &si->frags[i];
-		T_LOG_NL("  frag %d (addr=%p pg_off=%u size=%u pg_ref=%d):\n",
+		T_LOG_NL("  frag %2d (addr=%p pg_off=%-4u size=%-4u pg_ref=%d):\n",
 			 i, skb_frag_address(f), f->page_offset,
 			 skb_frag_size(f), page_ref_count(skb_frag_page(f)));
 		print_hex_dump(KERN_INFO, "    ", DUMP_PREFIX_OFFSET, 16, 1,

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -843,7 +843,7 @@ done:
 	return abs(len);
 }
 
-int
+static int
 skb_fragment(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
 	     int len, TfwStr *it, int *fragn)
 {

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -211,7 +211,7 @@ struct sk_buff *ss_skb_split(struct sk_buff *skb, int len);
 int ss_skb_get_room(struct sk_buff *skb_head, struct sk_buff *skb,
 		    char *pspt, unsigned int len, TfwStr *it);
 int ss_skb_get_room_w_frag(struct sk_buff *skb_head, struct sk_buff *skb,
-                           char *pspt, unsigned int len, TfwStr *it, int *fragn);
+			   char *pspt, unsigned int len, TfwStr *it, int *fragn);
 int ss_skb_expand_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,
 			    size_t head, size_t tail);
 int ss_skb_chop_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -208,8 +208,6 @@ char *ss_skb_fmt_src_addr(const struct sk_buff *skb, char *out_buf);
 int ss_skb_alloc_data(struct sk_buff **skb_head, size_t len,
 		      unsigned int tx_flags);
 struct sk_buff *ss_skb_split(struct sk_buff *skb, int len);
-int skb_fragment(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
-                 int len, TfwStr *it, int *fragn);
 int ss_skb_get_room(struct sk_buff *skb_head, struct sk_buff *skb,
 		    char *pspt, unsigned int len, TfwStr *it);
 int ss_skb_get_room_w_frag(struct sk_buff *skb_head, struct sk_buff *skb,

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -209,9 +209,11 @@ int ss_skb_alloc_data(struct sk_buff **skb_head, size_t len,
 		      unsigned int tx_flags);
 struct sk_buff *ss_skb_split(struct sk_buff *skb, int len);
 int skb_fragment(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
-		 int len, TfwStr *it);
+                 int len, TfwStr *it, int *fragn);
 int ss_skb_get_room(struct sk_buff *skb_head, struct sk_buff *skb,
 		    char *pspt, unsigned int len, TfwStr *it);
+int ss_skb_get_room_w_frag(struct sk_buff *skb_head, struct sk_buff *skb,
+                           char *pspt, unsigned int len, TfwStr *it, int *fragn);
 int ss_skb_expand_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,
 			    size_t head, size_t tail);
 int ss_skb_chop_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,

--- a/tempesta_fw/vhost.h
+++ b/tempesta_fw/vhost.h
@@ -66,7 +66,9 @@ typedef struct {
  * Headers modification description.
  *
  * @hdr		- Header string, see @tfw_http_msg_hdr_xfrm_str();
- * @add_hdrs	- Headers to modify;
+ * @hid		- Header index in the header table;
+ * @append	- if set the value is added to the end of an existing header,
+ *		  otherwise the original value is overwritten with given one.
  */
 struct tfw_hdr_mods_desc_t {
 	TfwStr		*hdr;


### PR DESCRIPTION
Although #1400 already fixed the issue, a bug remained hidden there thus client received 500 response instead of huge files over H2 connections. This happened because after H2 frame header is inserted, the message iterator and index pointer in whole represent invalid pointer to skb data. Now the pointer is fixed before iterator move and huge responsed are served as normal.

The second issue fixed in the PR is header modifications of http/1 responses served from cache. Detailed description is provided in commit messages.