### PR TITLE
Split unit tests to avoid compilation warnings

### DIFF
--- a/fw/t/unit/test.c
+++ b/fw/t/unit/test.c
@@ -21,6 +21,7 @@
 #include <linux/types.h>
 #include <linux/module.h>
 #include "test.h"
+#include "test_http_parser_defs.h"
 
 int test_fail_counter;
 test_fixture_fn_t test_setup_fn;
@@ -85,7 +86,7 @@ test_call_teardown_fn(void)
 TEST_SUITE(cfg);
 TEST_SUITE(tfw_str);
 TEST_SUITE(mem_fast);
-TEST_SUITE(http1_parser);
+extern TEST_SUITE_MPART_ARR(http1_parser, H1_SUITE_PART_CNT);
 TEST_SUITE(http2_parser);
 TEST_SUITE(http2_parser_hpack);
 TEST_SUITE(http_sticky);
@@ -127,7 +128,7 @@ test_run_all(void)
 	TEST_SUITE_RUN(mem_fast);
 	__fpu_schedule();
 
-	TEST_SUITE_RUN(http1_parser);
+	TEST_SUITE_MPART_RUN(http1_parser);
 	__fpu_schedule();
 
 	TEST_SUITE_RUN(http2_parser);

--- a/fw/t/unit/test.c
+++ b/fw/t/unit/test.c
@@ -83,11 +83,12 @@ test_call_teardown_fn(void)
 		test_teardown_fn();
 }
 
+extern TEST_SUITE_MPART_ARR(http1_parser, H1_SUITE_PART_CNT);
+extern TEST_SUITE_MPART_ARR(http2_parser, H2_SUITE_PART_CNT);
+
 TEST_SUITE(cfg);
 TEST_SUITE(tfw_str);
 TEST_SUITE(mem_fast);
-extern TEST_SUITE_MPART_ARR(http1_parser, H1_SUITE_PART_CNT);
-TEST_SUITE(http2_parser);
 TEST_SUITE(http2_parser_hpack);
 TEST_SUITE(http_sticky);
 TEST_SUITE(http_match);
@@ -131,7 +132,7 @@ test_run_all(void)
 	TEST_SUITE_MPART_RUN(http1_parser);
 	__fpu_schedule();
 
-	TEST_SUITE_RUN(http2_parser);
+	TEST_SUITE_MPART_RUN(http2_parser);
 	__fpu_schedule();
 
 	TEST_SUITE_RUN(http2_parser_hpack);

--- a/fw/t/unit/test.h
+++ b/fw/t/unit/test.h
@@ -129,6 +129,31 @@ do {									    \
 	test_call_teardown_fn();					    \
 } while(0)
 
+#define TEST_SUITE_MPART_NAME(name, part)		\
+	test_suite__ ##name ##__ ##part
+
+#define TEST_SUITE_MPART(name, part)			\
+	void TEST_SUITE_MPART_NAME(name, part)(void)
+
+#define TEST_SUITE_MPART_ARR(name, cnt)			\
+	void __attribute__((unused))			\
+	(*tsuite ##__ ##name ##__arr[cnt])(void)
+
+#define TEST_SUITE_MPART_DEFINE(name, cnt, ...)		\
+	void __attribute__((unused))			\
+	(*tsuite ##__ ##name ##__arr[cnt])(void) = {__VA_ARGS__}
+
+#define TEST_SUITE_MPART_RUN(name)					    \
+do {									    \
+	int i;								    \
+	for (i = 0; i < ARRAY_SIZE(tsuite ##__ ##name ##__arr); i++) {	    \
+		TEST_LOG_LF("TEST_SUITE_RUN(%s) #%d", #name, i);	    \
+		tsuite ##__ ##name ##__arr[i]();			    \
+	}								    \
+	test_set_setup_fn(NULL);					    \
+	test_set_teardown_fn(NULL);					    \
+} while(0)
+
 #define TEST_SUITE(name) void test_suite__##name(void)
 #define TEST_SETUP(fn) test_set_setup_fn(fn)
 #define TEST_TEARDOWN(fn) test_set_teardown_fn(fn)

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -20,7 +20,7 @@
  */
 
 #include "test_http_parser_common.h"
-
+#include "test_http_parser_defs.h"
 
 #define SAMPLE_REQ_STR	"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
 
@@ -1252,8 +1252,6 @@ TEST(http_parser, upgrade)
 
 }
 
-TEST(http1_parser, content_type_in_bodyless_requests)
-{
 #define EXPECT_BLOCK_BODYLESS_REQ(METHOD)					\
 	EXPECT_BLOCK_REQ(#METHOD " / HTTP/1.1\r\n"				\
 		 	 "Content-Length: 0\r\n"				\
@@ -1318,14 +1316,27 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
 	}
 
-
+TEST_MPART(http1_parser, content_type_in_bodyless_requests, 0)
+{
 	EXPECT_BLOCK_BODYLESS_REQ(GET);
 	EXPECT_BLOCK_BODYLESS_REQ(HEAD);
+}
+
+
+TEST_MPART(http1_parser, content_type_in_bodyless_requests, 1)
+{
 	EXPECT_BLOCK_BODYLESS_REQ(DELETE);
 	EXPECT_BLOCK_BODYLESS_REQ(TRACE);
+}
 
+TEST_MPART(http1_parser, content_type_in_bodyless_requests, 2)
+{
 	EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE(GET);
 	EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE(HEAD);
+}
+
+TEST_MPART(http1_parser, content_type_in_bodyless_requests, 3)
+{
 	EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE(DELETE);
 	EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE(TRACE);
 
@@ -1336,11 +1347,17 @@ TEST(http1_parser, content_type_in_bodyless_requests)
 		EXPECT_TFWSTR_EQ(&req->h_tbl->tbl[TFW_HTTP_HDR_CONTENT_TYPE],
 				 "Content-Type: text/plain");
 	}
-
+}
 
 #undef EXPECT_BLOCK_BODYLESS_REQ
 #undef EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE
-}
+
+TEST_MPART_DEFINE(http1_parser, content_type_in_bodyless_requests, H1_CT_BODYLESS_TCNT,
+	TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 0),
+	TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 1),
+	TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 2),
+	TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 3));
+
 
 TEST(http1_parser, content_length)
 {
@@ -3139,13 +3156,13 @@ end:
 	kernel_fpu_begin();
 }
 
-TEST(http1_parser, content_type_line_parser)
-{
 #define HEAD "POST / HTTP/1.1\r\nHost: localhost.localdomain\r\nContent-Type: "
 #define TAIL "\nContent-Length: 0\r\nKeep-Alive: timeout=98765\r\n\r\n"
 
 #define CT01 "multIPart/forM-data  ;    bouNDary=1234567890 ; otherparam=otherval  "
 
+TEST_MPART(http1_parser, content_type_line_parser, 0)
+{
 	FOR_REQ(HEAD CT01 TAIL) {
 		EXPECT_TRUE(test_bit(TFW_HTTP_B_CT_MULTIPART, req->flags));
 		EXPECT_TRUE(test_bit(TFW_HTTP_B_CT_MULTIPART_HAS_BOUNDARY,
@@ -3199,7 +3216,10 @@ TEST(http1_parser, content_type_line_parser)
 		EXPECT_TFWSTR_EQ(&req->h_tbl->tbl[TFW_HTTP_HDR_CONTENT_TYPE],
 				 "Content-Type: multipart/form-data1");
 	}
+}
 
+TEST_MPART(http1_parser, content_type_line_parser, 1)
+{
 	FOR_REQ(HEAD "multipart/form-data1; param=value" TAIL) {
 		EXPECT_FALSE(test_bit(TFW_HTTP_B_CT_MULTIPART, req->flags));
 		EXPECT_FALSE(test_bit(TFW_HTTP_B_CT_MULTIPART_HAS_BOUNDARY,
@@ -3258,7 +3278,10 @@ TEST(http1_parser, content_type_line_parser)
 		EXPECT_TFWSTR_EQ(&req->h_tbl->tbl[TFW_HTTP_HDR_CONTENT_TYPE],
 				 "Content-Type: application/octet-stream");
 	}
+}
 
+TEST_MPART(http1_parser, content_type_line_parser, 2)
+{
 	/* Multipart requests with multiple boundaries are clearly malicious. */
 	EXPECT_BLOCK_REQ(HEAD "multipart/form-data; boundary=1; boundary=2"
 			 TAIL);
@@ -3299,6 +3322,10 @@ TEST(http1_parser, content_type_line_parser)
 	EXPECT_BLOCK_REQ(HEAD "text/plain; name" TAIL);
 	EXPECT_BLOCK_REQ(HEAD "text/plain; name " TAIL);
 	EXPECT_BLOCK_REQ(HEAD "text/plain; name\t " TAIL);
+}
+
+TEST_MPART(http1_parser, content_type_line_parser, 3)
+{
 
 	/* Unfinished quoted parameter value */
 	EXPECT_BLOCK_REQ(HEAD "text/plain; name=\"unfinished" TAIL);
@@ -3338,9 +3365,16 @@ TEST(http1_parser, content_type_line_parser)
 				 "Content-Type: multitest");
 	}
 
+}
+
 #undef HEAD
 #undef TAIL
-}
+
+TEST_MPART_DEFINE(http1_parser, content_type_line_parser, H1_CT_LINE_PARSER_TCNT,
+	TEST_MPART_NAME(http1_parser, content_type_line_parser, 0),
+	TEST_MPART_NAME(http1_parser, content_type_line_parser, 1),
+	TEST_MPART_NAME(http1_parser, content_type_line_parser, 2),
+	TEST_MPART_NAME(http1_parser, content_type_line_parser, 3));
 
 TEST(http1_parser, xff)
 {
@@ -3366,8 +3400,6 @@ TEST(http1_parser, xff)
 	}
 }
 
-TEST(http1_parser, date)
-{
 #define FOR_EACH_DATE(strdate, expect_seconds)					\
 	FOR_RESP_SIMPLE("Last-Modified:" strdate)				\
 	{									\
@@ -3421,6 +3453,8 @@ TEST(http1_parser, date)
 		EXPECT_TRUE(req->cond.m_date == 0);				\
 	}
 
+TEST_MPART(http1_parser, date, 0)
+{
 	FOR_EACH_DATE_FORMAT("31", "Jan", "2012", "12", "15:02:53",
 				   1328022173);
 	FOR_EACH_DATE_FORMAT_INVALID("31", "JAN", "2012", "12", "15:02:53");
@@ -3460,7 +3494,10 @@ TEST(http1_parser, date)
 	{
 		EXPECT_TRUE(req->cond.m_date == 0);
 	}
+}
 
+TEST_MPART(http1_parser, date, 1)
+{
 	/*
 	 * RFC 7230 3.2.2:
 	 *
@@ -3513,7 +3550,10 @@ TEST(http1_parser, date)
 	FOR_EACH_DATE_RFC_822_ISOC_INVALID("01", "Jan", "0999", "00:00:00");
 	FOR_EACH_DATE_RFC_822_ISOC_INVALID("31", "Dec", "1969", "23:59:59");
 	FOR_EACH_DATE_RFC_822_ISOC_INVALID("01", "Jan", "1970", "00:00:00");
+}
 
+TEST_MPART(http1_parser, date, 2)
+{
 	/* More then 01 Jan 1970. */
 	/*
 	 * For ISO 850 this implementation violates RFC:
@@ -3550,7 +3590,10 @@ TEST(http1_parser, date)
 	FOR_EACH_DATE_FORMAT_INVALID("-1", "Jan", "2000", "00", "00:00:00");
 	FOR_EACH_DATE_FORMAT_INVALID("invalid", "Jan", "2000", "00",
 				     "00:00:00");
+}
 
+TEST_MPART(http1_parser, date, 3)
+{
 	FOR_EACH_DATE_FORMAT("30", "Apr", "1978", "78", "00:00:00",
 				   262742400);
 	FOR_EACH_DATE_FORMAT_INVALID("31", "Apr", "1995", "95", "00:00:00");
@@ -3582,7 +3625,11 @@ TEST(http1_parser, date)
 	FOR_EACH_DATE_FORMAT_INVALID("01", "Jan", "-1", "-1","00:00:00");
 	FOR_EACH_DATE_FORMAT_INVALID("01", "Jan", "invalid", "invalid",
 				     "00:00:00");
+}
 
+
+TEST_MPART(http1_parser, date, 4)
+{
 	/* Incorrect hours. */
 	FOR_EACH_DATE_FORMAT_INVALID("01", "Jan", "2000", "00", ":00:00");
 	FOR_EACH_DATE_FORMAT_INVALID("01", "Jan", "2000", "00", "00:00");
@@ -3636,6 +3683,7 @@ TEST(http1_parser, date)
 	FOR_EACH_DATE_INVALID("Inv Jan  01 00:00:01 1970");
 
 	FOR_EACH_DATE_INVALID("invalid");
+}
 
 #undef IF_MSINCE_INVALID
 #undef FOR_EACH_DATE_FORMAT_INVALID
@@ -3644,7 +3692,14 @@ TEST(http1_parser, date)
 #undef FOR_EACH_DATE_RFC_822_ISOC
 #undef FOR_EACH_DATE_INVALID
 #undef FOR_EACH_DATE
-}
+
+TEST_MPART_DEFINE(http1_parser, date, H1_DATE_PARSE_TCNT,
+	TEST_MPART_NAME(http1_parser, date, 0),
+	TEST_MPART_NAME(http1_parser, date, 1),
+	TEST_MPART_NAME(http1_parser, date, 2),
+	TEST_MPART_NAME(http1_parser, date, 3),
+	TEST_MPART_NAME(http1_parser, date, 4));
+
 
 TEST(http1_parser, method_override)
 {
@@ -3710,7 +3765,6 @@ TEST(http1_parser, method_override)
 		EXPECT_EQ(req->method_override, _TFW_HTTP_METH_UNKNOWN);
 	}
 }
-
 TEST(http1_parser, vchar)
 {
 /* Tests that header is validated by ctext_vchar alphabet. */
@@ -4271,7 +4325,6 @@ TEST_MPART(http1_parser, forwarded, 3) {
 				"for=1.2.3.4");
 }
 
-#define H1_FWD_TCNT 4
 TEST_MPART_DEFINE(http1_parser, forwarded, H1_FWD_TCNT,
 	TEST_MPART_NAME(http1_parser, forwarded, 0),
 	TEST_MPART_NAME(http1_parser, forwarded, 1),
@@ -4399,7 +4452,7 @@ do {									\
 #undef RESP_PERF
 }
 
-TEST_SUITE(http1_parser)
+TEST_SUITE_MPART(http1_parser, 0)
 {
 	int r;
 
@@ -4422,9 +4475,13 @@ TEST_SUITE(http1_parser)
 	TEST_RUN(http1_parser, status);
 	TEST_RUN(http1_parser, age);
 	TEST_RUN(http1_parser, pragma);
+}
+
+TEST_SUITE_MPART(http1_parser, 1)
+{
 	TEST_RUN(http1_parser, suspicious_x_forwarded_for);
 	TEST_RUN(http1_parser, parses_connection_value);
-	TEST_RUN(http1_parser, content_type_in_bodyless_requests);
+	TEST_MPART_RUN(http1_parser, content_type_in_bodyless_requests);
 	TEST_RUN(http1_parser, content_length);
 	TEST_RUN(http1_parser, eol_crlf);
 	TEST_RUN(http1_parser, ows);
@@ -4439,11 +4496,15 @@ TEST_SUITE(http1_parser)
 	TEST_RUN(http1_parser, if_none_match);
 	TEST_RUN(http1_parser, referer);
 	TEST_RUN(http1_parser, req_hop_by_hop);
+}
+
+TEST_SUITE_MPART(http1_parser, 2)
+{
 	TEST_RUN(http1_parser, resp_hop_by_hop);
 	TEST_RUN(http1_parser, fuzzer);
-	TEST_RUN(http1_parser, content_type_line_parser);
+	TEST_MPART_RUN(http1_parser, content_type_line_parser);
 	TEST_RUN(http1_parser, xff);
-	TEST_RUN(http1_parser, date);
+	TEST_MPART_RUN(http1_parser, date);
 	TEST_RUN(http1_parser, method_override);
 	TEST_RUN(http1_parser, x_tempesta_cache);
 	TEST_RUN(http1_parser, vchar);
@@ -4460,3 +4521,9 @@ TEST_SUITE(http1_parser)
 
 	TEST_RUN(http1_parser, perf);
 }
+
+TEST_SUITE_MPART_DEFINE(http1_parser, H1_SUITE_PART_CNT,
+	TEST_SUITE_MPART_NAME(http1_parser, 0),
+	TEST_SUITE_MPART_NAME(http1_parser, 1),
+	TEST_SUITE_MPART_NAME(http1_parser, 2));
+

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -1353,10 +1353,10 @@ TEST_MPART(http1_parser, content_type_in_bodyless_requests, 3)
 #undef EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE
 
 TEST_MPART_DEFINE(http1_parser, content_type_in_bodyless_requests, H1_CT_BODYLESS_TCNT,
-	TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 0),
-	TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 1),
-	TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 2),
-	TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 3));
+		  TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 0),
+		  TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 1),
+		  TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 2),
+		  TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 3));
 
 
 TEST(http1_parser, content_length)
@@ -3371,10 +3371,10 @@ TEST_MPART(http1_parser, content_type_line_parser, 3)
 #undef TAIL
 
 TEST_MPART_DEFINE(http1_parser, content_type_line_parser, H1_CT_LINE_PARSER_TCNT,
-	TEST_MPART_NAME(http1_parser, content_type_line_parser, 0),
-	TEST_MPART_NAME(http1_parser, content_type_line_parser, 1),
-	TEST_MPART_NAME(http1_parser, content_type_line_parser, 2),
-	TEST_MPART_NAME(http1_parser, content_type_line_parser, 3));
+		  TEST_MPART_NAME(http1_parser, content_type_line_parser, 0),
+		  TEST_MPART_NAME(http1_parser, content_type_line_parser, 1),
+		  TEST_MPART_NAME(http1_parser, content_type_line_parser, 2),
+		  TEST_MPART_NAME(http1_parser, content_type_line_parser, 3));
 
 TEST(http1_parser, xff)
 {
@@ -3694,11 +3694,11 @@ TEST_MPART(http1_parser, date, 4)
 #undef FOR_EACH_DATE
 
 TEST_MPART_DEFINE(http1_parser, date, H1_DATE_PARSE_TCNT,
-	TEST_MPART_NAME(http1_parser, date, 0),
-	TEST_MPART_NAME(http1_parser, date, 1),
-	TEST_MPART_NAME(http1_parser, date, 2),
-	TEST_MPART_NAME(http1_parser, date, 3),
-	TEST_MPART_NAME(http1_parser, date, 4));
+		  TEST_MPART_NAME(http1_parser, date, 0),
+		  TEST_MPART_NAME(http1_parser, date, 1),
+		  TEST_MPART_NAME(http1_parser, date, 2),
+		  TEST_MPART_NAME(http1_parser, date, 3),
+		  TEST_MPART_NAME(http1_parser, date, 4));
 
 
 TEST(http1_parser, method_override)
@@ -4326,10 +4326,10 @@ TEST_MPART(http1_parser, forwarded, 3) {
 }
 
 TEST_MPART_DEFINE(http1_parser, forwarded, H1_FWD_TCNT,
-	TEST_MPART_NAME(http1_parser, forwarded, 0),
-	TEST_MPART_NAME(http1_parser, forwarded, 1),
-	TEST_MPART_NAME(http1_parser, forwarded, 2),
-	TEST_MPART_NAME(http1_parser, forwarded, 3));
+		  TEST_MPART_NAME(http1_parser, forwarded, 0),
+		  TEST_MPART_NAME(http1_parser, forwarded, 1),
+		  TEST_MPART_NAME(http1_parser, forwarded, 2),
+		  TEST_MPART_NAME(http1_parser, forwarded, 3));
 
 TEST(http1_parser, perf)
 {

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -1352,11 +1352,16 @@ TEST_MPART(http1_parser, content_type_in_bodyless_requests, 3)
 #undef EXPECT_BLOCK_BODYLESS_REQ
 #undef EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE
 
-TEST_MPART_DEFINE(http1_parser, content_type_in_bodyless_requests, H1_CT_BODYLESS_TCNT,
-		  TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 0),
-		  TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 1),
-		  TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 2),
-		  TEST_MPART_NAME(http1_parser, content_type_in_bodyless_requests, 3));
+TEST_MPART_DEFINE(http1_parser, content_type_in_bodyless_requests,
+		  H1_CT_BODYLESS_TCNT,
+		  TEST_MPART_NAME(http1_parser,
+				  content_type_in_bodyless_requests, 0),
+		  TEST_MPART_NAME(http1_parser,
+				  content_type_in_bodyless_requests, 1),
+		  TEST_MPART_NAME(http1_parser,
+				  content_type_in_bodyless_requests, 2),
+		  TEST_MPART_NAME(http1_parser,
+				  content_type_in_bodyless_requests, 3));
 
 
 TEST(http1_parser, content_length)

--- a/fw/t/unit/test_http2_parser.c
+++ b/fw/t/unit/test_http2_parser.c
@@ -1068,10 +1068,14 @@ TEST_MPART(http2_parser, content_type_in_bodyless_requests, 2)
 #undef EXPECT_BLOCK_BODYLESS_REQ_H2
 #undef EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE_H2
 
-TEST_MPART_DEFINE(http2_parser, content_type_in_bodyless_requests, H2_CT_BODYLESS_TCNT,
-		  TEST_MPART_NAME(http2_parser, content_type_in_bodyless_requests, 0),
-		  TEST_MPART_NAME(http2_parser, content_type_in_bodyless_requests, 1),
-		  TEST_MPART_NAME(http2_parser, content_type_in_bodyless_requests, 2));
+TEST_MPART_DEFINE(http2_parser, content_type_in_bodyless_requests,
+		  H2_CT_BODYLESS_TCNT,
+		  TEST_MPART_NAME(http2_parser,
+				  content_type_in_bodyless_requests, 0),
+		  TEST_MPART_NAME(http2_parser,
+				  content_type_in_bodyless_requests, 1),
+		  TEST_MPART_NAME(http2_parser,
+				  content_type_in_bodyless_requests, 2));
 
 TEST(http2_parser, content_length)
 {

--- a/fw/t/unit/test_http_parser_defs.h
+++ b/fw/t/unit/test_http_parser_defs.h
@@ -29,7 +29,7 @@
 
 #define H1_SUITE_PART_CNT	3
 
-/* http1 tests parts count */
+/* http2 tests parts count */
 #define H2_CT_BODYLESS_TCNT	3
 #define H2_FWD_TCNT		4
 #define H2_ACCEPT_TCNT		4

--- a/fw/t/unit/test_http_parser_defs.h
+++ b/fw/t/unit/test_http_parser_defs.h
@@ -29,4 +29,14 @@
 
 #define H1_SUITE_PART_CNT	3
 
+/* http1 tests parts count */
+#define H2_CT_BODYLESS_TCNT	3
+#define H2_FWD_TCNT		4
+#define H2_ACCEPT_TCNT		4
+#define H2_HOST_TCNT		4
+#define H2_CC_TCNT		5
+#define H2_DATE_FMT_TCNT	2
+
+#define H2_SUITE_PART_CNT	8
+
 #endif

--- a/fw/t/unit/test_http_parser_defs.h
+++ b/fw/t/unit/test_http_parser_defs.h
@@ -1,0 +1,32 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_H1_DEFS__
+#define __TFW_H1_DEFS__
+
+/* http1 tests parts count */
+#define H1_CT_BODYLESS_TCNT	4
+#define H1_CT_LINE_PARSER_TCNT	4
+#define H1_DATE_PARSE_TCNT	5
+#define H1_FWD_TCNT		4
+
+#define H1_SUITE_PART_CNT	3
+
+#endif


### PR DESCRIPTION
Currently, while building unit tests, there is a warning: `note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’`.
Split large individual test functions and the test suite itself.