### PR TITLE
Proposals for #1061 issue

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -3050,8 +3050,8 @@ tfw_h1_chop_leading_crlf(struct sk_buff **head)
 	if (likely(skb_headlen(skb) >= 3))
 	{
 		p = q = skb->data;
-		if (unlikely(*p == \r)) p++;
-		if (unlikely(*p == \n)) p++;
+		if (unlikely(*p == '\r')) p++;
+		if (unlikely(*p == '\n')) p++;
 		if (unlikely(*p <= 0x20))
 			//Drop erroneous request
 			return EBADMSG;
@@ -3074,34 +3074,34 @@ tfw_h1_chop_leading_crlf(struct sk_buff **head)
 		{
 			if (unlikely(n >= 3))
 				goto end_grab;
-			buf[n++] = p++;
+			buf[n++] = *p++;
 		}
 		
 		si = skb_shinfo(skb);
 		for (i = 0; i < si->nr_frags; i++)
 		{
-			frag = &si->frag[i];
+			frag = &si->frags[i];
 			ba = skb_frag_size(frag);
 			p = skb_frag_address(frag);
 			while (likely(ba--))
 			{
 				if (unlikely(n >= 3))
 					goto end_grab;
-				buf[n++] = p++;
+				buf[n++] = *p++;
 			}
 		}
 		skb = skb->next;
 	} while (skb != stop);
 	
 end_grab:
-	if (unlikely(n < 3)
+	if (unlikely(n < 3))
 	{
 		// Impossible, however test for more correctness
 		return EBADMSG;
 	}
 	p = buf;
-	if (unlikely(*p == \r)) p++;
-	if (unlikely(*p == \n)) p++;
+	if (unlikely(*p == '\r')) p++;
+	if (unlikely(*p == '\n')) p++;
 	if (unlikely(*p <= 0x20))
 		//Drop erroneous request
 		return EBADMSG;
@@ -3111,17 +3111,17 @@ end_grab:
 		skb = *head;
 		while (n)
 		{
-			if (likely(skb->len > n)
+			if (likely(skb->len > n))
 			{
 				return ss_skb_chop_head_tail(skb, skb, n, 0);
 			}
-			if (unlikely(skb->next == skb)
+			if (unlikely(skb->next == skb))
 			{
 				// the single skb in list
 				return EBADMSG;
 			}
 			n -= skb->len;
-			skb->next->prev = skn->prev;
+			skb->next->prev = skb->prev;
 			skb->prev->next = skb->next;
 			*head = skb->next;
 			__kfree_skb(skb);
@@ -3141,7 +3141,7 @@ tfw_h1_adjust_req(TfwHttpReq *req)
 	int r;
 	TfwHttpMsg *hm = (TfwHttpMsg *)req;
 	
-	r = tfw_h1_chop_leading_crlf(&hm->msg.skb_head)
+	r = tfw_h1_chop_leading_crlf(&hm->msg.skb_head);
 	if (r)
 		return r;
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -5217,8 +5217,8 @@ tfw_h1_req_process(TfwStream *stream, struct sk_buff *skb)
 	return hmsib;
 }
 
-#define CHOP_LEADING CRLF
-#ifdef CHOP_LEADING CRLF
+#define CHOP_LEADING_CRLF
+#ifdef CHOP_LEADING_CRLF
 /**
  * Removes single leading CR or CRLF or LF.
  * Indicates a buggy message if there are more leading CR or LF or other characters <= 0x20.
@@ -5320,7 +5320,7 @@ tfw_http_req_process(TfwConn *conn, TfwStream *stream, const TfwFsmData *data)
 	TfwHttpMsg *hmsib;
 	TfwFsmData data_up;
 	int r = TFW_BLOCK;
-#ifdef CHOP_LEADING CRLF
+#ifdef CHOP_LEADING_CRLF
 	int rc;
 #endif
 
@@ -5339,7 +5339,7 @@ next_msg:
 	hmsib = NULL;
 	req = (TfwHttpReq *)stream->msg;
 
-#ifdef CHOP_LEADING CRLF
+#ifdef CHOP_LEADING_CRLF
 	rc = tfw_h1_chop_leading_crlf(struct sk_buff *skb);
 	if (unlikely(rc == EBADMSG))
 	{

--- a/fw/http.c
+++ b/fw/http.c
@@ -3030,16 +3030,19 @@ tfw_h1_rewrite_purge_to_get(struct sk_buff *head)
 }
 
 /**
- * Removes n bytes from the beginning of the message, iterating over skb chain if needed.
+ * Removes n bytes from the beginning of the message, iterating over skb chain
+ * if needed.
  * @return zero on success and error code on error.
  *
- * TODO: to be replaced with future version of ss_skb_chop_head_tail() over all skbs of the message
+ * TODO #1535: to be replaced with future version of ss_skb_chop_head_tail()
+ * over all skbs of the message
  */
 static int
-tfw_h1_chop_leading_crlf(struct sk_buff **head, unsigned n)
+tfw_h1_chop_leading_crlf(struct sk_buff **head, unsigned int n)
 {
-	struct sk_buff *skb = *head;
+	struct sk_buff *skb;
 	while (n) {
+		skb = *head;
 		if (likely(skb->len > n))
 			return ss_skb_chop_head_tail(skb, skb, n, 0);
 		if (unlikely(skb->next == skb))
@@ -3049,7 +3052,6 @@ tfw_h1_chop_leading_crlf(struct sk_buff **head, unsigned n)
 		skb->prev->next = skb->next;
 		*head = skb->next;
 		__kfree_skb(skb);
-		skb = *head;
 	}
 	return 0;
 }
@@ -3061,14 +3063,19 @@ static int
 tfw_h1_adjust_req(TfwHttpReq *req)
 {
 	int r;
-	unsigned n_to_strip = 0;
+	unsigned int n_to_strip = 0;
 	TfwHttpMsg *hm = (TfwHttpMsg *)req;
 	
-	n_to_strip = !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_CR, req->flags) +
-		     !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
+	n_to_strip = !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_CR,
+		                req->flags)
+		     +
+		     !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF,
+				 req->flags);
 	if (unlikely(n_to_strip)) {
 		r = tfw_h1_chop_leading_crlf(&hm->msg.skb_head, n_to_strip);
-		/* TODO: replace this with future version of ss_skb_chop_head_tail() over all skbs of the message */
+		/* TODO 1535: replace this with future version of
+		 * ss_skb_chop_head_tail() over all skbs of the message 
+		 */
 		if (r)
 			return r;
 	}

--- a/fw/http.c
+++ b/fw/http.c
@@ -3049,7 +3049,7 @@ tfw_h1_chop_leading_crlf(struct sk_buff **head, unsigned int n)
 			return -EBADMSG;
 		n -= skb->len;
 		/* We do not use ss_skb_unlink() here to prevent it
-		 * to remove the last skb in the list and to skip
+		 * from removing the last skb in the list and to skip
 		 * some actions using our apriori knowledge
 		 */
 		skb->next->prev = skb->prev;

--- a/fw/http.c
+++ b/fw/http.c
@@ -5217,6 +5217,94 @@ tfw_h1_req_process(TfwStream *stream, struct sk_buff *skb)
 	return hmsib;
 }
 
+#define CHOP_LEADING CRLF
+#ifdef CHOP_LEADING CRLF
+/**
+ * Removes single leading CR or CRLF or LF.
+ * Indicates a buggy message if there are more leading CR or LF or other characters <= 0x20.
+ * @return zero on success and error code on error.
+ * EBADMSG error code indicates a buggy message (for 400);
+ * other error codes indicates internal errors (for 500).
+ */
+static int
+tfw_h1_chop_leading_crlf(struct sk_buff *skb)
+{
+	struct sk_buff *stop = skb;
+	char *p, *q;
+	int i, n, ret, ba;
+	char buf[sizeof(__u32)];
+	struct skb_shared_info *si;
+	skb_frag_t *frag;
+
+	if (likely(skb_headlen(skb) >= 3))
+	{
+		p = q = skb->data;
+		if (unlikely(*p == \r)) p++;
+		if (unlikely(*p == \n)) p++;
+		if (unlikely(*p <= 0x20))
+			//Offloading subsequent parser from buggy message
+			return EBADMSG;
+		if (unlikely((n = p - q)))
+		{
+			// Cleaning the msg
+			ret = ss_skb_chop_head_tail(skb, skb, n, 0);
+			if (ret)
+				return ret;
+		}
+		return 0;
+	}
+
+	// grab 3 bytes
+	n = 0; *(__u32*)&buf = 0;
+	do {
+		ba = skb_headlen(skb);
+		p = skb->data;
+		while (likely(ba--))
+		{
+			if (unlikely(n >= 3))
+				goto end_grab;
+			buf[n++] = p++;
+		}
+		
+		si = skb_shinfo(skb);
+		for (i = 0; i < si->nr_frags; i++)
+		{
+			frag = &si->frag[i];
+			ba = skb_frag_size(frag);
+			p = skb_frag_address(frag);
+			while (likely(ba--))
+			{
+				if (unlikely(n >= 3))
+					goto end_grab;
+				buf[n++] = p++;
+			}
+		}
+		skb = skb->next;
+	} while (skb != stop);
+	
+end_grab:
+	if (unlikely(n < 3))
+	{
+		// Message is too short
+		return EBADMSG;
+	}
+	p = buf;
+	if (unlikely(*p == \r)) p++;
+	if (unlikely(*p == \n)) p++;
+	if (unlikely(*p <= 0x20))
+		//Offloading subsequent parser from buggy message
+		return EBADMSG;
+	if (unlikely((n = p - buf)))
+	{
+		// Cleaning the msg
+		ret = ss_skb_chop_head_tail(skb, skb, n, 0);
+		if (ret)
+			return ret;
+	}
+	return 0;
+}
+#endif
+
 /**
  * @return zero on success and negative value otherwise.
  * TODO enter the function depending on current GFSM state.
@@ -5232,6 +5320,9 @@ tfw_http_req_process(TfwConn *conn, TfwStream *stream, const TfwFsmData *data)
 	TfwHttpMsg *hmsib;
 	TfwFsmData data_up;
 	int r = TFW_BLOCK;
+#ifdef CHOP_LEADING CRLF
+	int rc;
+#endif
 
 	BUG_ON(!stream->msg);
 
@@ -5247,6 +5338,24 @@ next_msg:
 	parsed = 0;
 	hmsib = NULL;
 	req = (TfwHttpReq *)stream->msg;
+
+#ifdef CHOP_LEADING CRLF
+	rc = tfw_h1_chop_leading_crlf(struct sk_buff *skb);
+	if (unlikely(rc == EBADMSG))
+	{
+		T_DBG2("Block invalid HTTP request (leading CRLFs)\n");
+		TFW_INC_STAT_BH(clnt.msgs_parserr);
+		tfw_http_req_parse_drop(req, 400, "Failed to parse request");
+		return TFW_BLOCK;
+	}
+	else if (unlikely(rc != 0))
+	{
+		TFW_INC_STAT_BH(clnt.msgs_otherr);
+		tfw_http_req_parse_block(req, 500, "Request dropped: internal error");
+		return TFW_BLOCK;
+	}
+#endif
+	
 	actor = TFW_MSG_H2(req) ? tfw_h2_parse_req : tfw_http_parse_req;
 
 	r = ss_skb_process(skb, actor, req, &req->chunk_cnt, &parsed);

--- a/fw/http.c
+++ b/fw/http.c
@@ -3039,16 +3039,11 @@ static int
 tfw_h1_chop_leading_crlf(struct sk_buff **head, unsigned n)
 {
 	struct sk_buff *skb = *head;
-	while (n)
-	{
+	while (n) {
 		if (likely(skb->len > n))
-		{
 			return ss_skb_chop_head_tail(skb, skb, n, 0);
-		}
 		if (unlikely(skb->next == skb))
-		{
 			return -EBADMSG;
-		}
 		n -= skb->len;
 		skb->next->prev = skb->prev;
 		skb->prev->next = skb->next;
@@ -3070,9 +3065,8 @@ tfw_h1_adjust_req(TfwHttpReq *req)
 	TfwHttpMsg *hm = (TfwHttpMsg *)req;
 	
 	n_to_strip = !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_CR, req->flags) +
-	                !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
-	if (unlikely(n_to_strip))
-	{
+		     !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
+	if (unlikely(n_to_strip)) {
 		r = tfw_h1_chop_leading_crlf(&hm->msg.skb_head, n_to_strip);
 		/* TODO: replace this with future version of ss_skb_chop_head_tail() over all skbs of the message */
 		if (r)

--- a/fw/http.h
+++ b/fw/http.h
@@ -275,6 +275,10 @@ enum {
 	TFW_HTTP_B_REQ_DROP,
 	/* Request is PURGE with an 'X-Tempesta-Cache: get' header. */
 	TFW_HTTP_B_PURGE_GET,
+	/* Need strip 1 leading CR */
+	TFW_HTTP_B_NEED_STRIP_LEADING_CR,
+	/* Need strip 1 leading LF */
+	TFW_HTTP_B_NEED_STRIP_LEADING_LF,
 
 	/* Response flags */
 	TFW_HTTP_FLAGS_RESP,

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3635,7 +3635,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 	/* - Skipping and stripping leading CRLFs - */
 
 	/* The parser accepts 1 optional CRLF or LF before the request line.
-	 * The parser store the fact of presense of it for subsequent stripping.
+	 * The parser stores the fact of presense of it for subsequent stripping.
 	 * The parser blocks the request if it contains additional CRLFs before the request line.
 	 */
 	__FSM_STATE(Req_0, hot) {

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3635,23 +3635,27 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 	/* - Skipping and stripping leading CRLFs - */
 
 	/* The parser accepts 1 optional CRLF or LF before the request line.
-	 * The parser stores the fact of presense of it for subsequent stripping.
-	 * The parser blocks the request if it contains additional CRLFs before the request line.
+	 * The parser stores the fact of presense of it for subsequent
+	 * stripping. The parser blocks the request if it contains additional
+	 * CRLFs before the request line.
 	 */
 	__FSM_STATE(Req_0, hot) {
 		if (unlikely(c == '\r')) {
-			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_CR, req->flags);
+			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_CR,
+				  req->flags);
 			__FSM_MOVE_nofixup(Req_0_Wait_LF);
 		}
 		if (unlikely(c == '\n')) {
-			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
+			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF,
+				  req->flags);
 			__FSM_MOVE_nofixup(Req_0_CheckExtraLeadingCRLF);
 		}
-		goto Req_0_CheckExtraLeadingCRLF;
+		__FSM_JMP(Req_0_CheckExtraLeadingCRLF);
 	}
-	__FSM_STATE(Req_0_Wait_LF, hot) {
+	__FSM_STATE(Req_0_Wait_LF) {
 		if (likely(c == '\n')) 	{
-			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
+			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF,
+				  req->flags);
 			__FSM_MOVE_nofixup(Req_0_CheckExtraLeadingCRLF);
 		}
 		TFW_PARSER_BLOCK(Req_0_Wait_LF);

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3638,30 +3638,27 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 	 * The parser store the fact of presense of it for subsequent stripping.
 	 * The parser blocks the request if it contains additional CRLFs before the request line.
 	 */
-        __FSM_STATE(Req_0, hot) {
-                if (unlikely(c == '\r'))
-		{
+	__FSM_STATE(Req_0, hot) {
+		if (unlikely(c == '\r')) {
 			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_CR, req->flags);
-                        __FSM_MOVE_nofixup(Req_0_Wait_LF);
+			__FSM_MOVE_nofixup(Req_0_Wait_LF);
 		}
-                if (unlikely(c == '\n'))
-		{
+		if (unlikely(c == '\n')) {
 			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
 			__FSM_MOVE_nofixup(Req_0_CheckExtraLeadingCRLF);
 		}
-                goto Req_0_CheckExtraLeadingCRLF;
-        }
-        __FSM_STATE(Req_0_Wait_LF, hot) {
-                if (likely(c == '\n'))
-		{
+		goto Req_0_CheckExtraLeadingCRLF;
+	}
+	__FSM_STATE(Req_0_Wait_LF, hot) {
+		if (likely(c == '\n')) 	{
 			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
 			__FSM_MOVE_nofixup(Req_0_CheckExtraLeadingCRLF);
 		}
-                TFW_PARSER_BLOCK(Req_0_Wait_LF);
-        }
-        __FSM_STATE(Req_0_CheckExtraLeadingCRLF, hot) {
+		TFW_PARSER_BLOCK(Req_0_Wait_LF);
+	}
+	__FSM_STATE(Req_0_CheckExtraLeadingCRLF, hot) {
 		if (unlikely(c <= 0x20))
-                        TFW_PARSER_BLOCK(Req_0_CheckExtraLeadingCRLF);
+			TFW_PARSER_BLOCK(Req_0_CheckExtraLeadingCRLF);
 	}
 
 	/* ----------------    Request Line    ---------------- */

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3645,7 +3645,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 	}
 	__FSM_STATE(Req_0_ExtraLeadingCRLF, hot) {
 		if (unlikely(c <= 0x20))
-			TFW_PARSER_BLOCK(Req_ExtraLeadingCRLF);
+			TFW_PARSER_BLOCK(Req_0_ExtraLeadingCRLF);
 	}
 
 	/* HTTP method. */

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3645,7 +3645,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 	}
 	__FSM_STATE(Req_0_ExtraLeadingCRLF, hot) {
 		if (unlikely(c <= 0x20))
-			TFW_PARSER_BLOCK(Req_0_ExtraLeadingCRLF);
+			TFW_PARSER_BLOCK(Req_ExtraLeadingCRLF);
 	}
 
 	/* HTTP method. */

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3635,10 +3635,17 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 	/* ----------------    Request Line    ---------------- */
 
 	/* Parser internal initializers, must be called once per message. */
-	__FSM_STATE(Req_0, hot) {
-		if (unlikely(IS_CRLF(c)))
-			__FSM_MOVE_nofixup(Req_0);
-		/* fall through */
+	__FSM_STATE(Req_0_CR, hot) {
+		if (unlikely(c == \r))
+			__FSM_MOVE_nofixup(Req_0_LF);
+	}
+	__FSM_STATE(Req_0_LF, hot) {
+		if (unlikely(c == \n))
+			__FSM_MOVE_nofixup(Req_0_ExtraLeadingCRLF);
+	}
+	__FSM_STATE(Req_0_ExtraLeadingCRLF, hot) {
+		if (unlikely(c <= 0x20))
+			TFW_PARSER_BLOCK(Req_ExtraLeadingCRLF);
 	}
 
 	/* HTTP method. */

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3648,21 +3648,17 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 		if (unlikely(c == '\n')) {
 			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF,
 				  req->flags);
-			__FSM_MOVE_nofixup(Req_0_CheckExtraLeadingCRLF);
+			__FSM_MOVE_nofixup(Req_Method);
 		}
-		__FSM_JMP(Req_0_CheckExtraLeadingCRLF);
+		__FSM_JMP(Req_Method);
 	}
 	__FSM_STATE(Req_0_Wait_LF) {
 		if (likely(c == '\n')) 	{
 			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF,
 				  req->flags);
-			__FSM_MOVE_nofixup(Req_0_CheckExtraLeadingCRLF);
+			__FSM_MOVE_nofixup(Req_Method);
 		}
 		TFW_PARSER_BLOCK(Req_0_Wait_LF);
-	}
-	__FSM_STATE(Req_0_CheckExtraLeadingCRLF, hot) {
-		if (unlikely(c <= 0x20))
-			TFW_PARSER_BLOCK(Req_0_CheckExtraLeadingCRLF);
 	}
 
 	/* ----------------    Request Line    ---------------- */

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3635,17 +3635,10 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 	/* ----------------    Request Line    ---------------- */
 
 	/* Parser internal initializers, must be called once per message. */
-	__FSM_STATE(Req_0_CR, hot) {
-		if (unlikely(c == \r))
-			__FSM_MOVE_nofixup(Req_0_LF);
-	}
-	__FSM_STATE(Req_0_LF, hot) {
-		if (unlikely(c == \n))
-			__FSM_MOVE_nofixup(Req_0_ExtraLeadingCRLF);
-	}
-	__FSM_STATE(Req_0_ExtraLeadingCRLF, hot) {
-		if (unlikely(c <= 0x20))
-			TFW_PARSER_BLOCK(Req_ExtraLeadingCRLF);
+	__FSM_STATE(Req_0, hot) {
+		if (unlikely(IS_CRLF(c)))
+			__FSM_MOVE_nofixup(Req_0);
+		/* fall through */
 	}
 
 	/* HTTP method. */

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -3632,21 +3632,39 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
 
 	__FSM_START(parser->state);
 
-	/* ----------------    Request Line    ---------------- */
+	/* - Skipping and stripping leading CRLFs - */
 
-	/* Parser internal initializers, must be called once per message. */
-	__FSM_STATE(Req_0_CR, hot) {
-		if (unlikely(c == \r))
-			__FSM_MOVE_nofixup(Req_0_LF);
-	}
-	__FSM_STATE(Req_0_LF, hot) {
-		if (unlikely(c == \n))
-			__FSM_MOVE_nofixup(Req_0_ExtraLeadingCRLF);
-	}
-	__FSM_STATE(Req_0_ExtraLeadingCRLF, hot) {
+	/* The parser accepts 1 optional CRLF or LF before the request line.
+	 * The parser store the fact of presense of it for subsequent stripping.
+	 * The parser blocks the request if it contains additional CRLFs before the request line.
+	 */
+        __FSM_STATE(Req_0, hot) {
+                if (unlikely(c == '\r'))
+		{
+			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_CR, req->flags);
+                        __FSM_MOVE_nofixup(Req_0_Wait_LF);
+		}
+                if (unlikely(c == '\n'))
+		{
+			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
+			__FSM_MOVE_nofixup(Req_0_CheckExtraLeadingCRLF);
+		}
+                goto Req_0_CheckExtraLeadingCRLF;
+        }
+        __FSM_STATE(Req_0_Wait_LF, hot) {
+                if (likely(c == '\n'))
+		{
+			__set_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
+			__FSM_MOVE_nofixup(Req_0_CheckExtraLeadingCRLF);
+		}
+                TFW_PARSER_BLOCK(Req_0_Wait_LF);
+        }
+        __FSM_STATE(Req_0_CheckExtraLeadingCRLF, hot) {
 		if (unlikely(c <= 0x20))
-			TFW_PARSER_BLOCK(Req_0_ExtraLeadingCRLF);
+                        TFW_PARSER_BLOCK(Req_0_CheckExtraLeadingCRLF);
 	}
+
+	/* ----------------    Request Line    ---------------- */
 
 	/* HTTP method. */
 	__FSM_STATE(Req_Method, hot) {


### PR DESCRIPTION
This request is for review, not for real pull!

The main idea of #1061 was to allow an optional single CTRL before HTTP request and block the request if there is smth else before the request. A single LF is to be allowed as well.
The proposed code will also allow a single CR at that place. This contradicts a little with #1061 however, I suppose, this difference is not important. 
As a summary one of the CRLF, LF or CR is allowed and any other prepending character sequences will block the request.
The single CR can be disallowed by inserting one more "state" in func.