### PR TITLE
Make adx and bmi2 non-mandatory, disable tls build in absence

### DIFF
--- a/fw/Makefile
+++ b/fw/Makefile
@@ -20,14 +20,21 @@
 TTLS_CFLAGS += -I$(src)/../tls
 export TTLS_CFLAGS TFW_CFLAGS
 
-EXTRA_CFLAGS += $(TFW_CFLAGS) $(TTLS_CFLAGS)
+EXTRA_CFLAGS += $(TFW_CFLAGS)
+ifdef ENABLE_TLS
+EXTRA_CFLAGS += $(TTLS_CFLAGS)
+endif
 EXTRA_CFLAGS += -I$(src)/../db/core -I$(src)/../
 
 GCOV_PROFILE := $(TFW_GCOV)
 
 obj-m	= tempesta_fw.o t/
 
-tfw-srcs = $(wildcard $(obj)/*.c)
+tfw-srcs = $(filter-out $(obj)/tls.c $(obj)/tls_conf.c, $(wildcard $(obj)/*.c))
+ifdef ENABLE_TLS
+tfw-srcs += $(obj)/tls.c $(obj)/tls_conf.c
+endif
+
 tfw-objs = $(patsubst %.c, %.o, $(tfw-srcs))
 ifdef AVX2
 	tfw-objs += str_avx2.o


### PR DESCRIPTION
I have not so ancient, but relatively old hardware.

My processor family is IvyBridge. Wiki says that it is not supported and tempesta build fails.

But it seems that it is strongly requires only for Tempesta TLS. Just made simple PR that render adx and bmi2 feature non-mandatory, but instead of failure disables Tempesta TLS build in hope that Tempesta FW is usable without TLS too.

This PR is WIP. I'll update and finish it if it make sense overall.