### PR TITLE
Replace GFSM calls with direct calls to TLS and HTTP

### DIFF
--- a/fw/connection.c
+++ b/fw/connection.c
@@ -4,7 +4,7 @@
  * Generic connection management.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -24,6 +24,7 @@
 #include "gfsm.h"
 #include "log.h"
 #include "sync_socket.h"
+#include "http.h"
 
 TfwConnHooks *conn_hooks[TFW_CONN_MAX_PROTOS];
 
@@ -131,7 +132,7 @@ tfw_connection_recv(void *cdata, struct sk_buff *skb)
 		.skb = skb,
 	};
 
-	return tfw_gfsm_dispatch(&conn->state, conn, &fsm_data);
+	return tfw_http_msg_process(conn, &fsm_data);
 }
 
 void

--- a/fw/connection.h
+++ b/fw/connection.h
@@ -4,7 +4,7 @@
  * Definitions for generic connection management at OSI level 6 (presentation).
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -100,7 +100,7 @@ enum {
 	struct sock		*sk;			\
 	void			(*destructor)(void *);
 
-typedef struct {
+typedef struct TfwConn {
 	TFW_CONN_COMMON;
 } TfwConn;
 

--- a/fw/gfsm.h
+++ b/fw/gfsm.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -88,7 +88,6 @@ enum {
 	/* Security rules enforcement. */
 	TFW_FSM_FRANG_REQ,
 	TFW_FSM_FRANG_RESP,
-	TFW_FSM_FRANG_TLS,
 
 	TFW_FSM_NUM /* Must be <= TFW_GFSM_FSM_N */
 };
@@ -178,11 +177,12 @@ typedef struct {
 	unsigned short	states[TFW_GFSM_FSM_NUM];
 } TfwGState;
 
-#define TFW_GFSM_STATE(s)	((s)->states[(unsigned char)(s)->curr]	\
-				 & ((TFW_GFSM_FSM_MASK << TFW_GFSM_FSM_SHIFT) \
-				    | TFW_GFSM_STATE_MASK))
+#define TFW_GFSM_STATE(s) ((s)->states[(unsigned char)(s)->curr]	\
+			  & ((TFW_GFSM_FSM_MASK << TFW_GFSM_FSM_SHIFT)	\
+			    | TFW_GFSM_STATE_MASK))
 
-typedef int (*tfw_gfsm_handler_t)(void *obj, TfwFsmData *data);
+typedef struct TfwConn TfwConn;
+typedef int (*tfw_gfsm_handler_t)(TfwConn *conn, TfwFsmData *data);
 
 void tfw_gfsm_state_init(TfwGState *st, void *obj, int st0);
 int tfw_gfsm_dispatch(TfwGState *st, void *obj, TfwFsmData *data);

--- a/fw/http.h
+++ b/fw/http.h
@@ -668,7 +668,7 @@ tfw_h2_pseudo_index(unsigned short status)
 typedef void (*tfw_http_cache_cb_t)(TfwHttpMsg *);
 
 /* External HTTP functions. */
-int tfw_http_msg_process(void *conn, TfwFsmData *data);
+int tfw_http_msg_process(TfwConn *conn, TfwFsmData *data);
 int tfw_http_msg_process_generic(TfwConn *conn, TfwStream *stream,
 				 TfwFsmData *data);
 unsigned long tfw_http_req_key_calc(TfwHttpReq *req);

--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -1698,14 +1698,14 @@ tfw_h2_context_reinit(TfwH2Ctx *ctx, bool postponed)
 }
 
 int
-tfw_h2_frame_process(void *c, TfwFsmData *data)
+tfw_h2_frame_process(TfwConn *c, struct sk_buff *skb)
 {
 	int r;
 	bool postponed;
 	unsigned int parsed, unused;
 	TfwFsmData data_up = {};
 	TfwH2Ctx *h2 = tfw_h2_context(c);
-	struct sk_buff *nskb = NULL, *skb = data->skb;
+	struct sk_buff *nskb = NULL;
 
 next_msg:
 	postponed = false;

--- a/fw/http_frame.h
+++ b/fw/http_frame.h
@@ -200,11 +200,13 @@ typedef struct {
 	unsigned char	data_off;
 } TfwH2Ctx;
 
+typedef struct TfwConn TfwConn;
+
 int tfw_h2_init(void);
 void tfw_h2_cleanup(void);
 int tfw_h2_context_init(TfwH2Ctx *ctx);
 void tfw_h2_context_clear(TfwH2Ctx *ctx);
-int tfw_h2_frame_process(void *c, TfwFsmData *data);
+int tfw_h2_frame_process(TfwConn *c, struct sk_buff *skb);
 void tfw_h2_conn_streams_cleanup(TfwH2Ctx *ctx);
 unsigned int tfw_h2_stream_id(TfwHttpReq *req);
 unsigned int tfw_h2_stream_id_close(TfwHttpReq *req, unsigned char type,

--- a/fw/http_limits.h
+++ b/fw/http_limits.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -237,5 +237,7 @@ struct frang_vhost_cfg_t {
 	bool			http_trailer_split;
 	bool			http_method_override;
 };
+
+int frang_tls_handler(TlsCtx *tls, int state);
 
 #endif /* __HTTP_LIMITS__ */

--- a/fw/sock_srv.c
+++ b/fw/sock_srv.c
@@ -4,7 +4,7 @@
  * Handling server connections.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -3,7 +3,7 @@
  *
  * Transport Layer Security (TLS) interfaces to Tempesta TLS.
  *
- * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -29,7 +29,9 @@
 #include "client.h"
 #include "msg.h"
 #include "procfs.h"
+#include "http.h"
 #include "http_frame.h"
+#include "http_limits.h"
 #include "tls.h"
 #include "vhost.h"
 #include "lib/hash.h"
@@ -59,15 +61,6 @@ tfw_tls_purge_io_ctx(TlsIOCtx *io)
 	ttls_reset_io_ctx(io);
 }
 
-static int
-tfw_tls_hs_over(TlsCtx *ctx, int state)
-{
-	TfwCliConn *c = &container_of(ctx, TfwTlsConn, tls)->cli_conn;
-	TfwFsmData data_up = { .req = ERR_PTR(-state)};
-
-	return tfw_gfsm_move(&c->state, TFW_TLS_FSM_HS_DONE, &data_up);
-}
-
 /**
  * A connection has been lost during handshake processing, warn Frang.
  * It's relatively cheap to pass SYN cookie and then send previously captured
@@ -78,19 +71,17 @@ void
 tfw_tls_connection_lost(TfwConn *conn)
 {
 	TlsCtx *tls = &((TfwTlsConn *)conn)->tls;
-	TfwFsmData data_up = { .req = ERR_PTR(-TTLS_HS_CB_INCOMPLETE)};
 
 	if (!ttls_hs_done(tls))
-		tfw_gfsm_move(&conn->state, TFW_TLS_FSM_HS_DONE, &data_up);
+		frang_tls_handler(tls, TTLS_HS_CB_FINISHED_RESUMED);
 }
 
-static int
-tfw_tls_msg_process(void *conn, TfwFsmData *data)
+int
+tfw_tls_msg_process(void *conn, struct sk_buff *skb)
 {
 	int r, parsed;
-	struct sk_buff *nskb = NULL, *skb = data->skb;
-	TfwConn *c = conn;
-	TlsCtx *tls = tfw_tls_context(c);
+	struct sk_buff *nskb = NULL;
+	TlsCtx *tls = tfw_tls_context(conn);
 	TfwFsmData data_up = {};
 
 	/*
@@ -113,7 +104,7 @@ next_msg:
 	case T_DROP:
 		spin_unlock(&tls->lock);
 		if (!ttls_hs_done(tls))
-			tfw_tls_hs_over(tls, TTLS_HS_CB_INCOMPLETE);
+			frang_tls_handler(tls, TTLS_HS_CB_INCOMPLETE);
 		/* The skb is freed in tfw_tls_conn_dtor(). */
 		return r;
 	case T_POSTPONE:
@@ -180,7 +171,7 @@ next_msg:
 		ttls_reset_io_ctx(&tls->io_in);
 		spin_unlock(&tls->lock);
 
-		r = tfw_gfsm_move(&c->state, TFW_TLS_FSM_DATA_READY, &data_up);
+		r = tfw_http_msg_process(conn, &data_up);
 		if (r == TFW_BLOCK) {
 			kfree_skb(nskb);
 			return r;
@@ -682,7 +673,11 @@ tfw_tls_conn_init(TfwConn *c)
 	if ((r = tfw_h2_context_init(h2)))
 		return r;
 
-	tfw_gfsm_state_init(&c->state, c, TFW_TLS_FSM_INIT);
+	/*
+	 * We never hook TLS connections in GFSM, but initialize it with 0 state
+	 * to keep the things safe.
+	 */
+	tfw_gfsm_state_init(&c->state, c, 0);
 
 	c->destructor = tfw_tls_conn_dtor;
 
@@ -1047,22 +1042,17 @@ tfw_tls_init(void)
 	if (r)
 		return -EINVAL;
 
-	ttls_register_callbacks(tfw_tls_send, tfw_tls_sni, tfw_tls_hs_over,
+	ttls_register_callbacks(tfw_tls_send, tfw_tls_sni, frang_tls_handler,
 				ttls_cli_id);
 
 	if ((r = tfw_h2_init()))
 		goto err_h2;
 
-	if ((r = tfw_gfsm_register_fsm(TFW_FSM_TLS, tfw_tls_msg_process)))
-		goto err_fsm;
-
-	tfw_connection_hooks_register(&tls_conn_hooks, TFW_FSM_TLS);
+	tfw_connection_hooks_register(&tls_conn_hooks, TFW_FSM_HTTPS);
 	tfw_mod_register(&tfw_tls_mod);
 
 	return 0;
 
-err_fsm:
-	tfw_h2_cleanup();
 err_h2:
 	tfw_tls_do_cleanup();
 
@@ -1073,8 +1063,7 @@ void
 tfw_tls_exit(void)
 {
 	tfw_mod_unregister(&tfw_tls_mod);
-	tfw_connection_hooks_unregister(TFW_FSM_TLS);
-	tfw_gfsm_unregister_fsm(TFW_FSM_TLS);
+	tfw_connection_hooks_unregister(TFW_FSM_HTTPS);
 	tfw_h2_cleanup();
 	tfw_tls_do_cleanup();
 }

--- a/fw/tls.h
+++ b/fw/tls.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -20,33 +20,7 @@
 #ifndef __TFW_TLS_H__
 #define __TFW_TLS_H__
 
-#include "gfsm.h"
 #include "ttls.h"
-
-#define TFW_FSM_TLS		TFW_FSM_HTTPS
-
-/**
- * TLS states.
- */
-#define TFW_GFSM_TLS_STATE(s)	((TFW_FSM_TLS << TFW_GFSM_FSM_SHIFT) | (s))
-enum {
-	/* TLS FSM initial state, not hookable. */
-	TFW_TLS_FSM_INIT	= TFW_GFSM_TLS_STATE(0),
-	/*
-	 * A TLS Handshake has been completed on a connection. Client could
-	 * either process a new full handshake or resume previous session. The
-	 * state is also reached if the handshake process ended up with the
-	 * error or never reached the final stage.
-	 */
-	TFW_TLS_FSM_HS_DONE	= TFW_GFSM_TLS_STATE(1),
-	/*
-	 * A new portion of data is decrypted and ready to be consumed by the
-	 * upper layers.
-	 */
-	TFW_TLS_FSM_DATA_READY	= TFW_GFSM_TLS_STATE(2),
-
-	TFW_TLS_FSM_DONE	= TFW_GFSM_TLS_STATE(TFW_GFSM_STATE_LAST)
-};
 
 void tfw_tls_cfg_require(void);
 void tfw_tls_cfg_configured(bool global);
@@ -54,5 +28,7 @@ void tfw_tls_match_any_sni_to_dflt(bool match);
 int tfw_tls_cfg_alpn_protos(const char *cfg_str, bool *deprecated);
 void tfw_tls_free_alpn_protos(void);
 int tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int limit);
+
+int tfw_tls_msg_process(void *conn, struct sk_buff *skb);
 
 #endif /* __TFW_TLS_H__ */

--- a/fw/tls_conf.c
+++ b/fw/tls_conf.c
@@ -224,7 +224,7 @@ tfw_tls_cert_cfg_finish(TfwVhost *vhost)
 	curr_cert_conf = &conf->certs[conf->certs_num];
 	if (curr_cert_conf->conf_stage) {
 		T_ERR_NL("TLS: certificate configuration is not done, "
-			 "directive 'tls_certificate_key' is missing. \n");
+			 "directive 'tls_certificate_key' is missing.\n");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Contributes to #755

Porting of https://github.com/tempesta-tech/tempesta/commit/2eae1dae4fc579043773ca61f709cf8ab910f10f

>     Replace GFSM calls with direct calls to TLS and HTTP handlers
>      on low level networking layers.
> 
>     GFSM was designed to build graphs of network protocols FSMs (this
>     design was inspired by FreeBSD netgraph). However, during the years
>     neither we nor external users have any requirements to introduce
>     any modules which use GFSM to hook TLS or HTTP entry code. There
>     are only 2 users of the mechanism for TLS and HTTP for now:
>     1. TLS -> HTTP protocols handling
>     2. HTTP limits (the frang module)
> 
>     This patch replaces GFSM calls with direct calls to
>     tfw_http_req_process(), tfw_tls_msg_process() and frang_tls_handler()
>     in following paths:
>     1. sync sockets -> TLS
>     2. sync sockets -> HTTP
>     3. TLS -> HTTP
>     4. TLS -> Frang
> 
>     As the result the function tfw_connection_recv() was eliminated.
>     Now the code is simpler and has lower overhead.
> 
>     We still might need GFSM for the user-space requests handling (#77)
>     and Tempesta Language (#102).

Based-on-patch-by: Alexander K <ak@tempesta-tech.com>
Signed-off-by: Aleksey Mikhaylov <aym@tempesta-tech.com>