### PR TITLE
Remove the couple of unused symbol exports

### DIFF
--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -1272,7 +1272,6 @@ tfw_str_dprint(const TfwStr *str, const char *msg)
 			      (int)c->len, c->data);
 	}
 }
-EXPORT_SYMBOL(tfw_str_dprint);
 
 #define D(n)	(unsigned int)v[n]
 
@@ -1292,6 +1291,4 @@ tfw_dbg_vprint32(const char *prefix, const unsigned char *v)
 	       D(16), D(17), D(18), D(19), D(20), D(21), D(22), D(23),
 	       D(24), D(25), D(26), D(27), D(28), D(29), D(30), D(31));
 }
-EXPORT_SYMBOL(tfw_dbg_vprint32);
-
 #endif

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -427,9 +427,6 @@ u32 tfw_str_crc32_calc(const TfwStr *str);
 #ifdef DEBUG
 void tfw_str_dprint(const TfwStr *str, const char *msg);
 void tfw_dbg_vprint32(const char *prefix, const unsigned char *v);
-#else
-#define tfw_str_dprint(str, msg)
-#define tfw_dbg_vprint32(prefix, v)
 #endif
 
 #endif /* __TFW_STR_H__ */


### PR DESCRIPTION
tfw_str_dprint() and tfw_dbg_vprint32() are used in tempesta_fw.ko module only, so do not export the symbols.