### PR TITLE
Fixes build when dbg_hpack defined

### DIFF
--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -1717,6 +1717,7 @@ next_msg:
 	default:
 		T_WARN("Unrecognized return code %d during HTTP/2 frame"
 		       " receiving, drop frame\n", r);
+		// fallthrough
 	case T_DROP:
 		T_DBG3("Drop invalid HTTP/2 frame\n");
 		goto out;

--- a/fw/pool.h
+++ b/fw/pool.h
@@ -24,6 +24,7 @@
 #define __TFW_POOL_H__
 
 #include <linux/cache.h>
+#include <linux/kernel.h>
 #include "log.h"
 
 #define TFW_POOL_ZERO	0x1

--- a/fw/pool.h
+++ b/fw/pool.h
@@ -24,7 +24,7 @@
 #define __TFW_POOL_H__
 
 #include <linux/cache.h>
-#include <linux/kernel.h>
+#include <asm/page.h>
 #include "log.h"
 
 #define TFW_POOL_ZERO	0x1


### PR DESCRIPTION
No linked issue.

I ran into an issue when building unit tests with command:

```
> DEBUG=3 DBG_HTTP_PARSE=3 DBG_HPACK=3 make test
```

Build failed with error:

> In file included from ./include/linux/export.h:43,
>                  from ./include/linux/linkage.h:7,
>                  from ./arch/x86/include/asm/cache.h:5,
>                  from ./include/linux/cache.h:6,
>                  from /root/workspace/tempesta/fw/pool.h:26,
>                  from /root/workspace/tempesta/fw/hpack.c:26:
> /root/workspace/tempesta/fw/pool.h: In function 'tfw_pool_alloc_np':
> /root/workspace/tempesta/fw/pool.h:31:31: error: 'PAGE_SIZE' undeclared (first use in this function)
>    31 | #define TFW_POOL_CHUNK_SZ(p) (PAGE_SIZE << (p)->order)
>       |                               ^~~~~~~~~
> ./include/linux/compiler.h:78:42: note: in definition of macro 'unlikely'
>    78 | # define unlikely(x) __builtin_expect(!!(x), 0)
>       |                                          ^
> /root/workspace/tempesta/fw/pool.h:94:21: note: in expansion of macro 'TFW_POOL_CHUNK_SZ'
>    94 |  if (unlikely(off > TFW_POOL_CHUNK_SZ(p))) {
>       |                     ^~~~~~~~~~~~~~~~~
> /root/workspace/tempesta/fw/pool.h:31:31: note: each undeclared identifier is reported only once for each function it appears in
>    31 | #define TFW_POOL_CHUNK_SZ(p) (PAGE_SIZE << (p)->order)
>       |                               ^~~~~~~~~
> ./include/linux/compiler.h:78:42: note: in definition of macro 'unlikely'
>    78 | # define unlikely(x) __builtin_expect(!!(x), 0)
>       |                                          ^
> /root/workspace/tempesta/fw/pool.h:94:21: note: in expansion of macro 'TFW_POOL_CHUNK_SZ'
>    94 |  if (unlikely(off > TFW_POOL_CHUNK_SZ(p))) {

This PR fixes issue.
