### PR TITLE
Use unsigned_int instead of size_t in ss_skb_actor_t

### DIFF
--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -1481,7 +1481,7 @@ conn_term:
  * Main FSM for processing HTTP/2 frames.
  */
 static int
-tfw_h2_frame_recv(void *data, unsigned char *buf, size_t len,
+tfw_h2_frame_recv(void *data, unsigned char *buf, unsigned int len,
 		  unsigned int *read)
 {
 	int n, r = T_POSTPONE;

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -159,7 +159,7 @@ do {									\
 	register unsigned int __p_n = min_t(unsigned int, 48,		\
 					    data + len + __p_o - p);	\
 	T_WARN("Parser error: state=" #st " input(-%d)=%#x('%.*s')"	\
-	       " data_len=%lu off=%lu\n",				\
+	       " data_len=%u off=%lu\n",				\
 	       __p_o, (char)c, __p_n, p - __p_o, len, p - data);	\
 	return TFW_BLOCK;						\
 } while (0)
@@ -3927,7 +3927,7 @@ tfw_http_parse_check_bodyless_meth(TfwHttpReq *req)
 }
 
 int
-tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
+tfw_http_parse_req(void *req_data, unsigned char *data, unsigned int len,
 		   unsigned int *parsed)
 {
 	int r = TFW_BLOCK;
@@ -8902,10 +8902,10 @@ out:
 STACK_FRAME_NON_STANDARD(tfw_h2_parse_req_hdr);
 
 static int
-tfw_h2_parse_body(char *data, unsigned long len, TfwHttpReq *req,
+tfw_h2_parse_body(char *data, unsigned int len, TfwHttpReq *req,
 		  unsigned int *parsed)
 {
-	unsigned long m_len;
+	unsigned int m_len;
 	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
 	TfwHttpMsg *msg = (TfwHttpMsg *)req;
 	TfwHttpParser *parser = &msg->stream->parser;
@@ -8929,14 +8929,14 @@ tfw_h2_parse_body(char *data, unsigned long len, TfwHttpReq *req,
 	parser->to_read -= m_len;
 
 	if (parser->to_read) {
-		T_DBG3("%s: postpone, to_read=%ld, m_len=%lu, len=%lu\n",
+		T_DBG3("%s: postpone, to_read=%ld, m_len=%u, len=%u\n",
 		       __func__, parser->to_read, m_len, len);
 		__msg_field_fixup(&req->body, data + len);
 		goto out;
 	}
 
 	WARN_ON_ONCE(m_len != len);
-	T_DBG3("%s: to_read=%ld, m_len=%lu, len=%lu\n", __func__,
+	T_DBG3("%s: to_read=%ld, m_len=%u, len=%u\n", __func__,
 	       parser->to_read, m_len, len);
 
 	if (tfw_http_msg_add_str_data(msg, &req->body, data, m_len))
@@ -8960,7 +8960,7 @@ out:
  * parser state.
  */
 int
-tfw_h2_parse_req(void *req_data, unsigned char *data, size_t len,
+tfw_h2_parse_req(void *req_data, unsigned char *data, unsigned int len,
 		 unsigned int *parsed)
 {
 	int r;
@@ -9718,7 +9718,7 @@ tfw_http_adj_parser_resp(TfwHttpResp *resp)
 }
 
 int
-tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len,
+tfw_http_parse_resp(void *resp_data, unsigned char *data, unsigned int len,
 		    unsigned int *parsed)
 {
 	int r = TFW_BLOCK;

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -135,15 +135,15 @@ void tfw_http_init_parser_resp(TfwHttpResp *resp);
 
 int tfw_http_parse_check_bodyless_meth(TfwHttpReq *req);
 
-int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len,
+int tfw_http_parse_req(void *req_data, unsigned char *data, unsigned int len,
 		       unsigned int *parsed);
 
 int tfw_h2_parse_req_hdr(unsigned char *data, unsigned long len, TfwHttpReq *req,
 			 bool fin, bool value_stage);
-int tfw_h2_parse_req(void *req_data, unsigned char *data, size_t len,
+int tfw_h2_parse_req(void *req_data, unsigned char *data, unsigned int len,
 		     unsigned int *parsed);
 int tfw_h2_parse_req_finish(TfwHttpReq *req);
-int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len,
+int tfw_http_parse_resp(void *resp_data, unsigned char *data, unsigned int len,
 			unsigned int *parsed);
 int tfw_http_parse_terminate(TfwHttpMsg *hm);
 bool tfw_http_parse_is_done(TfwHttpMsg *hm);

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1245,7 +1245,7 @@ ss_skb_process(struct sk_buff *skb, ss_skb_actor_t actor, void *objdata,
 	       unsigned int *chunks, unsigned int *processed)
 {
 	int i, r = SS_OK;
-	int headlen = skb_headlen(skb);
+	unsigned int headlen = skb_headlen(skb);
 	unsigned int _processed;
 	struct skb_shared_info *si = skb_shinfo(skb);
 

--- a/fw/ss_skb.h
+++ b/fw/ss_skb.h
@@ -46,7 +46,7 @@ enum {
 	SS_OK		= 0,
 };
 
-typedef int ss_skb_actor_t(void *conn, unsigned char *data, size_t len,
+typedef int ss_skb_actor_t(void *conn, unsigned char *data, unsigned int len,
 			   unsigned int *read);
 
 /**

--- a/fw/t/bomber.c
+++ b/fw/t/bomber.c
@@ -159,7 +159,7 @@ tfw_bmb_conn_drop(struct sock *sk)
 }
 
 static int
-tfw_bmb_print_msg(void *msg_data, unsigned char *data, size_t len,
+tfw_bmb_print_msg(void *msg_data, unsigned char *data, unsigned int len,
 		  unsigned int *read)
 {
 	printk(KERN_INFO "%.*s\n", (int)len, data);

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -2134,7 +2134,7 @@ ttls_handshake_step(TlsCtx *tls, unsigned char *buf, size_t len, size_t hh_len,
  * The function adds the number of bytes parsed in @buf to @read.
  */
 int
-ttls_recv(void *tls_data, unsigned char *buf, size_t len, unsigned int *read)
+ttls_recv(void *tls_data, unsigned char *buf, unsigned int len, unsigned int *read)
 {
 	int r;
 	unsigned int hh_len = 0, parsed = *read;

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -604,7 +604,7 @@ void ttls_conf_version(TlsCfg *conf, int min_minor, int max_minor);
 
 int ttls_get_session(const TlsCtx *ssl, TlsSess *session);
 
-int ttls_recv(void *tls_data, unsigned char *buf, size_t len,
+int ttls_recv(void *tls_data, unsigned char *buf, unsigned int len,
 	      unsigned int *read);
 int ttls_encrypt(TlsCtx *tls, struct sg_table *sgt, struct sg_table *out_sgt);
 


### PR DESCRIPTION
Contributes to https://github.com/tempesta-tech/tempesta/issues/1297.

[@krizhanovsky](https://github.com/krizhanovsky) said very well:
> `len` in `ss_skb_actor_t()` comes from `skb_headlen()`, which is `unsigned int`. `unsigned int headlen` also makes the code more robust.

What was done here:

- used `unsigned int` instead of `size_t` in `ss_skb_actor_t`;
- also `unsigned int` is used instead of `size_t` at major network data processing points.