### PR TITLE
frang: handle the case of the missing http_ct_vals option

### DIFF
--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -475,6 +475,14 @@ frang_http_ct_check(const TfwHttpReq *req, FrangAcc *ra, FrangCtVals *ct_vals)
 		return TFW_BLOCK;
 	}
 
+	if (!ct_vals) {
+		/*
+		 * Configuration does not provide a list of allowed types for
+		 * Content-Type, so everything is permitted.
+		 */
+		return TFW_PASS;
+	}
+
 	tfw_http_msg_clnthdr_val(req,
 				 &req->h_tbl->tbl[TFW_HTTP_HDR_CONTENT_TYPE],
 				 TFW_HTTP_HDR_CONTENT_TYPE, &field);


### PR DESCRIPTION
Configuration may only have "http_ct_required" set without a list of types allowed for Content-Type field, "http_ct_vals". Handle this as a special case of every type allowed.

fixes #1671