### PR TITLE
Fix IPv4/port decimals formatting issue

### DIFF
--- a/fw/addr.c
+++ b/fw/addr.c
@@ -424,7 +424,7 @@ tfw_addr_ifmatch(const TfwAddr *server, const TfwAddr *listener)
  * e.g. 12345 -> "12345".
  *
  * The function can only print up to 5 digits and take input numbers that are
- * less than 65536, which is suitable for printing port and IPv4 octet values.
+ * less than 81920, which is suitable for printing port and IPv4 octet values.
  *
  * Returns a position behind the last digit in @out_buf.
  */
@@ -433,6 +433,8 @@ tfw_put_dec(u32 q, char *out_buf)
 {
 	u32 r;
 	u8 digits_n = 1 + (q > 9) + (q > 99) + (q > 999) + (q > 9999);
+
+	BUG_ON(q >= 81920);
 
 	/* Extract individual digits and convert them to ASCII characters.
 	 *
@@ -450,7 +452,7 @@ tfw_put_dec(u32 q, char *out_buf)
 		out_buf[2] = (r - 10 * q) + '0';
 		fallthrough;
 	case 2:
-		r = (q * 0x000d) >> 7;
+		r = (q * 0x00cd) >> 11;
 		out_buf[1] = (q - 10 * r) + '0';
 		out_buf[0] = r + '0';
 		break;
@@ -463,7 +465,7 @@ tfw_put_dec(u32 q, char *out_buf)
 	case 3:
 		r = (q * 0x00cd) >> 11;
 		out_buf[2] = (q - 10 * r) + '0';
-		q = (r * 0x000d) >> 7;
+		q = (r * 0x00cd) >> 11;
 		out_buf[1] = (r - 10 * q) + '0';
 		fallthrough;
 	case 1:

--- a/fw/t/unit/test.h
+++ b/fw/t/unit/test.h
@@ -188,7 +188,7 @@ do {						\
 		TEST_FAIL("EXPECT_STR_EQ(%s, %s) => NULL ptr: (%p, %p)\n", \
 			  #str1, #str2, _s1, _s2); \
 	else if (strcmp(_s1, _s2))		\
-		TEST_FAIL("EXPECT_STR_EQ(%s, %s) => NEQ:\n  str1: %s\n  str2: %s\n", \
+		TEST_FAIL("EXPECT_STR_EQ(%s, %s) => '%s' != '%s'\n", \
 			  #str1, #str2, _s1, _s2); \
 } while (0)
 


### PR DESCRIPTION
A bug in tfw_put_dec() cause a garbage printed on some rare IPv4/port
decimals. May fire in places calling tfw_addr_fmt() or tfw_addr_ntop(),
like log entries or X-Forwarded-For header.

Wrongly formatted address looks like '104.131.181.:/', where ':/'
stands for '99'. On 0..255 range only 69, 79, 89 and 99 affected.

To fix this issue we re-examined original code found in
https://elixir.bootlin.com/linux/v3.10.25/source/lib/vsprintf.c#L131
and check all valid inputs against dumb algorithm.

Found in #1511.