### PR TITLE
Fix unit test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,7 @@ endif
 
 test: build
 	./scripts/tempesta.sh --stop
-	./scripts/tempesta.sh --load
 	./fw/t/unit/run_all_tests.sh
-	./scripts/tempesta.sh --unload
 
 clean:
 	$(MAKE) -C $(KERNEL) M=$(shell pwd) clean

--- a/fw/t/unit/test.c
+++ b/fw/t/unit/test.c
@@ -95,9 +95,17 @@ TEST_SUITE(wq);
 TEST_SUITE(tls);
 TEST_SUITE(hpack);
 
+extern int tfw_pool_init(void);
+extern void tfw_pool_exit(void);
+
 int
 test_run_all(void)
 {
+	int r;
+
+	r = tfw_pool_init();
+	BUG_ON(r != 0);
+
 	test_fail_counter = 0;
 
 	/* Run sleeping tests first. */
@@ -135,6 +143,8 @@ test_run_all(void)
 	__fpu_schedule();
 
 	kernel_fpu_end();
+
+	tfw_pool_exit();
 
 	return test_fail_counter;
 }


### PR DESCRIPTION
There is a caching in the pool implementation that uses per-cpu arrays which must be allocated. Caches seems to work without initialization too, but they point to the beginning of %gs segment. That may cause false positive of the GCC's stack protector feature, as it relies on `(%gs:0x28)` keeping the same value all the time.