### PR TITLE
Implemented additional caching features for #530

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -1545,7 +1545,6 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 	ce->hdrs = TDB_OFF(db->hdr, p);
 	ce->hdr_len = 0;
 	ce->hdr_num = resp->h_tbl->off;
-	printk("Writing cache");
 	FOR_EACH_HDR_FIELD_FROM(field, end1, resp, TFW_HTTP_HDR_REGULAR) {
 		int hid = field - resp->h_tbl->tbl;
 		/*
@@ -1656,14 +1655,14 @@ check_cfg_ignored_header(const TfwStr *field, TfwCaToken *tokens,
 	TfwCaToken *token = tokens;
 	for (i = 0; i < tokens_sz; i++) {
 		const TfwStr to_del = {
-			.data = &token->str,
+			.data = token->str,
 			.len = token->len - 1
 		};
 		BUG_ON(token->len > 10000);
 		if (tfw_stricmpspn(field, &to_del, ':') == 0) {
 			return true;
 		}
-		bytes_count += offsetof(TfwCaToken, str) + token->len;
+		bytes_count += sizeof(TfwCaToken) + token->len;
 		token = (TfwCaToken *)(bytes_count + (char *)tokens);
 	}
 	return false;

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -307,7 +307,7 @@ tfw_cache_policy(TfwVhost *vhost, TfwLocation *loc, TfwStr *arg)
 {
 	TfwCaPolicy *capo;
 
-	/* Search locations in current vhost. */
+	/* Search locations in current loc. */
 	if (loc && loc->capo_sz) {
 		if ((capo = tfw_capolicy_match(loc, arg)))
 			return capo->cmd;
@@ -397,6 +397,9 @@ static bool
 tfw_cache_employ_resp(TfwHttpResp *resp)
 {
 	TfwHttpReq *req = resp->req;
+	unsigned int ignored_resp_flags =
+		tfw_vhost_get_cache_policy_mask(req->location, req->vhost);
+	resp->cache_ctl.flags &= ~ignored_resp_flags;
 
 #define CC_REQ_DONTCACHE				\
 	(TFW_HTTP_CC_CFG_CACHE_BYPASS | TFW_HTTP_CC_NO_STORE)
@@ -1434,6 +1437,42 @@ __save_hdr_304_off(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *hdr, long off)
 	return false;
 }
 
+static bool
+check_ignored_header(const TfwStr *field, const TfwCaPolicyTokens *tokens,
+		     TfwCacheEntry *ce)
+{
+	int i;
+	for (i = 0; i < tokens->sz; i++) {
+		const TfwStr to_del = {
+			.data = tokens->tokens[i]->arg,
+			.len = tokens->tokens[i]->len
+		};
+		if (tfw_stricmpspn(field, &to_del, ':') == 0) {
+			if (ce)
+				--ce->hdr_num;
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool
+check_ignored_header2(const TfwStr *field, const TfwStrArray *tokens,
+		      TfwCacheEntry *ce)
+{
+	int i;
+	/* TfwStrArray implies invariants:
+	   last < capacity and last = count - 1  */
+	for (i = 0; i < tokens->last; i++) {
+		if (tfw_stricmpspn(field, &tokens->items[i], ':') == 0) {
+			if (ce)
+				--ce->hdr_num;
+			return true;
+		}
+	}
+	return false;
+}
+
 /**
  * Copy response skbs to database mapped area.
  * @tot_len	- total length of actual data to write w/o TfwCStr's etc;
@@ -1450,6 +1489,7 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 	char *p;
 	unsigned short status_idx;
 	TfwStr *field, *h, *end1, *end2;
+	TfwCaPolicyTokens *hdr_del_tokens;
 	TDB *db = node_db();
 	TdbVRec *trec = &ce->trec, *etag_trec = NULL;
 	long n, etag_off = 0;
@@ -1538,9 +1578,12 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 	if (tfw_cache_h2_copy_str(&ce->rph_len, &p, &trec, rph, &tot_len))
 		return -ENOMEM;
 
+	hdr_del_tokens = tfw_vhost_get_cache_policy_tokens(req->location, req->vhost);
+
 	ce->hdrs = TDB_OFF(db->hdr, p);
 	ce->hdr_len = 0;
 	ce->hdr_num = resp->h_tbl->off;
+	printk("Writing cache");
 	FOR_EACH_HDR_FIELD_FROM(field, end1, resp, TFW_HTTP_HDR_REGULAR) {
 		int hid = field - resp->h_tbl->tbl;
 		/*
@@ -1554,6 +1597,23 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 		{
 			--ce->hdr_num;
 			continue;
+		}
+
+		if (hdr_del_tokens) {
+			/* remove headers mentioned in cache_resp_hdr_del */
+			if (check_ignored_header(field, hdr_del_tokens, ce))
+				continue;
+		}
+
+		if (resp->no_cache_tokens.last > 0) {
+			/* remove headers mentioned in Cache-Control: no-cache */
+			if (check_ignored_header2(field, &resp->no_cache_tokens, ce))
+				continue;
+		}
+		if (resp->private_tokens.last > 0) {
+			/* remove headers mentioned in Cache-Control: private */
+			if (check_ignored_header2(field, &resp->private_tokens, ce))
+				continue;
 		}
 
 		if (hid == TFW_HTTP_HDR_ETAG) {
@@ -1651,7 +1711,8 @@ __cache_entry_size(TfwHttpResp *resp)
 	TfwStr *host = &req->h_tbl->tbl[TFW_HTTP_HDR_HOST];
 	unsigned long via_sz = SLEN(S_VIA_H2_PROTO)
 		+ tfw_vhost_get_global()->hdr_via_len;
-
+	TfwCaPolicyTokens *hdr_del_tokens =
+			tfw_vhost_get_cache_policy_tokens(req->location, req->vhost);
 	/* Add compound key size */
 	res_size += req->uri_path.len;
 	tfw_http_msg_clnthdr_val(req, host, TFW_HTTP_HDR_HOST, &host_val);
@@ -1678,6 +1739,20 @@ __cache_entry_size(TfwHttpResp *resp)
 		    || hid == TFW_HTTP_HDR_SERVER
 		    || TFW_STR_EMPTY(hdr))
 			continue;
+
+		if (hdr_del_tokens) {
+			if (check_ignored_header(hdr, hdr_del_tokens, NULL))
+				continue;
+		}
+
+		if (resp->no_cache_tokens.last > 0) {
+			if (check_ignored_header2(hdr, &resp->no_cache_tokens, NULL))
+				continue;
+		}
+		if (resp->private_tokens.last > 0) {
+			if (check_ignored_header2(hdr, &resp->private_tokens, NULL))
+				continue;
+		}
 
 		size = sizeof(TfwCStr);
 

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -4,7 +4,7 @@
  * HTTP cache (RFC 7234).
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1888,6 +1888,11 @@ check_name_text:
 
 		NEXT_STATE(HPACK_STATE_VALUE_TEXT);
 
+		if (src >= last && !h2_mode) {
+			/* We are going to skip the HPACK_STATE_VALUE_TEXT,
+			   but still need the newline for a correct HTTP/1 */
+			EXPAND_DATA(S_CRLF, SLEN(S_CRLF));
+		}
 		GET_NEXT_DATA(src >= last);
 
 		fallthrough;

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1888,12 +1888,16 @@ check_name_text:
 
 		NEXT_STATE(HPACK_STATE_VALUE_TEXT);
 
-		if (src >= last && !h2_mode) {
-			/* We are going to skip the HPACK_STATE_VALUE_TEXT,
-			   but still need the newline for a correct HTTP/1 */
-			EXPAND_DATA(S_CRLF, SLEN(S_CRLF));
+		if (src >= last) {
+			if (!h2_mode) {
+				/*
+				 * We are going to skip the HPACK_STATE_VALUE_TEXT,
+				 * but still need the newline for a correct HTTP/1
+				 */
+				EXPAND_DATA(S_CRLF, SLEN(S_CRLF));
+			}
+			goto out;
 		}
-		GET_NEXT_DATA(src >= last);
 
 		fallthrough;
 

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1888,14 +1888,15 @@ check_name_text:
 
 		NEXT_STATE(HPACK_STATE_VALUE_TEXT);
 
-		if (src >= last) {
-			if (!h2_mode) {
-				/*
-				 * We are going to skip the HPACK_STATE_VALUE_TEXT,
-				 * but still need the newline for a correct HTTP/1
-				 */
+		if (unlikely(src >= last)) {
+			/*
+			 * The header has no value, so we are going to skip the
+			 * HPACK_STATE_VALUE_TEXT, but still need to write CRLF
+			 * at the end of the header line for a correct HTTP/1.
+			 */
+			if (!h2_mode)
 				EXPAND_DATA(S_CRLF, SLEN(S_CRLF));
-			}
+
 			goto out;
 		}
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -113,11 +113,6 @@
 #define S_H2_PATH		":path"
 #define S_H2_STAT		":status"
 
-#define T_WARN_ADDR_STATUS(msg, addr_ptr, print_port, status)		\
-	TFW_WITH_ADDR_FMT(addr_ptr, print_port, addr_str,		\
-			  T_WARN("%s, status %d: %s\n",			\
-				 msg, status, addr_str))
-
 #define RESP_BUF_LEN		128
 
 static DEFINE_PER_CPU(char[RESP_BUF_LEN], g_buf);

--- a/fw/http.c
+++ b/fw/http.c
@@ -66,7 +66,7 @@
  * created HTTP/1.1-message.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/http.h
+++ b/fw/http.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -615,6 +615,11 @@ enum {
 #define HTTP_CODE_MIN 100
 #define HTTP_CODE_MAX 599
 #define HTTP_CODE_BIT_NUM(code) ((code) - HTTP_CODE_MIN)
+
+#define T_WARN_ADDR_STATUS(msg, addr_ptr, print_port, status)		\
+	TFW_WITH_ADDR_FMT(addr_ptr, print_port, addr_str,		\
+			  T_WARN("%s, status %d: %s\n",			\
+				 msg, status, addr_str))
 
 static inline int
 tfw_http_resp_code_range(const int n)

--- a/fw/http.h
+++ b/fw/http.h
@@ -540,18 +540,6 @@ typedef struct {
 } TfwHttpTransIter;
 
 /**
- * @capacity 	- actually allocated items memory
- * @last 	- pointer to the last item, can be lower, equal, and even larger
- *		  than capacity, but never larger than capacity.
- *		  last = count_of_complete_items + 1
- */
-typedef struct {
-	unsigned int	capacity;
-	unsigned int	last;
-	TfwStr		*items;
-} TfwStrArray;
-
-/**
  * HTTP Response.
  * TfwStr members must be the first for efficient scanning.
  *
@@ -566,8 +554,8 @@ struct tfw_http_resp_t {
 	long			last_modified;
 	unsigned long		jrxtstamp;
 	TfwHttpTransIter	mit;
-	TfwStrArray		no_cache_tokens;
-	TfwStrArray		private_tokens;
+	TfwStr			no_cache_tokens;
+	TfwStr			private_tokens;
 };
 
 #define TFW_HDR_MAP_INIT_CNT		32

--- a/fw/http.h
+++ b/fw/http.h
@@ -138,7 +138,11 @@ enum {
 #define TFW_HTTP_CC_PROXY_REVAL		0x00000200
 #define TFW_HTTP_CC_PUBLIC		0x00000400
 #define TFW_HTTP_CC_PRIVATE		0x00000800
-#define TFW_HTTP_CC_S_MAXAGE		0x00001000
+#define TFW_HTTP_CC_NO_CACHE_QUAL	0x00001000
+#define TFW_HTTP_CC_PRIVATE_QUAL	0x00002000
+#define TFW_HTTP_CC_S_MAXAGE		0x00004000
+/* Unknown flag */
+#define TFW_HTTP_CC_OTHER		0x00008000
 /* Mask to indicate that CC header is present. */
 #define TFW_HTTP_CC_IS_PRESENT		0x0000ffff
 /* Headers that affect Cache Control. */
@@ -536,6 +540,18 @@ typedef struct {
 } TfwHttpTransIter;
 
 /**
+ * @capacity 	- actually allocated items memory
+ * @last 	- pointer to the last item, can be lower, equal, and even larger
+ *		  than capacity, but never larger than capacity.
+ *		  last = count_of_complete_items + 1
+ */
+typedef struct {
+	unsigned int	capacity;
+	unsigned int	last;
+	TfwStr		*items;
+} TfwStrArray;
+
+/**
  * HTTP Response.
  * TfwStr members must be the first for efficient scanning.
  *
@@ -550,6 +566,8 @@ struct tfw_http_resp_t {
 	long			last_modified;
 	unsigned long		jrxtstamp;
 	TfwHttpTransIter	mit;
+	TfwStrArray		no_cache_tokens;
+	TfwStrArray		private_tokens;
 };
 
 #define TFW_HDR_MAP_INIT_CNT		32

--- a/fw/http.h
+++ b/fw/http.h
@@ -138,11 +138,7 @@ enum {
 #define TFW_HTTP_CC_PROXY_REVAL		0x00000200
 #define TFW_HTTP_CC_PUBLIC		0x00000400
 #define TFW_HTTP_CC_PRIVATE		0x00000800
-#define TFW_HTTP_CC_NO_CACHE_QUAL	0x00001000
-#define TFW_HTTP_CC_PRIVATE_QUAL	0x00002000
-#define TFW_HTTP_CC_S_MAXAGE		0x00004000
-/* Unknown flag */
-#define TFW_HTTP_CC_OTHER		0x00008000
+#define TFW_HTTP_CC_S_MAXAGE		0x00001000
 /* Mask to indicate that CC header is present. */
 #define TFW_HTTP_CC_IS_PRESENT		0x0000ffff
 /* Headers that affect Cache Control. */

--- a/fw/http.h
+++ b/fw/http.h
@@ -539,9 +539,12 @@ typedef struct {
  * HTTP Response.
  * TfwStr members must be the first for efficient scanning.
  *
- * @jrxtstamp	- time the message has been received, in jiffies;
- * @mit		- iterator for controlling HTTP/1.1 => HTTP/2 message
- *		  transformation process (applicable for HTTP/2 mode only).
+ * @jrxtstamp	    - time the message has been received, in jiffies;
+ * @mit		    - iterator for controlling HTTP/1.1 => HTTP/2 message
+ *		      transformation process (applicable for HTTP/2 mode only).
+ * @no_cache_tokens - tokens for cache-control directive e.g.
+ *		      Cache-Control: no-cache="token1, token2"
+ * @private_tokens  - similar to @no_cache_tokens but for private="tokens"
  */
 struct tfw_http_resp_t {
 	TFW_HTTP_MSG_COMMON;

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -8810,7 +8810,7 @@ __resp_parse_cache_control(TfwHttpResp *resp, unsigned char *data, size_t len)
 		TRY_STR_LAMBDA_fixup(&TFW_STR_STRING("no-cache"),
 			&parser->hdr, {
 			parser->cache_control.dir_flag = TFW_HTTP_CC_NO_CACHE;
-		}, Resp_I_CC_n, Resp_I_Flag);
+		}, Resp_I_CC_n, Resp_I_Flag_Maybe_Qal);
 		TRY_STR_LAMBDA_fixup(&TFW_STR_STRING("no-store"),
 			&parser->hdr, {
 			parser->cache_control.dir_flag = TFW_HTTP_CC_NO_STORE;
@@ -8831,7 +8831,7 @@ __resp_parse_cache_control(TfwHttpResp *resp, unsigned char *data, size_t len)
 		}, Resp_I_CC_p, Resp_I_Flag);
 		TRY_STR_LAMBDA_fixup(&TFW_STR_STRING("private"), &parser->hdr, {
 			parser->cache_control.dir_flag = TFW_HTTP_CC_PRIVATE;
-		}, Resp_I_CC_p, Resp_I_Flag);
+		}, Resp_I_CC_p, Resp_I_Flag_Maybe_Qal);
 		TRY_STR_LAMBDA_fixup(&TFW_STR_STRING("proxy-revalidate"),
 			&parser->hdr, {
 			parser->cache_control.dir_flag = TFW_HTTP_CC_PROXY_REVAL;

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -8779,8 +8779,11 @@ __resp_parse_cache_control(TfwHttpResp *resp, unsigned char *data, size_t len)
 	}
 
 	__FSM_STATE(Resp_I_CC_Dir_Arg_Token) {
-		/* comma-separated field list (field-name/token) with optional
-		 * linear white space
+		/* Comma-separated field list (field-name/token) with optional
+		 * linear white space.
+		 * We do not set TfwStr->skb for tokens, since the tokens are
+		 * used in read-only fashion to compare strings and are never
+		 * rewriten (TfwStr->skb is used for rewriting raw data only).
 		 */
 #define __APPEND_CC_DIR(complete_current)					\
 do {										\

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -37,6 +37,12 @@ typedef struct {
 /** Maximum of hop-by-hop tokens listed in Connection header. */
 #define TFW_HBH_TOKENS_MAX		16
 
+/** Hard limit for no-cache and private tokens. The logic that uses them can be
+ *  pretty CPU-heavy, like O(N^2) or O(N*logN), so we avoid unintentional DOS
+ *  by limiting the N.
+ */
+#define TFW_CACHE_CONTROL_TOKENS_MAX	16
+
 /**
  * Non-cacheable hop-by-hop headers in terms of RFC 7230.
  *
@@ -93,6 +99,8 @@ typedef struct {
  *		  hop-by-hop
  * @_date	- currently parsed http date value;
  * @month_int	- accumulator for parsing of month;
+ * @cache_control - additional state for internal FSM used to parse
+ *		    cache-control values.
  */
 typedef struct {
 	unsigned short			to_go;
@@ -116,6 +124,11 @@ typedef struct {
 	union {
 		long			_date;
 		unsigned int		month_int;
+		struct {
+			short		dir_flag;
+			char		filled;
+			char		dir_allowed;
+		} cache_control;
 	};
 	TfwStr				_tmp_chunk;
 	TfwStr				hdr;

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -127,7 +127,6 @@ typedef struct {
 		struct {
 			short		dir_flag;
 			char		filled;
-			char		dir_allowed;
 		} cache_control;
 	};
 	TfwStr				_tmp_chunk;

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -41,7 +41,7 @@ typedef struct {
  *  pretty CPU-heavy, like O(N^2) or O(N*logN), so we avoid unintentional DOS
  *  by limiting the N.
  */
-#define TFW_CACHE_CONTROL_TOKENS_MAX	16
+#define TFW_CACHE_CONTROL_TOKENS_MAX	__TFW_STR_ARRAY_MAX
 
 /**
  * Non-cacheable hop-by-hop headers in terms of RFC 7230.
@@ -101,6 +101,10 @@ typedef struct {
  * @month_int	- accumulator for parsing of month;
  * @cache_control - additional state for internal FSM used to parse
  *		    cache-control values.
+ * @dir_flag	- designates an uncommitted directive currently being processed.
+ * @filled	- a flat set when the header is not empty, i.e. conain at
+ *		  least one directive-token.
+
  */
 typedef struct {
 	unsigned short			to_go;
@@ -126,7 +130,6 @@ typedef struct {
 		unsigned int		month_int;
 		struct {
 			short		dir_flag;
-			char		filled;
 		} cache_control;
 	};
 	TfwStr				_tmp_chunk;

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2018-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2018-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -99,11 +99,7 @@ typedef struct {
  *		  hop-by-hop
  * @_date	- currently parsed http date value;
  * @month_int	- accumulator for parsing of month;
- * @cache_control - additional state for internal FSM used to parse
- *		    cache-control values.
- * @dir_flag	- designates an uncommitted directive currently being processed.
- * @filled	- a flat set when the header is not empty, i.e. conain at
- *		  least one directive-token.
+ * @cc_dir_flag	- designates an uncommitted directive currently being processed.
 
  */
 typedef struct {
@@ -128,9 +124,7 @@ typedef struct {
 	union {
 		long			_date;
 		unsigned int		month_int;
-		struct {
-			short		dir_flag;
-		} cache_control;
+		unsigned int		cc_dir_flag;
 	};
 	TfwStr				_tmp_chunk;
 	TfwStr				hdr;

--- a/fw/str.c
+++ b/fw/str.c
@@ -6,7 +6,7 @@
  * configuration phase.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -689,7 +689,7 @@ tfw_str_add_duplicate(TfwPool *pool, TfwStr *str)
 }
 
 /**
- * Append the @data string as a leaf into 2-level tree @array. *
+ * Append the @data string as a leaf into 2-level tree @array.
  * Constracts:
  * 1. @data != NULL
  * 2. In case of error the caller do not proceed with the HTTP message and
@@ -720,7 +720,7 @@ tfw_str_array_append_chunk(TfwPool *pool, TfwStr *array,
 	bool shall_complete;
 
 	/* Quick return when there's nothing to do */
-	if (!len && !complete_last)
+	if (unlikely(!len && !complete_last))
 		return 0;
 
 	BUG_ON(!data);
@@ -738,7 +738,7 @@ tfw_str_array_append_chunk(TfwPool *pool, TfwStr *array,
 		shall_complete = false;
 	}
 
-	if (!len) {
+	if (unlikely(!len)) {
 		/* No chunks to be appended, just mark the item as completed */
 		if (shall_complete) /* implies last_token != NULL */
 			last_token->flags |= TFW_STR_COMPLETE;
@@ -805,8 +805,9 @@ tfw_str_array_append_chunk(TfwPool *pool, TfwStr *array,
 	last_chunk->len = len;
 	last_chunk->data = data;
 	/*
-	 * We don't care about array->len, but the last_token->len is required
-	 * for string comparison functions e.g. tfw_stricmpspn().
+	 * array->len has no sense since this is an array of independent strings.
+	 * However, last_token->len is required for string comparison functions
+	 * e.g. tfw_stricmpspn().
 	 * For one-chunk item the token->len is assigned directly on the parent,
 	 * it gets copied into a child chunk when the item grows to more than
 	 * one chunk, thus last_token->len = last_token->chunks[0].len

--- a/fw/str.h
+++ b/fw/str.h
@@ -397,7 +397,7 @@ TfwStr *tfw_str_add_compound(TfwPool *pool, TfwStr *str);
 TfwStr *tfw_str_add_duplicate(TfwPool *pool, TfwStr *str);
 int tfw_str_array_append_chunk(TfwPool *pool, TfwStr *array,
 			       char *data, unsigned long len,
-			       char *terminator, unsigned long terminator_len);
+			       bool complete_last);
 
 typedef enum {
 	TFW_STR_EQ_DEFAULT = 0x0,

--- a/fw/str.h
+++ b/fw/str.h
@@ -44,7 +44,7 @@
  * the number of chunks in a compound string. Zero means a plain string.
 
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/str.h
+++ b/fw/str.h
@@ -195,6 +195,7 @@ size_t tfw_ultohex(unsigned long ai, char *buf, unsigned int len);
  * ------------------------------------------------------------------------
  */
 #define __TFW_STR_CN_MAX	UINT_MAX
+#define __TFW_STR_ARRAY_MAX	16
 /*
  * Str consists from compound or plain strings.
  * Duplicate strings are also always compound on root level.
@@ -395,7 +396,6 @@ void tfw_str_collect_cmp(TfwStr *chunk, TfwStr *end, TfwStr *out,
 TfwStr *tfw_str_add_compound(TfwPool *pool, TfwStr *str);
 TfwStr *tfw_str_add_duplicate(TfwPool *pool, TfwStr *str);
 int tfw_str_array_append_chunk(TfwPool *pool, TfwStr *array,
-			       unsigned int count_limit,
 			       char *data, unsigned long len,
 			       char *terminator, unsigned long terminator_len);
 

--- a/fw/str.h
+++ b/fw/str.h
@@ -208,10 +208,12 @@ size_t tfw_ultohex(unsigned long ai, char *buf, unsigned int len);
 #define TFW_STR_VALUE		0x08
 /* The string represents hop-by-hop header, not end-to-end one */
 #define TFW_STR_HBH_HDR		0x10
+/* Not cachable due to configuration settings or no-cache/private directive */
+#define TFW_STR_NOCCPY_HDR	0x20
 /* Weak identifier was set for Etag value. */
-#define TFW_STR_ETAG_WEAK	0x20
+#define TFW_STR_ETAG_WEAK	0x40
 /* Trailer  header. */
-#define TFW_STR_TRAILER		0x40
+#define TFW_STR_TRAILER		0x80
 /*
  * The string/chunk is a header fully indexed in HPACK static
  * table (used only for HTTP/1.1=>HTTP/2 message transformation).
@@ -392,6 +394,10 @@ void tfw_str_collect_cmp(TfwStr *chunk, TfwStr *end, TfwStr *out,
 			 const char *stop);
 TfwStr *tfw_str_add_compound(TfwPool *pool, TfwStr *str);
 TfwStr *tfw_str_add_duplicate(TfwPool *pool, TfwStr *str);
+int tfw_str_array_append_chunk(TfwPool *pool, TfwStr *array,
+			       unsigned int count_limit,
+			       char *data, unsigned long len,
+			       char *terminator, unsigned long terminator_len);
 
 typedef enum {
 	TFW_STR_EQ_DEFAULT = 0x0,

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -980,6 +980,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 
 TEST(http_parser, cache_control)
 {
+	TfwStr dummy_header = { .data = "dummy:", .len = SLEN("dummy:") };
+
 	EXPECT_BLOCK_REQ_RESP_SIMPLE("Cache-Control: ");
 	EXPECT_BLOCK_REQ_RESP_SIMPLE("Cache-Control: no-cache no-store");
 	EXPECT_BLOCK_REQ_RESP_SIMPLE("Cache-Control: dummy0 dummy1");
@@ -1070,6 +1072,18 @@ TEST(http_parser, cache_control)
 	{								\
 		EXPECT_TRUE(MSG_LOWER->cache_ctl.flags & flag);		\
 	}								\
+	FOR_##MSG_UPPER##_SIMPLE("Cache-Control: ," directive)		\
+	{								\
+		EXPECT_TRUE(MSG_LOWER->cache_ctl.flags & flag);		\
+	}								\
+	FOR_##MSG_UPPER##_SIMPLE("Cache-Control: , " directive)		\
+	{								\
+		EXPECT_TRUE(MSG_LOWER->cache_ctl.flags & flag);		\
+	}								\
+	FOR_##MSG_UPPER##_SIMPLE("Cache-Control: " directive ",")	\
+	{								\
+		EXPECT_TRUE(MSG_LOWER->cache_ctl.flags & flag);		\
+	}								\
 	FOR_##MSG_UPPER##_SIMPLE("Cache-Control:1" directive)		\
 	{								\
 		EXPECT_FALSE(MSG_LOWER->cache_ctl.flags & flag);	\
@@ -1088,20 +1102,38 @@ TEST(http_parser, cache_control)
 	}								\
 	EXPECT_BLOCK_##MSG_UPPER##_SIMPLE("Cache-Control:" directive " = dummy");
 
-#define TEST_HAVING_ARGUMENT(directive, flag, MSG_UPPER, MSG_LOWER)	\
-	TEST_COMMON(directive, flag, MSG_UPPER, MSG_LOWER);		\
+#define TEST_HAVING_ARGUMENT(directive, flag, field, MSG_UPPER, MSG_LOWER)	\
+	TEST_COMMON(directive, flag, MSG_UPPER, MSG_LOWER);			\
 	EXPECT_BLOCK_##MSG_UPPER##_SIMPLE("Cache-Control:" directive "=");	\
 	EXPECT_BLOCK_##MSG_UPPER##_SIMPLE("Cache-Control:" directive "=1");	\
 	EXPECT_BLOCK_##MSG_UPPER##_SIMPLE("Cache-Control:" directive "=\"")	;\
+	EXPECT_BLOCK_##MSG_UPPER##_SIMPLE("Cache-Control:" directive "=\"dummy");\
 	EXPECT_BLOCK_##MSG_UPPER##_SIMPLE("Cache-Control:" directive "=dummy");	\
 	EXPECT_BLOCK_##MSG_UPPER##_SIMPLE("Cache-Control:" directive		\
-				 "=\",,\"");					\
+					  "=\",,\"");				\
 	EXPECT_BLOCK_##MSG_UPPER##_SIMPLE("Cache-Control:" directive		\
 				 "=\"dummy, ,\"");				\
+	FOR_##MSG_UPPER##_SIMPLE("Cache-Control:" directive		\
+				 "=\", dummy\"")			\
+	{								\
+		EXPECT_FALSE(MSG_LOWER->cache_ctl.flags & flag);	\
+		EXPECT_TRUE(MSG_LOWER->field.nchunks != 0);		\
+		EXPECT_TRUE(tfw_stricmpspn(&MSG_LOWER->field.chunks[0],	\
+					    &dummy_header, ':') == 0);	\
+	}								\
+	FOR_##MSG_UPPER##_SIMPLE("Cache-Control:" directive		\
+				 "=\"dummy,\"")				\
+	{								\
+		EXPECT_FALSE(MSG_LOWER->cache_ctl.flags & flag);	\
+		EXPECT_TRUE(MSG_LOWER->field.nchunks != 0);		\
+		EXPECT_TRUE(tfw_stricmpspn(&MSG_LOWER->field.chunks[0],	\
+					    &dummy_header, ':') == 0);	\
+	}								\
 	FOR_##MSG_UPPER##_SIMPLE("Cache-Control:" directive		\
 				 "=\"" TOKEN_ALPHABET "\"")		\
 	{								\
 		EXPECT_FALSE(MSG_LOWER->cache_ctl.flags & flag);	\
+		EXPECT_TRUE(MSG_LOWER->field.nchunks != 0);		\
 	}
 
 #define TEST_NO_ARGUMENT(directive, flag, MSG_UPPER, MSG_LOWER)		\
@@ -1208,15 +1240,16 @@ TEST(http_parser, cache_control)
 
 	/* Response directives. */
 	TEST_NO_ARGUMENT("only-if-cached", TFW_HTTP_CC_OIFCACHED, REQ, req);
-	TEST_HAVING_ARGUMENT("no-cache", TFW_HTTP_CC_NO_CACHE, RESP, resp);
-	TEST_HAVING_ARGUMENT("no-cache", TFW_HTTP_CC_NO_CACHE, RESP, resp);
+	TEST_HAVING_ARGUMENT("no-cache", TFW_HTTP_CC_NO_CACHE, no_cache_tokens,
+			     RESP, resp);
 	TEST_NO_ARGUMENT("no-store", TFW_HTTP_CC_NO_STORE, RESP, resp);
 	TEST_NO_ARGUMENT("no-transform", TFW_HTTP_CC_NO_TRANSFORM, RESP, resp);
 	TEST_NO_ARGUMENT("must-revalidate", TFW_HTTP_CC_MUST_REVAL, RESP, resp);
 	TEST_NO_ARGUMENT("proxy-revalidate", TFW_HTTP_CC_PROXY_REVAL, RESP, resp);
 	TEST_NO_ARGUMENT("public", TFW_HTTP_CC_PUBLIC, RESP, resp);
 
-	TEST_HAVING_ARGUMENT("private", TFW_HTTP_CC_PRIVATE, RESP, resp);
+	TEST_HAVING_ARGUMENT("private", TFW_HTTP_CC_PRIVATE, private_tokens,
+			     RESP, resp);
 	TEST_SECONDS("max-age", TFW_HTTP_CC_MAX_AGE, max_age, RESP, resp);
 	TEST_SECONDS("s-maxage", TFW_HTTP_CC_S_MAXAGE, s_maxage, RESP, resp);
 	EXPECT_BLOCK_DIGITS("Cache-Control: max-age=", "",

--- a/fw/t/unit/test_tfw_str.c
+++ b/fw/t/unit/test_tfw_str.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -1071,7 +1071,7 @@ tfw_cfgop_capo_hdr_del(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 		const char *arg = ce->vals[i];
 		size_t len = strlen(arg);
 		/* Need a trailing colon for header matching, and '\0'. */
-		int item_size = offsetof(TfwCaToken, str) + len + 1 + 1;
+		int item_size = sizeof(TfwCaToken) + len + 1 + 1;
 		total_size += item_size;
 	}
 	new_tokens = NULL;
@@ -1086,13 +1086,13 @@ tfw_cfgop_capo_hdr_del(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 		for (i = 0; i < ce->val_n; ++i) {
 			const char *arg = ce->vals[i];
 			size_t len = strlen(arg);
-			char *str = &token->str;
+			char *str = token->str;
 			token->len = len + 2;
 			memcpy(str, (void *)arg, len);
 			str[len] = ':';
-			str[len+1] = '\0';
+			str[len + 1] = '\0';
 
-			actual_bytes += offsetof(TfwCaToken, str) + len + 2;
+			actual_bytes += sizeof(TfwCaToken) + len + 2;
 			token = (TfwCaToken *)(actual_bytes + (char *)new_tokens);
 		}
 		BUG_ON(actual_bytes != total_size);
@@ -1111,11 +1111,11 @@ tfw_cfgop_capo_hdr_del(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 static int
 tfw_cfgop_cc_ignore(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 {
-#define STR_AND_LEN(s)  s, sizeof(s)-1
+#define STR_AND_LEN(s)  sizeof(s)-1, s
 const struct {
 	unsigned int flag;
-	char *dir;
 	unsigned int dir_sz;
+	char *dir;
 } dir_map[] = {
 	/* CC directives common to requests and responses. */
 	{ TFW_HTTP_CC_NO_CACHE, STR_AND_LEN("no-cache") },
@@ -1161,7 +1161,6 @@ const struct {
 
 	return 0;
 }
-#undef DIR_MAP_SIZE
 
 static int
 tfw_cfgop_loc_cache_resp_hdr_del(TfwCfgSpec *cs, TfwCfgEntry *ce)

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -90,6 +90,8 @@ static const TfwCfgEnum tfw_method_enum[] = {
  */
 #define TFW_CAPOLICY_ARRAY_SZ	(64)
 
+#define TFW_CAPOLICY_TOKEN_ARRAY_SZ	(16)
+
 /*
  * Each non-idempotent request definition directive is put into
  * a separately allocated memory area. The pointers to the memory
@@ -340,6 +342,38 @@ tfw_vhost_get_hdr_mods(TfwLocation *loc, TfwVhost *vhost, int mod_type)
 		return NULL;
 
 	return &loc->mod_hdrs[mod_type];
+}
+
+TfwCaPolicyTokens*
+tfw_vhost_get_cache_policy_tokens(TfwLocation *loc, TfwVhost *vhost)
+{
+	TfwVhost *vh_dflt = vhost->vhost_dflt;
+
+	/* TODO #862: req->location must be the full set of options. */
+	if (!loc || !loc->capo_hdr_del.sz)
+		loc = vhost->loc_dflt;
+	if (!loc || !loc->capo_hdr_del.sz)
+		loc = vh_dflt ? vh_dflt->loc_dflt : NULL;
+	if (!loc || !loc->capo_hdr_del.sz)
+		return NULL;
+
+	return &loc->capo_hdr_del;
+}
+
+unsigned int
+tfw_vhost_get_cache_policy_mask(TfwLocation *loc, TfwVhost *vhost)
+{
+	TfwVhost *vh_dflt = vhost->vhost_dflt;
+
+	/* TODO #862: req->location must be the full set of options. */
+	if (!loc || !loc->capo_ignore)
+		loc = vhost->loc_dflt;
+	if (!loc || !loc->capo_ignore)
+		loc = vh_dflt ? vh_dflt->loc_dflt : NULL;
+	if (!loc || !loc->capo_ignore)
+		return 0;
+
+	return loc->capo_ignore;
 }
 
 /*
@@ -1001,6 +1035,159 @@ tfw_cfgop_out_http_post_validate(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	return 0;
 }
 
+/* Extended caching policies */
+static TfwCaPolicyToken *
+tfw_capolicy_token_new(int op, const char *arg, size_t len)
+{
+	TfwCaPolicyToken *token;
+
+	if ((token = kmalloc(sizeof(TfwCaPolicyToken) + len + 1, GFP_KERNEL)) == NULL)
+		return NULL;
+	token->arg = (char *)(token + 1);
+	token->len = len;
+	memcpy((void *)token->arg, (void *)arg, len + 1);
+
+	return token;
+}
+
+static int
+tfw_cfgop_capolicy_token(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
+{
+	size_t i, len;
+	tfw_match_t op;
+	const char *arg;
+
+	if (ce->attr_n) {
+		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
+			 cs->name);
+		return -EINVAL;
+	}
+	if (ce->val_n < 1) {
+		T_ERR_NL("%s: Arguments required\n",
+			 cs->name);
+		return -EINVAL;
+	}
+
+	/* Add each token into the array.*/
+	for (i = 0; i < ce->val_n; ++i) {
+		TfwCaPolicyToken *token;
+
+		arg = ce->vals[i];
+		len = strlen(arg);
+
+		if (loc->capo_hdr_del.sz == TFW_CAPOLICY_TOKEN_ARRAY_SZ)
+			return -ENOMEM;
+		if (!(token = tfw_capolicy_token_new(op, arg, len+1)))
+			return -ENOMEM;
+		/* Need a trailing semicolumn for header matching.
+		   "token->arg" total length is "len+2" here. */
+		token->arg[len] = ':';
+		token->arg[len+1] = '\0';
+		loc->capo_hdr_del.tokens[loc->capo_hdr_del.sz++] = token;
+	}
+
+	return 0;
+}
+
+typedef const struct {
+	unsigned int flag;
+	char *dir;
+	unsigned int dir_sz;
+} capo_dir_map_t;
+#define STR_AND_LEN(s)  s, sizeof(s)-1
+#define DIR_MAP_SIZE  9
+const capo_dir_map_t dir_map[DIR_MAP_SIZE] = {
+	/* CC directives common to requests and responses. */
+	{ TFW_HTTP_CC_NO_CACHE, STR_AND_LEN("no-cache") },
+	{ TFW_HTTP_CC_NO_STORE, STR_AND_LEN("no-store") },
+	{ TFW_HTTP_CC_NO_TRANSFORM, STR_AND_LEN("no-transform") },
+	{ TFW_HTTP_CC_MAX_AGE, STR_AND_LEN("max-age") },
+	/* Response only CC directives. */
+	{ TFW_HTTP_CC_MUST_REVAL, STR_AND_LEN("must-revalidate") },
+	{ TFW_HTTP_CC_PROXY_REVAL, STR_AND_LEN("proxy-revalidate") },
+	{ TFW_HTTP_CC_PUBLIC, STR_AND_LEN("public") },
+	{ TFW_HTTP_CC_PRIVATE, STR_AND_LEN("private") },
+	{ TFW_HTTP_CC_S_MAXAGE, STR_AND_LEN("max-age") },
+};
+#undef 	STR_AND_LEN
+
+static int
+tfw_cfgop_capolicy_mask(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
+{
+	size_t i, len;
+	const char *arg;
+
+	if (ce->attr_n) {
+		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
+			 cs->name);
+		return -EINVAL;
+	}
+	if (ce->val_n < 1) {
+		T_ERR_NL("%s: Arguments required\n",
+			 cs->name);
+		return -EINVAL;
+	}
+
+	for (i = 0; i < ce->val_n; ++i) {
+		int map_idx;
+		arg = ce->vals[i];
+		len = strlen(arg);
+		for (map_idx = 0; map_idx < DIR_MAP_SIZE; map_idx++) {
+			if (tfw_cstricmp(arg, dir_map[map_idx].dir,
+					 dir_map[map_idx].dir_sz) == 0)
+			{
+				loc->capo_ignore |= dir_map[map_idx].flag;
+				break;
+			}
+		}
+	}
+
+	return 0;
+}
+#undef DIR_MAP_SIZE
+
+static int
+tfw_cfgop_loc_cache_resp_hdr_del(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	BUG_ON(!tfwcfg_this_location);
+	return tfw_cfgop_capolicy_token(cs, ce, tfwcfg_this_location);
+}
+
+static int
+tfw_cfgop_loc_cache_control_ignore(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	BUG_ON(!tfwcfg_this_location);
+	return tfw_cfgop_capolicy_mask(cs, ce, tfwcfg_this_location);
+}
+
+static int
+tfw_cfgop_in_cache_resp_hdr_del(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	BUG_ON(!tfw_vhost_entry);
+	return tfw_cfgop_capolicy_token(cs, ce, tfw_vhost_entry->loc_dflt);
+}
+
+static int
+tfw_cfgop_in_cache_control_ignore(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	BUG_ON(!tfw_vhost_entry);
+	return tfw_cfgop_capolicy_mask(cs, ce, tfw_vhost_entry->loc_dflt);
+}
+
+static int
+tfw_cfgop_out_cache_resp_hdr_del(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	TfwVhost *vh_dflt = tfw_vhosts_reconfig->vhost_dflt;
+	return tfw_cfgop_capolicy_token(cs, ce, vh_dflt->loc_dflt);
+}
+
+static int
+tfw_cfgop_out_cache_control_ignore(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	TfwVhost *vh_dflt = tfw_vhosts_reconfig->vhost_dflt;
+	return tfw_cfgop_capolicy_mask(cs, ce, vh_dflt->loc_dflt);
+}
+
 /*
  * Find a location directive entry. The entry is looked up
  * in the array that holds all location directives.
@@ -1083,9 +1270,13 @@ tfw_location_init(TfwLocation *loc, tfw_match_t op, const char *arg,
 	loc->arg = argmem;
 	loc->len = len;
 	loc->frang_cfg = (FrangVhostCfg *)data;
+	/* next array starts right after the previous one */
 	loc->capo = (TfwCaPolicy **)(loc->frang_cfg + 1);
 	loc->capo_sz = 0;
-	loc->nipdef = (TfwNipDef **)(loc->capo + TFW_CAPOLICY_ARRAY_SZ);
+	loc->capo_hdr_del.tokens = (TfwCaPolicyToken **)(loc->capo + TFW_CAPOLICY_ARRAY_SZ);
+	loc->capo_hdr_del.sz = 0;
+	loc->capo_ignore = 0;
+	loc->nipdef = (TfwNipDef **)(loc->capo_hdr_del.tokens + TFW_CAPOLICY_TOKEN_ARRAY_SZ);
 	loc->nipdef_sz = 0;
 	loc->hdrs_pool = pool;
 	loc->mod_hdrs[TFW_VHOST_HDRMOD_REQ].hdrs =
@@ -2735,6 +2926,22 @@ static TfwCfgSpec tfw_vhost_location_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
+		.name = "cache_resp_hdr_del",
+		.deflt = NULL,
+		.handler = tfw_cfgop_loc_cache_resp_hdr_del,
+		.allow_none = true,
+		.allow_repeat = true,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "cache_control_ignore",
+		.deflt = NULL,
+		.handler = tfw_cfgop_loc_cache_control_ignore,
+		.allow_none = true,
+		.allow_repeat = true,
+		.allow_reconfig = true,
+	},
+	{
 		.name = "nonidempotent",
 		.deflt = NULL,
 		.handler = tfw_cfgop_loc_nonidempotent,
@@ -2821,6 +3028,22 @@ static TfwCfgSpec tfw_vhost_internal_specs[] = {
 		.name = "cache_fulfill",
 		.deflt = NULL,
 		.handler = tfw_cfgop_in_cache_fulfill,
+		.allow_none = true,
+		.allow_repeat = true,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "cache_resp_hdr_del",
+		.deflt = NULL,
+		.handler = tfw_cfgop_in_cache_resp_hdr_del,
+		.allow_none = true,
+		.allow_repeat = true,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "cache_control_ignore",
+		.deflt = NULL,
+		.handler = tfw_cfgop_in_cache_control_ignore,
 		.allow_none = true,
 		.allow_repeat = true,
 		.allow_reconfig = true,
@@ -2987,6 +3210,22 @@ static TfwCfgSpec tfw_vhost_specs[] = {
 		.name = "cache_fulfill",
 		.deflt = NULL,
 		.handler = tfw_cfgop_out_cache_fulfill,
+		.allow_none = true,
+		.allow_repeat = true,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "cache_resp_hdr_del",
+		.deflt = NULL,
+		.handler = tfw_cfgop_out_cache_resp_hdr_del,
+		.allow_none = true,
+		.allow_repeat = true,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "cache_control_ignore",
+		.deflt = NULL,
+		.handler = tfw_cfgop_out_cache_control_ignore,
 		.allow_none = true,
 		.allow_repeat = true,
 		.allow_reconfig = true,

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -45,6 +45,8 @@ typedef struct {
 typedef enum {
 	TFW_D_CACHE_BYPASS,
 	TFW_D_CACHE_FULFILL,
+	TFW_D_CACHE_RESP_HDR_DEL,
+	TFW_D_CACHE_CONTROL_IGNORE
 } tfw_capo_t;
 
 /**
@@ -61,6 +63,28 @@ typedef struct {
 	size_t		len;
 	const char	*arg;
 } TfwCaPolicy;
+
+/**
+ * A single token from a list of tokens for cache policies.
+ *
+ * @len	- Length of the string in @arg (without null-terminator).
+ * @arg	- String with header name. Points to a char array placed in memory
+ *	  right behind the @arg field.
+ */
+typedef struct {
+	size_t		len;
+	char		*arg;
+} TfwCaPolicyToken;
+
+/**
+ * @tokens - Array of tokens. Point to an array of "TfwCaPolicyToken*" situated
+ *	     in memory right after this structure. Double indirection because
+ *	     the array is statically allocated and "TfwCaPolicyToken*" is dynamic.
+ */
+typedef struct {
+	size_t			sz;
+	TfwCaPolicyToken	**tokens;
+} TfwCaPolicyTokens;
 
 /**
  * Headers modification description.
@@ -117,6 +141,8 @@ typedef struct {
 	size_t			capo_sz;
 	size_t			nipdef_sz;
 	TfwCaPolicy		**capo;
+	TfwCaPolicyTokens	capo_hdr_del;
+	unsigned int		capo_ignore;
 	TfwNipDef		**nipdef;
 	FrangVhostCfg		*frang_cfg;
 	TfwSrvGroup		*main_sg;
@@ -235,6 +261,10 @@ TfwVhost *tfw_vhost_new(const char *name);
 TfwGlobal *tfw_vhost_get_global(void);
 TfwHdrMods *tfw_vhost_get_hdr_mods(TfwLocation *loc, TfwVhost *vhost,
 				   int mod_type);
+TfwCaPolicyTokens*
+tfw_vhost_get_cache_policy_tokens(TfwLocation *loc, TfwVhost *vhost);
+unsigned int
+tfw_vhost_get_cache_policy_mask(TfwLocation *loc, TfwVhost *vhost);
 
 static inline TfwVhost*
 tfw_vhost_from_tls_conf(const TlsPeerCfg *cfg)

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -65,26 +65,21 @@ typedef struct {
 } TfwCaPolicy;
 
 /**
- * A single token from a list of tokens for cache policies.
+ * Just a simple string.
  *
- * @len	- Length of the string in @arg (without null-terminator).
- * @arg	- String with header name. Points to a char array placed in memory
- *	  right behind the @arg field.
+ * @len	- Length of the string in @str (with null-terminator).
+ * @str	- First character of the string.
  */
 typedef struct {
 	size_t		len;
-	char		*arg;
-} TfwCaPolicyToken;
+	char		str;
+} TfwCaToken;
 
-/**
- * @tokens - Array of tokens. Point to an array of "TfwCaPolicyToken*" situated
- *	     in memory right after this structure. Double indirection because
- *	     the array is statically allocated and "TfwCaPolicyToken*" is dynamic.
- */
+/* tfw_vhost_get_capo_hdr_del result */
 typedef struct {
-	size_t			sz;
-	TfwCaPolicyToken	**tokens;
-} TfwCaPolicyTokens;
+	unsigned int	sz;
+	TfwCaToken	*tokens;
+} TfwCaTokenArray;
 
 /**
  * Headers modification description.
@@ -127,6 +122,9 @@ enum {
  * @capo_sz	- Size of @capo array.
  * @nipdef_sz	- Size of @nipdef array.
  * @capo	- Array of pointers to Cache Policy definitions.
+ * @capo_hdr_del - Flat array of cache_resp_hdr_del header names.
+ * @capo_hdr_del_sz - Number of headers in the @capo_hdr_del.
+ * @cc_ignore   - Mask for flags corresponding to cache_control_ignore headers.
  * @nipdef	- Array of pointers to Non-Idempotent Request definitions.
  * @frang_cfg	- Pointer to location-specific Frang settings structure.
  * @main_sg	- Main server group to which requests must be proxied.
@@ -141,8 +139,9 @@ typedef struct {
 	size_t			capo_sz;
 	size_t			nipdef_sz;
 	TfwCaPolicy		**capo;
-	TfwCaPolicyTokens	capo_hdr_del;
-	unsigned int		capo_ignore;
+	TfwCaToken		*capo_hdr_del;
+	unsigned int		capo_hdr_del_sz;
+	unsigned int		cc_ignore;
 	TfwNipDef		**nipdef;
 	FrangVhostCfg		*frang_cfg;
 	TfwSrvGroup		*main_sg;
@@ -261,10 +260,10 @@ TfwVhost *tfw_vhost_new(const char *name);
 TfwGlobal *tfw_vhost_get_global(void);
 TfwHdrMods *tfw_vhost_get_hdr_mods(TfwLocation *loc, TfwVhost *vhost,
 				   int mod_type);
-TfwCaPolicyTokens*
-tfw_vhost_get_cache_policy_tokens(TfwLocation *loc, TfwVhost *vhost);
-unsigned int
-tfw_vhost_get_cache_policy_mask(TfwLocation *loc, TfwVhost *vhost);
+TfwCaTokenArray tfw_vhost_get_capo_hdr_del(TfwLocation *loc,
+					   TfwVhost *vhost);
+unsigned int tfw_vhost_get_cc_ignore(TfwLocation *loc,
+				     TfwVhost *vhost);
 
 static inline TfwVhost*
 tfw_vhost_from_tls_conf(const TlsPeerCfg *cfg)

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -72,7 +72,7 @@ typedef struct {
  */
 typedef struct {
 	size_t		len;
-	char		str;
+	char		str[0];
 } TfwCaToken;
 
 /* tfw_vhost_get_capo_hdr_del result */

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Parsing and application of no-cache and private directives with arguments.
Additional validation of Cache-Control header.
New cache_control_ignore, cache_resp_hdr_del configuration options.
Fixed corruption of cached responses with empty header value.

Fixed all the comments from the https://github.com/tempesta-tech/tempesta/pull/1539 here.