### PR TITLE
Fix #1498: place each certificate of a loaded chain in separate page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,3 @@ following topics:
 * [Configuration guide](https://github.com/tempesta-tech/tempesta/wiki/Configuration)
 * [Use cases](https://github.com/tempesta-tech/tempesta/wiki/Use-cases)
 * [Performance benchmarks](https://github.com/tempesta-tech/tempesta/wiki/Benchmarks)
-
-
-# Join Us
-
-[Join our Slack public channel for Tempesta FW contributors and user](https://join.slack.com/share/zt-mf1o0fjr-nT9cppqcl4FThhpzLoh7KQ)
-and feel free to ask any questions and discuss any Tempesta Fw-related topics!

--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -1919,7 +1919,7 @@ tfw_cfg_parse(struct list_head *mod_list)
 	char *cfg_text_buf;
 
 	T_DBG3("reading configuration file...\n");
-	if (!(cfg_text_buf = tfw_cfg_read_file(tfw_cfg_path, &file_size, 0)))
+	if (!(cfg_text_buf = tfw_cfg_read_file(tfw_cfg_path, &file_size)))
 		return -ENOENT;
 
 	T_DBG2("parsing configuration and pushing it to modules...\n");
@@ -1960,12 +1960,11 @@ tfw_cfg_conclude(struct list_head *mod_list)
  * ------------------------------------------------------------------------
  */
 /**
- * The functions returns a buffer containing the whole file with offset
- * @prefix_off.
- * The buffer must be freed with free_pages().
+ * The functions returns a buffer containing the whole file.
+ * The buffer must be freed with kfree().
  */
 void *
-tfw_cfg_read_file(const char *path, size_t *file_size, size_t prefix_off)
+tfw_cfg_read_file(const char *path, size_t *file_size)
 {
 	char *out_buf;
 	struct file *fp;
@@ -1996,7 +1995,7 @@ tfw_cfg_read_file(const char *path, size_t *file_size, size_t prefix_off)
 	buf_size += 1; /* for '\0' */
 	*file_size = buf_size;
 
-	if (!(out_buf = kmalloc(buf_size + prefix_off, GFP_KERNEL))) {
+	if (!(out_buf = kmalloc(buf_size, GFP_KERNEL))) {
 		T_ERR_NL("can't allocate memory\n");
 		goto err_alloc;
 	}
@@ -2004,8 +2003,7 @@ tfw_cfg_read_file(const char *path, size_t *file_size, size_t prefix_off)
 	do {
 		T_DBG3("read to %pK by off %d\n", out_buf, (int)off);
 		read_size = min((size_t)(buf_size - off), PAGE_SIZE);
-		bytes_read = kernel_read(fp, out_buf + prefix_off + off,
-					 read_size, &off);
+		bytes_read = kernel_read(fp, out_buf + off, read_size, &off);
 		if (bytes_read < 0) {
 			T_ERR_NL("can't read file: %s (err: %zu)\n", path,
 				 bytes_read);
@@ -2021,7 +2019,7 @@ tfw_cfg_read_file(const char *path, size_t *file_size, size_t prefix_off)
 
 	filp_close(fp, NULL);
 
-	out_buf[prefix_off + off] = '\0';
+	out_buf[off] = '\0';
 	set_fs(oldfs);
 	return out_buf;
 

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -427,7 +427,7 @@ const char *tfw_cfg_get_attr(const TfwCfgEntry *e, const char *attr_key,
 TfwCfgSpec *tfw_cfg_spec_find(TfwCfgSpec specs[], const char *name);
 int tfw_cfg_parse_mods(const char *cfg_text, struct list_head *mod_list);
 
-void *tfw_cfg_read_file(const char *path, size_t *file_size, size_t off);
+void *tfw_cfg_read_file(const char *path, size_t *file_size);
 
 int tfw_cfg_parse(struct list_head *mod_list);
 void tfw_cfg_cleanup(struct list_head *mod_list);

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -6292,8 +6292,7 @@ __tfw_http_msg_body_dup(const char *filename, TfwStr *c_len_hdr, size_t *len,
 	char buff[TFW_ULTOA_BUF_SIZ] = {0};
 	TfwStr *cl_buf = c_len_hdr ? __TFW_STR_CH(c_len_hdr, 1) : 0;
 
-	body = tfw_cfg_read_file(filename, &b_sz, 0);
-	if (!body) {
+	if (!(body = tfw_cfg_read_file(filename, &b_sz, 0))) {
 		*len = *body_offset = 0;
 		return NULL;
 	}
@@ -6329,7 +6328,7 @@ err_2:
 	if (c_len_hdr)
 		c_len_hdr->len -= cl_buf->len;
 err:
-	free_pages((unsigned long)body, get_order(b_sz));
+	kfree(body);
 
 	return res;
 }

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -6292,7 +6292,7 @@ __tfw_http_msg_body_dup(const char *filename, TfwStr *c_len_hdr, size_t *len,
 	char buff[TFW_ULTOA_BUF_SIZ] = {0};
 	TfwStr *cl_buf = c_len_hdr ? __TFW_STR_CH(c_len_hdr, 1) : 0;
 
-	if (!(body = tfw_cfg_read_file(filename, &b_sz, 0))) {
+	if (!(body = tfw_cfg_read_file(filename, &b_sz))) {
 		*len = *body_offset = 0;
 		return NULL;
 	}

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2021 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,8 +30,6 @@
 typedef struct {
 	TlsX509Crt	crt;
 	TlsPkCtx	key;
-	unsigned long	crt_pg_addr;
-	unsigned int	crt_pg_order;
 	unsigned int	conf_stage;
 } TlsCertConf;
 
@@ -141,18 +139,13 @@ tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	r = ttls_x509_crt_parse(&conf->crt, crt_data + TTLS_CERT_LEN_LEN,
 				crt_size);
-	if (r) {
+	if (r)
 		T_ERR_NL("%s: Invalid certificate specified (%x)\n",
 			 cs->name, -r);
-		free_pages((unsigned long)crt_data, get_order(crt_size));
-		return -EINVAL;
-	}
-	ttls_x509_write_cert_len(&conf->crt, crt_data);
 
-	conf->crt_pg_addr = (unsigned long)crt_data;
-	conf->crt_pg_order = get_order(crt_size);
+	kfree(crt_data);
 
-	return 0;
+	return r;
 }
 
 int
@@ -208,7 +201,7 @@ tfw_tls_set_cert_key(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	r = ttls_pk_parse_key(&conf->key, key_data, key_size);
 	/* The key is copied, so free the paged data. */
-	free_pages((unsigned long)key_data, get_order(key_size));
+	kfree(key_data);
 	if (r) {
 		T_ERR_NL("%s: Invalid private key specified (%x)\n",
 			 cs->name, -r);
@@ -245,7 +238,6 @@ tfw_tls_cleanup_tls_cert(TlsCertConf *conf)
 	if (!(conf->conf_stage & TFW_TLS_CFG_F_CERT))
 		return;
 	ttls_x509_crt_free(&conf->crt);
-	free_pages(conf->crt_pg_addr, conf->crt_pg_order);
 }
 
 static void

--- a/tempesta_fw/tls_conf.c
+++ b/tempesta_fw/tls_conf.c
@@ -130,15 +130,14 @@ tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	ttls_x509_crt_init(&conf->crt);
 	/* Preserve 3 bytes for the certificate length. */
-	crt_data = tfw_cfg_read_file(ce->vals[0], &crt_size, TTLS_CERT_LEN_LEN);
+	crt_data = tfw_cfg_read_file(ce->vals[0], &crt_size);
 	if (!crt_data) {
 		T_ERR_NL("%s: Can't read certificate file '%s'\n",
 			 ce->name, ce->vals[0]);
 		return -EINVAL;
 	}
 
-	r = ttls_x509_crt_parse(&conf->crt, crt_data + TTLS_CERT_LEN_LEN,
-				crt_size);
+	r = ttls_x509_crt_parse(&conf->crt, crt_data, crt_size);
 	if (r)
 		T_ERR_NL("%s: Invalid certificate specified (%x)\n",
 			 cs->name, -r);
@@ -192,7 +191,7 @@ tfw_tls_set_cert_key(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	ttls_pk_init(&conf->key);
 
-	key_data = tfw_cfg_read_file(ce->vals[0], &key_size, 0);
+	key_data = tfw_cfg_read_file(ce->vals[0], &key_size);
 	if (!key_data) {
 		T_ERR_NL("%s: Can't read certificate file '%s'\n",
 			 ce->name, ce->vals[0]);

--- a/tls/ciphersuites.c
+++ b/tls/ciphersuites.c
@@ -9,7 +9,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,28 +58,6 @@ static TlsCiphersuite ciphersuite_definitions[] = {
 	  TTLS_CIPHER_AES_256_GCM, TTLS_MD_SHA384,
 	  TTLS_KEY_EXCHANGE_ECDHE_ECDSA,
 	  0, { &cs_mp_ecdhe_secp256.mp, &cs_mp_ecdhe_curve25519.mp } },
-	{ TTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CCM,
-	  "TLS-ECDHE-ECDSA-WITH-AES-256-CCM",
-	  TTLS_CIPHER_AES_256_CCM, TTLS_MD_SHA256,
-	  TTLS_KEY_EXCHANGE_ECDHE_ECDSA,
-	  0, { &cs_mp_ecdhe_secp256.mp, &cs_mp_ecdhe_curve25519.mp } },
-	{ TTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8,
-	  "TLS-ECDHE-ECDSA-WITH-AES-256-CCM-8",
-	  TTLS_CIPHER_AES_256_CCM, TTLS_MD_SHA256,
-	  TTLS_KEY_EXCHANGE_ECDHE_ECDSA,
-	  TTLS_CIPHERSUITE_SHORT_TAG,
-	  { &cs_mp_ecdhe_secp256.mp, &cs_mp_ecdhe_curve25519.mp } },
-	{ TTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
-	  "TLS-ECDHE-ECDSA-WITH-AES-128-CCM",
-	  TTLS_CIPHER_AES_128_CCM, TTLS_MD_SHA256,
-	  TTLS_KEY_EXCHANGE_ECDHE_ECDSA,
-	  0, { &cs_mp_ecdhe_secp256.mp, &cs_mp_ecdhe_curve25519.mp } },
-	{ TTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
-	  "TLS-ECDHE-ECDSA-WITH-AES-128-CCM-8",
-	  TTLS_CIPHER_AES_128_CCM, TTLS_MD_SHA256,
-	  TTLS_KEY_EXCHANGE_ECDHE_ECDSA,
-	  TTLS_CIPHERSUITE_SHORT_TAG,
-	  { &cs_mp_ecdhe_secp256.mp, &cs_mp_ecdhe_curve25519.mp } },
 	{ TTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	  "TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256",
 	  TTLS_CIPHER_AES_128_GCM, TTLS_MD_SHA256,
@@ -105,21 +83,11 @@ static TlsCiphersuite ciphersuite_definitions[] = {
 	  TTLS_CIPHER_AES_256_CCM, TTLS_MD_SHA256,
 	  TTLS_KEY_EXCHANGE_DHE_RSA,
 	  0, { &cs_mp_dhe.mp, NULL } },
-	{ TTLS_TLS_DHE_RSA_WITH_AES_256_CCM_8,
-	  "TLS-DHE-RSA-WITH-AES-256-CCM-8",
-	  TTLS_CIPHER_AES_256_CCM, TTLS_MD_SHA256,
-	  TTLS_KEY_EXCHANGE_DHE_RSA,
-	  TTLS_CIPHERSUITE_SHORT_TAG, { &cs_mp_dhe.mp, NULL } },
 	{ TTLS_TLS_DHE_RSA_WITH_AES_128_CCM,
 	  "TLS-DHE-RSA-WITH-AES-128-CCM",
 	  TTLS_CIPHER_AES_128_CCM, TTLS_MD_SHA256,
 	  TTLS_KEY_EXCHANGE_DHE_RSA,
 	  0, { &cs_mp_dhe.mp, NULL } },
-	{ TTLS_TLS_DHE_RSA_WITH_AES_128_CCM_8,
-	  "TLS-DHE-RSA-WITH-AES-128-CCM-8",
-	  TTLS_CIPHER_AES_128_CCM, TTLS_MD_SHA256,
-	  TTLS_KEY_EXCHANGE_DHE_RSA,
-	  TTLS_CIPHERSUITE_SHORT_TAG, { &cs_mp_dhe.mp, NULL } },
 	{ 0, "", TTLS_CIPHER_NONE, TTLS_MD_NONE, TTLS_KEY_EXCHANGE_NONE,
 	  0, { NULL, NULL } }
 };

--- a/tls/ciphersuites.h
+++ b/tls/ciphersuites.h
@@ -30,7 +30,7 @@
 #include "pk.h"
 
 /*
- * Supported ciphersuites (Official IANA names) and recommended ciphersuites
+ * Supported ciphersuites and/or recommended by IANA ciphersuites
  * https://www.iana.org/assignments/tls-parameters/tls-parameters.xml
  */
 #define TTLS_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256	0x9E

--- a/tls/ciphersuites.h
+++ b/tls/ciphersuites.h
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,12 +41,6 @@
 #define TTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384	0xC030
 #define TTLS_TLS_DHE_RSA_WITH_AES_128_CCM		0xC09E
 #define TTLS_TLS_DHE_RSA_WITH_AES_256_CCM		0xC09F
-#define TTLS_TLS_DHE_RSA_WITH_AES_128_CCM_8		0xC0A2
-#define TTLS_TLS_DHE_RSA_WITH_AES_256_CCM_8		0xC0A3
-#define TTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM		0xC0AC
-#define TTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CCM		0xC0AD
-#define TTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8		0xC0AE
-#define TTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8		0xC0AF
 
 /*
  * Reminder: update ttls_premaster_secret when adding a new key exchange.
@@ -58,9 +52,6 @@ typedef enum {
 	TTLS_KEY_EXCHANGE_ECDHE_RSA,
 	TTLS_KEY_EXCHANGE_ECDHE_ECDSA,
 } ttls_key_exchange_type_t;
-
-/* Short authentication tag, eg for CCM_8 */
-#define TTLS_CIPHERSUITE_SHORT_TAG	0x02
 
 /**
  * This structure is used for storing ciphersuite information.

--- a/tls/pk.c
+++ b/tls/pk.c
@@ -67,7 +67,7 @@ static int
 rsa_sign_wrap(void *ctx, ttls_md_type_t md_alg, const unsigned char *hash,
 	      size_t hash_len, unsigned char *sig, size_t *sig_len)
 {
-	TlsRSACtx * rsa = (TlsRSACtx *)ctx;
+	TlsRSACtx *rsa = (TlsRSACtx *)ctx;
 
 	if (WARN_ON_ONCE(md_alg == TTLS_MD_NONE))
 		return -EINVAL;

--- a/tls/rsa.h
+++ b/tls/rsa.h
@@ -46,14 +46,16 @@
 /*
  * RSA constants
  */
-#define TTLS_RSA_PUBLIC	  0 /**< Request private key operation. */
-#define TTLS_RSA_PRIVATE	 1 /**< Request public key operation. */
+#define TTLS_RSA_PUBLIC		0 /* Request private key operation. */
+#define TTLS_RSA_PRIVATE	1 /* Request public key operation. */
 
-#define TTLS_RSA_PKCS_V15	0 /**< Use PKCS-1 v1.5 encoding. */
-#define TTLS_RSA_PKCS_V21	1 /**< Use PKCS-1 v2.1 encoding. */
+#define TTLS_RSA_PKCS_V15	0 /* Use PKCS-1 v1.5 encoding. */
+#define TTLS_RSA_PKCS_V21	1 /* Use PKCS-1 v2.1 encoding. */
 
-#define TTLS_RSA_SIGN		1 /**< Identifier for RSA signature operations. */
-#define TTLS_RSA_CRYPT	   2 /**< Identifier for RSA encryption and decryption operations. */
+/* Identifier for RSA signature operations. */
+#define TTLS_RSA_SIGN		1
+/* Identifier for RSA encryption and decryption operations. */
+#define TTLS_RSA_CRYPT		2
 
 #define TTLS_RSA_SALT_LEN_ANY	-1
 

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -260,19 +260,9 @@ ttls_own_cert(TlsCtx *tls)
 	return key_cert ? key_cert->cert : NULL;
 }
 
-/*
- * Check usage of a certificate wrt extensions:
- * keyUsage, extendedKeyUsage (later), and nSCertType (later).
- *
- * Warning: cert_endpoint is the endpoint of the cert (ie, of our peer when we
- * check a cert we received from them)!
- *
- * Return 0 if everything is OK, -1 if not.
- */
 int ttls_check_cert_usage(const TlsX509Crt *cert,
 			  const TlsCiphersuite *ciphersuite,
-			  int cert_endpoint,
-			  uint32_t *flags);
+			  int cert_endpoint);
 
 void ttls_read_version(TlsCtx *tls, const unsigned char ver[2]);
 

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -69,7 +69,7 @@ ttls_max_ciphertext_len(const TlsXfrm *xfrm)
 static inline unsigned short
 ttls_msg2crypt_len(const TlsIOCtx *io, const TlsXfrm *xfrm)
 {
-	return io->msglen - ttls_expiv_len(xfrm) - ttls_xfrm_taglen(xfrm);
+	return io->msglen - ttls_expiv_len(xfrm) - TTLS_TAG_LEN;
 }
 
 static void
@@ -117,7 +117,7 @@ ttls_aad2hdriv(TlsXfrm *xfrm, unsigned char *buf)
 	 * TAG to the final record payload length.
 	 */
 	len = ((unsigned short)buf[3] << 8) + buf[4];
-	len += ttls_expiv_len(xfrm) + ttls_xfrm_taglen(xfrm);
+	len += ttls_expiv_len(xfrm) + TTLS_TAG_LEN;
 	buf[3] = (unsigned char)(len >> 8);
 	buf[4] = (unsigned char)len;
 
@@ -565,7 +565,7 @@ ttls_derive_keys(TlsCtx *tls)
 	const TlsCipherInfo *ci;
 	const TlsMdInfo *md_info;
 	size_t mac_key_len, iv_copy_len;
-	int r = 0, tag_size;
+	int r = 0;
 	TlsSess *sess = &tls->sess;
 	TlsXfrm *xfrm = &tls->xfrm;
 	TlsHandshake *hs = tls->hs;
@@ -582,7 +582,6 @@ ttls_derive_keys(TlsCtx *tls)
 		      xfrm->ciphersuite_info->mac);
 		return TTLS_ERR_BAD_INPUT_DATA;
 	}
-	tag_size = ttls_xfrm_taglen(xfrm);
 
 	/* Set appropriate PRF function and other TLS 1.2 functions. */
 	if (xfrm->ciphersuite_info->mac == TTLS_MD_SHA384) {
@@ -658,9 +657,7 @@ ttls_derive_keys(TlsCtx *tls)
 		xfrm->fixed_ivlen = 4;
 		WARN_ON_ONCE(ttls_expiv_len(xfrm) != TTLS_IV_LEN);
 		/* Minimum length is expicit IV + tag */
-		xfrm->minlen = ttls_expiv_len(xfrm)
-				+ ((xfrm->ciphersuite_info->flags
-				    & TTLS_CIPHERSUITE_SHORT_TAG) ? 8 : 16);
+		xfrm->minlen = ttls_expiv_len(xfrm) + TTLS_TAG_LEN;
 	} else {
 		BUG_ON(ci->mode != TTLS_MODE_STREAM);
 		/*
@@ -684,9 +681,8 @@ ttls_derive_keys(TlsCtx *tls)
 		/* Minimum length */
 		xfrm->minlen = xfrm->maclen;
 	}
-	T_DBG("keylen=%u minlen=%u ivlen=%u maclen=%u tagsize=%d"
-	      " mac_key_len=%lu\n", xfrm->keylen, xfrm->minlen, xfrm->ivlen,
-	      xfrm->maclen, tag_size, mac_key_len);
+	T_DBG("keylen=%u minlen=%u ivlen=%u maclen=%u mac_key_len=%lu\n",
+	      xfrm->keylen, xfrm->minlen, xfrm->ivlen, xfrm->maclen, mac_key_len);
 
 	/* Finally setup the cipher contexts, IVs and MAC secrets. */
 	if (tls->conf->endpoint == TTLS_IS_CLIENT) {
@@ -718,11 +714,11 @@ ttls_derive_keys(TlsCtx *tls)
 		ttls_md_hmac_starts(&xfrm->md_ctx_dec, mac_dec, mac_key_len);
 	}
 
-	if ((r = ttls_cipher_setup(&xfrm->cipher_ctx_enc, ci, tag_size))) {
+	if ((r = ttls_cipher_setup(&xfrm->cipher_ctx_enc, ci, TTLS_TAG_LEN))) {
 		T_DBG("cannot setup encryption cipher, %d\n", r);
 		return r;
 	}
-	if ((r = ttls_cipher_setup(&xfrm->cipher_ctx_dec, ci, tag_size))) {
+	if ((r = ttls_cipher_setup(&xfrm->cipher_ctx_dec, ci, TTLS_TAG_LEN))) {
 		T_DBG("cannot setup decryption cipher, %d\n", r);
 		return r;
 	}
@@ -868,7 +864,6 @@ __ttls_decrypt(TlsCtx *tls, unsigned char *buf)
 	TlsIOCtx *io = &tls->io_in;
 	struct crypto_aead *tfm = xfrm->cipher_ctx_dec.cipher_ctx;
 	unsigned int sgn = 1;
-	unsigned char taglen;
 	struct aead_request *req;
 	struct scatterlist *sg = NULL;
 	unsigned char aad_buf[TLS_AAD_SPACE_SIZE];
@@ -880,23 +875,21 @@ __ttls_decrypt(TlsCtx *tls, unsigned char *buf)
 	}
 
 	expiv_len = ttls_expiv_len(xfrm);
-	taglen = ttls_xfrm_taglen(xfrm);
 	mode = xfrm->cipher_ctx_enc.cipher_info->mode;
 
 	WARN_ON_ONCE(mode != TTLS_MODE_GCM && mode != TTLS_MODE_CCM);
 	T_DBG2("decrypt input record from network: hdr=%pK msglen=%d chunks=%u"
-	       " taglen=%u eiv_len=%lu\n",
-	       io->hdr, io->msglen, io->chunks, taglen, expiv_len);
-	if (unlikely(io->msglen < expiv_len + taglen)) {
-		T_DBG("%s: msglen (%u) < expiv_len (%lu) + taglen (%u)\n",
-		      __func__, io->msglen, expiv_len, taglen);
+	       " eiv_len=%lu\n", io->hdr, io->msglen, io->chunks, expiv_len);
+	if (unlikely(io->msglen < expiv_len + TTLS_TAG_LEN)) {
+		T_DBG("%s: msglen (%u) < expiv_len (%lu) + TAG_LEN (16)\n",
+		      __func__, io->msglen, expiv_len);
 		return TTLS_ERR_INVALID_MAC;
 	}
 
-	dec_msglen = io->msglen - expiv_len - taglen;
+	dec_msglen = io->msglen - expiv_len - TTLS_TAG_LEN;
 
 	memcpy_fast(xfrm->iv_dec + xfrm->fixed_ivlen, io->iv, sizeof(io->iv));
-	req = ttls_crypto_req_sglist(tls, tfm, dec_msglen + taglen, buf,
+	req = ttls_crypto_req_sglist(tls, tfm, dec_msglen + TTLS_TAG_LEN, buf,
 				     &sg, &sgn);
 	if (!req)
 		return TTLS_ERR_INTERNAL_ERROR;
@@ -909,7 +902,7 @@ __ttls_decrypt(TlsCtx *tls, unsigned char *buf)
 
 	T_DBG3_BUF("IV used", xfrm->iv_dec, xfrm->ivlen);
 	T_DBG3_SL("decrypt: AAD|msg|TAG", sg, sgn, 0, TLS_AAD_SPACE_SIZE +
-		  dec_msglen + taglen);
+		  dec_msglen + TTLS_TAG_LEN);
 
 	/*
 	 * Decrypt and authenticate.
@@ -922,7 +915,7 @@ __ttls_decrypt(TlsCtx *tls, unsigned char *buf)
 	aead_request_set_tfm(req, tfm);
 	aead_request_set_ad(req, TLS_AAD_SPACE_SIZE);
 	/* The crypto layer expects AAD segment in output scatter list. */
-	aead_request_set_crypt(req, sg, sg, dec_msglen + taglen,
+	aead_request_set_crypt(req, sg, sg, dec_msglen + TTLS_TAG_LEN,
 			       xfrm->iv_dec);
 	r = crypto_aead_decrypt(req);
 
@@ -2330,19 +2323,13 @@ static int ttls_default_ciphersuites[] = {
 	TTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	TTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	TTLS_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
-	TTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
 	TTLS_TLS_DHE_RSA_WITH_AES_128_CCM,
-	TTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
-	TTLS_TLS_DHE_RSA_WITH_AES_128_CCM_8,
 
 	/* All AES-256 ephemeral suites */
 	TTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	TTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	TTLS_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
-	TTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CCM,
 	TTLS_TLS_DHE_RSA_WITH_AES_256_CCM,
-	TTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8,
-	TTLS_TLS_DHE_RSA_WITH_AES_256_CCM_8,
 
 	0
 };

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -281,7 +281,6 @@ struct ttls_alpn_proto {
  * @peer_cert		- peer X.509 cert chain;
  * @start		- starting time;
  * @etm			- flag for Encrypt-then-MAC activation;
- * @verify_result	- verification result;
  * @ciphersuite		- chosen ciphersuite;
  * @id_len		- session id length;
  * @id			- session identifier;
@@ -292,7 +291,6 @@ typedef struct {
 	TlsX509Crt	*peer_cert;
 	time_t		start;
 	int		etm;
-	uint32_t	verify_result;
 	unsigned short	ciphersuite;
 	unsigned char	id_len;
 	unsigned char	id[TTLS_SESS_ID_LEN];

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -4,7 +4,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -108,6 +108,7 @@
 
 #define TTLS_IV_LEN				8 /* explicit IV size */
 #define TTLS_ALERT_LEN				2
+#define TTLS_TAG_LEN				16
 
 /* Maximum host name defined in RFC 1035. */
 #define TTLS_MAX_HOST_NAME_LEN			255
@@ -627,13 +628,6 @@ void ttls_aad2hdriv(TlsXfrm *xfrm, unsigned char *buf);
 
 bool ttls_alpn_ext_eq(const ttls_alpn_proto *proto, const unsigned char *buf,
 		      size_t len);
-
-static inline unsigned char
-ttls_xfrm_taglen(const TlsXfrm *xfrm)
-{
-	return xfrm->ciphersuite_info->flags & TTLS_CIPHERSUITE_SHORT_TAG
-		? 8 : 16;
-}
 
 static inline size_t
 ttls_expiv_len(const TlsXfrm *xfrm)

--- a/tls/x509.h
+++ b/tls/x509.h
@@ -78,11 +78,10 @@
  */
 #define TTLS_ERR_X509_FATAL_ERROR			-0x3000
 
-/**
- * \name X509 Verify codes
+/*
+ * X509 Verify codes
  */
-/* Reminder: update x509_crt_verify_strings[] in library/x509_crt.c */
- /* The certificate validity has expired. */
+/* The certificate validity has expired. */
 #define TTLS_X509_BADCERT_EXPIRED			    0x01
 /* The certificate has been revoked (is on a CRL). */
 #define TTLS_X509_BADCERT_REVOKED			    0x02
@@ -96,8 +95,6 @@
 #define TTLS_X509_BADCRL_EXPIRED			    0x20
 /* Certificate was missing. */
 #define TTLS_X509_BADCERT_MISSING			    0x40
-/* Certificate verification was skipped. */
-#define TTLS_X509_BADCERT_SKIP_VERIFY			    0x80
 /* Other reason (can be used by verify callback) */
 #define TTLS_X509_BADCERT_OTHER				  0x0100
 /* The certificate validity starts in the future. */

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -114,7 +114,7 @@ typedef struct TlsX509Crt {
 	struct TlsX509Crt *next;
 } TlsX509Crt;
 
-int ttls_x509_crt_parse_der(TlsX509Crt *chain, unsigned char *buf,
+int ttls_x509_crt_parse_der(TlsX509Crt *chain, const unsigned char *buf,
 			    size_t buflen);
 int ttls_x509_crt_parse(TlsX509Crt *chain, unsigned char *buf, size_t buflen);
 

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@
 /**
  * Container for an X.509 certificate. The certificate may be chained.
  *
- * @raw			- The raw certificate data (DER).
+ * @raw			- The raw certificate data (DER) prepended with length.
  * @tbs			- The raw certificate body (DER). The part that is
  *			  To Be Signed.
  * @version		- The X.509 version. (1=v1, 2=v2, 3=v3)
@@ -146,27 +146,10 @@ void ttls_x509_crt_init(TlsX509Crt *crt);
 void ttls_x509_crt_free(TlsX509Crt *crt);
 void ttls_x509_crt_destroy(TlsX509Crt **crt);
 
-/**
- * Writes certificate length in exactly TTLS_CERT_LEN_LEN bytes of @buf.
- */
-static inline void
-ttls_x509_write_cert_len(const TlsX509Crt *crt, unsigned char *buf)
-{
-	size_t n = crt->raw.len;
-
-	buf[0] = (unsigned char)(n >> 16);
-	buf[1] = (unsigned char)(n >> 8);
-	buf[2] = (unsigned char)n;
-}
-
 static inline void *
-ttls_x509_crt_page(const TlsX509Crt *crt)
+ttls_x509_crt_raw(TlsX509Crt *crt)
 {
-	unsigned long addr = (unsigned long)crt->raw.p - TTLS_CERT_LEN_LEN;
-
-	BUG_ON(addr & ~PAGE_MASK);
-
-	return (void *)addr;
+	return crt->raw.p + TTLS_CERT_LEN_LEN;
 }
 
 int ttls_x509_init(void);


### PR DESCRIPTION
The previous approach with storing all the certificates in the same set of contiguous pages has several bugs:
1. the address of a certificate raw data isn't page-aligned, so we got the assertion failure.
2. we have to prepend each of the certificates with 3 bytes of length, and we didn't do this in the previous approach
3. a certificate in the chain may cross the page boundaris, so it'd be quite hard to properly write the length bytes and set the skb fragments.