### PR TITLE
Merge TLS messages sent on session resumption scenario

### DIFF
--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -240,7 +240,8 @@ int ttls_write_certificate(TlsCtx *tls, struct sg_table *sgt,
 
 int ttls_parse_change_cipher_spec(TlsCtx *tls, unsigned char *buf,
 				  size_t len, unsigned int *read);
-void ttls_write_change_cipher_spec(TlsCtx *tls);
+void ttls_write_change_cipher_spec(TlsCtx *tls, struct sg_table *sgt,
+				   unsigned char **in_buf);
 
 int ttls_parse_finished(TlsCtx *tls, unsigned char *buf, size_t len,
 			unsigned int *read);

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1673,8 +1673,11 @@ void
 ttls_write_change_cipher_spec(TlsCtx *tls, struct sg_table *sgt,
 			      unsigned char **in_buf)
 {
-	/* The ChangeCipherSpec message is added after NewSessionTicket one. */
-	if (unlikely(in_buf)) {
+	/*
+	 * The ChangeCipherSpec message is added after another message:
+	 * NewSessionTicket on full handshake or ServerHello on abbreviated one.
+	 */
+	if (likely(in_buf)) {
 		ttls_write_hdr(tls, TTLS_MSG_CHANGE_CIPHER_SPEC, 1, *in_buf);
 		get_page(virt_to_page(*in_buf));
 		sg_set_buf(&sgt->sgl[sgt->nents++], *in_buf, TLS_HEADER_SIZE + 1);


### PR DESCRIPTION
Second part of the changes required by the #1054 

Merge TLS messages together when sending them to the client. The `ttls_handshake_server_hello()` and `ttls_handshake_finished()` declared their own buffers, which represented two separate message sets. In this PR both functions use a single buffer declared in `ttls_handshake_server_step()`. Now both functions only fills the buffer, while   `ttls_handshake_server_step()` triggers the send process.