### PR TITLE
Corrections for cache-control directives handling

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -1624,7 +1624,15 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 	ce->version = resp->version;
 	tfw_http_copy_flags(ce->hmflags, resp->flags);
 
-	/* See tfw_cache_entry_is_live() */
+	/* RFC 7234 Section 3.2:
+	 * Note that cached responses that contain the "must-revalidate" and/or
+	 * "s-maxage" response directives are not allowed to be served stale
+	 * (Section 4.2.4) by shared caches. In particular, a response with
+	 * either "max-age=0, must-revalidate" or "s-maxage=0" cannot be used to
+	 * satisfy a subsequent request without revalidating it on the origin
+	 * server.
+	 * Also see tfw_cache_entry_is_live().
+	 */
 	if (effective_resp_flags
 	    & (TFW_HTTP_CC_MUST_REVAL | TFW_HTTP_CC_PROXY_REVAL |
 	       TFW_HTTP_CC_S_MAXAGE))

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -1127,7 +1127,7 @@ const struct {
 	{ TFW_HTTP_CC_PROXY_REVAL, STR_AND_LEN("proxy-revalidate") },
 	{ TFW_HTTP_CC_PUBLIC, STR_AND_LEN("public") },
 	{ TFW_HTTP_CC_PRIVATE, STR_AND_LEN("private") },
-	{ TFW_HTTP_CC_S_MAXAGE, STR_AND_LEN("max-age") },
+	{ TFW_HTTP_CC_S_MAXAGE, STR_AND_LEN("s-maxage") },
 };
 #undef 	STR_AND_LEN
 


### PR DESCRIPTION
* Added max-age and s-maxage support for cache_control_ignore configuration
  option.
* Fixed interaction of Authorization request with s-maxage, public,
  must-revalidate, proxy-revalidate responses.

There still remain some problems with `only-if-cached` and `max-state+max-age`, so it's kind of a preview.