### PR TITLE
enforce invariant of TfwMsgIter::frag pointing to a current fragment

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -4195,7 +4195,7 @@ tfw_h2_append_predefined_body(TfwHttpResp *resp, unsigned int stream_id,
 		return -EINVAL;
 	it->frag = skb_shinfo(it->skb)->nr_frags - 1;
 
-	if ((++it->frag >= MAX_SKB_FRAGS)
+	if ((it->frag + 1 >= MAX_SKB_FRAGS)
 	    || (skb_shinfo(it->skb)->tx_flags & SKBTX_SHARED_FRAG))
 	{
 		if  ((r = tfw_msg_iter_append_skb(it)))
@@ -4221,13 +4221,13 @@ tfw_h2_append_predefined_body(TfwHttpResp *resp, unsigned int stream_id,
 		memcpy_fast(p + FRAME_HEADER_SIZE, data, copy);
 		data += copy;
 
+		++it->frag;
 		skb_fill_page_desc(it->skb, it->frag, page, 0,
 				   copy + FRAME_HEADER_SIZE);
 		skb_frag_ref(it->skb, it->frag);
 		ss_skb_adjust_data_len(it->skb, copy + FRAME_HEADER_SIZE);
-		++it->frag;
 
-		if (it->frag == MAX_SKB_FRAGS
+		if (it->frag + 1 == MAX_SKB_FRAGS
 		    && (r = tfw_msg_iter_append_skb(it)))
 		{
 			return r;

--- a/tempesta_fw/msg.c
+++ b/tempesta_fw/msg.c
@@ -53,7 +53,7 @@ tfw_msg_iter_setup(TfwMsgIter *it, struct sk_buff **skb_head, size_t data_len,
 	if ((r = ss_skb_alloc_data(skb_head, data_len, tx_flags)))
 		return r;
 	it->skb = it->skb_head = *skb_head;
-	it->frag = data_len ? -1 /* first 'frag' is the skb head */ : 0;
+	it->frag = -1;
 
 	BUG_ON(!it->skb);
 
@@ -73,7 +73,7 @@ tfw_msg_iter_append_skb(TfwMsgIter *it)
 	if ((r = ss_skb_alloc_data(&it->skb_head, 0, 0)))
 		return r;
 	it->skb = ss_skb_peek_tail(&it->skb_head);
-	it->frag = 0;
+	it->frag = -1;
 
 	skb_shinfo(it->skb)->tx_flags = skb_shinfo(it->skb->prev)->tx_flags;
 

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -529,7 +529,7 @@ tfw_tls_send(TlsCtx *tls, struct sg_table *sgt, bool close)
 	WARN_ON_ONCE(it.skb->next != io->skb_list
 		     || it.skb->prev != io->skb_list);
 	if (sgt) {
-		int f, i = ++it.frag;
+		int f, i = it.frag + 1;
 		struct sk_buff *skb = it.skb;
 		struct scatterlist *sg;
 


### PR DESCRIPTION
The meaning of `TfwMsgIter::frag` was not consistent before. In most of the places frag is the currently processed skb fragment. If it's -1, then we are processing a skb's body. If it's 0, the we are processing a first fragment, and that fragment does exist. But in some places, `TfwMsgIter::frag` pointed to a next-to-add fragment. These two approaches do not mix well, and when combined caused wild memory accesses.

This patch unifies meaning of `TfwMsgIter::frag`. Now if `frag` is non-negative, then there is a fragment with that index.

fixes #1399 
fixes #1438