### PR TITLE
Connection header parsing fix for well-known prefixed headers

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -786,7 +786,7 @@ mark_spec_hbh(TfwHttpMsg *hm)
 		TfwStr *hdr = &hm->h_tbl->tbl[id];
 		if ((hbh_hdrs->spec & (0x1 << id)) && (!TFW_STR_EMPTY(hdr))) {
 			T_DBG3("%s: hm %pK, tbl[%u] flags +TFW_STR_HBH_HDR\n",
-				__func__, hm, id);
+			       __func__, hm, id);
 			hdr->flags |= TFW_STR_HBH_HDR;
 		}
 	}
@@ -817,8 +817,8 @@ mark_raw_hbh(TfwHttpMsg *hm, TfwStr *hdr)
 		    && !(tfw_stricmpspn(&hbh->raw[i], hdr, ':')))
 		{
 			T_DBG3("%s: hbh raw[%d], hm %pK, hdr %pK ->flags %x, "
-				"flags +TFW_STR_HBH_HDR\n",
-				__func__, i, hm, hdr, hdr->flags);
+			       "flags +TFW_STR_HBH_HDR\n",
+			       __func__, i, hm, hdr, hdr->flags);
 			hdr->flags |= TFW_STR_HBH_HDR;
 			hbh_name->flags = hbh_name->flags &
 					~(unsigned int)TFW_STR_HBH_HDR;
@@ -848,7 +848,7 @@ __mark_hbh_hdr(TfwHttpMsg *hm, TfwStr *hdr)
 		return false;
 
 	T_DBG3("%s: hm %pK, hid %u, flags +TFW_STR_HBH_HDR\n",
-		__func__, hm, hid);
+	       __func__, hm, hid);
 	ht->tbl[hid].flags |= TFW_STR_HBH_HDR;
 	return true;
 }
@@ -874,12 +874,12 @@ __hbh_parser_finalize(TfwHttpMsg *hm)
 	hbh_hdr = &hbh->raw[hbh->off];
 
 	T_DBG3("%s: hbh->off %d, hbh_h %pK, hbh_h->nchunks %d, hbh_h->len %lu\n",
-		__func__, hbh->off, hbh_hdr, hbh_hdr->nchunks, hbh_hdr->len);
+	       __func__, hbh->off, hbh_hdr, hbh_hdr->nchunks, hbh_hdr->len);
 
 	append = tfw_str_add_compound(hm->pool, hbh_hdr);
 	if (!append)
 		return -ENOMEM;
-	memcpy(append, &s_colon, sizeof(TfwStr));
+	*append = s_colon;
 
 	hbh_hdr->len += s_colon.len;
 	++hbh->off;
@@ -910,7 +910,7 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len,
 	TfwHttpHbhHdrs *hbh = &hm->stream->parser.hbh_parser;
 
 	T_DBG3("%s: hm %pK, data %pK, *data [%c], len %lu, fin=%d\n",
-		__func__, hm, data, *data, len, finalize_item ? 1 : 0);
+	       __func__, hm, data, *data, len, finalize_item ? 1 : 0);
 
 	if (hbh->off == TFW_HBH_TOKENS_MAX)
 		return CSTR_NEQ;
@@ -931,7 +931,7 @@ __hbh_parser_add_data(TfwHttpMsg *hm, char *data, unsigned long len,
 	hbh_hdr->len += len;
 
 	T_DBG3("%s: hbh->off %d, hbh_h %pK, hbh_h->nchunks %d, hbh_h->len %lu\n",
-		__func__, hbh->off, hbh_hdr, hbh_hdr->nchunks, hbh_hdr->len);
+	       __func__, hbh->off, hbh_hdr, hbh_hdr->nchunks, hbh_hdr->len);
 
 	return finalize_item ? __hbh_parser_finalize(hm) : 0;
 }
@@ -993,11 +993,11 @@ process_trailer_hdr(TfwHttpMsg *hm, TfwStr *hdr, unsigned int id)
 	if (!chunk->data)						\
 		chunk->data = p;					\
 	T_DBG3("TSLBR_pre: data %pK, p %pK, c [%c], len %zu, "		\
-		"str='%s'\n", data, p, c, len, str);			\
+	       "str='%s'\n", data, p, c, len, str);			\
 	__fsm_n = __try_str(&parser->hdr, chunk, p, __data_remain(p),	\
 			    str, sizeof(str) - 1);			\
 	T_DBG3("TSLBR_post: __fsm_n: %d, chunk->len %lu\n",		\
-		__fsm_n, chunk->len);					\
+	       __fsm_n, chunk->len);					\
 	if (__fsm_n > 0) {						\
 		if (chunk->len == sizeof(str) - 1) {			\
 			lambda;						\

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -2911,6 +2911,7 @@ TEST(http1_parser, resp_hop_by_hop)
 	"Content-Type: text/html; charset=iso-8859-1\r\n"		\
 	"Dummy7: 7\r\n"							\
 	"Buzz: is hop-by-hop header\r\n"				\
+	"Keep-Alivevv: hello there\r\n"					\
 	"Dummy8: 8\r\n"							\
 	"Foo: is hop-by-hop header\r\n"					\
 	"Cache-Control: max-age=5, private, no-cache, ext=foo\r\n"	\
@@ -2919,6 +2920,7 @@ TEST(http1_parser, resp_hop_by_hop)
 	"Keep-Alive: timeout=600, max=65526\r\n"			\
 	"Server: Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"		\
 		" mod_fcgid/2.3.9\r\n"					\
+	"Bar: is hop-by-hop header\r\n"					\
 	"Age: 12  \n"							\
 	"Date: Sun, 9 Sep 2001 01:46:40 GMT\t\n"			\
 	"\r\n"								\
@@ -2930,7 +2932,7 @@ TEST(http1_parser, resp_hop_by_hop)
 	{
 		ht = resp->h_tbl;
 		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -2952,7 +2954,7 @@ TEST(http1_parser, resp_hop_by_hop)
 	{
 		ht = resp->h_tbl;
 		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -2971,12 +2973,12 @@ TEST(http1_parser, resp_hop_by_hop)
 
 	/* Hop-by-hop headers: Connection, Keep-Alive and user headers */
 	FOR_RESP(RESP_HBH_START
-		 "Connection: Foo, Keep-Alive, Bar, Buzz\r\n"
+		 "Connection: Foo, Keep-Alive, Bar, Buzz, Keep-Alivevv\r\n"
 		 RESP_HBH_END)
 	{
 		ht = resp->h_tbl;
 		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -2984,8 +2986,15 @@ TEST(http1_parser, resp_hop_by_hop)
 			case TFW_HTTP_HDR_SERVER:
 			case TFW_HTTP_HDR_CONNECTION:
 			case TFW_HTTP_HDR_KEEP_ALIVE:
+			/* Foo: is hop-by-hop header */
 			case TFW_HTTP_HDR_RAW + 3:
+			/* Buzz: is hop-by-hop header */
 			case TFW_HTTP_HDR_RAW + 9:
+			/* Keep-Alivevv: hello there */
+			case TFW_HTTP_HDR_RAW + 10:
+			/* Bar: is hop-by-hop header */
+			case TFW_HTTP_HDR_RAW + 15:
+				TEST_DBG3("test HBH flag, h_tbl->tbl[%lu]\n", id);
 				EXPECT_TRUE(field->flags & TFW_STR_HBH_HDR);
 				break;
 			default:


### PR DESCRIPTION
Fixes https://github.com/tempesta-tech/tempesta/issues/1579

Fix of `Connection` header parsing bug discovered.

Bug emerges when token name starts exactly with name of well-known option (`close`) or specially processed header (`keep-alive`).

PR includes fix and new unit test to cover this case.

Signed-off-by: Aleksey Mikhaylov <aym@tempesta-tech.com>