### PR TITLE
Fix #1650: configuration defaults

### DIFF
--- a/fw/tls.c
+++ b/fw/tls.c
@@ -801,17 +801,17 @@ static int
 fw_tls_apply_sni_wildcard(BasicStr *name)
 {
 	int n;
-	char *p = strchr(name->data, '.');
+	char *p = strnchr(name->data, name->len, '.');
 	if (!p)
 		return -ENOENT;
 	n = name->data + name->len - p;
 
 	/* The resulting name must be lower than a top level domain. */
-	if (n < 3 || !strchr(p + 1, '.'))
+	if (n < 3 || !strnchr(p + 1, n, '.'))
 		return -ENOENT;
 
 	/*
-	 * Store leading dot to match against chpped wildcard (see
+	 * Store leading dot to match against chopped wildcard (see
 	 * tfw_tls_add_cn()) and do not confuse the name with a CN.
 	 */
 	name->data = p;
@@ -841,7 +841,7 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 	if (data && len) {
 		vhost = tfw_vhost_lookup(&srv_name);
 
-		if (unlikely(vhost && !vhost->vhost_dflt)) {
+		if (unlikely(vhost && tfw_vhost_is_default(vhost))) {
 			SNI_WARN("default vhost by name '%s', reject connection.\n",
 				 TFW_VH_DFT_NAME);
 			tfw_vhost_put(vhost);

--- a/fw/tls_conf.c
+++ b/fw/tls_conf.c
@@ -121,11 +121,12 @@ tfw_tls_add_cn(const ttls_x509_buf *sname, const char *hname, int hlen)
 	BasicStr cn = {.data = sname->p, .len = sname->len};
 
 	/*
-	 * If the host name is default ('*'), then any SAN is good and we
+	 * If the host name is "default", then any SAN is good and we
 	 * place the certificate by '*' instead of the SAN.
 	 * Any SNI can be matched with the certificate regardless its SAN/CN.
 	 */
-	if (hlen == 1 && hname[0] == '*')
+	if (hlen == SLEN(TFW_VH_DFT_NAME)
+	    && !strncmp(hname, TFW_VH_DFT_NAME, hlen))
 		return 0;
 
 	/*

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -207,7 +207,7 @@ struct  tfw_vhost_t {
 };
 
 /* Default vhost is simply a full wildcard, matching any name. */
-#define TFW_VH_DFT_NAME		"*"
+#define TFW_VH_DFT_NAME		"default"
 
 /**
  * Global settings (exist only on top level and are not reconfigurable).


### PR DESCRIPTION
Please see the commit message for the details.

I did test the patch with just `server 192.168.100.4:8000;` in `tempesta_fw.conf`. Also I have tested
```
listen 192.168.100.4:443 proto=https;

server 127.0.0.1:8000;

tls_match_any_server_name;
tls_certificate /root/tempesta/etc/cert_with_san.crt;
tls_certificate_key /root/tempesta/etc/the.key;
```
to make sure that SAN certificates still work and they do work with the default server group, vhost and no http_chain rules.