### PR TITLE
Fix #1473

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -1310,7 +1310,7 @@ tfw_http_send_resp(TfwHttpReq *req, int status, const char *reason)
 {
 	if (!(tfw_blk_flags & TFW_BLK_ERR_NOLOG)) {
 		T_WARN_ADDR_STATUS(reason, &req->conn->peer->addr,
-				   TFW_WITH_PORT, status);
+				   TFW_NO_PORT, status);
 	}
 
 	if (TFW_MSG_H2(req))
@@ -4595,7 +4595,7 @@ static void
 tfw_http_conn_error_log(TfwConn *conn, const char *msg)
 {
 	if (!(tfw_blk_flags & TFW_BLK_ERR_NOLOG))
-		T_WARN_ADDR(msg, &conn->peer->addr, TFW_WITH_PORT);
+		T_WARN_ADDR(msg, &conn->peer->addr, TFW_NO_PORT);
 }
 
 static void
@@ -4913,7 +4913,7 @@ clean:
 	if (!(tfw_blk_flags & TFW_BLK_ERR_NOLOG))
 		T_WARN_ADDR_STATUS("response dropped: processing error",
 				   &req->conn->peer->addr,
-				   TFW_WITH_PORT, 500);
+				   TFW_NO_PORT, 500);
 	tfw_h2_send_resp(req, 500, stream_id);
 	tfw_hpack_enc_release(&ctx->hpack, resp->flags);
 	TFW_INC_STAT_BH(serv.msgs_otherr);

--- a/fw/http.c
+++ b/fw/http.c
@@ -4746,8 +4746,10 @@ tfw_http_cli_error_resp_and_log(TfwHttpReq *req, int status, const char *msg,
 		nolog = tfw_blk_flags & TFW_BLK_ERR_NOLOG;
 	}
 
+	/* Do not log client port as it doesn't provide useful information
+	 * and could contain outdated cached data (see #1473). */
 	if (!nolog)
-		T_WARN_ADDR(msg, &req->conn->peer->addr, TFW_WITH_PORT);
+		T_WARN_ADDR(msg, &req->conn->peer->addr, TFW_NO_PORT);
 
 	if (TFW_MSG_H2(req))
 		tfw_h2_error_resp(req, status, reply, attack, on_req_recv_event);

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -1362,7 +1362,7 @@ ss_getpeername(struct sock *sk, TfwAddr *addr)
 		       inet->inet_dport, sk->sk_state);
 
 	addr->sin6_family = AF_INET6;
-	addr->sin6_port = inet->inet_sport;
+	addr->sin6_port = inet->inet_dport;
 #if IS_ENABLED(CONFIG_IPV6)
 	if (inet6_sk(sk)) {
 		struct ipv6_pinfo *np = inet6_sk(sk);

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -740,7 +740,7 @@ tfw_tls_conn_close(TfwConn *c, bool sync)
 	 */
 	if (r) {
 		T_WARN_ADDR("Close TCP socket w/o sending alert to the peer",
-			    &c->peer->addr, TFW_WITH_PORT);
+			    &c->peer->addr, TFW_NO_PORT);
 		r = ss_close(c->sk, sync ? SS_F_SYNC : 0);
 	}
 


### PR DESCRIPTION
Fixed `ss_getpeername` so it uses source IP and port now.

`TfwClient` is cached across multiple connections and its `addr` field contains address with port from the first encounter of that client. This means that if we use said address for printing, port part will eventually get outdated. This is why we disabling client port printing from `tfw_http_cli_error_resp_and_log()`.