### PR TITLE
Handling web cache size configuration

### DIFF
--- a/db/core/file.c
+++ b/db/core/file.c
@@ -57,7 +57,7 @@ ma_get_best_fit(unsigned long len, int node)
 
 	for (ma = &mas[node]; ma; ma = ma->next) {
 		if (MA_FREE(ma)
-		    && ma->pages > req_pages
+		    && ma->pages >= req_pages
 		    && (!best_fit || best_fit->pages > ma->pages))
 			best_fit = ma;
 	}

--- a/db/core/main.c
+++ b/db/core/main.c
@@ -304,7 +304,7 @@ tdb_open(const char *path, size_t fsize, unsigned int rec_size, int node)
 	db->node = node;
 
 	if (tdb_file_open(db, fsize)) {
-		TDB_ERR("Cannot open db\n");
+		TDB_ERR("Cannot open db for %s\n", path);
 		goto err;
 	}
 

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -578,6 +578,7 @@
 #
 # SIZE is specified in bytes, suffixes like 'MB' are not supported yet.
 # Also, the number must be a multiple of 2MB (Tempesta DB extent size).
+# Allowed sizes are from 16MB to 128GB.
 #
 # Default:
 #   cache_size 268435456;  # 256MB

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -2531,7 +2531,7 @@ static TfwCfgSpec tfw_cache_specs[] = {
 		.dest = &cache_cfg.db_size,
 		.spec_ext = &(TfwCfgSpecInt) {
 			.multiple_of = 2 * 1024 * 1024,
-			.range = { 2 * 1024 * 1024, (1UL << 37) },
+			.range = { 16 * 1024 * 1024, (1UL << 37) },
 		}
 	},
 	{

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -154,7 +154,7 @@ typedef struct {
 static struct {
 	int cache;
 	unsigned int methods;
-	unsigned int db_size;
+	unsigned long db_size;
 	const char *db_path;
 } cache_cfg __read_mostly;
 
@@ -2527,11 +2527,11 @@ static TfwCfgSpec tfw_cache_specs[] = {
 	{
 		.name = "cache_size",
 		.deflt = "268435456",
-		.handler = tfw_cfg_set_int,
+		.handler = tfw_cfg_set_long,
 		.dest = &cache_cfg.db_size,
 		.spec_ext = &(TfwCfgSpecInt) {
-			.multiple_of = PAGE_SIZE,
-			.range = { PAGE_SIZE, (1 << 30) },
+			.multiple_of = 2 * 1024 * 1024,
+			.range = { 2 * 1024 * 1024, (1UL << 37) },
 		}
 	},
 	{


### PR DESCRIPTION
Fixes for #1513:

1. use unsigned long to handle values up to the maximum TDB table size
   of 128GB;
2. require multiplication of 2MB and range [16MB; 128GB].
3. Pick a huge pages memory region if it's exactly of requested size