### PR TITLE
EXPECT_BLOCK-macro post-checks

### DIFF
--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -1249,13 +1249,13 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 #define EXPECT_BLOCK_BODYLESS_REQ(METHOD)					\
 	EXPECT_BLOCK_REQ(#METHOD " / HTTP/1.1\r\n"				\
 		 	 "Content-Length: 0\r\n"				\
-		 	 "\r\n");						\
+		 	 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_##METHOD);			\
 	}									\
 	EXPECT_BLOCK_REQ(#METHOD " / HTTP/1.1\r\n"				\
 		 	 "Content-Type: text/html\r\n"				\
-		 	 "\r\n");						\
+		 	 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_##METHOD);			\
 	}
@@ -1264,7 +1264,7 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
 		 	 "Content-Length: 0\r\n"				\
 			 "X-Method-Override: " #METHOD "\r\n"			\
-		 	 "\r\n");						\
+		 	 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -1272,7 +1272,7 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
 		 	 "Content-Length: 0\r\n"				\
 			 "X-HTTP-Method-Override: " #METHOD "\r\n"		\
-		 	 "\r\n");						\
+		 	 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -1280,7 +1280,7 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
 		 	 "Content-Length: 0\r\n"				\
 			 "X-HTTP-Method: " #METHOD "\r\n"			\
-		 	 "\r\n");						\
+		 	 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -1288,7 +1288,7 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
 		 	 "Content-Type: text/html\r\n"				\
 			 "X-Method-Override: " #METHOD "\r\n"			\
-		 	 "\r\n");						\
+		 	 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -1296,7 +1296,7 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
 		 	 "Content-Type: text/html\r\n"				\
 			 "X-HTTP-Method-Override: " #METHOD "\r\n"		\
-		 	 "\r\n");						\
+		 	 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -1304,7 +1304,7 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
 		 	 "Content-Type: text/html\r\n"				\
 			 "X-HTTP-Method: " #METHOD "\r\n"			\
-		 	 "\r\n");						\
+		 	 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\

--- a/fw/t/unit/test_http2_parser.c
+++ b/fw/t/unit/test_http2_parser.c
@@ -925,7 +925,7 @@ TEST(http2_parser, content_type_in_bodyless_requests)
 		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));		\
 		HEADER(WO_IND(NAME("content-length"), VALUE("0")));		\
 	    HEADERS_FRAME_END();						\
-	);									\
+	)									\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_##METHOD);			\
 	}									\
@@ -936,7 +936,7 @@ TEST(http2_parser, content_type_in_bodyless_requests)
 		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));		\
 		HEADER(WO_IND(NAME("content-type"), VALUE("text/plain")));	\
 	    HEADERS_FRAME_END();						\
-	);									\
+	)									\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_##METHOD);			\
 	}
@@ -950,7 +950,7 @@ TEST(http2_parser, content_type_in_bodyless_requests)
 		HEADER(WO_IND(NAME("content-length"), VALUE("0")));		\
 		HEADER(WO_IND(NAME("x-method-override"), VALUE(#METHOD)));	\
 	    HEADERS_FRAME_END();						\
-	);									\
+	)									\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -963,7 +963,7 @@ TEST(http2_parser, content_type_in_bodyless_requests)
 		HEADER(WO_IND(NAME("content-type"), VALUE("text/plain")));	\
 		HEADER(WO_IND(NAME("x-method-override"), VALUE(#METHOD)));	\
 	    HEADERS_FRAME_END();						\
-	);									\
+	)									\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -976,7 +976,7 @@ TEST(http2_parser, content_type_in_bodyless_requests)
 		HEADER(WO_IND(NAME("content-length"), VALUE("0")));		\
 		HEADER(WO_IND(NAME("x-http-method-override"), VALUE(#METHOD)));	\
 	    HEADERS_FRAME_END();						\
-	);									\
+	)									\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -989,7 +989,7 @@ TEST(http2_parser, content_type_in_bodyless_requests)
 		HEADER(WO_IND(NAME("content-type"), VALUE("text/plain")));	\
 		HEADER(WO_IND(NAME("x-http-method-override"), VALUE(#METHOD)));	\
 	    HEADERS_FRAME_END();						\
-	);									\
+	)									\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -1002,7 +1002,7 @@ TEST(http2_parser, content_type_in_bodyless_requests)
 		HEADER(WO_IND(NAME("content-length"), VALUE("0")));		\
 		HEADER(WO_IND(NAME("x-http-method"), VALUE(#METHOD)));		\
 	    HEADERS_FRAME_END();						\
-	);									\
+	)									\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
@@ -1015,7 +1015,7 @@ TEST(http2_parser, content_type_in_bodyless_requests)
 		HEADER(WO_IND(NAME("content-type"), VALUE("text/plain")));	\
 		HEADER(WO_IND(NAME("x-http-method"), VALUE(#METHOD)));		\
 	    HEADERS_FRAME_END();						\
-	);									\
+	)									\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_PUT);			\
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\

--- a/fw/t/unit/test_http_parser_common.h
+++ b/fw/t/unit/test_http_parser_common.h
@@ -979,26 +979,20 @@ do {\
 	TRY_PARSE_EXPECT_PASS(FUZZ_REQ_H2, CHUNK_ON)
 
 #define EXPECT_BLOCK_REQ(str)						\
-do {									\
 	PRINT_REQ(str);							\
 	test_case_parse_prepare_http(str);				\
-	TRY_PARSE_EXPECT_BLOCK(FUZZ_REQ, CHUNK_ON);			\
-} while (0)
+	TRY_PARSE_EXPECT_BLOCK(FUZZ_REQ, CHUNK_ON)
 
 #define EXPECT_BLOCK_REQ_H2(frames_definition)				\
-do {									\
 	ASSIGN_FRAMES_FOR_H2(frames_definition);			\
 	PRINT_REQ_H2();							\
 	test_case_parse_prepare_h2();					\
-	TRY_PARSE_EXPECT_BLOCK(FUZZ_REQ_H2, CHUNK_ON);			\
-} while (0)
+	TRY_PARSE_EXPECT_BLOCK(FUZZ_REQ_H2, CHUNK_ON)
 
 #define EXPECT_BLOCK_REQ_H2_HPACK(frames_definition)			\
-do {									\
 	ASSIGN_FRAMES_FOR_H2(frames_definition);			\
 	PRINT_REQ_H2();							\
-	TRY_PARSE_EXPECT_BLOCK(FUZZ_REQ_H2, CHUNK_ON);			\
-} while (0)
+	TRY_PARSE_EXPECT_BLOCK(FUZZ_REQ_H2, CHUNK_ON)
 
 #define __FOR_RESP(str, sz_diff, chunk_mode)				\
 	TEST_LOG("=== response: [%s]\n", str);				\
@@ -1008,11 +1002,9 @@ do {									\
 #define FOR_RESP(str)	__FOR_RESP(str, 0, CHUNK_ON)
 
 #define EXPECT_BLOCK_RESP(str)						\
-do {									\
 	TEST_LOG("=== response: [%s]\n", str);				\
 	test_case_parse_prepare_http(str);				\
-	TRY_PARSE_EXPECT_BLOCK(FUZZ_RESP, CHUNK_ON);			\
-} while (0)
+	TRY_PARSE_EXPECT_BLOCK(FUZZ_RESP, CHUNK_ON)
 
 #define EXPECT_TFWSTR_EQ(tfw_str, cstr)					\
 	EXPECT_TRUE(tfw_str_eq_cstr(tfw_str, cstr, strlen(cstr), 0))


### PR DESCRIPTION
Thus we can use post-checks inside while-body related to EXPECT_BLOCK-macro for every chunk size but not only for the last.