### PR TITLE
Incorrect fixups for Accept and Content-Type in request parser

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1873,6 +1873,8 @@ __req_parse_content_type(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	__FSM_STATE(I_EoL) {
 		__FSM_I_MATCH_MOVE_fixup(ctext_vchar, I_EoL, 0);
 		if (IS_CRLF(*(p + __fsm_sz))) {
+			/* __TFW_HTTP_PARSE_SPECHDR_VAL is told to not fixup it */
+			__msg_hdr_chunk_fixup(p, __fsm_sz);
 			p += __fsm_sz;
 			goto finalize;
 		}
@@ -4602,7 +4604,7 @@ Req_Method_1CharStep: __attribute__((cold))
 	__FSM_TX_AF(Req_HdrAcc, 'e', Req_HdrAcce);
 	__FSM_TX_AF(Req_HdrAcce, 'p', Req_HdrAccep);
 	__FSM_TX_AF(Req_HdrAccep, 't', Req_HdrAccept);
-	__FSM_TX_AF(Req_HdrAccept, ':', Req_HdrAcceptV);
+	__FSM_TX_AF_OWS(Req_HdrAccept, Req_HdrAcceptV);
 
 	/* Authorization header processing. */
 	__FSM_TX_AF(Req_HdrAu, 't', Req_HdrAut);

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -1656,6 +1656,10 @@ TEST(http_parser, ows)
 	EXPECT_BLOCK_REQ("GET / HTTP/1.1\r\n"
 			 " Host: foo.com\r\n"
 			 "\r\n");
+
+	FOR_REQ_SIMPLE("Accept-Encoding: dummy");
+	EXPECT_BLOCK_REQ_SIMPLE("Accept -Encoding: dummy");
+	EXPECT_BLOCK_REQ_SIMPLE("Accept- Encoding: dummy");
 }
 
 TEST(http_parser, folding)


### PR DESCRIPTION
I really dislike the idea of "saveval" argument in __TFW_HTTP_PARSE_SPECHDR_VAL/__TFW_HTTP_PARSE_RAWHDR_VAL/TFW_H2_PARSE_HDR_VAL macroses, because it spreads a single fixups logic into three remote locations. However, I haven't been able to find an easy solution to avoid a significant refactoring of the parser. So I'm just leaving the saveval problem as is and just repairing the concrete fixup logic, which currently leads to additional 30 assertions in tests.