### PR TITLE
Corrected fixups for cache-control and authority

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -5422,9 +5422,6 @@ do {									\
 #define __FSM_H2_I_MOVE_LAMBDA_n(to, n, lambda)				\
 	__FSM_H2_I_MOVE_LAMBDA_n_flag(to, n, lambda, 0)
 
-#define __FSM_H2_I_MOVE_n_flag(to, n, flag)				\
-	__FSM_H2_I_MOVE_LAMBDA_n_flag(to, n, {}, flag)
-
 #define __FSM_H2_I_MOVE_n(to, n)					\
 	__FSM_H2_I_MOVE_LAMBDA_n(to, n, {})
 

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -2379,7 +2379,7 @@ __req_parse_cache_control(TfwHttpReq *req, unsigned char *data, size_t len)
 		/* Any directive we don't understand.
 		 * Here we just skip all the tokens, double quotes and equal signs.
 		 */
-		__FSM_I_MATCH_MOVE_fixup(qetoken, Req_I_CC_Ext, 0);
+		__FSM_I_MATCH_MOVE(qetoken, Req_I_CC_Ext);
 
 		__FSM_I_MOVE_n(Req_I_EoT, __fsm_sz);
 	}
@@ -5689,7 +5689,7 @@ __h2_req_parse_authority(TfwHttpReq *req, unsigned char *data, size_t len,
 	__FSM_STATE(Req_I_A_v6) {
 		/* See Req_UriAuthorityIPv6 processing. */
 		if (likely(isxdigit(c) || c == ':'))
-			__FSM_H2_I_MOVE_n_flag(Req_I_A_v6, 1, TFW_STR_VALUE);
+			__FSM_H2_I_MOVE_fixup(Req_I_A_v6, 1, TFW_STR_VALUE);
 		if (likely(c == ']')) {
 			__msg_hdr_chunk_fixup(data, (p - data + 1));
 			__msg_chunk_flags(TFW_STR_HDR_VALUE | TFW_STR_VALUE);

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -817,7 +817,8 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 	const char *s_xch = "X-Custom-Hdr: custom header values";
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
-	const char *s_cc  = "Cache-Control: max-age=1, no-store, min-fresh=30";
+	const char *s_cc  = "Cache-Control: "
+		"max-age=1, dummy, no-store, min-fresh=30";
 	const char *s_te  = "compress, gzip, chunked";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_pragma =  "Pragma: no-cache, fooo ";
@@ -842,7 +843,8 @@ TEST(http_parser, fills_hdr_tbl_for_req)
 		       /* That is done to check table reallocation. */
 		       "Dummy8: 8\r\n"
 		       "Dummy9: 9\r\n"
-		       "Cache-Control: max-age=1, no-store, min-fresh=30\r\n"
+		       "Cache-Control: "
+		       "max-age=1, dummy, no-store, min-fresh=30\r\n"
 		       "Pragma: no-cache, fooo \r\n"
 		       "Transfer-Encoding: compress, gzip, chunked\r\n"
 		       "Cookie: session=42; theme=dark\r\n"
@@ -917,24 +919,31 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 {
 	TfwHttpHdrTbl *ht;
 	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_age, *h_date, *h_exp;
-	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka;
+	TfwStr *h_lastmodified, *h_pragma;
+	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka, h_etag;
+	TfwStr h_setcookie;
 
 	/* Expected values for special headers. */
 	const char *s_connection = "Keep-Alive";
 	const char *s_ct = "text/html; charset=iso-8859-1";
 	const char *s_srv = "Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"
 			    " mod_fcgid/2.3.9";
+	const char *s_etag = "W/\"0815\" ";
+	const char *s_setcookie = "__Host-id=1; Secure; Path=/; domain=example.com ";
 	/* Expected values for raw headers. */
 	const char *s_dummy9 = "Dummy9: 9";
 	const char *s_dummy4 = "Dummy4: 4";
 	const char *s_cc = "Cache-Control: "
-			   "max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo";
+		"max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo";
 	const char *s_te = "compress, gzip, chunked";
 	const char *s_exp = "Expires: Tue, 31 Jan 2012 15:02:53 GMT";
 	const char *s_ka = "timeout=600, max=65526";
 	/* Trailing spaces are stored within header strings. */
 	const char *s_age = "Age: 12  ";
 	const char *s_date = "Date: Sun, 09 Sep 2001 01:46:40 GMT\t";
+	const char *s_lastmodified =
+		"Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT ";
+	const char *s_pragma = "Pragma: no-cache ";
 
 	FOR_RESP("HTTP/1.1 200 OK\r\n"
 		"Connection: Keep-Alive\r\n"
@@ -948,7 +957,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		"Content-Type: text/html; charset=iso-8859-1\r\n"
 		"Dummy7: 7\r\n"
 		"Dummy8: 8\r\n"
-		"Cache-Control: max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo\r\n"
+		"Cache-Control: "
+		"max-age=5, private, no-cache, no-cache=\"fieldname\", ext=foo\r\n"
 		"Dummy9: 9\r\n" /* That is done to check table reallocation. */
 		"Expires: Tue, 31 Jan 2012 15:02:53 GMT\r\n"
 		"Keep-Alive: timeout=600, max=65526\r\n"
@@ -957,6 +967,10 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		        " mod_fcgid/2.3.9\r\n"
 		"Age: 12  \n"
 		"Date: Sun, 09 Sep 2001 01:46:40 GMT\t\n"
+		"ETag: W/\"0815\" \r\n"
+		"Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com \r\n"
+		"Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT \r\n"
+		"Pragma: no-cache \r\n"
 		"\r\n"
 		"3\r\n"
 		"012\r\n"
@@ -981,12 +995,18 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 					TFW_HTTP_HDR_TRANSFER_ENCODING, &h_te);
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_KEEP_ALIVE],
 					TFW_HTTP_HDR_KEEP_ALIVE, &h_ka);
+		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_ETAG],
+					TFW_HTTP_HDR_ETAG,
+					&h_etag);
+		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_SET_COOKIE],
+					TFW_HTTP_HDR_SET_COOKIE,
+					&h_setcookie);
 
 		/*
 		 * Common (raw) headers: 10 dummies, Cache-Control,
 		 * Expires, Age, Date.
 		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 14);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
 
 		h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
 		h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
@@ -994,12 +1014,16 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
 		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
 		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
+		h_lastmodified = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
+		h_pragma = &ht->tbl[TFW_HTTP_HDR_RAW + 15];
 
 		EXPECT_TFWSTR_EQ(&h_connection, s_connection);
 		EXPECT_TFWSTR_EQ(&h_conttype, s_ct);
 		EXPECT_TFWSTR_EQ(&h_srv, s_srv);
 		EXPECT_TFWSTR_EQ(&h_te, s_te);
 		EXPECT_TFWSTR_EQ(&h_ka, s_ka);
+		EXPECT_TFWSTR_EQ(&h_etag, s_etag);
+		EXPECT_TFWSTR_EQ(&h_setcookie, s_setcookie);
 
 		EXPECT_TFWSTR_EQ(h_dummy4, s_dummy4);
 		EXPECT_TFWSTR_EQ(h_cc, s_cc);
@@ -1007,6 +1031,8 @@ TEST(http_parser, fills_hdr_tbl_for_resp)
 		EXPECT_TFWSTR_EQ(h_exp, s_exp);
 		EXPECT_TFWSTR_EQ(h_age, s_age);
 		EXPECT_TFWSTR_EQ(h_date, s_date);
+		EXPECT_TFWSTR_EQ(h_lastmodified, s_lastmodified);
+		EXPECT_TFWSTR_EQ(h_pragma, s_pragma);
 
 		EXPECT_TRUE(resp->keep_alive == 600);
 		EXPECT_TRUE(h_dummy9->eolen == 2);


### PR DESCRIPTION
Extracted from #1562

Also added more headers into fills_hdr_tbl_for_resp test

__req_parse_cache_control() bug:

__FSM_I_MATCH_MOVE and __FSM_I_MATCH_MOVE_fixup only differ in calling
__msg_hdr_chunk_fixup() with data + len and p + __fsm_size
correspondingly. This creates a problem when p != data e.g. we are
parsing multiple tokens.
The whole __req_parse_cache_control() function normally uses
__FSM_I_MATCH_MOVE, thus doing lazy fixups over complete chunks with
TFW_POSTPONE return value and the final fixup is performed by parent
TFW_HTTP_PARSE_RAWHDR_VAL with return value greater or equal 0.

The fills_hdr_tbl_for_req test shows a mishandling of Cache-Control
header value when it's equal to

Cache-Control: max-age=1, dummy, no-store, min-fresh=30

Let's suppose the string is chunked into

max-age=1, dum
my, no-store, min-fresh=30

blocks. The first chunk will be processed via labels

 m  -> Req_I_CC_start, Req_I_CC
max-age=  -> Req_I_CC_m, Req_I_CC_MaxAgeVBeg
 1  -> Req_I_CC_MaxAgeVBeg, Req_I_CC_MaxAgeV
 ,  -> Req_I_EoT
" " -> Req_I_After_Comma
 d  -> Req_I_CC
dum -> Req_I_CC_Ext (returns TFW_POSTPONE)

When the wrong fixup macro is used, the parsing of the first chunk
will reach the Req_I_CC_Ext label and trigger the __fsm_sz == __fsm_n
condition (chunk exhaustion) in the __FSM_I_MATCH_MOVE_fixup, thus
doing a __msg_hdr_chunk_fixup("dum", 3) fixup and returning
TFW_POSTPONE. This way the starting portion of the first chunk will
never be fixed up. Parsing of the second chunk, will be resumed on
the same __FSM_I_MATCH_MOVE_fixup, which will effectively return a
__fsm_sz value and continue normal processing in the
__req_parse_cache_control().

This way the final value for msg->stream->parser.hdr string will be

Cache-Control: dummy, no-store, min-fresh=30

Which might look fine, aprat from the missing starting portion.

__h2_req_parse_authority() bug:

This function has an inverse problem: a lazy __FSM_H2_I_MOVE_n_flag
fixup is used instead of explicit __FSM_H2_I_MOVE_fixup.

Suppose the header is

Authority: [::1]:5001

and its value is chunked as

[:
:1]:5001

The processing will go through the following FSM states:

"[" -> Req_I_A_Start (fixups "[")
":" -> Req_I_A_v6 (fixups ???, returns TFW_POSTPONE \ CSTR_NEQ)
":" -> Req_I_A_v6 (fixups ":")
"1" -> Req_I_A_v6 (fixups "1")
"]" -> Req_I_A_v6 (fixups "]")
":" -> Req_I_A_End (fixups ":")
5000 -> Req_I_A_Port (fixups "5000", returns 0 \ CSTR_EQ)

The use of __FSM_H2_I_MOVE_n_flag macro inside Req_I_A_v6 leads to
a __msg_hdr_chunk_fixup("[:", 2) call instead of a correct
__msg_hdr_chunk_fixup(":", 1). Thus the final parsed string will look
like

Authority: [[::1]:5001