### PR TITLE
Kernel crash on ws.test_ws_ping.CacheTest.test_ping_websockets

### DIFF
--- a/fw/connection.h
+++ b/fw/connection.h
@@ -100,6 +100,8 @@ enum {
  * @peer	- TfwClient or TfwServer handler. Hop-by-hop peer;
  * @pair	- Paired TfwCliConn or TfwSrvConn for websocket connections;
  * @sk		- an appropriate sock handler;
+ * @get_refcnt	- flag of getting an additional refcnt for an websocket upgrade;
+ * @get_pair	- pair capture flag for websocket;
  * @destructor	- called when a connection is destroyed;
  */
 typedef struct tfw_conn_t TfwConn;
@@ -113,6 +115,8 @@ typedef struct tfw_conn_t TfwConn;
 	TfwPeer 		*peer;			\
 	TfwConn			*pair;			\
 	struct sock		*sk;			\
+	bool			get_refcnt;		\
+	atomic_t		get_pair;		\
 	void			(*destructor)(void *);
 
 typedef struct tfw_conn_t {

--- a/fw/websocket.c
+++ b/fw/websocket.c
@@ -112,8 +112,7 @@ tfw_ws_srv_new_steal_sk(TfwSrvConn *srv_conn)
 
 	/* Connection destructor does failover for server connections */
 	srv_conn->sk = NULL;
-	if (srv_conn->destructor)
-		srv_conn->destructor(srv_conn);
+
 err:
 	clear_bit(TFW_CONN_B_UNSCHED, &srv_conn->flags);
 


### PR DESCRIPTION
https://github.com/tempesta-tech/tempesta/issues/1647

~Increment the reference count of connections in case of an attempt to destroy them.~
~`tfw_ws_conn_drop()` and `tfw_ws_msg_process()` can run in parallel.~

~We do not nullify paired connections - this can lead to null dereference.~

~We get a client connection for the websocket upgrade so that it is not
destroyed by the original drop callback before the upgrade is completed.~

Eliminate the race between client, server tfw_ws_conn_drop() and
tfw_ws_msg_process()