### PR TITLE
Fix tls.test_tls_cert.RSA512_SHA256 test

### DIFF
--- a/tls/bignum.c
+++ b/tls/bignum.c
@@ -1434,4 +1434,6 @@ ttls_mpi_inv_mod(TlsMpi *X, const TlsMpi *A, const TlsMpi *N)
 		ttls_mpi_sub_mpi(V1, V1, N);
 
 	ttls_mpi_copy(X, V1);
+
+	ttls_mpi_pool_cleanup_ctx((unsigned long)TA, false);
 }

--- a/tls/mpool.c
+++ b/tls/mpool.c
@@ -87,7 +87,7 @@ ttls_mpool(void *addr)
 		goto check;
 	}
 
-	mp = *this_cpu_ptr(&g_tmp_mpool);
+	mp = this_cpu_read(g_tmp_mpool);
 	mp_name = "temporary";
 	if ((unsigned long)mp < a
 	    && a < (unsigned long)mp + (PAGE_SIZE << mp->order))
@@ -143,7 +143,7 @@ ttls_mpi_pool_alloc_mpi(TlsMpi *x, size_t n)
 void *
 ttls_mpool_alloc_stack(size_t n)
 {
-	return ttls_mpool_alloc_data(*this_cpu_ptr(&g_tmp_mpool), n);
+	return ttls_mpool_alloc_data(this_cpu_read(g_tmp_mpool), n);
 }
 
 /**
@@ -158,7 +158,7 @@ ttls_mpool_alloc_stack(size_t n)
 void
 ttls_mpi_pool_cleanup_ctx(unsigned long addr, bool zero)
 {
-	TlsMpiPool *mp = *this_cpu_ptr(&g_tmp_mpool);
+	TlsMpiPool *mp = this_cpu_read(g_tmp_mpool);
 	unsigned long clean_off, m = (unsigned long)mp;
 
 	/* The tail part must be cleaned up with ttls_mpool_shrink_tailtmp(). */
@@ -396,7 +396,7 @@ ttls_mpool_exit(void)
 	TlsMpiPool *mp;
 
 	for_each_possible_cpu(i) {
-		mp = *per_cpu_ptr(&g_tmp_mpool, i);
+		mp = per_cpu(g_tmp_mpool, i);
 		ttls_bzero_safe(MPI_POOL_DATA(mp), mp->curr - sizeof(*mp));
 		free_pages((unsigned long)mp, mp->order);
 	}

--- a/tls/pkparse.c
+++ b/tls/pkparse.c
@@ -259,17 +259,17 @@ ttls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
 	 * function failure, ttls_x509_crt_free() in particular.
 	 */
 
-	if (pk_alg == TTLS_PK_RSA)
-	{
+	if (pk_alg == TTLS_PK_RSA) {
 		ret = pk_get_rsapubkey(p, end, ttls_pk_rsa(*pk));
 	}
-	else if (pk_alg == TTLS_PK_ECKEY_DH || pk_alg == TTLS_PK_ECKEY)
-	{
+	else if (pk_alg == TTLS_PK_ECKEY_DH || pk_alg == TTLS_PK_ECKEY) {
 		ret = pk_use_ecparams(&alg_params, &ttls_pk_ec(*pk)->grp);
 		if (ret == 0)
 			ret = pk_get_ecpubkey(p, end, ttls_pk_ec(*pk));
-	} else
+	}
+	else {
 		ret = TTLS_ERR_PK_UNKNOWN_PK_ALG;
+	}
 
 	if (ret == 0 && *p != end)
 		ret = TTLS_ERR_PK_INVALID_PUBKEY

--- a/tls/rsa.c
+++ b/tls/rsa.c
@@ -111,6 +111,11 @@ __rsa_setup_ctx(TlsRSACtx *ctx)
 		return 0;
 
 	ctx->len = ttls_mpi_size(&ctx->N);
+	if (ctx->len < 128) {
+		T_WARN("Trying to load an RSA key smaller than 1024 bits."
+		       " Please use stronger keys.\n");
+		return -EINVAL;
+	}
 
 	ctx->Vi = __alloc_percpu(sizeof(TlsMpi) + ctx->len * 2,
 				 __alignof__(TlsMpi));
@@ -967,9 +972,6 @@ ttls_rsa_rsassa_pss_sign(TlsRSACtx *ctx, ttls_md_type_t md_alg,
 	const TlsMdInfo *md_info;
 	TlsMdCtx md_ctx;
 
-	if (ctx->padding != TTLS_RSA_PKCS_V21)
-		return(TTLS_ERR_RSA_BAD_INPUT_DATA);
-
 	olen = ctx->len;
 
 	/* Gather length of hash to sign */
@@ -1065,13 +1067,13 @@ static int
 rsa_rsassa_pkcs1_v15_encode(ttls_md_type_t md_alg, const unsigned char *hash,
 			    size_t hashlen, size_t dst_len, unsigned char *dst)
 {
-	size_t oid_size  = 0;
-	size_t nb_pad	= dst_len;
+	size_t oid_size = 0;
+	size_t nb_pad = dst_len;
 	unsigned char *p = dst;
-	const char *oid  = NULL;
+	const char *oid = NULL;
 
-	if (ttls_oid_get_oid_by_md(md_alg, &oid, &oid_size) != 0)
-		return(TTLS_ERR_RSA_BAD_INPUT_DATA);
+	if (ttls_oid_get_oid_by_md(md_alg, &oid, &oid_size))
+		return TTLS_ERR_RSA_BAD_INPUT_DATA;
 
 	/*
 	 * Double-check that 8 + hashlen + oid_size can be used as a
@@ -1093,13 +1095,13 @@ rsa_rsassa_pkcs1_v15_encode(ttls_md_type_t md_alg, const unsigned char *hash,
 	 * - Need oid_size bytes for hash alg OID.
 	 */
 	if (nb_pad < 10 + hashlen + oid_size)
-		return(TTLS_ERR_RSA_BAD_INPUT_DATA);
+		return TTLS_ERR_RSA_BAD_INPUT_DATA;
 	nb_pad -= 10 + hashlen + oid_size;
 
 	/* Need space for signature header and padding delimiter (3 bytes),
 	 * and 8 bytes for the minimal padding */
 	if (nb_pad < 3 + 8)
-		return(TTLS_ERR_RSA_BAD_INPUT_DATA);
+		return TTLS_ERR_RSA_BAD_INPUT_DATA;
 	nb_pad -= 3;
 
 	/* Now nb_pad is the amount of memory to be filled
@@ -1142,10 +1144,9 @@ rsa_rsassa_pkcs1_v15_encode(ttls_md_type_t md_alg, const unsigned char *hash,
 
 	/* Just a sanity-check, should be automatic
 	 * after the initial bounds check. */
-	if (p != dst + dst_len)
-	{
+	if (p != dst + dst_len) {
 		bzero_fast(dst, dst_len);
-		return(TTLS_ERR_RSA_BAD_INPUT_DATA);
+		return TTLS_ERR_RSA_BAD_INPUT_DATA;
 	}
 
 	return 0;
@@ -1162,9 +1163,6 @@ ttls_rsa_rsassa_pkcs1_v15_sign(TlsRSACtx *ctx, ttls_md_type_t md_alg,
 {
 	int ret;
 	unsigned char *sig_try = NULL, *verif = NULL;
-
-	if (ctx->padding != TTLS_RSA_PKCS_V15)
-		return(TTLS_ERR_RSA_BAD_INPUT_DATA);
 
 	/*
 	 * Prepare PKCS1-v1.5 encoding (padding and hash identifier)
@@ -1186,8 +1184,7 @@ ttls_rsa_rsassa_pkcs1_v15_sign(TlsRSACtx *ctx, ttls_md_type_t md_alg,
 	TTLS_MPI_CHK(ttls_rsa_private(ctx, sig, sig_try));
 	TTLS_MPI_CHK(ttls_rsa_public(ctx, sig_try, verif));
 
-	if (ttls_safer_memcmp(verif, sig, ctx->len) != 0)
-	{
+	if (ttls_safer_memcmp(verif, sig, ctx->len)) {
 		ret = TTLS_ERR_RSA_PRIVATE_FAILED;
 		goto cleanup;
 	}


### PR DESCRIPTION
Print warning and exit with error if a user tries to load an RSA certificate with a key smaller than 1024 bits.

Do not check ctx->padding since we check it before the function calls.

Small coding style cleanups.

Note that `__rsa_setup_ctx()` during the `for_each_possible_cpu()` loop uses current CPU stack for all the big integer allocations, including `ttls_mpi_inv_mod()` and `ttls_mpi_exp_mod()`, and that's OK since the function is called on configuration time only and the stack allocations are used for temporal data only.