### PR TITLE
Implement frang limits for TLS layer

### DIFF
--- a/lib/hash.h
+++ b/lib/hash.h
@@ -39,4 +39,14 @@ hash_calc(const char *data, size_t len)
 	return (crc1 << 32) | crc0;
 }
 
+static inline unsigned long
+hash_calc_update(const char *data, size_t len, unsigned long hash)
+{
+	unsigned long crc0 = hash >> 32, crc1 = hash & 0xFFFFFFFF;
+
+	__hash_calc(&crc0, &crc1, data, len);
+
+	return (crc1 << 32) | crc0;
+}
+
 #endif /* __LIB_HASH_H__ */

--- a/tempesta_fw/client.h
+++ b/tempesta_fw/client.h
@@ -45,4 +45,6 @@ void tfw_cli_conn_release(TfwCliConn *cli_conn);
 int tfw_cli_conn_send(TfwCliConn *cli_conn, TfwMsg *msg);
 int tfw_cli_conn_close_all_sync(TfwClient *cli);
 
+void tfw_tls_connection_lost(TfwConn *conn);
+
 #endif /* __TFW_CLIENT_H__ */

--- a/tempesta_fw/gfsm.h
+++ b/tempesta_fw/gfsm.h
@@ -88,6 +88,7 @@ enum {
 	/* Security rules enforcement. */
 	TFW_FSM_FRANG_REQ,
 	TFW_FSM_FRANG_RESP,
+	TFW_FSM_FRANG_TLS,
 
 	TFW_FSM_NUM /* Must be <= TFW_GFSM_FSM_N */
 };

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -447,6 +447,7 @@ struct tfw_http_req_t {
 	unsigned long		hash;
 	unsigned int		frang_st;
 	unsigned int		chunk_cnt;
+	unsigned int		host_port;
 	unsigned short		node;
 	unsigned short		retries;
 	unsigned char		method;

--- a/tempesta_fw/http_limits.h
+++ b/tempesta_fw/http_limits.h
@@ -38,7 +38,7 @@
 #ifdef CONFIG_DEBUG_LOCK_ALLOC
 #define TFW_CLASSIFIER_ACCSZ	512
 #else
-#define TFW_CLASSIFIER_ACCSZ	256
+#define TFW_CLASSIFIER_ACCSZ	264
 #endif
 
 typedef struct { char _[TFW_CLASSIFIER_ACCSZ]; } TfwClassifierPrvt;
@@ -174,6 +174,10 @@ typedef struct {
  *			  client;
  * @conn_burst		- Allowed connection rate burst;
  * @conn_max		- Maximum number of allowed concurrent connections;
+ * @tls_new_conn_rate	- Maximum new tls connections with full handshakes per
+ *			  second from the same client;
+ * @tls_new_conn_burst	- New tls connections burst;
+ * @tls_uncomplete_rate - Maximum rate of uncompleted tls connections;
  * @http_hchunk_cnt	- Maximum number of chunks in header part;
  * @http_bchunk_cnt	- Maximum number of chunks in body part;
  * @ip_block		- Block clients by IP address if set, if not - just
@@ -189,6 +193,10 @@ struct frang_global_cfg_t {
 	unsigned int		conn_rate;
 	unsigned int		conn_burst;
 	unsigned int		conn_max;
+
+	unsigned int		tls_new_conn_rate;
+	unsigned int		tls_new_conn_burst;
+	unsigned int		tls_uncomplete_rate;
 
 	unsigned int		http_hchunk_cnt;
 	unsigned int		http_bchunk_cnt;

--- a/tempesta_fw/http_limits.h
+++ b/tempesta_fw/http_limits.h
@@ -177,7 +177,7 @@ typedef struct {
  * @tls_new_conn_rate	- Maximum new tls connections with full handshakes per
  *			  second from the same client;
  * @tls_new_conn_burst	- New tls connections burst;
- * @tls_uncomplete_rate - Maximum rate of uncompleted tls connections;
+ * @tls_incomplete_conn_rate - Maximum rate of uncompleted tls connections;
  * @http_hchunk_cnt	- Maximum number of chunks in header part;
  * @http_bchunk_cnt	- Maximum number of chunks in body part;
  * @ip_block		- Block clients by IP address if set, if not - just
@@ -196,7 +196,7 @@ struct frang_global_cfg_t {
 
 	unsigned int		tls_new_conn_rate;
 	unsigned int		tls_new_conn_burst;
-	unsigned int		tls_uncomplete_rate;
+	unsigned int		tls_incomplete_conn_rate;
 
 	unsigned int		http_hchunk_cnt;
 	unsigned int		http_bchunk_cnt;

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -251,7 +251,7 @@ tfw_sock_clnt_drop(struct sock *sk)
 	/*
 	 * A TLS connection was lost during handshake processing. Call FSM
 	 * hooks to warn the Frang, since it accounts uncompleted TLS
-	 * handshakes. Can't done it on frang_conn_close() since connection is
+	 * handshakes. Can't be done on frang_conn_close() since connection is
 	 * unlinked from socket on that time and can be already destroyed.
 	 */
 	if (TFW_CONN_TLS(conn))

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -249,6 +249,15 @@ tfw_sock_clnt_drop(struct sock *sk)
 	spin_unlock(&((TfwCliConn *)conn)->timer_lock);
 
 	/*
+	 * A TLS connection was lost during handshake processing. Call FSM
+	 * hooks to warn the Frang, since it accounts uncompleted TLS
+	 * handshakes. Can't done it on frang_conn_close() since connection is
+	 * unlinked from socket on that time and can be already destroyed.
+	 */
+	if (TFW_CONN_TLS(conn))
+		tfw_tls_connection_lost(conn);
+
+	/*
 	 * Withdraw from socket activity. Connection is now closed,
 	 * and Tempesta is not called anymore on events in the socket.
 	 * Remove the connection from the list that is kept in @peer.

--- a/tempesta_fw/t/unit/test_http_parser.c
+++ b/tempesta_fw/t/unit/test_http_parser.c
@@ -1778,7 +1778,7 @@ TEST(http_parser, host)
 			 "Host: tempesta-tech.com 443\n"
 			 "\n");
 
-	/* No braces around IPv6. */
+	/* No brackets around IPv6. */
 	EXPECT_BLOCK_REQ("GET / HTTP/1.1\n"
 			 "Host: fd42:5ca1:e3a7::1000\n"
 			 "\n");

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -822,7 +822,8 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 	return 0;
 }
 
-unsigned long ttls_cli_id(TlsCtx *tls, unsigned long hash)
+static unsigned long
+ttls_cli_id(TlsCtx *tls, unsigned long hash)
 {
 	TfwCliConn *cli_conn = &container_of(tls, TfwTlsConn, tls)->cli_conn;
 

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -816,7 +816,8 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 		      __func__, PR_TFW_STR(&srv_name),
 		      PR_TFW_STR(&vhost->name));
 	}
-	ttls_hs_add_sni_hash(ctx, data, len);
+	/* Save processed server name as hash. */
+	ctx->sni_hash = len ? hash_calc(data, len) : 0;
 
 	return 0;
 }

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -117,7 +117,7 @@ void
 tfw_tls_connection_lost(TfwConn *conn)
 {
 	TlsCtx *tls = &((TfwTlsConn *)conn)->tls;
-	TfwFsmData data_up = { .req = ERR_PTR(-TTLS_HS_CB_UNCOMPLETE)};
+	TfwFsmData data_up = { .req = ERR_PTR(-TTLS_HS_CB_INCOMPLETE)};
 
 	if (!ttls_hs_done(tls))
 		tfw_gfsm_move(&conn->state, TFW_TLS_FSM_HS_DONE, &data_up);
@@ -152,7 +152,7 @@ next_msg:
 	case T_DROP:
 		spin_unlock(&tls->lock);
 		if (!ttls_hs_done(tls))
-			tfw_tls_hs_over(tls, TTLS_HS_CB_UNCOMPLETE);
+			tfw_tls_hs_over(tls, TTLS_HS_CB_INCOMPLETE);
 		/* The skb is freed in tfw_tls_conn_dtor(). */
 		return r;
 	case T_POSTPONE:

--- a/tempesta_fw/tls.h
+++ b/tempesta_fw/tls.h
@@ -32,8 +32,18 @@
 enum {
 	/* TLS FSM initial state, not hookable. */
 	TFW_TLS_FSM_INIT	= TFW_GFSM_TLS_STATE(0),
-
-	TFW_TLS_FSM_DATA_READY	= TFW_GFSM_TLS_STATE(1),
+	/*
+	 * A TLS Handshake has been completed on a connection. Client could
+	 * either process a new full handshake or resume previous session. The
+	 * state is also reached if the handshake process ended up with the
+	 * error or never reached the final stage.
+	 */
+	TFW_TLS_FSM_HS_DONE	= TFW_GFSM_TLS_STATE(1),
+	/*
+	 * A new portion of data is decrypted and ready to be consumed by the
+	 * upper layers.
+	 */
+	TFW_TLS_FSM_DATA_READY	= TFW_GFSM_TLS_STATE(2),
 
 	TFW_TLS_FSM_DONE	= TFW_GFSM_TLS_STATE(TFW_GFSM_STATE_LAST)
 };

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -28,7 +28,7 @@
 #define TLS_CONF_CERT_NUM	8
 
 typedef struct {
-	ttls_x509_crt	crt;
+	TlsX509Crt	crt;
 	TlsPkCtx	key;
 	unsigned long	crt_pg_addr;
 	unsigned int	crt_pg_order;

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -297,7 +297,7 @@ tfw_tls_set_tickets(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 	ce_tmp = *ce;
 	ce_tmp.attr_n = 0;
 	cs->dest = &enabled;
-	if (tfw_cfg_set_bool(cs, ce))  {
+	if (tfw_cfg_set_bool(cs, &ce_tmp)) {
 		T_ERR_NL("%s: can't parse positional values!\n", cs->name);
 		cs->dest = NULL;
 		return -EINVAL;

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -2421,6 +2421,36 @@ static TfwCfgSpec tfw_global_frang_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
+		.name = "tls_connection_rate",
+		.deflt = "0",
+		.handler = tfw_cfgop_frang_glob_set_int,
+		.dest = &tfw_frang_glob_reconfig.tls_new_conn_rate,
+		.spec_ext = &(TfwCfgSpecInt) {
+			.range = { 0, INT_MAX },
+		},
+		.allow_reconfig = true,
+	},
+	{
+		.name = "tls_connection_burst",
+		.deflt = "0",
+		.handler = tfw_cfgop_frang_glob_set_int,
+		.dest = &tfw_frang_glob_reconfig.tls_new_conn_burst,
+		.spec_ext = &(TfwCfgSpecInt) {
+			.range = { 0, INT_MAX },
+		},
+		.allow_reconfig = true,
+	},
+	{
+		.name = "tls_uncomplete_rate",
+		.deflt = "0",
+		.handler = tfw_cfgop_frang_glob_set_int,
+		.dest = &tfw_frang_glob_reconfig.tls_uncomplete_rate,
+		.spec_ext = &(TfwCfgSpecInt) {
+			.range = { 0, INT_MAX },
+		},
+		.allow_reconfig = true,
+	},
+	{
 		.name = "client_header_timeout",
 		.deflt = "0",
 		.handler = tfw_cfgop_frang_hdr_timeout,
@@ -2564,6 +2594,24 @@ static TfwCfgSpec tfw_vhost_frang_specs[] = {
 	},
 	{
 		.name = "concurrent_connections",
+		.handler = tfw_cfgop_frang_glob_in_vhost,
+		.allow_reconfig = true,
+		.allow_none = true,
+	},
+	{
+		.name = "tls_connection_rate",
+		.handler = tfw_cfgop_frang_glob_in_vhost,
+		.allow_reconfig = true,
+		.allow_none = true,
+	},
+	{
+		.name = "tls_connection_burst",
+		.handler = tfw_cfgop_frang_glob_in_vhost,
+		.allow_reconfig = true,
+		.allow_none = true,
+	},
+	{
+		.name = "tls_uncomplete_rate",
 		.handler = tfw_cfgop_frang_glob_in_vhost,
 		.allow_reconfig = true,
 		.allow_none = true,

--- a/tempesta_fw/vhost.c
+++ b/tempesta_fw/vhost.c
@@ -2441,10 +2441,10 @@ static TfwCfgSpec tfw_global_frang_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
-		.name = "tls_uncomplete_rate",
+		.name = "tls_incomplete_connection_rate",
 		.deflt = "0",
 		.handler = tfw_cfgop_frang_glob_set_int,
-		.dest = &tfw_frang_glob_reconfig.tls_uncomplete_rate,
+		.dest = &tfw_frang_glob_reconfig.tls_incomplete_conn_rate,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.range = { 0, INT_MAX },
 		},
@@ -2611,7 +2611,7 @@ static TfwCfgSpec tfw_vhost_frang_specs[] = {
 		.allow_none = true,
 	},
 	{
-		.name = "tls_uncomplete_rate",
+		.name = "tls_incomplete_connection_rate",
 		.handler = tfw_cfgop_frang_glob_in_vhost,
 		.allow_reconfig = true,
 		.allow_none = true,

--- a/tls/error.c
+++ b/tls/error.c
@@ -216,7 +216,7 @@ void ttls_strerror(int ret, char *buf, size_t buflen)
 		if (use_ret == -(TTLS_ERR_X509_UNKNOWN_SIG_ALG))
 			snprintf(buf, buflen, "X509 - Signature algorithm (oid) is unsupported");
 		if (use_ret == -(TTLS_ERR_X509_SIG_MISMATCH))
-			snprintf(buf, buflen, "X509 - Signature algorithms do not match. (see \\c ::ttls_x509_crt sig_oid)");
+			snprintf(buf, buflen, "X509 - Signature algorithms do not match. (see \\c ::TlsX509Crt sig_oid)");
 		if (use_ret == -(TTLS_ERR_X509_CERT_VERIFY_FAILED))
 			snprintf(buf, buflen, "X509 - Certificate verification failed, e.g. CRL, CA or signature check failed");
 		if (use_ret == -(TTLS_ERR_X509_CERT_UNKNOWN_FORMAT))

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -247,7 +247,7 @@ int ttls_check_sig_hash(const TlsCtx *tls, ttls_md_type_t md);
 int ttls_match_sig_hashes(const TlsCtx *tls);
 void ttls_update_checksum(TlsCtx *tls, const unsigned char *buf, size_t len);
 
-static inline ttls_x509_crt *
+static inline TlsX509Crt *
 ttls_own_cert(TlsCtx *tls)
 {
 	TlsKeyCert *key_cert;
@@ -269,7 +269,7 @@ ttls_own_cert(TlsCtx *tls)
  *
  * Return 0 if everything is OK, -1 if not.
  */
-int ttls_check_cert_usage(const ttls_x509_crt *cert,
+int ttls_check_cert_usage(const TlsX509Crt *cert,
 			  const TlsCiphersuite *ciphersuite,
 			  int cert_endpoint,
 			  uint32_t *flags);

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -1592,7 +1592,7 @@ ttls_write_certificate_request(TlsCtx *tls, struct sg_table *sgt,
 	total_dn_size = 0;
 
 	if (tls->conf->cert_req_ca_list) {
-		const ttls_x509_crt * crt = tls->hs->key_cert->ca_chain;
+		const TlsX509Crt *crt = tls->hs->key_cert->ca_chain;
 
 		while (crt && crt->version) {
 			dn_size = crt->subject_raw.len;

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -31,6 +31,7 @@
 #include "tls_ticket.h"
 
 ttls_sni_cb_t *ttls_sni_cb;
+ttls_hs_over_cb_t *ttls_hs_over_cb;
 
 /**
  * TLS Fallback Signaling Cipher Suite Value (SCSV), RFC 7507 3.
@@ -2088,7 +2089,7 @@ int
 ttls_handshake_server_step(TlsCtx *tls, unsigned char *buf, size_t len,
 			   size_t hh_len, unsigned int *read)
 {
-	int r = 0;
+	int r = 0, resumed = 0;
 	/*
 	 * On session resumption the ChangeCipherSpec is sent right immediately
 	 * after ServerHello. Use shared buffer to send both messages at once.
@@ -2097,6 +2098,7 @@ ttls_handshake_server_step(TlsCtx *tls, unsigned char *buf, size_t len,
 	struct sg_table sgt = { .sgl = sg };
 	unsigned char *p = NULL;
 	struct page *pg = NULL;
+
 	T_FSM_INIT(tls->state, "TLS Server Handshake");
 
 	T_DBG("server state: %x\n", tls->state);
@@ -2218,11 +2220,14 @@ ttls_handshake_server_step(TlsCtx *tls, unsigned char *buf, size_t len,
 	}
 
 	T_FSM_STATE(TTLS_HANDSHAKE_WRAPUP) {
+		resumed = tls->hs->resume;
 		ttls_handshake_wrapup(tls);
 		tls->state = TTLS_HANDSHAKE_OVER;
 	}
 	T_FSM_STATE(TTLS_HANDSHAKE_OVER) {
 		WARN_ON_ONCE(r);
+		r = ttls_hs_over_cb(tls, resumed ? TTLS_HS_CB_FINISHED_RESUMED
+						 : TTLS_HS_CB_FINISHED_NEW);
 		T_FSM_EXIT();
 	}
 

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -1801,6 +1801,15 @@ ttls_parse_certificate_verify(TlsCtx *tls, unsigned char *buf, size_t len,
 	ttls_md_type_t md_alg;
 	TlsIOCtx *io = &tls->io_in;
 
+	/*
+	 * TODO #830. The timeout between the Certificate Request message and
+	 * Certificate verify is not known and can be extended to infinite by
+	 * constant activity on TLS connections (e.g. by non-critical alerts).
+	 * There can be some concerns that client has actual access to the
+	 * private key, see
+	 * https://www.ndss-symposium.org/wp-content/uploads/2017/09/12_4_1.pdf
+	 */
+
 	BUG_ON(io->msgtype != TTLS_MSG_HANDSHAKE);
 	if (io->hstype != TTLS_HS_CERTIFICATE_VERIFY) {
 		T_DBG("bad certificate verify message\n");

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -485,17 +485,14 @@ ttls_ticket_sess_load(TlsState *state, size_t len, unsigned long lifetime)
 		TlsSess *sess = &state->sess;
 		int r;
 
-		sess->peer_cert = kmalloc(sizeof(TlsX509Crt), GFP_ATOMIC);
+		sess->peer_cert = ttls_x509_crt_alloc();
 		if (!sess->peer_cert)
 			return TTLS_ERR_ALLOC_FAILED;
 
-		ttls_x509_crt_init(sess->peer_cert);
 		r = ttls_x509_crt_parse_der(sess->peer_cert, state->cert_data,
 					    state->cert_len);
 		if (r) {
-			ttls_x509_crt_free(sess->peer_cert);
-			kfree(sess->peer_cert);
-			sess->peer_cert = NULL;
+			ttls_x509_crt_destroy(&sess->peer_cert);
 			return r;
 		}
 	}

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -485,7 +485,7 @@ ttls_ticket_sess_load(TlsState *state, size_t len, unsigned long lifetime)
 		TlsSess *sess = &state->sess;
 		int r;
 
-		sess->peer_cert = kmalloc(sizeof(ttls_x509_crt), GFP_ATOMIC);
+		sess->peer_cert = kmalloc(sizeof(TlsX509Crt), GFP_ATOMIC);
 		if (!sess->peer_cert)
 			return TTLS_ERR_ALLOC_FAILED;
 

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -498,12 +498,7 @@ ttls_ticket_sess_load(TlsState *state, size_t len, unsigned long lifetime)
 
 	/*
 	 * TODO #830: we can save resources on certificate parsing and
-	 * validating, if the restored session is relatively young or last
-	 * client TLS session was successfully resumed recently. In normal
-	 * conditions a client opens a several TLS connections at once. It makes
-	 * sense to avoid frequent validations of the same certificate,
-	 * especially if it was validated on a full handshake.
-	 *
+	 * validating, if the restored session is relatively young.
 	 * Or we can fully bypass certificate-related code in this module
 	 * if ticket lifetime is less that timeout to deliver revoked
 	 * certificates to revoked storage. Alternatively if a lot of

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -309,7 +309,7 @@ ttls_tickets_configure(TlsPeerCfg *cfg, unsigned long lifetime,
 	}
 
 	for (i = 0; i < 2; i++) {
-		unsigned char kn_hash[TTLS_TICKET_KEY_LEN];
+		unsigned char kn_hash[SHA256_DIGEST_SIZE];
 		TlsTicketKey *key = &tcfg->keys[i];
 		unsigned long ts;
 

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -295,7 +295,7 @@ ttls_session_copy(TlsSess *dst, const TlsSess *src)
 	if (src->peer_cert) {
 		int r;
 
-		dst->peer_cert = kmalloc(sizeof(ttls_x509_crt), GFP_ATOMIC);
+		dst->peer_cert = kmalloc(sizeof(TlsX509Crt), GFP_ATOMIC);
 		if (!dst->peer_cert)
 			return -ENOMEM;
 
@@ -1362,7 +1362,7 @@ ttls_write_certificate(TlsCtx *tls, struct sg_table *sgt,
 {
 	unsigned int sg_i;
 	size_t n, tot_len = 0;
-	const ttls_x509_crt *crt;
+	const TlsX509Crt *crt;
 	TlsIOCtx *io = &tls->io_out;
 	unsigned char *p = *in_buf;
 
@@ -1532,10 +1532,10 @@ parse:
 		ttls_x509_crt_free(sess->peer_cert);
 		kfree(sess->peer_cert);
 	}
-	sess->peer_cert = kmalloc(sizeof(ttls_x509_crt), GFP_ATOMIC);
+	sess->peer_cert = kmalloc(sizeof(TlsX509Crt), GFP_ATOMIC);
 	if (!sess->peer_cert) {
 		T_DBG("can not allocate a certificate (%lu bytes)\n",
-		      sizeof(ttls_x509_crt));
+		      sizeof(TlsX509Crt));
 		ttls_send_alert(tls, TTLS_ALERT_LEVEL_FATAL,
 				    TTLS_ALERT_MSG_INTERNAL_ERROR);
 		r = TTLS_ERR_ALLOC_FAILED;
@@ -1590,15 +1590,12 @@ parse:
 
 	if (authmode != TTLS_VERIFY_NONE) {
 		const TlsPkCtx *pk = &sess->peer_cert->pk;
-		ttls_x509_crt *ca_chain = tls->hs->key_cert->ca_chain;
+		TlsX509Crt *ca_chain = tls->hs->key_cert->ca_chain;
 		ttls_x509_crl *ca_crl = tls->hs->key_cert->ca_crl;
 
 		/* Main check: verify certificate */
-		r = ttls_x509_crt_verify_with_profile(sess->peer_cert, ca_chain,
-						      ca_crl,
-						      &ttls_x509_crt_profile_suiteb,
-						      tls->hostname,
-						      &sess->verify_result);
+		r = ttls_x509_crt_verify(sess->peer_cert, ca_chain, ca_crl,
+					 tls->hostname, &sess->verify_result);
 		if (r)
 			T_DBG("client cert verification status: %d\n", r);
 
@@ -1927,8 +1924,8 @@ ttls_set_session(TlsCtx *tls, const TlsSess *sess)
  * Called in process context on the startup.
  */
 int
-ttls_conf_own_cert(TlsPeerCfg *conf, ttls_x509_crt *own_cert, TlsPkCtx *pk_key,
-		   ttls_x509_crt *ca_chain, ttls_x509_crl *ca_crl)
+ttls_conf_own_cert(TlsPeerCfg *conf, TlsX509Crt *own_cert, TlsPkCtx *pk_key,
+		   TlsX509Crt *ca_chain, ttls_x509_crl *ca_crl)
 {
 	TlsKeyCert *new;
 
@@ -2651,7 +2648,7 @@ err:
 }
 
 int
-ttls_check_cert_usage(const ttls_x509_crt *cert,
+ttls_check_cert_usage(const TlsX509Crt *cert,
 		      const TlsCiphersuite *ciphersuite, int cert_endpoint,
 		      uint32_t *flags)
 {

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1487,6 +1487,7 @@ ttls_parse_certificate(TlsCtx *tls, unsigned char *buf, size_t len,
 		io->rlen += n;
 		if (io->rlen == io->hslen)
 			T_FSM_JMP(TTLS_CC_HS_PARSE);
+		tls->state = ttls_state(tls) + TTLS_CC_HS_READ;
 		return T_POSTPONE;
 	}
 	T_FSM_STATE(TTLS_CC_HS_PARSE) {

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -50,6 +50,8 @@ static DEFINE_PER_CPU(struct aead_request *, g_req) ____cacheline_aligned;
 static struct kmem_cache *ttls_hs_cache = NULL;
 static ttls_send_cb_t *ttls_send_cb;
 extern ttls_sni_cb_t *ttls_sni_cb;
+extern ttls_hs_over_cb_t *ttls_hs_over_cb;
+extern ttls_cli_id_t *ttls_cli_id_cb;
 
 static inline size_t
 ttls_max_ciphertext_len(const TlsXfrm *xfrm)
@@ -233,12 +235,25 @@ ttls_skb_extract_alert(TlsIOCtx *io, TlsXfrm *xfrm)
  * Register I/O callbacks from the underlying network layer.
  */
 void
-ttls_register_callbacks(ttls_send_cb_t *send_cb, ttls_sni_cb_t *sni_cb)
+ttls_register_callbacks(ttls_send_cb_t *send_cb, ttls_sni_cb_t *sni_cb,
+			ttls_hs_over_cb_t *hs_over_cb, ttls_cli_id_t *cli_id_cb)
 {
 	ttls_send_cb = send_cb;
 	ttls_sni_cb = sni_cb;
+	ttls_hs_over_cb = hs_over_cb;
+	ttls_cli_id_cb = cli_id_cb;
 }
 EXPORT_SYMBOL(ttls_register_callbacks);
+
+/**
+ * Returns true if handshake is fully processed.
+ */
+bool
+ttls_hs_done(TlsCtx *tls)
+{
+	return tls->state == TTLS_HANDSHAKE_OVER;
+}
+EXPORT_SYMBOL(ttls_hs_done);
 
 /**
  * Whether TLS context transformation is ready for crypto and we should encrypt

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1527,8 +1527,7 @@ parse:
 	}
 
 	/* In case we tried to reuse a session but it failed */
-	if (sess->peer_cert)
-		ttls_x509_crt_destroy(&sess->peer_cert);
+	ttls_x509_crt_destroy(&sess->peer_cert);
 	sess->peer_cert = ttls_x509_crt_alloc();
 	if (!sess->peer_cert) {
 		T_DBG("can not allocate a certificate\n");
@@ -2302,9 +2301,8 @@ ttls_ctx_clear(TlsCtx *tls)
 	ttls_cipher_free(&tls->xfrm.cipher_ctx_enc);
 	ttls_cipher_free(&tls->xfrm.cipher_ctx_dec);
 
-	if (tls->sess.peer_cert)
-		/* #830 check that all the data is freed correctly. */
-		ttls_x509_crt_destroy(&tls->sess.peer_cert);
+	/* #830 check that all the data is freed correctly. */
+	ttls_x509_crt_destroy(&tls->sess.peer_cert);
 
 	bzero_fast(tls, sizeof(TlsCtx));
 }

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -349,7 +349,7 @@ typedef struct ttls_key_cert {
 	struct ttls_key_cert		*next;
 } TlsKeyCert;
 
-#define TTLS_TICKET_KEY_LEN		32 /* 256 bits */
+#define TTLS_TICKET_KEY_LEN		16 /* 128 bits */
 #define TTLS_TICKET_KEY_NAME_LEN	16
 #define TTLS_TICKET_MAX_SZ		512
 

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -288,7 +288,7 @@ struct ttls_alpn_proto {
  *			  from TLS ticket);
  */
 typedef struct {
-	ttls_x509_crt	*peer_cert;
+	TlsX509Crt	*peer_cert;
 	time_t		start;
 	int		etm;
 	uint32_t	verify_result;
@@ -342,9 +342,9 @@ typedef struct {
  * @next		- next certificate in list;
  */
 typedef struct ttls_key_cert {
-	ttls_x509_crt			*cert;
+	TlsX509Crt			*cert;
 	TlsPkCtx			*key;
-	ttls_x509_crt			*ca_chain;
+	TlsX509Crt			*ca_chain;
 	ttls_x509_crl			*ca_crl;
 	struct ttls_key_cert		*next;
 } TlsKeyCert;
@@ -594,8 +594,8 @@ void ttls_conf_authmode(TlsCfg *conf, int authmode);
 
 int ttls_set_session(TlsCtx *ssl, const TlsSess *session);
 
-int ttls_conf_own_cert(TlsPeerCfg *conf, ttls_x509_crt *own_cert,
-		       TlsPkCtx *pk_key, ttls_x509_crt *ca_chain,
+int ttls_conf_own_cert(TlsPeerCfg *conf, TlsX509Crt *own_cert,
+		       TlsPkCtx *pk_key, TlsX509Crt *ca_chain,
 		       ttls_x509_crl *ca_crl);
 int ttls_conf_tickets(TlsPeerCfg *conf, bool enable, unsigned long lifetime,
 		      const char *secret_str, size_t len,

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -399,12 +399,17 @@ typedef struct {
 } TlsTicketPeerCfg;
 
 /**
- * Tls Session ticket context.
+ * TLS Session ticket context.
  *
  * Unlike other extensions, ticket can't be parsed immediately, instead it's
  * required to know about target SNI first.
+ *
+ * @t_len			- ticket length;
+ * @ticket			- ticket data, sent by client;
+ * @sni_hash			- hash of requested server names;
  */
 typedef struct {
+	unsigned long		sni_hash;
 	size_t			t_len;
 	char			ticket[TTLS_TICKET_MAX_SZ];
 } TlSTicketCtx;
@@ -562,7 +567,7 @@ typedef struct ttls_context {
 
 typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt, bool close);
 typedef int ttls_sni_cb_t(TlsCtx *tls, const unsigned char *data, size_t len);
-typedef unsigned long ttls_cli_id_t(TlsCtx *tls);
+typedef unsigned long ttls_cli_id_t(TlsCtx *tls, unsigned long hash);
 
 enum {
 	TTLS_HS_CB_FINISHED_NEW,
@@ -571,6 +576,7 @@ enum {
 };
 typedef int ttls_hs_over_cb_t(TlsCtx *tls, int state);
 
+void ttls_hs_add_sni_hash(TlsCtx *tls, const char* data, size_t len);
 bool ttls_hs_done(TlsCtx *tls);
 bool ttls_xfrm_ready(TlsCtx *tls);
 bool ttls_xfrm_need_encrypt(TlsCtx *tls);

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -406,10 +406,8 @@ typedef struct {
  *
  * @t_len			- ticket length;
  * @ticket			- ticket data, sent by client;
- * @sni_hash			- hash of requested server names;
  */
 typedef struct {
-	unsigned long		sni_hash;
 	size_t			t_len;
 	char			ticket[TTLS_TICKET_MAX_SZ];
 } TlSTicketCtx;
@@ -542,6 +540,7 @@ typedef struct tls_handshake_t TlsHandshake;
  * @io_{in,out}	- I/O contexts for ingress and egress messages correspondingly;
  * @sess	- session data;
  * @xfrm	- transform params;
+ * @sni_hash	- hash of requested server names;
  * @nb_zero	-  # of 0-length encrypted messages;
  * @client_auth	- flag for client authentication (client side only);
  * @hostname	- expected peer CN for verification (and SNI if available);
@@ -560,6 +559,7 @@ typedef struct ttls_context {
 	TlsSess			sess;
 	TlsXfrm			xfrm;
 
+	unsigned long		sni_hash;
 	unsigned int		nb_zero;
 	int			client_auth;
 	char			*hostname;

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -562,13 +562,23 @@ typedef struct ttls_context {
 
 typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt, bool close);
 typedef int ttls_sni_cb_t(TlsCtx *tls, const unsigned char *data, size_t len);
+typedef unsigned long ttls_cli_id_t(TlsCtx *tls);
 
+enum {
+	TTLS_HS_CB_FINISHED_NEW,
+	TTLS_HS_CB_FINISHED_RESUMED,
+	TTLS_HS_CB_UNCOMPLETE,
+};
+typedef int ttls_hs_over_cb_t(TlsCtx *tls, int state);
+
+bool ttls_hs_done(TlsCtx *tls);
 bool ttls_xfrm_ready(TlsCtx *tls);
 bool ttls_xfrm_need_encrypt(TlsCtx *tls);
 void ttls_write_hshdr(unsigned char type, unsigned char *buf,
 		      unsigned short len);
 void *ttls_alloc_crypto_req(unsigned int extra_size, unsigned int *rsz);
-void ttls_register_callbacks(ttls_send_cb_t *send_cb, ttls_sni_cb_t *sni_cb);
+void ttls_register_callbacks(ttls_send_cb_t *send_cb, ttls_sni_cb_t *sni_cb,
+			     ttls_hs_over_cb_t *hs_over_cb, ttls_cli_id_t *cli_id_cb);
 
 const char *ttls_get_ciphersuite_name(const int ciphersuite_id);
 

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -576,7 +576,6 @@ enum {
 };
 typedef int ttls_hs_over_cb_t(TlsCtx *tls, int state);
 
-void ttls_hs_add_sni_hash(TlsCtx *tls, const char* data, size_t len);
 bool ttls_hs_done(TlsCtx *tls);
 bool ttls_xfrm_ready(TlsCtx *tls);
 bool ttls_xfrm_need_encrypt(TlsCtx *tls);

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -572,7 +572,7 @@ typedef unsigned long ttls_cli_id_t(TlsCtx *tls, unsigned long hash);
 enum {
 	TTLS_HS_CB_FINISHED_NEW,
 	TTLS_HS_CB_FINISHED_RESUMED,
-	TTLS_HS_CB_UNCOMPLETE,
+	TTLS_HS_CB_INCOMPLETE,
 };
 typedef int ttls_hs_over_cb_t(TlsCtx *tls, int state);
 

--- a/tls/x509.c
+++ b/tls/x509.c
@@ -758,6 +758,17 @@ static int x509_check_time(const ttls_x509_time *before, const ttls_x509_time *a
 	return 0;
 }
 
+/**
+ * Check a given ttls_x509_time against the system time and tell if it's in the
+ * past.
+ *
+ * Intended usage is "if (is_past(valid_to)) ERROR". Hence the return value of
+ * 1 if on internal errors.
+ *
+ * @to		- ttls_x509_time to check;
+ *
+ * @return 1 if the given time is in the past or an error occurred, 0 otherwise.
+ */
 int
 ttls_x509_time_is_past(const ttls_x509_time *to)
 {
@@ -768,6 +779,15 @@ ttls_x509_time_is_past(const ttls_x509_time *to)
 	return x509_check_time(&now, to);
 }
 
+/**
+ * heck a given ttls_x509_time against the system time and tell if it's in the
+ * future. Intended usage is "if (is_future(valid_from)) ERROR".
+ * Hence the return value of 1 if on internal errors.
+ *
+ * @from	- ttls_x509_time to check
+ *
+ * @return 1 if the given time is in the future or an error occurred, 0 otherwise.
+ */
 int
 ttls_x509_time_is_future(const ttls_x509_time *from)
 {

--- a/tls/x509.h
+++ b/tls/x509.h
@@ -62,7 +62,7 @@
 #define TTLS_ERR_X509_UNKNOWN_VERSION			-0x2580
 /* Signature algorithm (oid) is unsupported. */
 #define TTLS_ERR_X509_UNKNOWN_SIG_ALG			-0x2600
-/* Signature algorithms do not match. (see \c ::ttls_x509_crt sig_oid) */
+/* Signature algorithms do not match. (see \c ::TlsX509Crt sig_oid) */
 #define TTLS_ERR_X509_SIG_MISMATCH			-0x2680
 /* Certificate verification failed, e.g. CRL, CA or signature check failed. */
 #define TTLS_ERR_X509_CERT_VERIFY_FAILED		-0x2700
@@ -82,38 +82,58 @@
  * \name X509 Verify codes
  */
 /* Reminder: update x509_crt_verify_strings[] in library/x509_crt.c */
-#define TTLS_X509_BADCERT_EXPIRED			 0x01  /**< The certificate validity has expired. */
-#define TTLS_X509_BADCERT_REVOKED			 0x02  /**< The certificate has been revoked (is on a CRL). */
-#define TTLS_X509_BADCERT_CN_MISMATCH		 0x04  /**< The certificate Common Name (CN) does not match with the expected CN. */
-#define TTLS_X509_BADCERT_NOT_TRUSTED		 0x08  /**< The certificate is not correctly signed by the trusted CA. */
-#define TTLS_X509_BADCRL_NOT_TRUSTED		  0x10  /**< The CRL is not correctly signed by the trusted CA. */
-#define TTLS_X509_BADCRL_EXPIRED			  0x20  /**< The CRL is expired. */
-#define TTLS_X509_BADCERT_MISSING			 0x40  /**< Certificate was missing. */
-#define TTLS_X509_BADCERT_SKIP_VERIFY		 0x80  /**< Certificate verification was skipped. */
-#define TTLS_X509_BADCERT_OTHER			 0x0100  /**< Other reason (can be used by verify callback) */
-#define TTLS_X509_BADCERT_FUTURE			0x0200  /**< The certificate validity starts in the future. */
-#define TTLS_X509_BADCRL_FUTURE			 0x0400  /**< The CRL is from the future */
-#define TTLS_X509_BADCERT_KEY_USAGE		 0x0800  /**< Usage does not match the keyUsage extension. */
-#define TTLS_X509_BADCERT_EXT_KEY_USAGE	 0x1000  /**< Usage does not match the extendedKeyUsage extension. */
-#define TTLS_X509_BADCERT_NS_CERT_TYPE	  0x2000  /**< Usage does not match the nsCertType extension. */
-#define TTLS_X509_BADCERT_BAD_MD			0x4000  /**< The certificate is signed with an unacceptable hash. */
-#define TTLS_X509_BADCERT_BAD_PK			0x8000  /**< The certificate is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
-#define TTLS_X509_BADCERT_BAD_KEY		 0x010000  /**< The certificate is signed with an unacceptable key (eg bad curve, RSA too short). */
-#define TTLS_X509_BADCRL_BAD_MD		   0x020000  /**< The CRL is signed with an unacceptable hash. */
-#define TTLS_X509_BADCRL_BAD_PK		   0x040000  /**< The CRL is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
-#define TTLS_X509_BADCRL_BAD_KEY		  0x080000  /**< The CRL is signed with an unacceptable key (eg bad curve, RSA too short). */
+ /* The certificate validity has expired. */
+#define TTLS_X509_BADCERT_EXPIRED			    0x01
+/* The certificate has been revoked (is on a CRL). */
+#define TTLS_X509_BADCERT_REVOKED			    0x02
+/* The certificate Common Name (CN) does not match with the expected CN. */
+#define TTLS_X509_BADCERT_CN_MISMATCH			    0x04
+/* The certificate is not correctly signed by the trusted CA. */
+#define TTLS_X509_BADCERT_NOT_TRUSTED			    0x08
+/* The CRL is not correctly signed by the trusted CA. */
+#define TTLS_X509_BADCRL_NOT_TRUSTED			    0x10
+/* The CRL is expired. */
+#define TTLS_X509_BADCRL_EXPIRED			    0x20
+/* Certificate was missing. */
+#define TTLS_X509_BADCERT_MISSING			    0x40
+/* Certificate verification was skipped. */
+#define TTLS_X509_BADCERT_SKIP_VERIFY			    0x80
+/* Other reason (can be used by verify callback) */
+#define TTLS_X509_BADCERT_OTHER				  0x0100
+/* The certificate validity starts in the future. */
+#define TTLS_X509_BADCERT_FUTURE			  0x0200
+/* The CRL is from the future */
+#define TTLS_X509_BADCRL_FUTURE				  0x0400
+/* Usage does not match the keyUsage extension. */
+#define TTLS_X509_BADCERT_KEY_USAGE			  0x0800
+/* Usage does not match the extendedKeyUsage extension. */
+#define TTLS_X509_BADCERT_EXT_KEY_USAGE			  0x1000
+/* Usage does not match the nsCertType extension. */
+#define TTLS_X509_BADCERT_NS_CERT_TYPE			  0x2000
+/* The certificate is signed with an unacceptable hash. */
+#define TTLS_X509_BADCERT_BAD_MD			  0x4000
+/* The certificate is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
+#define TTLS_X509_BADCERT_BAD_PK			  0x8000
+/* The certificate is signed with an unacceptable key (eg bad curve, RSA too short). */
+#define TTLS_X509_BADCERT_BAD_KEY			0x010000
+/* The CRL is signed with an unacceptable hash. */
+#define TTLS_X509_BADCRL_BAD_MD				0x020000
+/* The CRL is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
+#define TTLS_X509_BADCRL_BAD_PK				0x040000
+/* The CRL is signed with an unacceptable key (eg bad curve, RSA too short). */
+#define TTLS_X509_BADCRL_BAD_KEY			0x080000
 
 /*
  * X.509 v3 Key Usage Extension flags
  */
-#define TTLS_X509_KU_DIGITAL_SIGNATURE			(0x80)  /* bit 0 */
-#define TTLS_X509_KU_NON_REPUDIATION			  (0x40)  /* bit 1 */
-#define TTLS_X509_KU_KEY_ENCIPHERMENT			 (0x20)  /* bit 2 */
-#define TTLS_X509_KU_DATA_ENCIPHERMENT			(0x10)  /* bit 3 */
-#define TTLS_X509_KU_KEY_CERT_SIGN				(0x04)  /* bit 5 */
-#define TTLS_X509_KU_CRL_SIGN		 (0x02)  /* bit 6 */
-#define TTLS_X509_KU_ENCIPHER_ONLY				(0x01)  /* bit 7 */
-#define TTLS_X509_KU_DECIPHER_ONLY			  (0x8000)  /* bit 8 */
+#define TTLS_X509_KU_DIGITAL_SIGNATURE			0x80	/* bit 0 */
+#define TTLS_X509_KU_NON_REPUDIATION			0x40	/* bit 1 */
+#define TTLS_X509_KU_KEY_ENCIPHERMENT			0x20	/* bit 2 */
+#define TTLS_X509_KU_DATA_ENCIPHERMENT			0x10	/* bit 3 */
+#define TTLS_X509_KU_KEY_CERT_SIGN			0x04	/* bit 5 */
+#define TTLS_X509_KU_CRL_SIGN				0x02	/* bit 6 */
+#define TTLS_X509_KU_ENCIPHER_ONLY			0x01	/* bit 7 */
+#define TTLS_X509_KU_DECIPHER_ONLY			0x8000	/* bit 8 */
 
 /*
  * X.509 extension types
@@ -121,32 +141,33 @@
  * Comments refer to the status for using certificates. Status can be
  * different for writing certificates or reading CRLs or CSRs.
  */
-#define TTLS_X509_EXT_AUTHORITY_KEY_IDENTIFIER	(1 << 0)
-#define TTLS_X509_EXT_SUBJECT_KEY_IDENTIFIER	  (1 << 1)
-#define TTLS_X509_EXT_KEY_USAGE				   (1 << 2)
+#define TTLS_X509_EXT_AUTHORITY_KEY_IDENTIFIER		(1 << 0)
+#define TTLS_X509_EXT_SUBJECT_KEY_IDENTIFIER		(1 << 1)
+#define TTLS_X509_EXT_KEY_USAGE				(1 << 2)
 #define TTLS_X509_EXT_CERTIFICATE_POLICIES		(1 << 3)
-#define TTLS_X509_EXT_POLICY_MAPPINGS			 (1 << 4)
-#define TTLS_X509_EXT_SUBJECT_ALT_NAME			(1 << 5)	/* Supported (DNS) */
-#define TTLS_X509_EXT_ISSUER_ALT_NAME			 (1 << 6)
-#define TTLS_X509_EXT_SUBJECT_DIRECTORY_ATTRS	 (1 << 7)
-#define TTLS_X509_EXT_BASIC_CONSTRAINTS		   (1 << 8)	/* Supported */
+#define TTLS_X509_EXT_POLICY_MAPPINGS			(1 << 4)
+#define TTLS_X509_EXT_SUBJECT_ALT_NAME			(1 << 5) /* Supported (DNS) */
+#define TTLS_X509_EXT_ISSUER_ALT_NAME			(1 << 6)
+#define TTLS_X509_EXT_SUBJECT_DIRECTORY_ATTRS		(1 << 7)
+#define TTLS_X509_EXT_BASIC_CONSTRAINTS			(1 << 8) /* Supported */
 #define TTLS_X509_EXT_NAME_CONSTRAINTS			(1 << 9)
-#define TTLS_X509_EXT_POLICY_CONSTRAINTS		  (1 << 10)
-#define TTLS_X509_EXT_EXTENDED_KEY_USAGE		  (1 << 11)
-#define TTLS_X509_EXT_CRL_DISTRIBUTION_POINTS	 (1 << 12)
-#define TTLS_X509_EXT_INIHIBIT_ANYPOLICY		  (1 << 13)
-#define TTLS_X509_EXT_FRESHEST_CRL				(1 << 14)
+#define TTLS_X509_EXT_POLICY_CONSTRAINTS		(1 << 10)
+#define TTLS_X509_EXT_EXTENDED_KEY_USAGE		(1 << 11)
+#define TTLS_X509_EXT_CRL_DISTRIBUTION_POINTS		(1 << 12)
+#define TTLS_X509_EXT_INIHIBIT_ANYPOLICY		(1 << 13)
+#define TTLS_X509_EXT_FRESHEST_CRL			(1 << 14)
 
-#define TTLS_X509_EXT_NS_CERT_TYPE				(1 << 16)
+#define TTLS_X509_EXT_NS_CERT_TYPE			(1 << 16)
 
 /*
  * Storage format identifiers
  * Recognized formats: PEM and DER
  */
-#define TTLS_X509_FORMAT_DER				 1
-#define TTLS_X509_FORMAT_PEM				 2
+#define TTLS_X509_FORMAT_DER				1
+#define TTLS_X509_FORMAT_PEM				2
 
-#define TTLS_X509_MAX_DN_NAME_SIZE		 256 /**< Maximum value size of a DN entry */
+/* Maximum value size of a DN entry */
+#define TTLS_X509_MAX_DN_NAME_SIZE			256
 
 /**
  * \name Structures for parsing X.509 certificates, CRLs and CSRs
@@ -173,40 +194,19 @@ typedef ttls_asn1_named_data ttls_x509_name;
  */
 typedef ttls_asn1_sequence ttls_x509_sequence;
 
-/** Container for date and time (precision in seconds). */
+/**
+ * Container for date and time (precision in seconds).
+ * @year, @mon, @day	- date;
+ * @hour, @min, @sec	- time
+ */
 typedef struct ttls_x509_time
 {
-	int year, mon, day;		 /**< Date. */
-	int hour, min, sec;		 /**< Time. */
-}
-ttls_x509_time;
+	int year, mon, day;
+	int hour, min, sec;
+} ttls_x509_time;
 
-/**
- * \brief		  Check a given ttls_x509_time against the system time
- *				 and tell if it's in the past.
- *
- * \note		   Intended usage is "if (is_past(valid_to)) ERROR".
- *				 Hence the return value of 1 if on internal errors.
- *
- * \param to	   ttls_x509_time to check
- *
- * \return		 1 if the given time is in the past or an error occurred,
- *				 0 otherwise.
- */
+
 int ttls_x509_time_is_past(const ttls_x509_time *to);
-
-/**
- * \brief		  Check a given ttls_x509_time against the system time
- *				 and tell if it's in the future.
- *
- * \note		   Intended usage is "if (is_future(valid_from)) ERROR".
- *				 Hence the return value of 1 if on internal errors.
- *
- * \param from	 ttls_x509_time to check
- *
- * \return		 1 if the given time is in the future or an error
- *			 occurred, 0 otherwise.
- */
 int ttls_x509_time_is_future(const ttls_x509_time *from);
 
 /*
@@ -214,26 +214,26 @@ int ttls_x509_time_is_future(const ttls_x509_time *from);
  * know you do.
  */
 int ttls_x509_get_name(unsigned char **p, const unsigned char *end,
-				   ttls_x509_name *cur);
+		       ttls_x509_name *cur);
 int ttls_x509_get_alg_null(unsigned char **p, const unsigned char *end,
-		   ttls_x509_buf *alg);
+			   ttls_x509_buf *alg);
 int ttls_x509_get_alg(unsigned char **p, const unsigned char *end,
-				  ttls_x509_buf *alg, ttls_x509_buf *params);
+		      ttls_x509_buf *alg, ttls_x509_buf *params);
 int ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
-		ttls_md_type_t *md_alg, ttls_md_type_t *mgf_md,
-		int *salt_len);
+				    ttls_md_type_t *md_alg, ttls_md_type_t *mgf_md,
+				    int *salt_len);
 int ttls_x509_get_sig(unsigned char **p, const unsigned char *end, ttls_x509_buf *sig);
 int ttls_x509_get_sig_alg(const ttls_x509_buf *sig_oid, const ttls_x509_buf *sig_params,
-		  ttls_md_type_t *md_alg, ttls_pk_type_t *pk_alg,
-		  void **sig_opts);
+			  ttls_md_type_t *md_alg, ttls_pk_type_t *pk_alg,
+			  void **sig_opts);
 int ttls_x509_get_time(unsigned char **p, const unsigned char *end,
-				   ttls_x509_time *t);
+		       ttls_x509_time *t);
 int ttls_x509_get_serial(unsigned char **p, const unsigned char *end,
-		 ttls_x509_buf *serial);
+			 ttls_x509_buf *serial);
 int ttls_x509_get_ext(unsigned char **p, const unsigned char *end,
-				  ttls_x509_buf *ext, int tag);
+		      ttls_x509_buf *ext, int tag);
 int ttls_x509_write_sig(unsigned char **p, unsigned char *start,
-		const char *oid, size_t oid_len,
-		unsigned char *sig, size_t size);
+			const char *oid, size_t oid_len,
+			unsigned char *sig, size_t size);
 
 #endif /* x509.h */

--- a/tls/x509_crl.c
+++ b/tls/x509_crl.c
@@ -264,10 +264,18 @@ static int x509_get_entries(unsigned char **p,
 	return 0;
 }
 
-/*
- * Parse one  CRLs in DER format and append it to the chained list
+/**
+ * Parse a DER-encoded CRL and append it to the chained list
+ *
+ * @chain	- points to the start of the chain;
+ * @buf		- buffer holding the CRL data in DER format;
+ * @buflen	- size of the buffer (including the terminating null byte for
+ *		  PEM data);
+ *
+ * Return 0 if successful, or a specific X509 or PEM error code
  */
-int ttls_x509_crl_parse_der(ttls_x509_crl *chain,
+int
+ttls_x509_crl_parse_der(ttls_x509_crl *chain,
 			const unsigned char *buf, size_t buflen)
 {
 	int ret;
@@ -504,7 +512,16 @@ int ttls_x509_crl_parse_der(ttls_x509_crl *chain,
 }
 
 /**
- * Parse one or more CRLs and add them to the chained list.
+ * Parse one or more CRLs and add them to the chained list. Multiple CRLs are
+ * accepted only if using PEM format.
+ *
+ * @chain	- points to the start of the chain;
+ * @buf		- buffer holding the CRL data in PEM or DER format;
+ * @buflen	- size of the buffer (including the terminating null byte for
+ *		  PEM data)
+ *
+ * Return 0 if successful, or a specific X509 or PEM error code.
+ *
  * BEWARE @buf is overwritten by the PEM decoder.
  */
 int
@@ -554,7 +571,7 @@ ttls_x509_crl_parse(ttls_x509_crl *chain, unsigned char *buf, size_t buflen)
 	return ttls_x509_crl_parse_der(chain, buf, buflen);
 }
 
-/*
+/**
  * Initialize a CRL chain
  */
 void ttls_x509_crl_init(ttls_x509_crl *crl)
@@ -562,7 +579,7 @@ void ttls_x509_crl_init(ttls_x509_crl *crl)
 	memset(crl, 0, sizeof(ttls_x509_crl));
 }
 
-/*
+/**
  * Unallocate all CRL data
  */
 void ttls_x509_crl_free(ttls_x509_crl *crl)

--- a/tls/x509_crl.h
+++ b/tls/x509_crl.h
@@ -31,91 +31,75 @@
  * Certificate revocation list entry.
  * Contains the CA-specific serial numbers and revocation dates.
  */
-typedef struct ttls_x509_crl_entry
-{
+typedef struct ttls_x509_crl_entry {
 	ttls_x509_buf raw;
-
 	ttls_x509_buf serial;
-
 	ttls_x509_time revocation_date;
-
 	ttls_x509_buf entry_ext;
-
 	struct ttls_x509_crl_entry *next;
 }
 ttls_x509_crl_entry;
 
 /**
- * Certificate revocation list structure.
- * Every CRL may have multiple entries.
+ * Certificate revocation list structure. Every CRL may have multiple entries.
+ *
+ * @raw;		- The raw certificate data (DER).
+ * @tbs;		- The raw certificate body (DER). The part that is
+ *			  To Be Signed.
+ * @version;		- CRL version (1=v1, 2=v2)
+ * @sig_oid;		- CRL signature type identifier
+ * @issuer_raw;		- The raw issuer data (DER).
+ * @issuer;		- The parsed issuer data (named information object).
+ * @this_update;
+ * @next_update;
+ * @entry;		- The CRL entries containing the certificate revocation
+ *			  times for this CA.
+ * @crl_ext;
+ * @sig_oid2;
+ * @sig;
+ * @sig_md;		- Internal representation of the MD algorithm of the
+ *			  signature algorithm, e.g. TTLS_MD_SHA256
+ * @sig_pk;		- Internal representation of the Public Key algorithm
+ *			  of the signature algorithm, e.g. TTLS_PK_RSA
+ * @*sig_opts;		- Signature options to be passed to ttls_pk_verify_ext(),
+ *			  e.g. for RSASSA-PSS
+
+ * @ttls_x509_crl *next;
  */
-typedef struct ttls_x509_crl
-{
-	ttls_x509_buf raw;		   /**< The raw certificate data (DER). */
-	ttls_x509_buf tbs;		   /**< The raw certificate body (DER). The part that is To Be Signed. */
+typedef struct ttls_x509_crl {
+	ttls_x509_buf raw;
+	ttls_x509_buf tbs;
 
-	int version;			/**< CRL version (1=v1, 2=v2) */
-	ttls_x509_buf sig_oid;	   /**< CRL signature type identifier */
+	int version;
+	ttls_x509_buf sig_oid;
 
-	ttls_x509_buf issuer_raw;	/**< The raw issuer data (DER). */
+	ttls_x509_buf issuer_raw;
 
-	ttls_x509_name issuer;	   /**< The parsed issuer data (named information object). */
+	ttls_x509_name issuer;
 
 	ttls_x509_time this_update;
 	ttls_x509_time next_update;
 
-	ttls_x509_crl_entry entry;   /**< The CRL entries containing the certificate revocation times for this CA. */
+	ttls_x509_crl_entry entry;
 
 	ttls_x509_buf crl_ext;
 
 	ttls_x509_buf sig_oid2;
 	ttls_x509_buf sig;
-	ttls_md_type_t sig_md;		   /**< Internal representation of the MD algorithm of the signature algorithm, e.g. TTLS_MD_SHA256 */
-	ttls_pk_type_t sig_pk;		   /**< Internal representation of the Public Key algorithm of the signature algorithm, e.g. TTLS_PK_RSA */
-	void *sig_opts;			 /**< Signature options to be passed to ttls_pk_verify_ext(), e.g. for RSASSA-PSS */
+	ttls_md_type_t sig_md;
+	ttls_pk_type_t sig_pk;
+	void *sig_opts;
 
 	struct ttls_x509_crl *next;
 }
 ttls_x509_crl;
 
-/**
- * \brief		  Parse a DER-encoded CRL and append it to the chained list
- *
- * \param chain	points to the start of the chain
- * \param buf	  buffer holding the CRL data in DER format
- * \param buflen   size of the buffer
- *				 (including the terminating null byte for PEM data)
- *
- * \return		 0 if successful, or a specific X509 or PEM error code
- */
+
 int ttls_x509_crl_parse_der(ttls_x509_crl *chain,
 			const unsigned char *buf, size_t buflen);
-/**
- * \brief		  Parse one or more CRLs and append them to the chained list
- *
- * \note		   Multiple CRLs are accepted only if using PEM format
- *
- * \param chain	points to the start of the chain
- * \param buf	  buffer holding the CRL data in PEM or DER format
- * \param buflen   size of the buffer
- *				 (including the terminating null byte for PEM data)
- *
- * \return		 0 if successful, or a specific X509 or PEM error code
- */
 int ttls_x509_crl_parse(ttls_x509_crl *chain, unsigned char *buf, size_t buflen);
 
-/**
- * \brief		  Initialize a CRL (chain)
- *
- * \param crl	  CRL chain to initialize
- */
 void ttls_x509_crl_init(ttls_x509_crl *crl);
-
-/**
- * \brief		  Unallocate all CRL data
- *
- * \param crl	  CRL chain to free
- */
 void ttls_x509_crl_free(ttls_x509_crl *crl);
 
 #endif /* ttls_x509_crl.h */

--- a/tls/x509_crt.c
+++ b/tls/x509_crt.c
@@ -1825,7 +1825,7 @@ TlsX509Crt *
 ttls_x509_crt_alloc(void)
 {
 	/*
-	 * Certificates are always manually zerised before deallocation,
+	 * Certificates are always manually zeroised before deallocation,
 	 * avoid GFP_ZERO flag here.
 	 */
 	TlsX509Crt *crt = kmem_cache_alloc(cert_cache, GFP_ATOMIC);

--- a/tls/x509_crt.c
+++ b/tls/x509_crt.c
@@ -1824,13 +1824,8 @@ exit:
 TlsX509Crt *
 ttls_x509_crt_alloc(void)
 {
-	/*
-	 * Certificates are always manually zeroised before deallocation,
-	 * avoid GFP_ZERO flag here.
-	 */
-	TlsX509Crt *crt = kmem_cache_alloc(cert_cache, GFP_ATOMIC);
-	if (crt)
-		ttls_bzero_safe(crt, sizeof(TlsX509Crt));
+	TlsX509Crt *crt = kmem_cache_zalloc(cert_cache, GFP_ATOMIC);
+
 	return crt;
 }
 

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -141,8 +141,10 @@ int ttls_x509_crt_check_extended_key_usage(const TlsX509Crt *crt,
 					   const char *usage_oid,
 					   size_t usage_len);
 
+TlsX509Crt *ttls_x509_crt_alloc(void);
 void ttls_x509_crt_init(TlsX509Crt *crt);
 void ttls_x509_crt_free(TlsX509Crt *crt);
+void ttls_x509_crt_destroy(TlsX509Crt **crt);
 
 /**
  * Writes certificate length in exactly TTLS_CERT_LEN_LEN bytes of @buf.
@@ -166,5 +168,8 @@ ttls_x509_crt_page(const TlsX509Crt *crt)
 
 	return (void *)addr;
 }
+
+int ttls_x509_init(void);
+void ttls_x509_exit(void);
 
 #endif /* TTLS_X509_CRT_H */

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -32,265 +32,123 @@
 
 /**
  * Container for an X.509 certificate. The certificate may be chained.
- */
-typedef struct ttls_x509_crt
-{
-	ttls_x509_buf raw;			   /**< The raw certificate data (DER). */
-	ttls_x509_buf tbs;			   /**< The raw certificate body (DER). The part that is To Be Signed. */
-
-	int version;				/**< The X.509 version. (1=v1, 2=v2, 3=v3) */
-	ttls_x509_buf serial;			/**< Unique id for certificate issued by a specific CA. */
-	ttls_x509_buf sig_oid;		   /**< Signature algorithm, e.g. sha1RSA */
-
-	ttls_x509_buf issuer_raw;		/**< The raw issuer data (DER). Used for quick comparison. */
-	ttls_x509_buf subject_raw;	   /**< The raw subject data (DER). Used for quick comparison. */
-
-	ttls_x509_name issuer;		   /**< The parsed issuer data (named information object). */
-	ttls_x509_name subject;		  /**< The parsed subject data (named information object). */
-
-	ttls_x509_time valid_from;	   /**< Start time of certificate validity. */
-	ttls_x509_time valid_to;		 /**< End time of certificate validity. */
-
-	TlsPkCtx pk;			  /**< Container for the public key context. */
-
-	ttls_x509_buf issuer_id;		 /**< Optional X.509 v2/v3 issuer unique identifier. */
-	ttls_x509_buf subject_id;		/**< Optional X.509 v2/v3 subject unique identifier. */
-	ttls_x509_buf v3_ext;			/**< Optional X.509 v3 extensions.  */
-	ttls_x509_sequence subject_alt_names;	/**< Optional list of Subject Alternative Names (Only dNSName supported). */
-
-	int ext_types;			  /**< Bit string containing detected and parsed extensions */
-	int ca_istrue;			  /**< Optional Basic Constraint extension value: 1 if this certificate belongs to a CA, 0 otherwise. */
-	int max_pathlen;			/**< Optional Basic Constraint extension value: The maximum path length to the root certificate. Path length is 1 higher than RFC 5280 'meaning', so 1+ */
-
-	unsigned int key_usage;	 /**< Optional key usage extension value: See the values in x509.h */
-
-	ttls_x509_sequence ext_key_usage; /**< Optional list of extended key usage OIDs. */
-
-	unsigned char ns_cert_type; /**< Optional Netscape certificate type extension value: See the values in x509.h */
-
-	ttls_x509_buf sig;			   /**< Signature: hash of the tbs part signed with the private key. */
-	ttls_md_type_t sig_md;		   /**< Internal representation of the MD algorithm of the signature algorithm, e.g. TTLS_MD_SHA256 */
-	ttls_pk_type_t sig_pk;		   /**< Internal representation of the Public Key algorithm of the signature algorithm, e.g. TTLS_PK_RSA */
-	void *sig_opts;			 /**< Signature options to be passed to ttls_pk_verify_ext(), e.g. for RSASSA-PSS */
-
-	struct ttls_x509_crt *next;	 /**< Next certificate in the CA-chain. */
-}
-ttls_x509_crt;
-
-/**
- * Build flag from an algorithm/curve identifier (pk, md, ecp)
- * Since 0 is always XXX_NONE, ignore it.
- */
-#define TTLS_X509_ID_FLAG(id)   (1 << (id - 1))
-
-/**
- * Security profile for certificate verification.
  *
- * All lists are bitfields, built by ORing flags from TTLS_X509_ID_FLAG().
+ * @raw			- The raw certificate data (DER).
+ * @tbs			- The raw certificate body (DER). The part that is
+ *			  To Be Signed.
+ * @version		- The X.509 version. (1=v1, 2=v2, 3=v3)
+ * @serial		- Unique id for certificate issued by a specific CA.
+ * @sig_oid		- Signature algorithm, e.g. sha1RSA.
+ * @issuer_raw		- The raw issuer data (DER). Used for quick comparison.
+ * @subject_raw		- The raw subject data (DER). Used for quick comparison.
+ * @issuer		- The parsed issuer data (named information object).
+ * @subject		- The parsed subject data (named information object).
+ * @valid_from		- Start time of certificate validity.
+ * @valid_to		- End time of certificate validity.
+ * @pk			- Container for the public key context.
+ * @issuer_id		- Optional X.509 v2/v3 issuer unique identifier.
+ * @subject_id		- Optional X.509 v2/v3 subject unique identifier.
+ * @v3_ext		- Optional X.509 v3 extensions.
+ * @subject_alt_names	- Optional list of Subject Alternative Names
+ *			  (Only dNSName supported).
+ * @ext_types		- Bit string containing detected and parsed extensions
+ * @ca_istrue		- Optional Basic Constraint extension value:
+ *			  1 if this certificate belongs to a CA, 0 otherwise.
+ * @max_pathlen		- Optional Basic Constraint extension value:
+ *			  The maximum path length to the root certificate.
+ *			  Path length is 1 higher than RFC 5280 'meaning', so 1+
+ * @int key_usage	- Optional key usage extension value: See the values in
+ *			  x509.h
+ * @ext_key_usage	- Optional list of extended key usage OIDs.
+ * @char ns_cert_type	- Optional Netscape certificate type extension value:
+ *			  See the values in x509.h
+ * @sig			- Signature: hash of the tbs part signed with the
+ *			  private key.
+ * @sig_md		- Internal representation of the MD algorithm of the
+ *			  signature algorithm, e.g. TTLS_MD_SHA256
+ * @sig_pk		- Internal representation of the Public Key algorithm
+ *			  of the signature algorithm, e.g. TTLS_PK_RSA
+ * @*sig_opts		- Signature options to be passed to ttls_pk_verify_ext(),
+ *			  e.g. for RSASSA-PSS
+ * @TlsX509Crt *next	- Next certificate in the CA-chain.
  */
-typedef struct
-{
-	uint32_t allowed_mds;	   /**< MDs for signatures		 */
-	uint32_t allowed_pks;	   /**< PK algs for signatures	 */
-	uint32_t allowed_curves;	/**< Elliptic curves for ECDSA  */
-	uint32_t rsa_min_bitlen;	/**< Minimum size for RSA keys  */
-}
-ttls_x509_crt_profile;
+typedef struct TlsX509Crt {
+	ttls_x509_buf raw;
+	ttls_x509_buf tbs;
 
-#define TTLS_X509_CRT_VERSION_1			  0
-#define TTLS_X509_CRT_VERSION_2			  1
-#define TTLS_X509_CRT_VERSION_3			  2
-
-#define TTLS_X509_RFC5280_MAX_SERIAL_LEN 32
-#define TTLS_X509_RFC5280_UTC_TIME_LEN   15
-
-/**
- * Container for writing a certificate (CRT)
- */
-typedef struct ttls_x509write_cert
-{
 	int version;
-	TlsMpi serial;
-	TlsPkCtx *subject_key;
-	TlsPkCtx *issuer_key;
-	ttls_asn1_named_data *subject;
-	ttls_asn1_named_data *issuer;
-	ttls_md_type_t md_alg;
-	char not_before[TTLS_X509_RFC5280_UTC_TIME_LEN + 1];
-	char not_after[TTLS_X509_RFC5280_UTC_TIME_LEN + 1];
-	ttls_asn1_named_data *extensions;
-}
-ttls_x509write_cert;
+	ttls_x509_buf serial;
+	ttls_x509_buf sig_oid;
 
-/**
- * Default security profile. Should provide a good balance between security
- * and compatibility with current deployments.
- */
-extern const ttls_x509_crt_profile ttls_x509_crt_profile_default;
+	ttls_x509_buf issuer_raw;
+	ttls_x509_buf subject_raw;
 
-/**
- * Expected next default profile. Recommended for new deployments.
- * Currently targets a 128-bit security level, except for RSA-2048.
- */
-extern const ttls_x509_crt_profile ttls_x509_crt_profile_next;
+	ttls_x509_name issuer;
+	ttls_x509_name subject;
 
-/**
- * NSA Suite B profile.
- */
-extern const ttls_x509_crt_profile ttls_x509_crt_profile_suiteb;
+	ttls_x509_time valid_from;
+	ttls_x509_time valid_to;
 
-int ttls_x509_crt_parse_der(ttls_x509_crt *chain, unsigned char *buf,
+	TlsPkCtx pk;
+
+	ttls_x509_buf issuer_id;
+	ttls_x509_buf subject_id;
+	ttls_x509_buf v3_ext;
+	ttls_x509_sequence subject_alt_names;
+
+	int ext_types;
+	int ca_istrue;
+	int max_pathlen;
+
+	unsigned int key_usage;
+
+	ttls_x509_sequence ext_key_usage;
+
+	unsigned char ns_cert_type;
+
+	ttls_x509_buf sig;
+	ttls_md_type_t sig_md;
+	ttls_pk_type_t sig_pk;
+	void *sig_opts;
+
+	struct TlsX509Crt *next;
+} TlsX509Crt;
+
+int ttls_x509_crt_parse_der(TlsX509Crt *chain, unsigned char *buf,
 			    size_t buflen);
+int ttls_x509_crt_parse(TlsX509Crt *chain, unsigned char *buf, size_t buflen);
 
-/**
- * Parse one or more certificates and add them to the chained list. Parses
- * permissively. If some certificates can be parsed, the result is the number
- * of failed certificates it encountered. If none complete correctly, the first
- * error is returned.
- */
-int ttls_x509_crt_parse(ttls_x509_crt *chain, unsigned char *buf, size_t buflen);
+enum {
+	TLS_X509_CERT_PROFILE_DEFAULT,
+	TLS_X509_CERT_PROFILE_NEXT,
+	TLS_X509_CERT_PROFILE_SUITEB
+};
 
-/**
- * \brief	  Verify the certificate signature
- *
- *			 The verify callback is a user-supplied callback that
- *			 can clear / modify / add flags for a certificate. If set,
- *			 the verification callback is called for each
- *			 certificate in the chain (from the trust-ca down to the
- *			 presented crt). The parameters for the callback are:
- *			 (void *parameter, ttls_x509_crt *crt, int certificate_depth,
- *			 int *flags). With the flags representing current flags for
- *			 that specific certificate and the certificate depth from
- *			 the bottom (Peer cert depth = 0).
- *
- *			 All flags left after returning from the callback
- *			 are also returned to the application. The function should
- *			 return 0 for anything (including invalid certificates)
- *			 other than fatal error, as a non-zero return code
- *			 immediately aborts the verification process. For fatal
- *			 errors, a specific error code should be used (different
- *			 from TTLS_ERR_X509_CERT_VERIFY_FAILED which should not
- *			 be returned at this point), or TTLS_ERR_X509_FATAL_ERROR
- *			 can be used if no better code is available.
- *
- * \note	   Same as \c ttls_x509_crt_verify_with_profile() with the
- *			 default security profile.
- *
- * \note	   It is your responsibility to provide up-to-date CRLs for
- *			 all trusted CAs. If no CRL is provided for the CA that was
- *			 used to sign the certificate, CRL verification is skipped
- *			 silently, that is *without* setting any flag.
- *
- * \param crt	  a certificate (chain) to be verified
- * \param trust_ca the list of trusted CAs
- * \param ca_crl   the list of CRLs for trusted CAs (see note above)
- * \param cn	   expected Common Name (can be set to
- *				 NULL if the CN must not be verified)
- * \param flags	result of the verification
- *
- * \return		 0 (and flags set to 0) if the chain was verified and valid,
- *			 TTLS_ERR_X509_CERT_VERIFY_FAILED if the chain was verified
- *			 but found to be invalid, in which case *flags will have one
- *			 or more TTLS_X509_BADCERT_XXX or TTLS_X509_BADCRL_XXX
- *			 flags set, or another error (and flags set to 0xffffffff)
- *			 in case of a fatal error encountered during the
- *			 verification process.
- */
-int ttls_x509_crt_verify(ttls_x509_crt *crt, ttls_x509_crt *trust_ca,
-			 ttls_x509_crl *ca_crl, const char *cn,
-			 uint32_t *flags);
+int ttls_x509_crt_verify_with_profile(TlsX509Crt *crt,
+				      TlsX509Crt *trust_ca,
+				      ttls_x509_crl *ca_crl,
+				      int profile_id,
+				      const char *cn, uint32_t *flags);
+/* ttls_x509_crt_verify_with_profile with default profile. */
+#define ttls_x509_crt_verify(crt, trust_ca, ca_clrm, cn, flags)			\
+	ttls_x509_crt_verify_with_profile((crt), (trust_ca), (ca_clrm),		\
+					  TLS_X509_CERT_PROFILE_SUITEB, (cn),	\
+					  (flags))
 
-/**
- * \brief		  Verify the certificate signature according to profile
- *
- * \note		   Same as \c ttls_x509_crt_verify(), but with explicit
- *				 security profile.
- *
- * \note		   The restrictions on keys (RSA minimum size, allowed curves
- *				 for ECDSA) apply to all certificates: trusted root,
- *				 intermediate CAs if any, and end entity certificate.
- *
- * \param crt	  a certificate (chain) to be verified
- * \param trust_ca the list of trusted CAs
- * \param ca_crl   the list of CRLs for trusted CAs
- * \param profile  security profile for verification
- * \param cn	   expected Common Name (can be set to
- *				 NULL if the CN must not be verified)
- * \param flags	result of the verification
- *
- * \return		 0 if successful or TTLS_ERR_X509_CERT_VERIFY_FAILED
- *				 in which case *flags will have one or more
- *				 TTLS_X509_BADCERT_XXX or TTLS_X509_BADCRL_XXX flags
- *				 set,
- *				 or another error in case of a fatal error encountered
- *				 during the verification process.
- */
-int ttls_x509_crt_verify_with_profile(ttls_x509_crt *crt,
-		 ttls_x509_crt *trust_ca,
-		 ttls_x509_crl *ca_crl,
-		 const ttls_x509_crt_profile *profile,
-		 const char *cn, uint32_t *flags);
+int ttls_x509_crt_check_key_usage(const TlsX509Crt *crt,
+				  unsigned int usage);
+int ttls_x509_crt_check_extended_key_usage(const TlsX509Crt *crt,
+					   const char *usage_oid,
+					   size_t usage_len);
 
-/**
- * \brief		  Check usage of certificate against keyUsage extension.
- *
- * \param crt	  Leaf certificate used.
- * \param usage	Intended usage(s) (eg TTLS_X509_KU_KEY_ENCIPHERMENT
- *				 before using the certificate to perform an RSA key
- *				 exchange).
- *
- * \note		   Except for decipherOnly and encipherOnly, a bit set in the
- *				 usage argument means this bit MUST be set in the
- *				 certificate. For decipherOnly and encipherOnly, it means
- *				 that bit MAY be set.
- *
- * \return		 0 is these uses of the certificate are allowed,
- *				 TTLS_ERR_X509_BAD_INPUT_DATA if the keyUsage extension
- *				 is present but does not match the usage argument.
- *
- * \note		   You should only call this function on leaf certificates, on
- *				 (intermediate) CAs the keyUsage extension is automatically
- *				 checked by \c ttls_x509_crt_verify().
- */
-int ttls_x509_crt_check_key_usage(const ttls_x509_crt *crt,
-			  unsigned int usage);
-
-/**
- * \brief		   Check usage of certificate against extendedKeyUsage.
- *
- * \param crt	   Leaf certificate used.
- * \param usage_oid Intended usage (eg TTLS_OID_SERVER_AUTH or
- *				  TTLS_OID_CLIENT_AUTH).
- * \param usage_len Length of usage_oid (eg given by TTLS_OID_SIZE()).
- *
- * \return		  0 if this use of the certificate is allowed,
- *				  TTLS_ERR_X509_BAD_INPUT_DATA if not.
- *
- * \note			Usually only makes sense on leaf certificates.
- */
-int ttls_x509_crt_check_extended_key_usage(const ttls_x509_crt *crt,
-		   const char *usage_oid,
-		   size_t usage_len);
-
-/**
- * \brief		  Verify the certificate revocation status
- *
- * \param crt	  a certificate to be verified
- * \param crl	  the CRL to verify against
- *
- * \return		 1 if the certificate is revoked, 0 otherwise
- *
- */
-int ttls_x509_crt_is_revoked(const ttls_x509_crt *crt, const ttls_x509_crl *crl);
-
-void ttls_x509_crt_init(ttls_x509_crt *crt);
-void ttls_x509_crt_free(ttls_x509_crt *crt);
+void ttls_x509_crt_init(TlsX509Crt *crt);
+void ttls_x509_crt_free(TlsX509Crt *crt);
 
 /**
  * Writes certificate length in exactly TTLS_CERT_LEN_LEN bytes of @buf.
  */
 static inline void
-ttls_x509_write_cert_len(const ttls_x509_crt *crt, unsigned char *buf)
+ttls_x509_write_cert_len(const TlsX509Crt *crt, unsigned char *buf)
 {
 	size_t n = crt->raw.len;
 
@@ -300,7 +158,7 @@ ttls_x509_write_cert_len(const ttls_x509_crt *crt, unsigned char *buf)
 }
 
 static inline void *
-ttls_x509_crt_page(const ttls_x509_crt *crt)
+ttls_x509_crt_page(const TlsX509Crt *crt)
 {
 	unsigned long addr = (unsigned long)crt->raw.p - TTLS_CERT_LEN_LEN;
 


### PR DESCRIPTION
This PR implements Frang requirements from the #1054. I've got a few questions with glueing multiple tls messages into a  singe tcp packet, so I decided to move it to a separate PR. In this PR: 

Three limits was added:

- New TLS sessions rate/burst limit:
Block clients which creates a lot of new full TLS handshakes, which are proven to be expensive. On the first sight the limit duplicates connection rate/burst limit, but it _can_ help mitigate TLS DDoS. Usually default TLS configuration is not redefined on client side, and TLS Tickets are enabled on the client. Using tickets client reduces TLS handshake footprint on a server performance. But in TLS Handshake DDoS client is more interested to stress the server as much as possible, thus it's expected that new full TLS handshakes will be performed more frequently.  With the new limit such clients can be identified and blocked, while the  connection rate/burst limit can remain more relaxed, not to introduce strict  limits on the application level side.

- Uncomplete TLS sessions limit:
Block clients, which trigger errors during TLS handshakes or drops the connections before a handshake is completed. The limit represents defence against TLS traffic replays or forged TLS traffic. Such traffic is easy to generate and doesn't require a lot of computation  on client side. 

A new limitation is  introduced to the TLS tickets: a session can be resumed with the client only if it's address was not changed: This doesn't badly affect us or normal client when it moves between cellular networks / wifi, but denies distribution  of a single TLS session between group of bots, allowing them to bypass full tls handshake process.