### PR TITLE
Fix #1404: 

### DIFF
--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -198,7 +198,7 @@ start()
 		mkdir -p /opt/tempesta/db/;
 		# At this time we don't have stable TDB data format, so
 		# it would be nice to clean all the tables before the start.
-		# TODO: Remove the hack when TDB is fixed.
+		# TODO #515: Remove the hack when TDB is fixed.
 		rm -f /opt/tempesta/db/*.tdb;
 	}
 

--- a/tempesta_fw/client.c
+++ b/tempesta_fw/client.c
@@ -250,6 +250,14 @@ EXPORT_SYMBOL(tfw_client_obtain);
 
 /**
  * Beware: @fn is called under client hash bucket spin lock.
+ *
+ * TODO #515: tfw_client_for_each() can cause a scheduler stall message in
+ * kernel log. Earlier TfwClients were organised as a list and looping through
+ * all the clients involved a schedule() call like all other long loops in
+ * process context. So it was safe to dive into a long tfw_client_for_each()
+ * loop. But after TDB become the storage for TfwClient instances, a new
+ * procedure tdb_entry_walk() was introduced, that can grab the scheduler for
+ * a long time while interrupts are disabled.
  */
 int
 tfw_client_for_each(int (*fn)(void *))

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -440,6 +440,11 @@ static inline void
 tfw_connection_unlink_from_sk(struct sock *sk)
 {
 	BUG_ON(!sk->sk_user_data);
+
+	sk->sk_data_ready = NULL;
+	sk->sk_state_change = NULL;
+	sk->sk_write_xmit = NULL;
+
 	sk->sk_user_data = NULL;
 }
 

--- a/tempesta_fw/http_limits.c
+++ b/tempesta_fw/http_limits.c
@@ -401,19 +401,17 @@ frang_conn_close(struct sock *sk)
 {
 	FrangAcc *ra = sk->sk_security;
 
+	if (unlikely(!sk->sk_user_data))
+		return;
+
 	BUG_ON(!ra);
 
 	spin_lock(&ra->lock);
-#if 0
+
 	BUG_ON(!ra->conn_curr);
-#else
-	/* TODO #1404 temporal workaround. */
-	if (!ra->conn_curr) {
-		spin_unlock(&ra->lock);
-		return;
-	}
-#endif
 	ra->conn_curr--;
+
+	sk->sk_security = NULL;
 
 	spin_unlock(&ra->lock);
 


### PR DESCRIPTION
We fristly shutdown sync_socket and then http_limits (the reverse order of the initialization). So there is a small window on the shutown phase, when all the connections on Tempesta layer are dead, but the sockets are still alive (typically half closed) and can call sk->sk_security callback from http_limits untill we unregester the callbacks.

The fix checks sk->sk_user_data and do not proceed frang_conn_close() all if it's NULL (the Tempesta connection is closed).

Besides the fix, we initialize sk_security and all the callbacks to not to call them, when the socket is unlinked.