### PR TITLE
Handle Content-Type in GET requests, fixes #1296

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -5495,7 +5495,7 @@ next_msg:
 			&& !TFW_HTTP_IS_METH_SAFE(req->method_override))
 		{
 			tfw_http_req_parse_block(req, 400,
-				"request dropped: unsafe method override attempted");
+				"request dropped: unsafe method override");
 			return TFW_BLOCK;
 		}
 		req->method = req->method_override;

--- a/fw/http.c
+++ b/fw/http.c
@@ -4010,7 +4010,7 @@ tfw_http_hdr_split(TfwStr *hdr, TfwStr *name_out, TfwStr *val_out, bool inplace)
 
 		val_out->len += chunk->len;
 
-		/* 
+		/*
 		 * Skip OWS after the header value (RWS) - they must be in
 		 * separate chunks too.
 		 */
@@ -5485,14 +5485,15 @@ next_msg:
 	 * We don't rewrite the method string and don't remove override header
 	 * since there can be additional intermediates between TempestaFW and
 	 * backend.
-	 * 
+	 *
 	 * While non-idempotent method can be hidden behind idempotent, it is
 	 * reasonable to expect that non-safe method can not be hidden behind
 	 * safe method.
 	 */
 	if (unlikely(req->method_override)) {
 		if (TFW_HTTP_IS_METH_SAFE(req->method)
-			&& !TFW_HTTP_IS_METH_SAFE(req->method_override)) {
+			&& !TFW_HTTP_IS_METH_SAFE(req->method_override))
+		{
 			tfw_http_req_parse_block(req, 400,
 				"request dropped: unsafe method override attempted");
 			return TFW_BLOCK;

--- a/fw/http.c
+++ b/fw/http.c
@@ -5487,9 +5487,8 @@ next_msg:
 	 * backend.
 	 * 
 	 * While non-idempotent method can be hidden behind idempotent, it is
-	 * reasonable to expect that safe method will be hidden only behind
-	 * safe method (usually GET), and non-safe behind non-safe method
-	 * (usually POST).
+	 * reasonable to expect that non-safe method can not be hidden behind
+	 * safe method.
 	 */
 	if (unlikely(req->method_override)) {
 		if (TFW_HTTP_IS_METH_SAFE(req->method)

--- a/fw/http.h
+++ b/fw/http.h
@@ -116,9 +116,9 @@ typedef enum {
 	_TFW_HTTP_METH_COUNT
 } tfw_http_meth_t;
 
-#define TFW_HTTP_IS_METH_SAFE(meth)	\
-(  meth == TFW_HTTP_METH_GET     || meth == TFW_HTTP_METH_HEAD	\
-|| meth == TFW_HTTP_METH_OPTIONS || meth == TFW_HTTP_METH_PROPFIND)
+#define TFW_HTTP_IS_METH_SAFE(meth)									\
+	((meth) == TFW_HTTP_METH_GET || (meth) == TFW_HTTP_METH_HEAD	\
+	 || (meth) == TFW_HTTP_METH_OPTIONS || (meth) == TFW_HTTP_METH_PROPFIND)
 
 /* HTTP protocol versions. */
 enum {

--- a/fw/http.h
+++ b/fw/http.h
@@ -86,6 +86,7 @@ enum {
 };
 
 /* TODO: When CONNECT will be added, add it to tfw_handle_validation_req() */
+/* New safe methods MUST be added to TFW_HTTP_IS_METH_SAFE macro */
 typedef enum {
 	_TFW_HTTP_METH_NONE,
 	/*
@@ -113,6 +114,10 @@ typedef enum {
 	_TFW_HTTP_METH_UNKNOWN,
 	_TFW_HTTP_METH_COUNT
 } tfw_http_meth_t;
+
+#define TFW_HTTP_IS_METH_SAFE(meth)	\
+(  meth == TFW_HTTP_METH_GET     || meth == TFW_HTTP_METH_HEAD	\
+|| meth == TFW_HTTP_METH_OPTIONS || meth == TFW_HTTP_METH_PROPFIND)
 
 /* HTTP protocol versions. */
 enum {

--- a/fw/http.h
+++ b/fw/http.h
@@ -116,7 +116,7 @@ typedef enum {
 	_TFW_HTTP_METH_COUNT
 } tfw_http_meth_t;
 
-#define TFW_HTTP_IS_METH_SAFE(meth)									\
+#define TFW_HTTP_IS_METH_SAFE(meth)					\
 	((meth) == TFW_HTTP_METH_GET || (meth) == TFW_HTTP_METH_HEAD	\
 	 || (meth) == TFW_HTTP_METH_OPTIONS || (meth) == TFW_HTTP_METH_PROPFIND)
 

--- a/fw/http.h
+++ b/fw/http.h
@@ -85,7 +85,8 @@ enum {
 	TFW_HTTP_FSM_DONE	= TFW_GFSM_HTTP_STATE(TFW_GFSM_STATE_LAST)
 };
 
-/* TODO: When CONNECT will be added, add it to tfw_handle_validation_req() */
+/* TODO: When CONNECT will be added, add it to tfw_handle_validation_req()
+ * and to body processing content-length filtering */
 /* New safe methods MUST be added to TFW_HTTP_IS_METH_SAFE macro */
 typedef enum {
 	_TFW_HTTP_METH_NONE,

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1170,9 +1170,9 @@ __FSM_STATE(RGen_BodyInit, cold) {					\
 			 || req->method_override == TFW_HTTP_METH_TRACE)	\
 				TFW_PARSER_BLOCK(RGen_BodyInit);			\
 		} else if (req->method == TFW_HTTP_METH_GET	\
-			  || req->method == TFW_HTTP_METH_HEAD	\
-			  || req->method == TFW_HTTP_METH_DELETE	\
-			  || req->method == TFW_HTTP_METH_TRACE) {	\
+				|| req->method == TFW_HTTP_METH_HEAD	\
+				|| req->method == TFW_HTTP_METH_DELETE	\
+				|| req->method == TFW_HTTP_METH_TRACE) {	\
 			TFW_PARSER_BLOCK(RGen_BodyInit);			\
 		}	\
 	}	\

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1156,26 +1156,30 @@ __FSM_STATE(RGen_BodyInit, cold) {					\
 		TFW_PARSER_BLOCK(RGen_BodyInit);			\
 	}								\
 	/* According to RFC 7231 4.3.* a payload within GET, HEAD, DELETE,	\
-	 * TRACE and CONNECT requests has no defined semantics and	\
+	 * TRACE and CONNECT requests has no defined semantics and			\
 	 * implementations can reject it. We do this respecting overrides.	\
 	*/	\
-	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])	\
-	 || !TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_TYPE])) {	\
+	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])		\
+		|| !TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_TYPE])) {	\
 		/* Method override either honored or request message with method	\
-		 * override header dropped later in processing */	\
-		if (unlikely(req->method_override)) {	\
-			if (req->method_override == TFW_HTTP_METH_GET	\
-			 || req->method_override == TFW_HTTP_METH_HEAD	\
-			 || req->method_override == TFW_HTTP_METH_DELETE	\
-			 || req->method_override == TFW_HTTP_METH_TRACE)	\
-				TFW_PARSER_BLOCK(RGen_BodyInit);			\
-		} else if (req->method == TFW_HTTP_METH_GET	\
-				|| req->method == TFW_HTTP_METH_HEAD	\
-				|| req->method == TFW_HTTP_METH_DELETE	\
-				|| req->method == TFW_HTTP_METH_TRACE) {	\
-			TFW_PARSER_BLOCK(RGen_BodyInit);			\
-		}	\
-	}	\
+		 * override header dropped later in processing */					\
+		if (unlikely(req->method_override)) {					\
+			if (req->method_override == TFW_HTTP_METH_GET		\
+				|| req->method_override == TFW_HTTP_METH_HEAD	\
+				|| req->method_override == TFW_HTTP_METH_DELETE	\
+				|| req->method_override == TFW_HTTP_METH_TRACE)	\
+			{													\
+				TFW_PARSER_BLOCK(RGen_BodyInit);				\
+			}													\
+		}														\
+		else if (req->method == TFW_HTTP_METH_GET				\
+				 || req->method == TFW_HTTP_METH_HEAD			\
+				 || req->method == TFW_HTTP_METH_DELETE			\
+				 || req->method == TFW_HTTP_METH_TRACE)			\
+		{														\
+			TFW_PARSER_BLOCK(RGen_BodyInit);					\
+		}														\
+	}															\
 	if (msg->content_length) {					\
 		parser->to_read = msg->content_length;			\
 		__FSM_MOVE_nofixup(RGen_BodyStart);			\

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1155,13 +1155,21 @@ __FSM_STATE(RGen_BodyInit, cold) {					\
 		 */							\
 		TFW_PARSER_BLOCK(RGen_BodyInit);			\
 	}								\
-	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])	\
-		&& ((req->method == TFW_HTTP_METH_GET)	\
-		 || (req->method == TFW_HTTP_METH_HEAD)	\
-		 || (req->method == TFW_HTTP_METH_DELETE)	\
-		 || (req->method == TFW_HTTP_METH_TRACE)	\
-		   )) {	\
-		TFW_PARSER_BLOCK(RGen_BodyInit);			\
+	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])) {	\
+		/* Method override either honored or request message with method	\
+		 * override header dropped later in processing */	\
+		if (unlikely(req->method_override)) {	\
+			if (req->method_override == TFW_HTTP_METH_GET	\
+			 || req->method_override == TFW_HTTP_METH_HEAD	\
+			 || req->method_override == TFW_HTTP_METH_DELETE	\
+			 || req->method_override == TFW_HTTP_METH_TRACE)	\
+				TFW_PARSER_BLOCK(RGen_BodyInit);			\
+		} else if (req->method == TFW_HTTP_METH_GET	\
+			  || req->method == TFW_HTTP_METH_HEAD	\
+			  || req->method == TFW_HTTP_METH_DELETE	\
+			  || req->method == TFW_HTTP_METH_TRACE) {	\
+			TFW_PARSER_BLOCK(RGen_BodyInit);			\
+		}	\
 	}	\
 	if (msg->content_length) {					\
 		parser->to_read = msg->content_length;			\

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1155,6 +1155,10 @@ __FSM_STATE(RGen_BodyInit, cold) {					\
 		 */							\
 		TFW_PARSER_BLOCK(RGen_BodyInit);			\
 	}								\
+	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])	\
+		&& (req->method == TFW_HTTP_METH_GET)) {	\
+		TFW_PARSER_BLOCK(RGen_BodyInit);			\
+	}	\
 	if (msg->content_length) {					\
 		parser->to_read = msg->content_length;			\
 		__FSM_MOVE_nofixup(RGen_BodyStart);			\
@@ -8557,6 +8561,8 @@ tfw_h2_parse_req(void *req_data, unsigned char *data, size_t len,
 
 	if (likely(type != HTTP2_DATA))
 		r = tfw_hpack_decode(&ctx->hpack, data, len, req, parsed);
+	else if (unlikely(req->method == TFW_HTTP_METH_GET))
+		r = T_DROP;
 	else
 		r = tfw_h2_parse_body(data, len, req, parsed);
 

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1155,7 +1155,12 @@ __FSM_STATE(RGen_BodyInit, cold) {					\
 		 */							\
 		TFW_PARSER_BLOCK(RGen_BodyInit);			\
 	}								\
-	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])) {	\
+	/* According to RFC 7231 4.3.* a payload within GET, HEAD, DELETE,	\
+	 * TRACE and CONNECT requests has no defined semantics and	\
+	 * implementations can reject it. We do this respecting overrides.	\
+	*/	\
+	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])	\
+	 || !TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_TYPE])) {	\
 		/* Method override either honored or request message with method	\
 		 * override header dropped later in processing */	\
 		if (unlikely(req->method_override)) {	\

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -8489,7 +8489,7 @@ tfw_h2_parse_req_hdr(unsigned char *data, unsigned long len, TfwHttpReq *req,
 		__FSM_H2_DROP(Req_MethodUnknown);
 	}
 
-	/* Improbable states of shceme value processing. */
+	/* Improbable states of scheme value processing. */
 
 	__FSM_H2_SCHEME_STATE_MOVE(Req_Scheme_1CharStep, 'h', Req_SchemeH);
 	__FSM_H2_SCHEME_STATE_MOVE(Req_SchemeH, 't', Req_SchemeHt);

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1155,31 +1155,34 @@ __FSM_STATE(RGen_BodyInit, cold) {					\
 		 */							\
 		TFW_PARSER_BLOCK(RGen_BodyInit);			\
 	}								\
-	/* According to RFC 7231 4.3.* a payload within GET, HEAD, DELETE,	\
-	 * TRACE and CONNECT requests has no defined semantics and			\
-	 * implementations can reject it. We do this respecting overrides.	\
-	*/	\
+	/* According to RFC 7231 4.3.* a payload within GET, HEAD,	\
+	 * DELETE, TRACE and CONNECT requests has no defined semantics	\
+	 * and implementations can reject it. We do this respecting	\
+	 * overrides.							\
+	 */								\
 	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])		\
-		|| !TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_TYPE])) {	\
-		/* Method override either honored or request message with method	\
-		 * override header dropped later in processing */					\
-		if (unlikely(req->method_override)) {					\
+	    || !TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_TYPE]))		\
+	{								\
+		/* Method override either honored or request message	\
+		 * with method override header dropped later in		\
+		 * processing */					\
+		if (unlikely(req->method_override)) {			\
 			if (req->method_override == TFW_HTTP_METH_GET		\
-				|| req->method_override == TFW_HTTP_METH_HEAD	\
-				|| req->method_override == TFW_HTTP_METH_DELETE	\
-				|| req->method_override == TFW_HTTP_METH_TRACE)	\
-			{													\
-				TFW_PARSER_BLOCK(RGen_BodyInit);				\
-			}													\
-		}														\
-		else if (req->method == TFW_HTTP_METH_GET				\
-				 || req->method == TFW_HTTP_METH_HEAD			\
-				 || req->method == TFW_HTTP_METH_DELETE			\
-				 || req->method == TFW_HTTP_METH_TRACE)			\
-		{														\
-			TFW_PARSER_BLOCK(RGen_BodyInit);					\
-		}														\
-	}															\
+			    || req->method_override == TFW_HTTP_METH_HEAD	\
+			    || req->method_override == TFW_HTTP_METH_DELETE	\
+			    || req->method_override == TFW_HTTP_METH_TRACE)	\
+			{							\
+				TFW_PARSER_BLOCK(RGen_BodyInit);		\
+			}						\
+		}							\
+		else if (req->method == TFW_HTTP_METH_GET		\
+			 || req->method == TFW_HTTP_METH_HEAD		\
+			 || req->method == TFW_HTTP_METH_DELETE		\
+			 || req->method == TFW_HTTP_METH_TRACE)		\
+		{							\
+			TFW_PARSER_BLOCK(RGen_BodyInit);		\
+		}							\
+	}								\
 	if (msg->content_length) {					\
 		parser->to_read = msg->content_length;			\
 		__FSM_MOVE_nofixup(RGen_BodyStart);			\
@@ -8582,11 +8585,13 @@ tfw_h2_parse_req(void *req_data, unsigned char *data, size_t len,
 
 	if (likely(type != HTTP2_DATA))
 		r = tfw_hpack_decode(&ctx->hpack, data, len, req, parsed);
-	else if (unlikely(req->method == TFW_HTTP_METH_GET)
-		  || unlikely(req->method == TFW_HTTP_METH_HEAD)
-		  || unlikely(req->method == TFW_HTTP_METH_DELETE)
-		  || unlikely(req->method == TFW_HTTP_METH_TRACE))
+	else if (unlikely(req->method == TFW_HTTP_METH_GET
+		 || req->method == TFW_HTTP_METH_HEAD
+		 || req->method == TFW_HTTP_METH_DELETE
+		 || req->method == TFW_HTTP_METH_TRACE))
+	{
 		r = T_DROP;
+	}
 	else
 		r = tfw_h2_parse_body(data, len, req, parsed);
 

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1156,7 +1156,11 @@ __FSM_STATE(RGen_BodyInit, cold) {					\
 		TFW_PARSER_BLOCK(RGen_BodyInit);			\
 	}								\
 	if (!TFW_STR_EMPTY(&tbl[TFW_HTTP_HDR_CONTENT_LENGTH])	\
-		&& (req->method == TFW_HTTP_METH_GET)) {	\
+		&& ((req->method == TFW_HTTP_METH_GET)	\
+		 || (req->method == TFW_HTTP_METH_HEAD)	\
+		 || (req->method == TFW_HTTP_METH_DELETE)	\
+		 || (req->method == TFW_HTTP_METH_TRACE)	\
+		   )) {	\
 		TFW_PARSER_BLOCK(RGen_BodyInit);			\
 	}	\
 	if (msg->content_length) {					\
@@ -8561,7 +8565,10 @@ tfw_h2_parse_req(void *req_data, unsigned char *data, size_t len,
 
 	if (likely(type != HTTP2_DATA))
 		r = tfw_hpack_decode(&ctx->hpack, data, len, req, parsed);
-	else if (unlikely(req->method == TFW_HTTP_METH_GET))
+	else if (unlikely(req->method == TFW_HTTP_METH_GET)
+		  || unlikely(req->method == TFW_HTTP_METH_HEAD)
+		  || unlikely(req->method == TFW_HTTP_METH_DELETE)
+		  || unlikely(req->method == TFW_HTTP_METH_TRACE))
 		r = T_DROP;
 	else
 		r = tfw_h2_parse_body(data, len, req, parsed);

--- a/fw/t/fuzzer.h
+++ b/fw/t/fuzzer.h
@@ -30,7 +30,8 @@ enum {
 
 enum {
 	FUZZ_REQ,
-	FUZZ_RESP
+	FUZZ_RESP,
+	FUZZ_REQ_H2
 };
 
 typedef enum {

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -109,8 +109,7 @@ tfw_h2_pack_hdr_frame(const char *str, char buf[], unsigned int buf_len)
 		hdr_one = strsep(strp, "\n");
 		hdr = hdr_one;
 		if (*hdr == ':') {
-			++hdr;
-			if (!*hdr)
+			if (!*(++hdr))
 				continue;
 		}
 		hdrp = &hdr;
@@ -1642,7 +1641,7 @@ TEST(http_parser, content_type_in_bodyless_requests)
 			   ":scheme: https\n"
 			   ":path: /");
 
-	/* But wiht content-length will be block for http2 too */
+	/* But with content-length will be block for http2 too */
 	EXPECT_BLOCK_REQ_H2(":authority: debian\n"
 						":method: GET\n"
 						":scheme: http\n"
@@ -1784,10 +1783,10 @@ TEST(http_parser, content_length)
 		 "Content-Length: 0\r\n"
 		 "\r\n");
 
-		/*
-		* A server MAY send a Content-Length header field in a 304
-		* (Not Modified) response to a conditional GET request.
-		*/
+	/*
+	 * A server MAY send a Content-Length header field in a 304
+	 * (Not Modified) response to a conditional GET request.
+	 */
 #define NOT_PARSED "dummy_body"
 #define RESP	"HTTP/1.1 304 Not Modified\r\n"		\
 		"Content-Length: 5\r\n"			\

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -1623,11 +1623,6 @@ TEST(http_parser, content_type_in_bodyless_requests)
 			  "Content-Type: application/octet-stream\r\n"
 			  "\r\n");
 
-	/* Uncomment when CONNECT method will be added to Tempesta FW */
-	// EXPECT_BLOCK_REQ("CONNECT / HTTP/1.1\r\n"
-	// 		  "Content-Type: application/octet-stream\r\n"
-	// 		  "\r\n");
-
 	FOR_REQ("OPTIONS / HTTP/1.1\r\n"
 			"Content-Type: text/plain\r\n"
 			"\r\n")
@@ -3064,7 +3059,7 @@ TEST(http_parser, req_hop_by_hop)
 	TfwStr *field;
 	long id;
 #define REQ_HBH_START							\
-	"GET /foo HTTP/1.1\r\n"						\
+	"POST /foo HTTP/1.1\r\n"						\
 	"User-Agent: Wget/1.13.4 (linux-gnu)\r\n"			\
 	"Accept: */*\r\n"						\
 	"Host: localhost\r\n"						\
@@ -3082,9 +3077,12 @@ TEST(http_parser, req_hop_by_hop)
 	"Dummy5: 5\r\n"							\
 	"Foo: is hop-by-hop header\r\n"					\
 	"Dummy6: 6\r\n"							\
-	"Buzz: is hop-by-hop header\r\n"				\
+	"Content-Length: 0\r\n"						\
+	"Content-Type: text/html; charset=iso-8859-1\r\n"		\
 	"Dummy7: 7\r\n"							\
 	"Dummy8: 8\r\n"							\
+	"Buzz: is hop-by-hop header\r\n"				\
+	"Dummy9: 9\r\n"							\
 	"Cache-Control: max-age=1, no-store, min-fresh=30\r\n"		\
 	"Pragma: no-cache, fooo \r\n"					\
 	"Cookie: session=42; theme=dark\r\n"				\
@@ -3096,8 +3094,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 16 total with 9 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		/* Common (raw) headers: 17 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -3111,8 +3109,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 16 total with 9 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		/* Common (raw) headers: 17 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -3134,8 +3132,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 16 total with 9 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		/* Common (raw) headers: 17 total with 10 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -3143,7 +3141,7 @@ TEST(http_parser, req_hop_by_hop)
 			case TFW_HTTP_HDR_CONNECTION:
 			case TFW_HTTP_HDR_KEEP_ALIVE:
 			case TFW_HTTP_HDR_RAW + 4:
-			case TFW_HTTP_HDR_RAW + 10:
+			case TFW_HTTP_HDR_RAW + 12:
 				EXPECT_TRUE(field->flags & TFW_STR_HBH_HDR);
 				break;
 			default:

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -1659,11 +1659,7 @@ TEST(http_parser, eol_crlf)
 		EXPECT_TRUE(ht->tbl[TFW_HTTP_HDR_CONTENT_LENGTH].eolen == 1);
 	}
 
-	/*
-	 * It seems RFC 7230 3.3 doesn't prohibit message body
-	 * for GET requests.
-	 */
-	__FOR_REQ("GET / HTTP/1.1\n"
+	__FOR_REQ("POST / HTTP/1.1\n"
 		  "Host: b.com\n"
 		  "Content-Length: 6\n"
 		  "\r\n"
@@ -2914,12 +2910,9 @@ TEST(http_parser, req_hop_by_hop)
 	"Dummy5: 5\r\n"							\
 	"Foo: is hop-by-hop header\r\n"					\
 	"Dummy6: 6\r\n"							\
-	"Content-Length: 0\r\n"						\
-	"Content-Type: text/html; charset=iso-8859-1\r\n"		\
+	"Buzz: is hop-by-hop header\r\n"				\
 	"Dummy7: 7\r\n"							\
 	"Dummy8: 8\r\n"							\
-	"Buzz: is hop-by-hop header\r\n"				\
-	"Dummy9: 9\r\n"							\
 	"Cache-Control: max-age=1, no-store, min-fresh=30\r\n"		\
 	"Pragma: no-cache, fooo \r\n"					\
 	"Cookie: session=42; theme=dark\r\n"				\
@@ -2931,8 +2924,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 17 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
+		/* Common (raw) headers: 16 total with 9 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -2946,8 +2939,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 17 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
+		/* Common (raw) headers: 16 total with 9 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -2969,8 +2962,8 @@ TEST(http_parser, req_hop_by_hop)
 		REQ_HBH_END)
 	{
 		ht = req->h_tbl;
-		/* Common (raw) headers: 17 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
+		/* Common (raw) headers: 16 total with 9 dummies. */
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -2978,7 +2971,7 @@ TEST(http_parser, req_hop_by_hop)
 			case TFW_HTTP_HDR_CONNECTION:
 			case TFW_HTTP_HDR_KEEP_ALIVE:
 			case TFW_HTTP_HDR_RAW + 4:
-			case TFW_HTTP_HDR_RAW + 12:
+			case TFW_HTTP_HDR_RAW + 10:
 				EXPECT_TRUE(field->flags & TFW_STR_HBH_HDR);
 				break;
 			default:


### PR DESCRIPTION
Fixes #1296 

Considerations. For methods: GET, HEAD, DELETE, CONNECT, TRACE requests with payload to be dropped.

CONNECT method not supported now and need considerably more work to support.

For HTTP/1.1 payload indicated by presence of Content-Length or Transfer-Encoding headers. Even if Content-Length is zero message to be dropped, because Content-Length header may change semantics for recipient.

For HTTP/2.0 payload indicated by underlying framing protocol, but content-length header may be present and must be consistent with it. So message to be dropped once content-length header is seen or data frame for message is seen.

One more consideration is X-Http-Method-Override header, that used for method tunnelling. It to be respected when do the filtering. It is reasonable to expect that non-safe override methods can not be hidden behind safe method.

The same to be done for Content-Type header as it can change semantics for back-end server and its presence in request message with no payload have no meaningful reason.

For further discussions go to linked issue.