### PR TITLE
parser: check return value of __tfw_http_msg_add_str_data

### DIFF
--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -149,8 +149,9 @@ tfw_h2_msg_hdr_add(TfwHttpResp *resp, char *name, size_t nlen, char *val,
 	return tfw_hpack_encode(resp, &hdr, TFW_H2_TRANS_ADD, true);
 }
 
-int __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str, void *data,
-				size_t len, struct sk_buff *skb);
+int __must_check __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str,
+					     void *data, size_t len,
+					     struct sk_buff *skb);
 #define tfw_http_msg_add_str_data(hm, str, data, len)			\
 	__tfw_http_msg_add_str_data(hm, str, data, len,			\
 				    ss_skb_peek_tail(&hm->msg.skb_head))

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -67,7 +67,11 @@
 	tfw_http_msg_set_str_data(msg, field, pos)
 
 #define __msg_field_fixup(field, pos)					\
-	tfw_http_msg_add_str_data(msg, field, data, __data_off(pos))
+do {									\
+	if (unlikely(tfw_http_msg_add_str_data(msg, field, data,	\
+					       __data_off(pos))))	\
+		return CSTR_NEQ;					\
+} while (0)
 
 #define __msg_field_finish(field, pos)					\
 do {									\
@@ -76,7 +80,10 @@ do {									\
 } while (0)
 
 #define __msg_field_fixup_pos(field, data, len)				\
-	tfw_http_msg_add_str_data(msg, field, data, len)
+do {									\
+	if (unlikely(tfw_http_msg_add_str_data(msg, field, data, len)))	\
+		return CSTR_NEQ;					\
+} while (0)
 
 #define __msg_field_finish_pos(field, data, len)			\
 do {									\
@@ -94,7 +101,11 @@ do {									\
 	__msg_field_chunk_flags(&msg->stream->parser.hdr, flag)
 
 #define __msg_hdr_chunk_fixup(data, len)				\
-	tfw_http_msg_add_str_data(msg, &msg->stream->parser.hdr, data, len)
+do {									\
+	if (unlikely(tfw_http_msg_add_str_data(msg,			\
+			&msg->stream->parser.hdr, data, len)))		\
+		return CSTR_NEQ;					\
+} while (0)
 
 #define __msg_hdr_set_hpack_index(idx)					\
 	parser->hdr.hpack_idx = idx;

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -558,7 +558,11 @@ void tfw_str_collect_cmp(TfwStr *chunk, TfwStr *end, TfwStr *out,
  * TFW_STR_DUPLICATE - grow as duplicate string
  * @return pointer to the first of newly added chunk.
  *
- * TODO do we need exponential growing?
+ * Note that there are no separate notions of chunk count and chunk capacity.
+ * They are always identical. As other code is careful to grow only one TfwStr
+ * at a time, its TfwStr::chunks keeps being the rightmost allocated memory area
+ * in a pool. As there is nothing to the right from that area, resizing doesn't
+ * involve additional work most of the time, and is cheap.
  */
 static TfwStr *
 __str_grow_tree(TfwPool *pool, TfwStr *str, unsigned int flag, int n)


### PR DESCRIPTION
In extreme cases string operations may return -ENOMEM. It's better to stop parsing at that point.

Fixes #1494 by early dropping heavily-fragmented responses.