### PR TITLE
Initialize sk->sk_cgrp_data in ss_sock_create/ss_inet_create

### DIFF
--- a/fw/sock.c
+++ b/fw/sock.c
@@ -1160,6 +1160,16 @@ ss_inet_create(struct net *net, int family,
 	if (!(sk = sk_alloc(net, pfinet, GFP_ATOMIC, answer_prot, 1)))
 		return -ENOBUFS;
 
+	if (in_interrupt()) {
+		/*
+		 * When called from an interrupt context, sk_alloc() does not
+		 * initialize sk->sk_cgrp_data, so we must do it here. Other
+		 * socket-related functions assume that sk->sk_cgrp_data.val
+		 * is always non-zero.
+		 */
+		sk->sk_cgrp_data.val = (unsigned long) &cgrp_dfl_root.cgrp;
+	}
+
 	inet = inet_sk(sk);
 	inet->is_icsk = 1;
 	inet->nodefrag = 0;


### PR DESCRIPTION
When CONFIG_CGROUP_BPF is enabled, but CONFIG_CGROUP_NET_PRIO and/or
CONFIG_CGROUP_NET_CLASSID are not, sock_cgroup_ptr() just returns
sk->sk_cgrp_data.val as is, without checking for NULL. Other functions in
the networking stack, say __cgroup_bpf_run_filter_sock_addr(), may then
try to dereference the pointer, causing the kernel to crash. As sk_alloc()
doesn't initialize sk->sk_cgrp_data when called from an interrupt
context, we need to do the initialization work themselves.