### PR TITLE
#1697 Fix header field name length check

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1254,8 +1254,8 @@ __FSM_STATE(RGen_HdrOtherN) {						\
 		 * ':' can be found at the beginning of a new skb or	\
 		 * fragment, it's ok.					\
 		*/							\
-		if (unlikely(!__fsm_sz					\
-			     && TFW_STR_EMPTY(&msg->stream->parser.hdr))) \
+		if (unlikely(!__fsm_sz && TFW_STR_EMPTY(&parser->hdr)	\
+			     && p == (unsigned char *)parser->hdr.data))\
 		{							\
 			TFW_PARSER_BLOCK(RGen_HdrOtherN);		\
 		}							\

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -93,6 +93,13 @@ TEST(http1_parser, leading_eol)
 	FOR_RESP("\n\n\n" EMPTY_RESP);
 }
 
+TEST(http1_parser, short_name)
+{
+	FOR_REQ_SIMPLE("X: test");
+	FOR_REQ_SIMPLE("Z: test");
+	EXPECT_BLOCK_REQ_SIMPLE(": test");
+}
+
 TEST(http1_parser, parses_req_method)
 {
 #define TEST_REQ_METHOD(METHOD)					\
@@ -4469,6 +4476,7 @@ TEST_SUITE_MPART(http1_parser, 0)
 
 	TEST_RUN(http1_parser, leading_eol);
 	TEST_RUN(http1_parser, parses_req_method);
+	TEST_RUN(http1_parser, short_name);
 	TEST_RUN(http1_parser, parses_req_uri);
 	TEST_RUN(http1_parser, mangled_messages);
 	TEST_RUN(http1_parser, alphabets);

--- a/fw/t/unit/test_http2_parser.c
+++ b/fw/t/unit/test_http2_parser.c
@@ -21,6 +21,36 @@
 #include "test_http_parser_common.h"
 #include "test_http_parser_defs.h"
 
+TEST(http2_parser, short_name)
+{
+	FOR_REQ_H2(
+		HEADERS_FRAME_BEGIN();
+		HEADER(WO_IND(NAME(":method"), VALUE("GET")));
+		HEADER(WO_IND(NAME(":scheme"), VALUE("https")));
+		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));
+		HEADER(WO_IND(NAME("x"), VALUE("test")));
+		HEADERS_FRAME_END();
+	);
+
+	FOR_REQ_H2(
+		HEADERS_FRAME_BEGIN();
+		HEADER(WO_IND(NAME(":method"), VALUE("GET")));
+		HEADER(WO_IND(NAME(":scheme"), VALUE("https")));
+		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));
+		HEADER(WO_IND(NAME("z"), VALUE("test")));
+		HEADERS_FRAME_END();
+	);
+
+	EXPECT_BLOCK_REQ_H2(
+		HEADERS_FRAME_BEGIN();
+		HEADER(WO_IND(NAME(":method"), VALUE("GET")));
+		HEADER(WO_IND(NAME(":scheme"), VALUE("https")));
+		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));
+		HEADER(WO_IND(NAME(""), VALUE("test")));
+		HEADERS_FRAME_END();
+	);
+}
+
 TEST(http2_parser, http2_check_important_fields)
 {
 	EXPECT_BLOCK_REQ_H2(
@@ -3304,6 +3334,7 @@ TEST_MPART_DEFINE(http2_parser, forwarded, H2_FWD_TCNT,
 
 TEST_SUITE_MPART(http2_parser, 0)
 {
+	TEST_RUN(http2_parser, short_name);
 	TEST_RUN(http2_parser, http2_check_important_fields);
 	TEST_RUN(http2_parser, parses_req_method);
 	TEST_RUN(http2_parser, parses_req_uri);


### PR DESCRIPTION
https://github.com/tempesta-tech/tempesta/issues/1697

~In checking the length of the header field name, we take into account the processed unfixed characters (__FSM_MOVE) and fixed, and not just parsed at the current iteration of the state~
Add a check that we haven't passed a single character since the beginning
of the header

Zero length header field name for http/2 is forbidden in tfw_hpack_decode.