### PR TITLE
PURGE w/ update implementation (#1516)

### DIFF
--- a/fw/http.h
+++ b/fw/http.h
@@ -197,6 +197,7 @@ typedef enum {
 	TFW_HTTP_HDR_REFERER,
 	TFW_HTTP_HDR_IF_NONE_MATCH,
 	TFW_HTTP_HDR_ETAG = TFW_HTTP_HDR_IF_NONE_MATCH,
+	TFW_HTTP_HDR_X_TEMPESTA_CACHE,
 
 	/* End of list of singular header. */
 	TFW_HTTP_HDR_NONSINGULAR,
@@ -209,7 +210,7 @@ typedef enum {
 	/* Start of list of generic (raw) headers. */
 	TFW_HTTP_HDR_RAW,
 
-	TFW_HTTP_HDR_NUM	= 16,
+	TFW_HTTP_HDR_NUM,
 } tfw_http_hdr_t;
 
 enum {
@@ -272,6 +273,8 @@ enum {
 	TFW_HTTP_B_WHITELIST,
 	/* Client was disconnected, drop the request. */
 	TFW_HTTP_B_REQ_DROP,
+	/* Request is PURGE with an 'X-Tempesta-Cache: get' header. */
+	TFW_HTTP_B_PURGE_GET,
 
 	/* Response flags */
 	TFW_HTTP_FLAGS_RESP,

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -154,6 +154,7 @@ tfw_http_msg_resp_spec_hid(const TfwStr *hdr)
 		TfwStrDefV("set-cookie:",	TFW_HTTP_HDR_SET_COOKIE),
 		TfwStrDefV("transfer-encoding:",TFW_HTTP_HDR_TRANSFER_ENCODING),
 		TfwStrDefV("x-forwarded-for:",	TFW_HTTP_HDR_X_FORWARDED_FOR),
+		TfwStrDefV("x-tempesta-cache:",	TFW_HTTP_HDR_X_TEMPESTA_CACHE),
 	};
 
 	BUILD_BUG_ON(ARRAY_SIZE(resp_hdrs) !=
@@ -180,6 +181,7 @@ tfw_http_msg_req_spec_hid(const TfwStr *hdr)
 		TfwStrDefV("transfer-encoding:",TFW_HTTP_HDR_TRANSFER_ENCODING),
 		TfwStrDefV("user-agent:",	TFW_HTTP_HDR_USER_AGENT),
 		TfwStrDefV("x-forwarded-for:",	TFW_HTTP_HDR_X_FORWARDED_FOR),
+		TfwStrDefV("x-tempesta-cache:",	TFW_HTTP_HDR_X_TEMPESTA_CACHE),
 	};
 
 	BUILD_BUG_ON(ARRAY_SIZE(req_hdrs) !=
@@ -206,6 +208,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 			[TFW_HTTP_HDR_CONTENT_TYPE]	= SLEN("Content-Type:"),
 			[TFW_HTTP_HDR_CONNECTION]	= SLEN("Connection:"),
 			[TFW_HTTP_HDR_X_FORWARDED_FOR]	= SLEN("X-Forwarded-For:"),
+			[TFW_HTTP_HDR_X_TEMPESTA_CACHE]	= SLEN("X-Tempesta-Cache:"),
 			[TFW_HTTP_HDR_KEEP_ALIVE]	= SLEN("Keep-Alive:"),
 			[TFW_HTTP_HDR_TRANSFER_ENCODING]= SLEN("Transfer-Encoding:"),
 			[TFW_HTTP_HDR_SERVER]		= SLEN("Server:"),
@@ -219,6 +222,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 			[TFW_HTTP_HDR_CONTENT_TYPE]	= SLEN("Content-Type:"),
 			[TFW_HTTP_HDR_CONNECTION]	= SLEN("Connection:"),
 			[TFW_HTTP_HDR_X_FORWARDED_FOR]	= SLEN("X-Forwarded-For:"),
+			[TFW_HTTP_HDR_X_TEMPESTA_CACHE]	= SLEN("X-Tempesta-Cache:"),
 			[TFW_HTTP_HDR_KEEP_ALIVE]	= SLEN("Keep-Alive:"),
 			[TFW_HTTP_HDR_TRANSFER_ENCODING]= SLEN("Transfer-Encoding:"),
 			[TFW_HTTP_HDR_USER_AGENT]	= SLEN("User-Agent:"),

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -3893,6 +3893,22 @@ TEST(http_parser, vchar)
 #undef TEST_VCHAR_HEADER
 }
 
+TEST(http_parser, x_tempesta_cache)
+{
+	FOR_REQ_SIMPLE("X-Tempesta-Cache: get ") {
+		EXPECT_TRUE(test_bit(TFW_HTTP_B_PURGE_GET, req->flags));
+	}
+	FOR_REQ_SIMPLE("X-Tempesta-Cache: get, get") {
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_PURGE_GET, req->flags));
+	}
+	FOR_REQ_SIMPLE("X-Tempesta-Cache: ge ") {
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_PURGE_GET, req->flags));
+	}
+	FOR_REQ_SIMPLE("X-Tempesta-Cache: head ") {
+		EXPECT_FALSE(test_bit(TFW_HTTP_B_PURGE_GET, req->flags));
+	}
+}
+
 TEST_SUITE(http_parser)
 {
 	int r;
@@ -3938,6 +3954,7 @@ TEST_SUITE(http_parser)
 	TEST_RUN(http_parser, xff);
 	TEST_RUN(http_parser, date);
 	TEST_RUN(http_parser, method_override);
+	TEST_RUN(http_parser, x_tempesta_cache);
 	TEST_RUN(http_parser, vchar);
 
 	/*


### PR DESCRIPTION
Note that while this seems to work for me, there are some quirks I didn't fix yet. For example:

- "X-Tempesta-Cache" is forwarded to an upstream. Probably need to mark it as an HBH header somewhere.
- The upstream GET request comes with a "Content-Length: 0" header.

There might be other similar problems. I need to properly test everything now.

The original commit message:

1. During the request parsing, if there is an "X-Tempesta-Cache"
   header, set the TFW_HTTP_B_PURGE_GET request flag. If the request
   method isn't PURGE, the flag is cleared at a later processing
   stage.

2. PURGE request handling is mostly the same as before, i.e. it will
   invalidate all matching cache entries, but also invoke a "cache
   action" callback if the request flag (1) is set, so the request may
   be forwarded to an upstream.

3. The message adjustment functions that are called before forwarding
   (in both directions) now support PURGE requests.

   - During downstream to upstream forwarding, we rewrite the request
     method to "GET" directly in an underlying SKB.

   - During upstream to downstream forwarding, the response body is
     removed and the "Content-Length" is set to zero. So clients can
     see original headers and a response status.

HTTP/2 is not supported for such requests.