### PR TITLE
Inherit sticky cookie configuration as stated in wiki

### DIFF
--- a/tempesta_fw/http_sess.c
+++ b/tempesta_fw/http_sess.c
@@ -368,12 +368,12 @@ tfw_http_sticky_get_req(TfwHttpReq *req, TfwStr *cookie_val)
 #define T_DBG_PRINT_STICKY_COOKIE(addr, ua, sv)				\
 do {									\
 	char abuf[TFW_ADDR_STR_BUF_SIZE] = {0};				\
-	char hbuf[STICKY_KEY_HMAC_LEN * 2] = {0};				\
+	char hbuf[STICKY_KEY_HMAC_LEN * 2] = {0};			\
 	tfw_addr_fmt(addr, TFW_NO_PORT, abuf);				\
-	bin2hex(hbuf, sticky->key, STICKY_KEY_HMAC_LEN);			\
+	bin2hex(hbuf, sticky->key, STICKY_KEY_HMAC_LEN);		\
 	T_DBG("http_sess: calculate sticky cookie for %s,"		\
 	      " ts=%#lx(now=%#lx)...\n", abuf, (sv)->ts, jiffies);	\
-	T_DBG("\t...secret: %.*s\n", (int)STICKY_KEY_HMAC_LEN * 2, hbuf);	\
+	T_DBG("\t...secret: %.*s\n", (int)STICKY_KEY_HMAC_LEN * 2, hbuf); \
 	tfw_str_dprint(ua, "\t...User-Agent");				\
 } while (0)
 #else
@@ -1506,7 +1506,7 @@ err:
 }
 
 static int
-tfw_http_sess_cfgstart(void)
+tfw_http_sess_cfgstart_local(void)
 {
 	redir_mark_enabled_reconfig = false;
 	return 0;
@@ -1578,7 +1578,7 @@ static TfwCfgSpec tfw_http_sess_specs_table[] = {
 
 TfwMod tfw_http_sess_mod = {
 	.name		= "http_sess",
-	.cfgstart	= tfw_http_sess_cfgstart,
+	.cfgstart	= tfw_http_sess_cfgstart_local,
 	.start		= tfw_http_sess_start,
 	.stop		= tfw_http_sess_stop,
 	.specs		= tfw_http_sess_specs_table,
@@ -1595,5 +1595,6 @@ tfw_http_sess_init(void)
 void
 tfw_http_sess_exit(void)
 {
+	tfw_http_sess_cfgend();
 	tfw_mod_unregister(&tfw_http_sess_mod);
 }

--- a/tempesta_fw/http_sess.h
+++ b/tempesta_fw/http_sess.h
@@ -78,6 +78,7 @@
  * @delay_range	- time interval starting after @delay_min for a client to make
  *		  a repeated request, in msecs;
  * @st_code	- status code for response with JS challenge;
+ * @users	- reference counter.
  */
 typedef struct {
 	TfwStr			body;
@@ -85,6 +86,7 @@ typedef struct {
 	unsigned long		delay_limit;
 	unsigned long		delay_range;
 	unsigned short		st_code;
+	refcount_t		users;
 } TfwCfgJsCh;
 
 /**
@@ -92,6 +94,8 @@ typedef struct {
  *
  * @shash		- Secret server value to generate reliable client
  *			  identifiers.
+ * @key			- string representation of secret key for shash,
+ *			  used only for debugging.
  * @name		- name of sticky cookie;
  * @name_eq		- @name plus "=" to make some operations faster;
  * @js_challenge	- JS challenge configuration;
@@ -108,7 +112,9 @@ typedef struct {
  */
 struct tfw_http_cookie_t {
 	struct crypto_shash	*shash;
+#ifdef DEBUG
 	char			key[STICKY_KEY_HMAC_LEN];
+#endif
 	char			sticky_name[STICKY_NAME_MAXLEN + 1];
 	char			options_str[STICKY_OPT_MAXLEN];
 	TfwStr			options;

--- a/tempesta_fw/http_sess_conf.c
+++ b/tempesta_fw/http_sess_conf.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2020 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tempesta_fw/http_sess_conf.h
+++ b/tempesta_fw/http_sess_conf.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2020 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tempesta_fw/http_sess_conf.h
+++ b/tempesta_fw/http_sess_conf.h
@@ -28,6 +28,9 @@
 
 extern TfwCfgSpec tfw_http_sess_specs[];
 
+void tfw_http_sess_cfgstart(void);
+int tfw_http_sess_cfgend(void);
+
 int tfw_http_sess_cfgop_begin(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce);
 int tfw_http_sess_cfgop_finish(TfwVhost *vhost, TfwCfgSpec *cs);
 void tfw_http_sess_cfgop_cleanup(TfwCfgSpec *cs);

--- a/tempesta_fw/t/unit/helpers.c
+++ b/tempesta_fw/t/unit/helpers.c
@@ -165,6 +165,15 @@ tfw_http_sess_cfg_finish(TfwVhost *vhost)
 	return 0;
 }
 
+void tfw_http_sess_cfgstart(void)
+{
+}
+
+int tfw_http_sess_cfgend(void)
+{
+	return 0;
+}
+
 int
 tfw_cache_process(TfwHttpMsg *msg, tfw_http_cache_cb_t action)
 {


### PR DESCRIPTION
Inherit sticky cookie configuration as stated in wiki

Main changes:
- 'sticky' directive at top-level now updates default values instead of configuring implicit default vhost. Named vhosts inherit 'sticky' directive if it was defined at top-level.
- implicit default vhost now inherits effective defaults from 'sticky'
- sticky cookie secret is not stored as plain text for release configuration, but is still available in debug builds.
- Sticky cookie secret length is relaxed to 1kb when it overrides default values.   If configured for named vhost, there is no limitation at all. Previously it had length of 20 bytes with very limited entropy since it was defined as a string in the configuration file. Now the length is relaxed, so keys with better entropy can be used.
