### PR TITLE
Comments and small refactoring of fixup macroses

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -310,8 +310,7 @@ do {									\
 #define __FSM_I_MOVE_BY_REF(to)						\
 	__FSM_I_MOVE_BY_REF_n(to, 1, 0)
 
-#define __FSM_I_MOVE(to)						\
-	__FSM_I_MOVE_BY_REF_n(&&to, 1, 0)
+#define __FSM_I_MOVE(to)		__FSM_I_MOVE_n(to, 1)
 /* The same as __FSM_I_MOVE_n(), but exactly for jumps w/o data moving. */
 #define __FSM_I_JMP(to)			goto to
 

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -877,6 +877,8 @@ process_trailer_hdr(TfwHttpMsg *hm, TfwStr *hdr, unsigned int id)
 
 /**
  * Parsing helpers.
+ * TRY_STR_* macros are supposed to be used without explicit fixups, so the
+ * whole data + len chunk will be fixed up on chunk exhaustion.
  * @str in TRY_STR_LAMBDA must be in lower case.
  * @lambda is called on successfull match.
  * @finish is called when the current data+len chunk is exhausted.
@@ -892,6 +894,7 @@ process_trailer_hdr(TfwHttpMsg *hm, TfwStr *hdr, unsigned int id)
 			TRY_STR_INIT();					\
 			__FSM_I_MOVE_BY_REF_n(state, __fsm_n, 0);	\
 		}							\
+		/* Here __fsm_n == __data_remain(p) i.e. chunk exhausted */ \
 		__msg_hdr_chunk_fixup(data, len);			\
 		finish;							\
 		return CSTR_POSTPONE;					\
@@ -2423,7 +2426,7 @@ __req_parse_cache_control(TfwHttpReq *req, unsigned char *data, size_t len)
 		/* Any directive we don't understand.
 		 * Here we just skip all the tokens, double quotes and equal signs.
 		 */
-		__FSM_I_MATCH_MOVE(qetoken, Req_I_CC_Ext);
+		__FSM_I_MATCH_MOVE_fixup(qetoken, Req_I_CC_Ext, 0);
 
 		__FSM_I_MOVE_n(Req_I_EoT, __fsm_sz);
 	}
@@ -5704,7 +5707,7 @@ do {									\
 		__FSM_I_field_chunk_flags(fld, TFW_STR_HDR_VALUE);	\
 		__FSM_EXIT(CSTR_POSTPONE);				\
 	}
-
+ 
 #define H2_TRY_STR_LAMBDA_fixup(str, fld, lambda, curr_st, next_st)	\
 	H2_TRY_STR_2LAMBDA_fixup(str, fld, {}, lambda, curr_st, next_st)
 
@@ -5763,7 +5766,7 @@ __h2_req_parse_authority(TfwHttpReq *req, unsigned char *data, size_t len,
 	__FSM_STATE(Req_I_A_v6) {
 		/* See Req_UriAuthorityIPv6 processing. */
 		if (likely(isxdigit(c) || c == ':'))
-			__FSM_H2_I_MOVE_fixup(Req_I_A_v6, 1, TFW_STR_VALUE);
+			__FSM_H2_I_MOVE_n_flag(Req_I_A_v6, 1, TFW_STR_VALUE);
 		if (likely(c == ']')) {
 			__msg_hdr_chunk_fixup(data, (p - data + 1));
 			__msg_chunk_flags(TFW_STR_HDR_VALUE | TFW_STR_VALUE);

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -817,8 +817,7 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 	const char *s_xch = "X-Custom-Hdr: custom header values";
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
-	const char *s_cc  = "Cache-Control: "
-		"max-age=1, dummy, no-store, min-fresh=30";
+	const char *s_cc  = "Cache-Control: max-age=1, no-store, min-fresh=30";
 	const char *s_te  = "compress, gzip, chunked";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_pragma =  "Pragma: no-cache, fooo ";
@@ -843,8 +842,7 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 		       /* That is done to check table reallocation. */
 		       "Dummy8: 8\r\n"
 		       "Dummy9: 9\r\n"
-		       "Cache-Control: "
-		       "max-age=1, dummy, no-store, min-fresh=30\r\n"
+		       "Cache-Control: max-age=1, no-store, min-fresh=30\r\n"
 		       "Pragma: no-cache, fooo \r\n"
 		       "Transfer-Encoding: compress, gzip, chunked\r\n"
 		       "Cookie: session=42; theme=dark\r\n"
@@ -919,31 +917,24 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 {
 	TfwHttpHdrTbl *ht;
 	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_age, *h_date, *h_exp;
-	TfwStr *h_lastmodified, *h_pragma;
-	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka, h_etag;
-	TfwStr h_setcookie;
+	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka;
 
 	/* Expected values for special headers. */
 	const char *s_connection = "Keep-Alive";
 	const char *s_ct = "text/html; charset=iso-8859-1";
 	const char *s_srv = "Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"
 			    " mod_fcgid/2.3.9";
-	const char *s_etag = "W/\"0815\" ";
-	const char *s_setcookie = "__Host-id=1; Secure; Path=/; domain=example.com ";
 	/* Expected values for raw headers. */
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
 	const char *s_cc = "Cache-Control: "
-		"max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo";
+			   "max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo";
 	const char *s_te = "compress, gzip, chunked";
 	const char *s_exp = "Expires: Tue, 31 Jan 2012 15:02:53 GMT";
 	const char *s_ka = "timeout=600, max=65526";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_age = "Age: 12  ";
 	const char *s_date = "Date: Sun, 09 Sep 2001 01:46:40 GMT\t";
-	const char *s_lastmodified =
-		"Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT ";
-	const char *s_pragma = "Pragma: no-cache ";
 
 	FOR_RESP("HTTP/1.1 200 OK\r\n"
 		"Connection: Keep-Alive\r\n"
@@ -957,8 +948,7 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		"Content-Type: text/html; charset=iso-8859-1\r\n"
 		"Dummy7: 7\r\n"
 		"Dummy8: 8\r\n"
-		"Cache-Control: "
-		"max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo\r\n"
+		"Cache-Control: max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo\r\n"
 		"Dummy9: 9\r\n" /* That is done to check table reallocation. */
 		"Expires: Tue, 31 Jan 2012 15:02:53 GMT\r\n"
 		"Keep-Alive: timeout=600, max=65526\r\n"
@@ -967,10 +957,6 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		        " mod_fcgid/2.3.9\r\n"
 		"Age: 12  \n"
 		"Date: Sun, 09 Sep 2001 01:46:40 GMT\t\n"
-		"ETag: W/\"0815\" \r\n"
-		"Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com \r\n"
-		"Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT \r\n"
-		"Pragma: no-cache \r\n"
 		"\r\n"
 		"3\r\n"
 		"012\r\n"
@@ -995,49 +981,35 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					TFW_HTTP_HDR_TRANSFER_ENCODING, &h_te);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_KEEP_ALIVE],
 					TFW_HTTP_HDR_KEEP_ALIVE, &h_ka);
-		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_ETAG],
-					TFW_HTTP_HDR_ETAG,
-					&h_etag);
-		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_SET_COOKIE],
-					TFW_HTTP_HDR_SET_COOKIE,
-					&h_setcookie);
 
 		/*
 		 * Common (raw) headers: 10 dummies, Cache-Control,
 		 * Expires, Age, Date.
 		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
-		if (ht->off >= TFW_HTTP_HDR_RAW + 16) {
-			h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
-			h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
-			h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
-			h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
-			h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
-			h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
-			h_lastmodified = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
-			h_pragma = &ht->tbl[TFW_HTTP_HDR_RAW + 15];
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 14);
 
-			EXPECT_TFWSTR_EQ(h_dummy4, s_dummy4);
-			EXPECT_TFWSTR_EQ(h_cc, s_cc);
-			EXPECT_TFWSTR_EQ(h_dummy9, s_dummy9);
-			EXPECT_TFWSTR_EQ(h_exp, s_exp);
-			EXPECT_TFWSTR_EQ(h_age, s_age);
-			EXPECT_TFWSTR_EQ(h_date, s_date);
-			EXPECT_TFWSTR_EQ(h_lastmodified, s_lastmodified);
-			EXPECT_TFWSTR_EQ(h_pragma, s_pragma);
-
-			EXPECT_TRUE(h_dummy9->eolen == 2);
-		}
+		h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
+		h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
+		h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
+		h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
+		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
+		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
 
 		EXPECT_TFWSTR_EQ(&h_connection, s_connection);
 		EXPECT_TFWSTR_EQ(&h_conttype, s_ct);
 		EXPECT_TFWSTR_EQ(&h_srv, s_srv);
 		EXPECT_TFWSTR_EQ(&h_te, s_te);
 		EXPECT_TFWSTR_EQ(&h_ka, s_ka);
-		EXPECT_TFWSTR_EQ(&h_etag, s_etag);
-		EXPECT_TFWSTR_EQ(&h_setcookie, s_setcookie);
+
+		EXPECT_TFWSTR_EQ(h_dummy4, s_dummy4);
+		EXPECT_TFWSTR_EQ(h_cc, s_cc);
+		EXPECT_TFWSTR_EQ(h_dummy9, s_dummy9);
+		EXPECT_TFWSTR_EQ(h_exp, s_exp);
+		EXPECT_TFWSTR_EQ(h_age, s_age);
+		EXPECT_TFWSTR_EQ(h_date, s_date);
 
 		EXPECT_TRUE(resp->keep_alive == 600);
+		EXPECT_TRUE(h_dummy9->eolen == 2);
 	}
 }
 

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -817,7 +817,8 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 	const char *s_xch = "X-Custom-Hdr: custom header values";
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
-	const char *s_cc  = "Cache-Control: max-age=1, no-store, min-fresh=30";
+	const char *s_cc  = "Cache-Control: "
+		"max-age=1, dummy, no-store, min-fresh=30";
 	const char *s_te  = "compress, gzip, chunked";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_pragma =  "Pragma: no-cache, fooo ";
@@ -842,7 +843,8 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 		       /* That is done to check table reallocation. */
 		       "Dummy8: 8\r\n"
 		       "Dummy9: 9\r\n"
-		       "Cache-Control: max-age=1, no-store, min-fresh=30\r\n"
+		       "Cache-Control: "
+		       "max-age=1, dummy, no-store, min-fresh=30\r\n"
 		       "Pragma: no-cache, fooo \r\n"
 		       "Transfer-Encoding: compress, gzip, chunked\r\n"
 		       "Cookie: session=42; theme=dark\r\n"
@@ -917,24 +919,31 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 {
 	TfwHttpHdrTbl *ht;
 	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_age, *h_date, *h_exp;
-	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka;
+	TfwStr *h_lastmodified, *h_pragma;
+	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka, h_etag;
+	TfwStr h_setcookie;
 
 	/* Expected values for special headers. */
 	const char *s_connection = "Keep-Alive";
 	const char *s_ct = "text/html; charset=iso-8859-1";
 	const char *s_srv = "Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"
 			    " mod_fcgid/2.3.9";
+	const char *s_etag = "W/\"0815\" ";
+	const char *s_setcookie = "__Host-id=1; Secure; Path=/; domain=example.com ";
 	/* Expected values for raw headers. */
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
 	const char *s_cc = "Cache-Control: "
-			   "max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo";
+		"max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo";
 	const char *s_te = "compress, gzip, chunked";
 	const char *s_exp = "Expires: Tue, 31 Jan 2012 15:02:53 GMT";
 	const char *s_ka = "timeout=600, max=65526";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_age = "Age: 12  ";
 	const char *s_date = "Date: Sun, 09 Sep 2001 01:46:40 GMT\t";
+	const char *s_lastmodified =
+		"Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT ";
+	const char *s_pragma = "Pragma: no-cache ";
 
 	FOR_RESP("HTTP/1.1 200 OK\r\n"
 		"Connection: Keep-Alive\r\n"
@@ -948,7 +957,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		"Content-Type: text/html; charset=iso-8859-1\r\n"
 		"Dummy7: 7\r\n"
 		"Dummy8: 8\r\n"
-		"Cache-Control: max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo\r\n"
+		"Cache-Control: "
+		"max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo\r\n"
 		"Dummy9: 9\r\n" /* That is done to check table reallocation. */
 		"Expires: Tue, 31 Jan 2012 15:02:53 GMT\r\n"
 		"Keep-Alive: timeout=600, max=65526\r\n"
@@ -957,6 +967,10 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		        " mod_fcgid/2.3.9\r\n"
 		"Age: 12  \n"
 		"Date: Sun, 09 Sep 2001 01:46:40 GMT\t\n"
+		"ETag: W/\"0815\" \r\n"
+		"Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com \r\n"
+		"Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT \r\n"
+		"Pragma: no-cache \r\n"
 		"\r\n"
 		"3\r\n"
 		"012\r\n"
@@ -981,97 +995,49 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					TFW_HTTP_HDR_TRANSFER_ENCODING, &h_te);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_KEEP_ALIVE],
 					TFW_HTTP_HDR_KEEP_ALIVE, &h_ka);
-
-		/*
-		 * Common (raw) headers: 10 dummies, Cache-Control,
-		 * Expires, Age, Date.
-		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 14);
-
-		h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
-		h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
-		h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
-		h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
-		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
-		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
-
-		EXPECT_TFWSTR_EQ(&h_connection, s_connection);
-		EXPECT_TFWSTR_EQ(&h_conttype, s_ct);
-		EXPECT_TFWSTR_EQ(&h_srv, s_srv);
-		EXPECT_TFWSTR_EQ(&h_te, s_te);
-		EXPECT_TFWSTR_EQ(&h_ka, s_ka);
-
-		EXPECT_TFWSTR_EQ(h_dummy4, s_dummy4);
-		EXPECT_TFWSTR_EQ(h_cc, s_cc);
-		EXPECT_TFWSTR_EQ(h_dummy9, s_dummy9);
-		EXPECT_TFWSTR_EQ(h_exp, s_exp);
-		EXPECT_TFWSTR_EQ(h_age, s_age);
-		EXPECT_TFWSTR_EQ(h_date, s_date);
-
-		EXPECT_TRUE(resp->keep_alive == 600);
-		EXPECT_TRUE(h_dummy9->eolen == 2);
-	}
-}
-
-TEST(http_parser, fills_hdr_tbl_for_resp2)
-{
-	TfwHttpHdrTbl *ht;
-	TfwStr *h_lastmodified, *h_cc, *h_pragma;
-	TfwStr h_etag, h_setcookie, h_contlen;
-
-	/* Expected values for special headers. */
-	const char *s_etag = "W/\"0815\" ";
-	const char *s_setcookie = "__Host-id=1; Secure; Path=/; domain=example.com ";
-	const char *s_contlen = "5";
-	/* Expected values for raw headers. */
-	const char *s_lastmodified = "Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT ";
-	const char *s_cc = "Cache-Control: dummy=\"\", dummy ";
-	const char *s_pragma = "Pragma: no-cache ";
-
-	FOR_RESP(
-		"HTTP/1.1 200 OK\r\n"
-		"ETag: W/\"0815\" \r\n"
-		"Content-Length: 5 \r\n"
-		"Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com \r\n"
-		"Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT \r\n"
-		"Cache-Control: dummy=\"\", dummy \r\n"
-		"Pragma: no-cache \r\n"
-		"\r\n"
-		"01234")
-	{
-		ht = resp->h_tbl;
-
-		EXPECT_TFWSTR_EQ(&ht->tbl[TFW_HTTP_STATUS_LINE],
-				 "HTTP/1.1 200 OK");
-
-		/* Special headers: */
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_ETAG],
 					TFW_HTTP_HDR_ETAG,
 					&h_etag);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_SET_COOKIE],
 					TFW_HTTP_HDR_SET_COOKIE,
 					&h_setcookie);
-		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_CONTENT_LENGTH],
-					TFW_HTTP_HDR_CONTENT_LENGTH, &h_contlen);
 
 		/*
-		 * Common (raw) headers: Cache-Control, Last-Modified, Pragma.
+		 * Common (raw) headers: 10 dummies, Cache-Control,
+		 * Expires, Age, Date.
 		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 3);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		if (ht->off >= TFW_HTTP_HDR_RAW + 16) {
+			h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
+			h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
+			h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
+			h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
+			h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
+			h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
+			h_lastmodified = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
+			h_pragma = &ht->tbl[TFW_HTTP_HDR_RAW + 15];
 
-		if (ht->off == TFW_HTTP_HDR_RAW + 3) {
-			h_lastmodified = &ht->tbl[TFW_HTTP_HDR_RAW + 0];
-			h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 1];
-			h_pragma = &ht->tbl[TFW_HTTP_HDR_RAW + 2];
-
-			EXPECT_TFWSTR_EQ(h_lastmodified, s_lastmodified);
+			EXPECT_TFWSTR_EQ(h_dummy4, s_dummy4);
 			EXPECT_TFWSTR_EQ(h_cc, s_cc);
+			EXPECT_TFWSTR_EQ(h_dummy9, s_dummy9);
+			EXPECT_TFWSTR_EQ(h_exp, s_exp);
+			EXPECT_TFWSTR_EQ(h_age, s_age);
+			EXPECT_TFWSTR_EQ(h_date, s_date);
+			EXPECT_TFWSTR_EQ(h_lastmodified, s_lastmodified);
 			EXPECT_TFWSTR_EQ(h_pragma, s_pragma);
+
+			EXPECT_TRUE(h_dummy9->eolen == 2);
 		}
 
+		EXPECT_TFWSTR_EQ(&h_connection, s_connection);
+		EXPECT_TFWSTR_EQ(&h_conttype, s_ct);
+		EXPECT_TFWSTR_EQ(&h_srv, s_srv);
+		EXPECT_TFWSTR_EQ(&h_te, s_te);
+		EXPECT_TFWSTR_EQ(&h_ka, s_ka);
 		EXPECT_TFWSTR_EQ(&h_etag, s_etag);
 		EXPECT_TFWSTR_EQ(&h_setcookie, s_setcookie);
-		EXPECT_TFWSTR_EQ(&h_contlen, s_contlen);
+
+		EXPECT_TRUE(resp->keep_alive == 600);
 	}
 }
 
@@ -4179,7 +4145,6 @@ TEST_SUITE(http_parser)
 	TEST_RUN(http_parser, hdr_token_confusion);
 	TEST_RUN(http_parser, fills_hdr_tbl_for_req);
 	TEST_RUN(http_parser, fills_hdr_tbl_for_resp);
-	TEST_RUN(http_parser, fills_hdr_tbl_for_resp2);
 	TEST_RUN(http_parser, cache_control);
 	TEST_RUN(http_parser, status);
 	TEST_RUN(http_parser, age);


### PR DESCRIPTION
As a part of #1547 
* Commented FSM variables, fixup macroses and their naming convention.
* Marked with a comment all nested FSM-s that use explicit chunking.
  Verified they actually use explicit chunking macroses only.
* Removed some unused macroses.
* Corrected excessive fixup in __req_parse_cache_control() and missing
  fixup in __h2_req_parse_authority().
* Wrote additional tests for response chunking.