### PR TITLE
Handle 0-bits left shift.

### DIFF
--- a/tls/bignum.c
+++ b/tls/bignum.c
@@ -273,8 +273,13 @@ ttls_mpi_shift_l(TlsMpi *X, const TlsMpi *A, size_t count)
 	size_t limbs, bits, old_used = A->used;
 	unsigned long *x = MPI_P(X), *a = MPI_P(A);
 
-	if (WARN_ON_ONCE(!count || !old_used))
+	if (WARN_ON_ONCE(!old_used))
 		return;
+	if (unlikely(!count)) {
+		if (X != A)
+			ttls_mpi_copy_alloc(X, A, false);
+		return;
+	}
 
 	limbs = count >> BSHIFT;
 	bits = count & BMASK;

--- a/tls/bignum.h
+++ b/tls/bignum.h
@@ -75,7 +75,7 @@ do {									\
  * @used	- used limbs;
  * @limbs	- total # of limbs;
  * @_off	- offset of limbs array remote memory. Can be negative for MPIs
- *            allocated on the stack;
+ *		  allocated on the stack;
  *
  * MPI is placed in relatively small areas of memory (PK context pages or
  * per-cpu pages for temporal calculations withing single handshake FSM state),


### PR DESCRIPTION
ttls_mpi_div_mpi() may call the function with the zero count value if X and Y are of the same size, which doesn't look exceptional.

Fixes https://github.com/tempesta-tech/tempesta-test/issues/302