### PR TITLE
fw/cache: Do not take an additional reference on paged sk_buff fragment while copying http/2 response body

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -2251,7 +2251,8 @@ tfw_cache_add_body_page(TfwMsgIter *it, char *p, int sz, TfwFrameHdr *frame_hdr,
 
 	++it->frag;
 	skb_fill_page_desc(it->skb, it->frag, page, off, sz);
-	skb_frag_ref(it->skb, it->frag);
+	if (!h2)
+		skb_frag_ref(it->skb, it->frag);
 	ss_skb_adjust_data_len(it->skb, sz);
 
 	return 0;

--- a/fw/http.c
+++ b/fw/http.c
@@ -4807,7 +4807,6 @@ tfw_h2_append_predefined_body(TfwHttpResp *resp, unsigned int stream_id,
 		++it->frag;
 		skb_fill_page_desc(it->skb, it->frag, page, 0,
 				   copy + FRAME_HEADER_SIZE);
-		skb_frag_ref(it->skb, it->frag);
 		ss_skb_adjust_data_len(it->skb, copy + FRAME_HEADER_SIZE);
 
 		if (it->frag + 1 == MAX_SKB_FRAGS


### PR DESCRIPTION

Signed-off-by: Petr Vyazovik <xen@f-m.fm>