### PR TITLE
Close tls connection after encryption is complete

### DIFF
--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -216,7 +216,7 @@ int ttls_derive_keys(TlsCtx *tls);
 
 void __ttls_add_record(TlsCtx *tls, struct sg_table *sgt, int sg_i,
 		       unsigned char *hdr_buf);
-int __ttls_send_record(TlsCtx *tls, struct sg_table *sgt, bool close);
+int __ttls_send_record(TlsCtx *tls, struct sg_table *sgt);
 int ttls_sendmsg(TlsCtx *tls, const char *buf, size_t len);
 
 int ttls_parse_certificate(TlsCtx *tls, unsigned char *buf, size_t len,

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -2088,7 +2088,7 @@ ttls_handshake_send_out_buffers(TlsCtx *tls, struct sg_table *sgt,
 	*pg = NULL;
 	sg_mark_end(&sgt->sgl[sgt->nents - 1]);
 	/* Exit, enter the FSM on more data from the client. */
-	return __ttls_send_record(tls, sgt, false);
+	return __ttls_send_record(tls, sgt);
 }
 
 /**

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1038,24 +1038,24 @@ __ttls_add_record(TlsCtx *tls, struct sg_table *sgt, int sg_i,
 }
 
 int
-__ttls_send_record(TlsCtx *tls, struct sg_table *sgt, bool close)
+__ttls_send_record(TlsCtx *tls, struct sg_table *sgt)
 {
 	int r;
 
-	if ((r = ttls_send_cb(tls, sgt, close)))
+	if ((r = ttls_send_cb(tls, sgt)))
 		T_DBG("TLS send callback error %d\n", r);
 	return r;
 }
 
 static int
-ttls_write_record(TlsCtx *tls, struct sg_table *sgt, bool close)
+ttls_write_record(TlsCtx *tls, struct sg_table *sgt)
 {
 	/* Change __ttls_add_record() call if you need it for handshakes. */
 	WARN_ON_ONCE(tls->io_out.msgtype == TTLS_MSG_HANDSHAKE);
 
 	__ttls_add_record(tls, NULL, 0, NULL);
 
-	return __ttls_send_record(tls, sgt, close);
+	return __ttls_send_record(tls, sgt);
 }
 
 static int
@@ -1336,7 +1336,6 @@ ttls_handle_alert(TlsCtx *tls)
 int
 ttls_send_alert(TlsCtx *tls, unsigned char lvl, unsigned char msg)
 {
-	bool close = false;
 	TlsIOCtx *io = &tls->io_out;
 
 	T_DBG("send alert level=%u message=%u\n", lvl, msg);
@@ -1348,10 +1347,7 @@ ttls_send_alert(TlsCtx *tls, unsigned char lvl, unsigned char msg)
 	io->alert[0] = lvl;
 	io->alert[1] = msg;
 
-	if (msg == TTLS_ALERT_MSG_CLOSE_NOTIFY || lvl == TTLS_ALERT_LEVEL_FATAL)
-		close = true;
-
-	return ttls_write_record(tls, NULL, close);
+	return ttls_write_record(tls, NULL);
 }
 
 int

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -565,7 +565,7 @@ typedef struct ttls_context {
 	char			*hostname;
 } TlsCtx;
 
-typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt, bool close);
+typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt);
 typedef int ttls_sni_cb_t(TlsCtx *tls, const unsigned char *data, size_t len);
 typedef unsigned long ttls_cli_id_t(TlsCtx *tls, unsigned long hash);
 


### PR DESCRIPTION
Fix #1431
Fix #1435 
Close tls connection after encryption is complete, if it is a fatal alert or close notify



