### PR TITLE
Add runtime check for not present adx, may be false negative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,11 @@ else
 ifdef M
 	DIR = $(M)/
 endif
-	# Some cloud providers hide ADX support bit in vCPU, but it still present, make run-rime check to discard false negative cases
+	# Some cloud providers hide ADX support bit in vCPU, but it still present,
+	# make run-rime check to discard false negative cases
 	CHECK_CONF = $(DIR)scripts/check_conf.pl
-	ADX_SUPPORTED := $(shell $(CHECK_CONF) 2>/dev/null | grep ADX | if grep -q ': found'; then echo y; fi)
+	ADX_SUPPORTED := $(shell $(CHECK_CONF) 2>/dev/null | \
+	grep ADX | if grep -q ': found'; then echo y; fi)
 ifeq ($(ADX_SUPPORTED), y)
 	ADX = "y"
 else

--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,21 @@ else
 endif
 ifneq (, $(findstring adx, $(PROC)))
 	ADX = "y"
-	TFW_CFLAGS += -DADX=1
+else
+ifdef M
+	DIR = $(M)/
+endif
+	# Some cloud providers hide ADX support bit in vCPU, but it still present, make run-rime check to discard false negative cases
+	CHECK_CONF = $(DIR)scripts/check_conf.pl
+	ADX_SUPPORTED := $(shell $(CHECK_CONF) 2>/dev/null | grep ADX | if grep -q ': found'; then echo y; fi)
+ifeq ($(ADX_SUPPORTED), y)
+	ADX = "y"
 else
 	ERROR = "ADX CPU extension is required for Tempesta TLS"
+endif
+endif
+ifeq ($(ADX),y)
+	TFW_CFLAGS += -DADX=1
 endif
 
 KERNEL = /lib/modules/$(shell uname -r)/build

--- a/scripts/check_conf.pl
+++ b/scripts/check_conf.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# Copyright (C) 2020-2021 Tempesta Technologies, Inc.
+# Copyright (C) 2020-2022 Tempesta Technologies, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -44,7 +44,9 @@ int main() {
     $tmp_exe_filename =~ s{\.[^.]*(?:\.c)?$}{};
     my $exit_status = system("gcc", $tmp_src->filename, "-o", $tmp_exe_filename);
     my $test_output = `$tmp_exe_filename`;
-    print "'Intel ADX Instruction Extensions' support: ", index($test_output, "ADX supported") == -1 || $exit_status != 0 ? "NOT " : "", "found\n";
+    print "'Intel ADX Instruction Extensions' support: ",
+        index($test_output, "ADX supported") == -1 || $exit_status != 0 ?
+        "NOT " : "", "found\n";
     if ($exit_status != 0) {
         return;
     }

--- a/scripts/check_conf.pl
+++ b/scripts/check_conf.pl
@@ -18,12 +18,37 @@
 use 5.16.0;
 use strict;
 use warnings;
+require File::Temp;
+use File::Temp ();
 
 `modprobe msr`;
 
+sub rtrim { my $s = shift; $s =~ s/\s+$//; return $s };
+
 sub test {
     print "'$_[0]' bit: ",
-    (hex(`rdmsr $_[1]`) & (1 << $_[2]) ? "" : "NOT "), "found\n";
+    (hex(rtrim(`rdmsr $_[1]`)) & (1 << $_[2]) ? "" : "NOT "), "found\n";
+}
+
+sub adx_test {
+    my $adx_test_src = q|#include <stdio.h>
+int main() {
+  unsigned long long op1 = 0x1100110022002200;
+  unsigned long long op2 = 0x00ff11ee22dd33cc;
+  __asm__ __volatile__("adcx %%rbx,%%rax" : "=a"(op1) : "a"(op1), "b"(op2));
+  printf("%s\n", "ADX supported");
+}|;
+    my $tmp_src = File::Temp->new(SUFFIX => '.c');
+    print $tmp_src $adx_test_src;
+    my $tmp_exe_filename = $tmp_src->filename;
+    $tmp_exe_filename =~ s{\.[^.]*(?:\.c)?$}{};
+    my $exit_status = system("gcc", $tmp_src->filename, "-o", $tmp_exe_filename);
+    my $test_output = `$tmp_exe_filename`;
+    print "'Intel ADX Instruction Extensions' support: ", index($test_output, "ADX supported") == -1 || $exit_status != 0 ? "NOT " : "", "found\n";
+    if ($exit_status != 0) {
+        return;
+    }
+    unlink($tmp_exe_filename);
 }
 
 test 'Activate secondary controls', 0x482, 63;
@@ -32,7 +57,9 @@ test 'APIC-register virtualization', 0x48b, 40;
 test 'Virtual-interrupt delivery', 0x48b, 41;
 
 print "'Process posted interrupts' bit: ",
-    (((hex(`rdmsr 0x480`) & (1 << 55))
-      && (hex(`rdmsr 0x48d`) & (1 << 39)))
-     || (hex(`rdmsr 0x481`) & (1 << 39)))
+    (((hex(rtrim(`rdmsr 0x480`)) & (1 << 55))
+      && (hex(rtrim(`rdmsr 0x48d`)) & (1 << 39)))
+     || (hex(rtrim(`rdmsr 0x481`)) & (1 << 39)))
     ? "" : "NOT ", "found\n";
+
+adx_test;


### PR DESCRIPTION
There are some cloud providers that do support adx instructions in their VPS but do not show this support in /proc/cpuinfo.

I suppose there is need for runtime check of supporting theas instruct if their support not present in /proc/cpuinfo by running binary that contain adcx instruction for example emmited by inline asm.