### PR TITLE
Simple access log

### DIFF
--- a/fw/access_log.c
+++ b/fw/access_log.c
@@ -110,7 +110,13 @@ append_to_cstr_bounded(char *p, char *end, TfwStr *s,
 void
 do_access_log(TfwHttpResp *resp)
 {
-	TfwHttpReq *req = resp->req;
+	do_access_log_req(resp->req, resp->status, resp->content_length);
+}
+
+
+void
+do_access_log_req(TfwHttpReq *req, int status, unsigned long content_length)
+{
 	char *buf = this_cpu_ptr(access_log_buf);
 	char *p = buf, *end = p + ACCESS_LOG_BUF_SIZE;
 
@@ -186,7 +192,7 @@ do_access_log(TfwHttpResp *resp)
 	default: CONCAT_STR("-");
 	}
 
-	CONCAT_PRINTF("\" %d %lu \"", (int)resp->status, resp->content_length);
+	CONCAT_PRINTF("\" %d %lu \"", status, content_length);
 	CONCAT_HDR(TFW_HTTP_HDR_REFERER, 2, 3 + 1);
 	CONCAT_STR("\" \"");
 	CONCAT_HDR(TFW_HTTP_HDR_USER_AGENT, 1, 1);
@@ -194,7 +200,7 @@ do_access_log(TfwHttpResp *resp)
 
 overflow:
 	*(p < end ? p : end - 1) = 0;
-	pr_info("%s", buf);
+	pr_info("%s\n", buf);
 #undef CONCAT_CASE_STR_XX
 #undef CONCAT_CASE_STR
 #undef CONCAT_STR

--- a/fw/access_log.c
+++ b/fw/access_log.c
@@ -1,0 +1,209 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#include "connection.h"
+#include "server.h"
+#include "http.h"
+#include "lib/common.h"
+#include <linux/timekeeping.h>
+
+static bool access_log_enabled = false;
+
+/** Build string consists of chunks that belong to the header value.
+ * @param http_version is TFW_HTTP_VER_xx enum
+ * @param line is the request line from TfwHttpReq::h_tbl */
+static TfwStr
+get_http_header_value(char http_version, TfwStr *line)
+{
+	WARN_ONCE(TFW_STR_PLAIN(line), "Got plain string from parser");
+	if (TFW_STR_PLAIN(line))
+		return *line;
+	if (http_version >= TFW_HTTP_VER_09 && http_version <= TFW_HTTP_VER_11) {
+		TfwStr result;
+		TfwStr *chunk = line->chunks, *end = chunk + line->nchunks;
+		for (; chunk < end; chunk++) {
+			if (chunk->len == 1 && *chunk->data == ':')
+				break;
+		}
+		if (chunk == end)
+			return TFW_STR_STRING("");
+		chunk++;
+		while (chunk < end && (chunk->flags & TFW_STR_OWS) != 0)
+			chunk++;
+		if (chunk == end)
+			return TFW_STR_STRING("");
+		TFW_STR_INIT(&result);
+		result.chunks = chunk;
+		result.nchunks = end - chunk;
+		return result;
+	} else {
+		WARN_ONCE(true, "HTTP/2.0 not handled yet");
+		return *line;
+	}
+}
+
+void tfw_str_info(TfwStr *str) {
+	unsigned i = 0;
+	const TfwStr *s, *end;
+	pr_info("======================== %ld bytes, %d chunks", str->len, str->nchunks);
+	TFW_STR_FOR_EACH_CHUNK(s, str, end) {
+		pr_info("         chunk %d => %02x, len = %d, [%.*s]", i, s->flags, (int)s->len, (int)s->len, s->data);
+		i++;
+	}
+
+}
+
+void
+do_access_log(TfwHttpResp *resp)
+{
+	TfwHttpReq *req = resp->req;
+	// TODO: make it larger and per-cpu statically allocated
+	char buf[1024], *p = buf, *end = buf + sizeof(buf);
+
+#define CONCAT_TFW_STR(s) do {                               \
+		if ((s) != NULL) {                           \
+                        p += tfw_str_to_cstr(s, p, end - p); \
+			if (p + 1 >= end) goto overflow;     \
+		}                                            \
+	} while (0)
+#define CONCAT_HDR(hdr_id) do {                                  \
+                TfwStr hdr = get_http_header_value(req->version, \
+				req->h_tbl->tbl + hdr_id);       \
+                CONCAT_TFW_STR(&hdr);                            \
+	} while (0)
+#define CONCAT_PRINTF(fmt, ...) do {                           \
+		p += snprintf(p, end - p, fmt, ##__VA_ARGS__); \
+		if (p >= end) goto overflow;                   \
+	} while (0)
+#define CONCAT_STR(str) do {                               \
+		if (p + sizeof(str) >= end) goto overflow; \
+		memcpy(p, str, sizeof(str) - 1);           \
+		p += sizeof(str) - 1;                      \
+	} while (0)
+
+	/* Resp->conn is NULL if invalid response had been received */
+	if (resp->conn && resp->conn->peer)
+		p = tfw_addr_fmt(&resp->conn->peer->addr, TFW_NO_PORT, p);
+	else
+		CONCAT_STR("0.0.0.0");
+	do {
+		struct tm t;
+		static const char months[12][4] = {
+			"Jan", "Feb", "Mar",
+			"Apr", "May", "Jun",
+			"Jul", "Aug", "Sep",
+			"Oct", "Nov", "Dec"
+		};
+		time64_t now =ktime_get_real_seconds();
+		time64_to_tm(now, 0, &t);
+		CONCAT_PRINTF(" [%d/%s/%ld:%02d:%02d:%02d +0000] \"",
+			      t.tm_mday, months[t.tm_mon], 1900 + t.tm_year,
+			      t.tm_hour, t.tm_min, t.tm_sec);
+	} while (0);
+	if (req->vhost != NULL)
+		CONCAT_TFW_STR(&req->vhost->name);
+#define CONCAT_CASE_STR(x, str) case x: CONCAT_STR(str); break
+
+#define CONCAT_CASE_STR_XX(x, str) CONCAT_CASE_STR(x, XX(str))
+	switch (req->method) {
+#define XX(str) "\" \"" str " "
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_COPY,       "COPY");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_DELETE,     "DELETE");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_GET,        "GET");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_HEAD,       "HEAD");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_LOCK,       "LOCK");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_MKCOL,      "MKCOL");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_MOVE,       "MOVE");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_OPTIONS,    "OPTIONS");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_PATCH,      "PATCH");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_POST,       "POST");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_PROPFIND,   "PROPFIND");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_PROPPATCH,  "PROPPATCH");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_PUT,        "PUT");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_TRACE,      "TRACE");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_UNLOCK,     "UNLOCK");
+	CONCAT_CASE_STR_XX(TFW_HTTP_METH_PURGE,      "PURGE");
+	default: CONCAT_STR("UNKNOWN");
+#undef XX
+	}
+	CONCAT_TFW_STR(&req->uri_path);
+
+	switch (req->version) {
+#define XX(str) " " str
+	CONCAT_CASE_STR_XX(TFW_HTTP_VER_09, "HTTP/0.9");
+	CONCAT_CASE_STR_XX(TFW_HTTP_VER_10, "HTTP/1.0");
+	CONCAT_CASE_STR_XX(TFW_HTTP_VER_11, "HTTP/1.1");
+	CONCAT_CASE_STR_XX(TFW_HTTP_VER_20, "HTTP/2.0");
+#undef XX
+	default: CONCAT_STR("INVALID");
+	}
+
+	CONCAT_PRINTF("\" %d %lu \"", (int)resp->status, resp->content_length);
+	CONCAT_HDR(TFW_HTTP_HDR_REFERER);
+	CONCAT_STR("\" \"");
+	CONCAT_HDR(TFW_HTTP_HDR_USER_AGENT);
+	CONCAT_STR("\"");
+overflow:
+	*(p < end ? p : buf + sizeof(buf) - 1) = 0;
+	pr_info("%s", buf);
+	tfw_str_info(req->h_tbl->tbl + TFW_HTTP_HDR_COOKIE);
+#undef CONCAT_CASE_STR_XX
+#undef CONCAT_CASE_STR
+#undef CONCAT_STR
+#undef CONCAT_PRINTF
+#undef CONCAT_HDR
+#undef CONCAT_TFW_STR
+}
+
+static TfwCfgSpec tfw_http_specs[] = {
+	{
+		.name = "access_log",
+		.deflt = "off",
+		.handler = tfw_cfg_set_bool,
+		.dest = &access_log_enabled,
+		.allow_none = true,
+		.allow_repeat = true,
+	},
+	{ 0 }
+};
+
+TfwMod tfw_access_log_mod  = {
+	.name	= "access_log",
+	.specs	= tfw_http_specs,
+};
+
+/*
+ * ------------------------------------------------------------------------
+ *	init/exit
+ * ------------------------------------------------------------------------
+ */
+
+int __init
+tfw_access_log_init(void)
+{
+	tfw_mod_register(&tfw_access_log_mod);
+	return 0;
+}
+
+void
+tfw_access_log_exit(void)
+{
+	tfw_mod_unregister(&tfw_access_log_mod);
+}

--- a/fw/access_log.c
+++ b/fw/access_log.c
@@ -119,27 +119,6 @@ get_http_header_value(char http_version, TfwStr *line)
 }
 
 
-static inline size_t
-append_to_cstr_truncated(char *p, char *end, TfwStr *s,
-		unsigned remaining, unsigned reserve)
-{
-	ssize_t limit, n;
-	if (s == NULL)
-		return 0;
-	limit = (end - p) / remaining - reserve;
-	if (limit <= 0)
-		return 0;
-	n = tfw_str_to_cstr(s, p, limit);
-	if (n + 1 == limit && n >= 3) {
-		p[n - 3] = '.';
-		p[n - 2] = '.';
-		p[n - 1] = '.';
-	}
-	p += n;
-	return n;
-}
-
-
 void
 do_access_log(TfwHttpResp *resp)
 {

--- a/fw/access_log.h
+++ b/fw/access_log.h
@@ -1,0 +1,28 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_ACCESS_LOG_H__
+#define __TFW_ACCESS_LOG_H__
+
+#include "http_types.h"
+
+void do_access_log(TfwHttpResp *resp);
+
+#endif /* __TFW_ACCESS_LOG_H__ */

--- a/fw/access_log.h
+++ b/fw/access_log.h
@@ -1,8 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -23,7 +22,6 @@
 
 #include "http_types.h"
 
-#define TODO_LOG_CONN(resp)  pr_info("%s:%d (%s): conn => %p, conn->peer => %p", &__FILE__[28], __LINE__, __FUNCTION__, (resp)->conn, (resp)->conn ? (resp)->conn->peer : NULL);
 void do_access_log_req(TfwHttpReq *req, int status, unsigned long content_length);
 void do_access_log(TfwHttpResp *resp);
 

--- a/fw/access_log.h
+++ b/fw/access_log.h
@@ -23,6 +23,8 @@
 
 #include "http_types.h"
 
+#define TODO_LOG_CONN(resp)  pr_info("%s:%d (%s): conn => %p, conn->peer => %p", &__FILE__[28], __LINE__, __FUNCTION__, (resp)->conn, (resp)->conn ? (resp)->conn->peer : NULL);
+void do_access_log_req(TfwHttpReq *req, int status, unsigned long content_length);
 void do_access_log(TfwHttpResp *resp);
 
 #endif /* __TFW_ACCESS_LOG_H__ */

--- a/fw/http.c
+++ b/fw/http.c
@@ -4614,11 +4614,14 @@ tfw_h2_error_resp(TfwHttpReq *req, int status, bool reply, bool attack,
 
 skip_stream:
 	if (attack) {
-		if (reply)
+		if (reply) {
 			tfw_h2_conn_terminate_close(ctx, HTTP2_ECODE_PROTO,
 						    !on_req_recv_event);
-		else if (!on_req_recv_event)
-			tfw_connection_close(req->conn, true);
+		} else {
+			do_access_log_req(req, 403, 0);
+			if (!on_req_recv_event)
+				tfw_connection_close(req->conn, true);
+		}
 	}
 
 	tfw_http_conn_msg_free((TfwHttpMsg *)req);

--- a/fw/http.c
+++ b/fw/http.c
@@ -873,6 +873,7 @@ tfw_h2_resp_fwd(TfwHttpResp *resp)
 	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
 
 	tfw_connection_get(req->conn);
+	do_access_log(resp);
 
 	if (tfw_cli_conn_send((TfwCliConn *)req->conn, (TfwMsg *)resp)) {
 		T_DBG("%s: cannot send data to client via HTTP/2\n", __func__);

--- a/fw/http.c
+++ b/fw/http.c
@@ -4668,6 +4668,7 @@ tfw_h1_error_resp(TfwHttpReq *req, int status, bool reply, bool attack,
 
 		if (!attack)
 			close &= !tfw_http_req_prev_conn_close(req);
+		do_access_log_req(req, status, 0);
 		if (close)
 			tfw_connection_close(req->conn, true);
 		tfw_http_conn_req_clean(req);

--- a/fw/http.c
+++ b/fw/http.c
@@ -863,6 +863,9 @@ tfw_h2_resp_status_write(TfwHttpResp *resp, unsigned short status,
 	if ((ret = tfw_hpack_encode(resp, &s_hdr, op, !cache)))
 		return ret;
 
+	/* set status on response for access logging */
+	resp->status = status;
+
 	return 0;
 }
 
@@ -1055,6 +1058,8 @@ tfw_h1_send_resp(TfwHttpReq *req, int status)
 	date = TFW_STR_DATE_CH(&msg);
 	date->data = *this_cpu_ptr(&g_buf);
 	tfw_http_prep_date(date->data);
+	resp->status = status;
+	resp->content_length = body->len;
 	if (!body->data)
 		msg.nchunks = 5;
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -103,6 +103,7 @@
 #include "server.h"
 #include "tls.h"
 #include "apm.h"
+#include "access_log.h"
 
 #include "sync_socket.h"
 #include "lib/common.h"
@@ -3706,6 +3707,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 
 	T_DBG2("%s: req=[%p], resp=[%p]\n", __func__, req, resp);
 	WARN_ON_ONCE(req->resp != resp);
+	do_access_log(resp);
 
 	/*
 	 * If the list is empty, then it's either a bug, or the client

--- a/fw/main.c
+++ b/fw/main.c
@@ -456,6 +456,7 @@ tfw_init(void)
 	/* The order of initialization is highly important. */
 	DO_INIT(pool);
 	DO_INIT(cfg);
+	DO_INIT(access_log);
 	DO_INIT(apm);
 	DO_INIT(vhost);
 

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -362,3 +362,5 @@ void
 tfw_server_destroy(TfwServer *srv)
 {
 }
+
+void do_access_log(TfwHttpResp *resp) {}

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -363,4 +363,10 @@ tfw_server_destroy(TfwServer *srv)
 {
 }
 
-void do_access_log(TfwHttpResp *resp) {}
+void do_access_log(TfwHttpResp *resp)
+{
+}
+
+void do_access_log_req(TfwHttpReq *req, int status, unsigned long content_length)
+{
+}


### PR DESCRIPTION
Add simple access logging (see #1154)

Access logging is enabled/disabled globally via config option
```
access_log on;
```
Messages are being printed to klog with printk and truncated to 990 bytes with about ~300 bytes limit per uri/referer/user-agent.
Missing entries are replaced with `-`. In case of parser errors request method, uri, and version may be "missing separately" and resulting request line could look like `"GET /some-uri -"` or even `"- - -"`.

Access logging works for http/1.x and http/2 for frang-rejected requests too (though I fake http response status in `tfw_h2_error_resp`).