### PR TITLE
Fix kernel hang on boot using patched vanilla linux-5.10.35

### DIFF
--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -1009,7 +1009,6 @@ index 000000000..9dc507aab
 +	count_vm_event(HTLB_BUDDY_PGALLOC);
 +
 +	__ClearPageReserved(p);
-+	prep_compound_page(p, HUGETLB_PAGE_ORDER);
 +
 +	return p;
 +}

--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -1011,9 +1011,6 @@ index 000000000..9dc507aab
 +	__ClearPageReserved(p);
 +	prep_compound_page(p, HUGETLB_PAGE_ORDER);
 +
-+	/* Acquire the page immediately. */
-+	set_page_refcounted(p);
-+
 +	return p;
 +}
 +


### PR DESCRIPTION
* Fixes #1626

* Remove duplicate call to `prep_compound_page()`