### PR TITLE
Content length zero in h2 get request fix

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -6308,6 +6308,15 @@ __h2_req_parse_content_length(TfwHttpMsg *msg, unsigned char *data, size_t len,
 			      bool fin)
 {
 	int ret;
+	TfwHttpReq *req = (TfwHttpReq *)msg;
+
+	if (unlikely(req->method == TFW_HTTP_METH_GET
+		     || req->method == TFW_HTTP_METH_HEAD
+		     || req->method == TFW_HTTP_METH_DELETE
+		     || req->method == TFW_HTTP_METH_TRACE))
+	{
+		return CSTR_NEQ;
+	}
 
 	ret = parse_long_ws(data, len, &msg->content_length);
 

--- a/fw/t/unit/test_http_parser.c
+++ b/fw/t/unit/test_http_parser.c
@@ -1692,7 +1692,7 @@ TEST(http_parser, content_type_in_bodyless_requests)
 	/* But with content-length will be block for http2 too */
 	EXPECT_BLOCK_REQ_H2(":authority: debian\n"
 			    ":method: GET\n"
-			    ":scheme: http\n"
+			    ":scheme: https\n"
 			    ":path: /\n"
 			    "content-length: 0");
 }


### PR DESCRIPTION
Fixes discovered false-pass unit test.

```patch
	/* But with content-length will be block for http2 too */
	EXPECT_BLOCK_REQ_H2(":authority: debian\n"
			    ":method: GET\n"
-			    ":scheme: http\n"
+			    ":scheme: https\n"
			    ":path: /\n"
			    "content-length: 0");
```

Http2 only viable when https scheme, so was block, but not on `content-length` bot on `scheme`. PR fixes that and `content-legnth` h2 parsing code.

Signed-off-by: Aleksey Mikhaylov <aym@tempesta-tech.com>