### PR TITLE
Solution for #1535 issue

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -2987,22 +2987,24 @@ tfw_h1_set_loc_hdrs(TfwHttpMsg *hm, bool is_resp, bool from_cache)
  * Rewrite HTTP/1 "PURGE" method to "GET" directly inside a request SKB.
  */
 static int
-tfw_h1_rewrite_purge_to_get(struct sk_buff *head)
+tfw_h1_rewrite_purge_to_get(struct sk_buff **head_p)
 {
 	const char *q = "GET";
 	char *p;
 	struct skb_shared_info *si;
-	struct sk_buff *skb = head;
+	struct sk_buff *skb, *head;
 	unsigned int f, z;
 	int ret;
 
 	/* Possible if somehow we already sent a response  */
-	BUG_ON(!head);
+	BUG_ON(!*head_p);
 
 	/* Chop two bytes from the beginning of SKB data. */
-	ret = ss_skb_chop_head_tail(head, head, 2, 0);
+	ret = ss_skb_list_chop_head_tail(head_p, 2, 0);
 	if (ret)
 		return ret;
+	/* List head element *head_p could change above */
+	skb = head = *head_p;
 
 	do {
 		p = skb->data;
@@ -3030,37 +3032,6 @@ tfw_h1_rewrite_purge_to_get(struct sk_buff *head)
 }
 
 /**
- * Removes n bytes from the beginning of the message, iterating over skb chain
- * if needed.
- * @return zero on success and error code on error.
- *
- * TODO #1535: to be replaced with future version of ss_skb_chop_head_tail()
- * over all skbs of the message
- */
-static int
-tfw_h1_chop_leading_crlf(struct sk_buff **head, unsigned int n)
-{
-	struct sk_buff *skb;
-	while (n) {
-		skb = *head;
-		if (likely(skb->len > n))
-			return ss_skb_chop_head_tail(skb, skb, n, 0);
-		if (WARN_ON_ONCE(skb->next == skb))
-			return -EBADMSG;
-		n -= skb->len;
-		/* We do not use ss_skb_unlink() here to avoid
-		 * the removal of the last skb in the list and
-		 * to skip extra actions that are unnecessary here.
-		 */
-		skb->next->prev = skb->prev;
-		skb->prev->next = skb->next;
-		*head = skb->next;
-		__kfree_skb(skb);
-	}
-	return 0;
-}
-
-/**
  * Adjust the request before proxying it to real server.
  */
 static int
@@ -3073,16 +3044,13 @@ tfw_h1_adjust_req(TfwHttpReq *req)
 	n_to_strip = !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_CR, req->flags) +
 		     !!test_bit(TFW_HTTP_B_NEED_STRIP_LEADING_LF, req->flags);
 	if (unlikely(n_to_strip)) {
-		r = tfw_h1_chop_leading_crlf(&hm->msg.skb_head, n_to_strip);
-		/* TODO 1535: replace this with future version of
-		 * ss_skb_chop_head_tail() over all skbs of the message 
-		 */
+		r =  ss_skb_list_chop_head_tail(&hm->msg.skb_head, n_to_strip, 0);
 		if (r)
 			return r;
 	}
 
 	if (test_bit(TFW_HTTP_B_PURGE_GET, req->flags)) {
-		r = tfw_h1_rewrite_purge_to_get(hm->msg.skb_head);
+		r = tfw_h1_rewrite_purge_to_get(&hm->msg.skb_head);
 		if (r)
 			return r;
 	}

--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -1770,6 +1770,10 @@ next_msg:
 	 * will be just split into separate skb (above).
 	 */
 	if (APP_FRAME(h2)) {
+		/* This chopping algorithm could be repleces with a call
+		 * of ss_skb_list_chop_head_tail(). We refrain of it
+		 * to proccess a special case !h2->skb_head below.
+		 */
 		while (unlikely(h2->skb_head->len <= h2->data_off)) {
 			struct sk_buff *skb = ss_skb_dequeue(&h2->skb_head);
 			h2->data_off -= skb->len;

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1061,10 +1061,10 @@ multi_buffs:
 	while (unlikely(skb->len <= head))
 	{
 		head -= skb->len;
-		/* We do not use ss_skb_unlink() here to prevent it
-	 	 * to remove the last skb in the list and to skip
-	 	 * unneccessary checks and actions inside it, here
-		 * and in the similar loop for tail below.
+		/* We do not use ss_skb_unlink() here and in
+		 * in the similar loop for tail below to prevent
+	 	 * removing the last skb in the list and to skip
+	 	 * unneccessary checks and actions inside the func.
 	 	 */
 		skb->next->prev = skb->prev;
 		skb->prev->next = skb->next;

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1017,18 +1017,18 @@ ss_skb_chop_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,
  * otherwise an error is retuned.
  */
 int
-ss_skb_list_chop_head_tail(struct sk_buff **skb_list_head, 
+ss_skb_list_chop_head_tail(struct sk_buff **skb_list_head,
 			   size_t head, size_t trail)
 {
 	struct sk_buff *skb, *skb_hd;
 	size_t sum;
 	int ret;
-	
+
 	skb_hd = *skb_list_head;
 	if (likely(skb_hd->next == skb_hd))
 		goto single_buff;
 	goto multi_buffs;
-	
+
 	/* Everywhere in the function we perform 'redundant'
 	 * checks for head and tail values to avoid unneccessary
 	 * calls to underlying ss_skb_chop_head_tail() for
@@ -1049,14 +1049,14 @@ single_buff:
 	return ss_skb_chop_head_tail(NULL, skb_hd, head, trail);
 
 multi_buffs:
-    /* skb_list contains more than 1 skb &&
+	/* skb_list contains more than 1 skb &&
 	 * skb_hd points to head element of the list
 	 */
-	 
+
 	/* Here below we delete heading skbs which size
 	 * is less than chop demand at the head,
 	 * switching to single_buff: in case
-	 */ 
+	 */
 	skb = skb_hd;
 	while (unlikely(skb->len <= head))
 	{
@@ -1074,15 +1074,15 @@ multi_buffs:
 		if (unlikely(skb->next == skb))
 			goto single_buff;
 	}
-	
-    /* skb_list still contains more than 1 skb &&
+
+	/* skb_list still contains more than 1 skb &&
 	 * skb_hd points to head element of the list
 	 */
 
 	/* Here below we delete trailing skbs which size
 	 * is less than chop demand at the tail,
 	 * switching to single_buff: in case
-	 */ 
+	 */
 	skb = skb_hd->prev;
 	while (unlikely(skb->len <= trail)) {
 		trail -= skb->len;
@@ -1093,23 +1093,21 @@ multi_buffs:
 		if (unlikely(skb == skb_hd))
 			goto single_buff;
 	}
-	
-    /* skb_list still contains more than 1 skb &&
+
+	/* skb_list still contains more than 1 skb &&
 	 * skb_hd points to head element of the list &&
 	 * skb points to last element of the list
 	 */
-	 
+
 	/* Here we remove remaining head and trail bytes, if any */
-	if (head)
-	{
+	if (head) {
 		ret = ss_skb_chop_head_tail(NULL, skb_hd, head, 0);
 		if (unlikely(ret))
 			return ret;
 	}
-	
 	if (trail)
 		return ss_skb_chop_head_tail(NULL, skb, 0, trail);
-	
+
 	return 0;
 }
 

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1025,9 +1025,8 @@ ss_skb_list_chop_head_tail(struct sk_buff **skb_list_head,
 	int ret;
 
 	skb_hd = *skb_list_head;
-	if (likely(skb_hd->next == skb_hd))
-		goto single_buff;
-	goto multi_buffs;
+	if (unlikely(skb_hd->next != skb_hd))
+		goto multi_buffs;
 
 	/* Everywhere in the function we perform 'redundant'
 	 * checks for @head and @trail values to avoid unneccessary
@@ -1041,7 +1040,7 @@ single_buff:
 	 */
 	sum = head + trail;
 	if (WARN_ON_ONCE(skb_hd->len <= sum))
-		return -EBADMSG;
+		return -EINVAL;
 	if (unlikely(sum == 0))
 		/* Nothing to chop */
 		/* This check is mostly for jumps from branches below */

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1061,7 +1061,7 @@ multi_buffs:
 	while (unlikely(skb->len <= head)) {
 		head -= skb->len;
 		/* We do not use ss_skb_unlink() here and in
-		 * in the similar loop for tail below to prevent
+		 * the similar loop for tail below to prevent
 	 	 * removing the last skb in the list and to skip
 	 	 * unneccessary checks and actions inside the func.
 	 	 */

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1058,8 +1058,7 @@ multi_buffs:
 	 * switching to single_buff: in case
 	 */
 	skb = skb_hd;
-	while (unlikely(skb->len <= head))
-	{
+	while (unlikely(skb->len <= head)) {
 		head -= skb->len;
 		/* We do not use ss_skb_unlink() here and in
 		 * in the similar loop for tail below to prevent

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1100,12 +1100,12 @@ multi_buffs:
 	 */
 
 	/* Here we remove remaining head and trail bytes, if any */
-	if (head) {
+	if (likely(head)) {
 		ret = ss_skb_chop_head_tail(NULL, skb_hd, head, 0);
 		if (unlikely(ret))
 			return ret;
 	}
-	if (trail)
+	if (likely(trail))
 		return ss_skb_chop_head_tail(NULL, skb, 0, trail);
 
 	return 0;

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1030,7 +1030,7 @@ ss_skb_list_chop_head_tail(struct sk_buff **skb_list_head,
 	goto multi_buffs;
 
 	/* Everywhere in the function we perform 'redundant'
-	 * checks for head and tail values to avoid unneccessary
+	 * checks for @head and @trail values to avoid unneccessary
 	 * calls to underlying ss_skb_chop_head_tail() for
 	 * optimization purpose
 	 */

--- a/fw/ss_skb.h
+++ b/fw/ss_skb.h
@@ -216,6 +216,9 @@ int ss_skb_expand_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,
 			    size_t head, size_t tail);
 int ss_skb_chop_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,
 			  size_t head, size_t tail);
+int
+ss_skb_list_chop_head_tail(struct sk_buff **skb_list_head,
+                           size_t head, size_t trail);
 int ss_skb_cutoff_data(struct sk_buff *skb_head, const TfwStr *hdr,
 		       int skip, int tail);
 int skb_next_data(struct sk_buff *skb, char *last_ptr, TfwStr *it);

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -76,9 +76,9 @@ tfw_tls_chop_skb_rec(TlsCtx *tls, struct sk_buff *skb,
 	while (unlikely(skb->len <= tail)) {
 		tail -= skb->len;
 		ss_skb_unlink(&data->skb, skb);
+		__kfree_skb(skb);
 		if (WARN_ON_ONCE(!data->skb))
 			return -EIO;
-		__kfree_skb(skb);
 		skb = data->skb->prev;
 	}
 


### PR DESCRIPTION
The PR contains (probably final) proposals for solution for issue #1535 .
The new function `ss_skb_list_chop_head_tail()` was intoduced.
The function chops given number of bytes from head and tail of skb list, iterating over the list if neccessary.
The function is a wrapper around older function `ss_skb_chop_head_tail()`, which remains unchanged.

Examples of usage:
- the temporary function `tfw_h1_chop_leading_crlf()` was replaced completely with  `ss_skb_list_chop_head_tail()`
- in the   the `tfw_h1_rewrite_purge_to_get` function an erroneous call to  `ss_skb_chop_head_tail()` was replaced with correct call to `ss_skb_list_chop_head_tail()`. This replacement fixes the bug https://github.com/tempesta-tech/tempesta/issues/1535#issuecomment-988478106 which was the formal reason to open the #1535  isddue.


Correctness is checked by the `tests test_malformed_crlfs.py` and `test_purge_hch.py`; both tests passed.
(Both tests reside in #195 https://github.com/tempesta-tech/tempesta-test/pull/195#issue-1073979863  PR for now :( ).

However chopping from the tail of the list and both from the head and the tail is still not tested.