### PR TITLE
JSCH usability and documentation

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -5215,7 +5215,8 @@ tfw_h1_error_resp(TfwHttpReq *req, int status, bool reply, bool attack,
  *
  * @req			- malicious or malformed request;
  * @status		- response status code to use;
- * @msg			- message to be logged;
+ * @msg			- message to be logged. Can be NULL if the caller does
+ *			  logging on their side;
  * @attack		- true if the request was sent intentionally, false for
  *			  internal errors or misconfigurations;
  * @on_req_recv_event	- true if request is not fully parsed and the caller
@@ -5248,7 +5249,7 @@ tfw_http_cli_error_resp_and_log(TfwHttpReq *req, int status, const char *msg,
 	/* Do not log client port as it doesn't provide useful information
 	 * and could contain outdated cached data.
 	 */
-	if (!nolog)
+	if (!nolog && msg)
 		T_WARN_ADDR(msg, &req->conn->peer->addr, TFW_NO_PORT);
 
 	if (TFW_MSG_H2(req))
@@ -6052,8 +6053,7 @@ next_msg:
 
 	case TFW_HTTP_SESS_VIOLATE:
 		TFW_INC_STAT_BH(clnt.msgs_filtout);
-		tfw_http_req_parse_block(req, 503,
-			"request dropped: sticky cookie challenge was failed");
+		tfw_http_req_parse_block(req, 503, NULL);
 		return TFW_BLOCK;
 
 	case TFW_HTTP_SESS_JS_NOT_SUPPORTED:

--- a/fw/http_sess_conf.c
+++ b/fw/http_sess_conf.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2022 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +29,14 @@ static TfwVhost *cur_vhost;
 
 #define STICKY_NAME_DEFAULT	"__tfw"
 
+/*
+ * JavaScript challenge requires a browser to execute a code from the response
+ * body, so 30x redirects don't work for us since browsers ignore the body
+ * and perfrom redirects automatically. We still send location header, which
+ * is ignored by the browser in case of 50x error code, but the logic is simpler
+ * for us to allow a configurations with 30x redirects and unify the code for
+ * the JavaScript and Cookie challenges.
+ */
 static const unsigned int tfw_cfg_jsch_code_dflt = 503;
 #define TFW_CFG_JS_PATH "/etc/tempesta/js_challenge.html"
 


### PR DESCRIPTION
There was a user request that Tempesta FW with the config like (my testing config)
```
listen 192.168.100.4:443 proto=https;
listen 192.168.100.4:80;

block_action attack reply;
block_action error reply;

srv_group default {
        server 192.168.100.4:8000;
}

#vhost default {
vhost ubuntu {
        tls_certificate /root/tempesta/etc/tfw-root.crt;
        tls_certificate_key /root/tempesta/etc/tfw-root.key;

        proxy_pass default;

        sticky {
                cookie enforce options="Max-Age=900";
                js_challenge delay_min=1000 delay_range=1000;
        }
}

cache 1;
cache_fulfill * *;

access_log on;

http_chain {
        -> ubuntu;
}
```
sends 503 error codes regardless any cookies and with normal browser.

Firstly, I was surprised seeing 503 codes in redirects, but it does make sense (see the commit message and the code comment). Next, I saw a Tempesta FW warning, which didn't help me to debug the problem.

This PR adds a comment and makes reporting more administrator-friendly. I also updated https://github.com/tempesta-tech/tempesta/wiki/Sticky-Cookie#configuration with better description of all the `delay` parameters and troubleshooting.

P.S. The original problem was due to too low default value for the `delay_limit` and was fixed by adding ` delay_limit=10000` to `js_challenge`.