### PR TITLE
update .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # Kbuild output
+*.cmd
 *.o
 *.o.*
 *.ko
 *.ko.cmd
 *.obj
+*.mod
 *.mod.c
 .tmp_versions
 modules.order
@@ -25,8 +27,8 @@ Module.symvers
 *.pyc
 
 # tdb binaries
-/tempesta_db/libtdb/libtdb.so
-/tempesta_db/tdbq/tdbq
+/db/libtdb/libtdb.so
+/db/tdbq/tdbq
 
 #debian package
 build-stamp


### PR DESCRIPTION
Pull-request #1505 renamed `tempesta_db/` to `db/`, so we need to update paths mentioned. And the newer Kbuild version started to create `.mod` and `.cmd` files that need to be ignored too.