### PR TITLE
Write header names in lower case when transform h1 responses to h2

### DIFF
--- a/tempesta_fw/hpack.c
+++ b/tempesta_fw/hpack.c
@@ -3648,7 +3648,7 @@ tfw_hpack_hdr_inplace(TfwHttpResp *__restrict resp, TfwStr *__restrict hdr,
 
 		bnd = __TFW_STR_CH(&s_val, 0)->data;
 
-		r = tfw_h2_msg_rewrite_data(mit, &s_name, bnd);
+		r = tfw_h2_msg_rewrite_data_lc(mit, &s_name, bnd);
 		if (unlikely(r))
 			return r;
 	} else {

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -1360,9 +1360,10 @@ this_chunk:
 	return 0;
 }
 
-int
-tfw_h2_msg_rewrite_data(TfwHttpTransIter *mit, const TfwStr *str,
-			const char *stop)
+static int
+tfw_h2_msg_rewrite_data_common(TfwHttpTransIter *mit, const TfwStr *str,
+                               const char *stop,
+                               void cpy(void *dest, const void *src, size_t n))
 {
 	const TfwStr *c, *end;
 	TfwMsgIter *it = &mit->iter;
@@ -1417,8 +1418,7 @@ this_chunk:
 
 			return -E2BIG;
 		}
-
-		memcpy_fast(mit->curr_ptr, c->data + c_off, n_copy);
+		cpy(mit->curr_ptr, c->data + c_off, n_copy);
 
 		T_DBG3("%s: acc_len=%lu, n_copy=%u, mit->curr_ptr='%.*s',"
 		       " ptr_diff=%ld\n", __func__, mit->acc_len, n_copy,
@@ -1457,6 +1457,20 @@ this_chunk:
 	}
 
 	return 0;
+}
+
+int
+tfw_h2_msg_rewrite_data(TfwHttpTransIter *mit, const TfwStr *str,
+                        const char *stop)
+{
+	return tfw_h2_msg_rewrite_data_common(mit, str, stop, memcpy_fast);
+}
+
+int
+tfw_h2_msg_rewrite_data_lc(TfwHttpTransIter *mit, const TfwStr *str,
+                           const char *stop)
+{
+	return tfw_h2_msg_rewrite_data_common(mit, str, stop, tfw_cstrtolower);
 }
 
 /**

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -42,18 +42,41 @@ tfw_http_msg_make_hdr(TfwPool *pool, const char *name, const char *val)
 {
 	size_t n_len = strlen(name);
 	size_t v_len = val ? strlen(val) : 0;
-	const TfwStr tmp_hdr = {
-		.chunks = (TfwStr []){
-			{ .data = (void *)name,	.len = n_len },
-			{ .data = (void *)val,	.len = v_len,
-			  .flags = TFW_STR_HDR_VALUE},
-		},
-		.len = n_len + v_len,
-		.eolen = 2,
-		.nchunks = (val ? 2 : 1)
-	};
+	size_t n;
+	TfwStr *hdr, *h_c;
+	char *data;
 
-	return tfw_strdup(pool, &tmp_hdr);
+	n = ((val ? 2 : 1) + 1) * sizeof(TfwStr) + n_len + v_len;
+	hdr = (TfwStr *)tfw_pool_alloc(pool, n);
+	if (!hdr)
+		return NULL;
+	TFW_STR_INIT(hdr);
+
+	hdr->len = n_len + v_len;
+	hdr->eolen = 2;
+	hdr->nchunks = (val ? 2 : 1);
+	hdr->chunks = hdr + 1;
+	data = (char *)(TFW_STR_LAST(hdr) + 1);
+
+	h_c = TFW_STR_CHUNK(hdr, 0);
+
+	TFW_STR_INIT(h_c);
+	h_c->data = data;
+	h_c->len = n_len;
+	tfw_cstrtolower_wo_avx2(data, name, n_len);
+
+	if (val) {
+		data += h_c->len;
+		++h_c;
+
+		TFW_STR_INIT(h_c);
+		h_c->data = data;
+		h_c->len = v_len;
+		h_c->flags = TFW_STR_HDR_VALUE;
+		memcpy(data, val, v_len);
+	}
+
+	return hdr;
 }
 
 /**

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -187,6 +187,8 @@ int __hdr_name_cmp(const TfwStr *hdr, const TfwStr *cmp_hdr);
 int __http_hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr);
 int tfw_h2_msg_rewrite_data(TfwHttpTransIter *mit, const TfwStr *str,
 			    const char *stop);
+int tfw_h2_msg_rewrite_data_lc(TfwHttpTransIter *mit, const TfwStr *str,
+                               const char *stop);
 
 int tfw_http_msg_insert(TfwMsgIter *it, char *off, const TfwStr *data);
 

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -718,6 +718,8 @@ tfw_strdup(TfwPool *pool, const TfwStr *src)
 	const TfwStr *s_c, *end;
 	char *data;
 
+	WARN_ON(in_softirq());
+
 	n = (src->nchunks + 1) * sizeof(TfwStr) + src->len;
 	dst = (TfwStr *)tfw_pool_alloc(pool, n);
 	if (!dst)
@@ -731,7 +733,7 @@ tfw_strdup(TfwPool *pool, const TfwStr *src)
 	TFW_STR_FOR_EACH_CHUNK(s_c, src, end) {
 		*d_c = *s_c;
 		d_c->data = data;
-		memcpy_fast(data, s_c->data, s_c->len);
+		memcpy(data, s_c->data, s_c->len);
 		data += s_c->len;
 		++d_c;
 	}

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -106,6 +106,17 @@ void tfw_init_custom_ctext_vchar(const unsigned char *a);
 void tfw_init_custom_xff(const unsigned char *a);
 void tfw_init_custom_cookie(const unsigned char *a);
 
+static inline void
+tfw_cstrtolower_wo_avx2(void *dest, const void *src, size_t len)
+{
+	int i;
+	unsigned char *d = dest;
+	const unsigned char *s = src;
+
+	for (i = 0; i < len; ++i)
+		d[i] = tolower(s[i]);
+}
+
 #ifdef AVX2
 /*
  * The functions expect non-ovelapping strings, so use restrict notation in
@@ -152,12 +163,7 @@ tfw_cstricmp_2lc(const char *__restrict s1, const char *__restrict s2,
 static inline void
 tfw_cstrtolower(void *dest, const void *src, size_t len)
 {
-	int i;
-	unsigned char *d = dest;
-	const unsigned char *s = src;
-
-	for (i = 0; i < len; ++i)
-		d[i] = tolower(s[i]);
+	tfw_cstrtolower_wo_avx2(dest, src, len);
 }
 
 static inline int


### PR DESCRIPTION
Fix #1380 

When placing in the cache and when transforming header names into h2, we transform them to lowercase