### PR TITLE
fw: Fix compilation errors reported by GCC 12 [-Werror=address]

### DIFF
--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1911,7 +1911,9 @@ check_name_text:
 			 * empty, then the header is about to be removed,
 			 * don't write it.
 			 */
-			if (!TFW_STR_CHUNK(dc_iter->desc->hdr, 1)) {
+
+			/* FIXME: this is a temporary WA for GCC12, see #1695 for details */
+			if (TFW_STR_CHUNK(dc_iter->desc->hdr, 1) == NULL) {
 				dc_iter->skip = true;
 				goto out;
 			}

--- a/fw/http.c
+++ b/fw/http.c
@@ -4406,7 +4406,8 @@ tfw_h2_resp_add_loc_hdrs(TfwHttpResp *resp, const TfwHdrMods *h_mods,
 		const TfwHdrModsDesc *desc = &h_mods->hdrs[i];
 		int r;
 
-		if (test_bit(i, mit->found) || !TFW_STR_CHUNK(desc->hdr, 1))
+		/* FIXME: this is a temporary WA for GCC12, see #1695 for details */
+		if (test_bit(i, mit->found) || (TFW_STR_CHUNK(desc->hdr, 1) == NULL))
 			continue;
 
 		r = tfw_hpack_encode(resp, desc->hdr, op, !cache);


### PR DESCRIPTION
Caught the following errors while compiling TFW using GCC 12:
```
  CC [M]  /root/host/tempesta/fw/t/unit/test_http2_parser.o                                                                                                    
/root/host/tempesta/fw/http.c: In function ‘tfw_h2_resp_add_loc_hdrs’:                                                                                         
/root/host/tempesta/fw/http.c:4409:48: error: the comparison will always evaluate as ‘true’ for the pointer operand in ‘((TfwStr *)desc->hdr)-><U1558>.chunks + 32’ must not be NULL [-Werror=address]
 4409 |                 if (test_bit(i, mit->found) || !TFW_STR_CHUNK(desc->hdr, 1))                                                                           
      |                                                ^                                                                                                       
In file included from /root/host/tempesta/fw/t/unit/test_hpack.c:24:                                                                                           
/root/host/tempesta/fw/t/unit/../../..//fw/http.c: In function ‘tfw_h2_resp_add_loc_hdrs’:                                                                     
/root/host/tempesta/fw/t/unit/../../..//fw/http.c:4409:48: error: the comparison will always evaluate as ‘true’ for the pointer operand in ‘((TfwStr *)desc->hdr)-><U9980>.chunks + 32’ must not be NULL [-Werror=address]
 4409 |                 if (test_bit(i, mit->found) || !TFW_STR_CHUNK(desc->hdr, 1))
      |                                                ^                                              
```
GCC version:
```
f36tfw :: host/tempesta » gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/12/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,objc,obj-c++,ada,go,d,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --enable-libstdcxx-backtrace --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl=/builddir/build/BUILD/gcc-12.2.1-20220819/obj-x86_64-redhat-linux/isl-install --enable-offload-targets=nvptx-none --without-cuda-driver --enable-offload-defaulted --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux --with-build-config=bootstrap-lto --enable-link-serialization=1
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.2.1 20220819 (Red Hat 12.2.1-1) (GCC) 

```


