### PR TITLE
Fix inversed logic for http_trailer_split_allowed (#1725)

### DIFF
--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -966,7 +966,7 @@ frang_http_req_trailer_check(FrangAcc *ra, TfwFsmData *data,
 	 * trailers (RFC 7540 section 8.1.2.1), and during parsing stage, in
 	 * @H2_MSG_VERIFY(), we have already verified that.
 	 */
-	if (!f_cfg->http_trailer_split)
+	if (f_cfg->http_trailer_split)
 		return TFW_PASS;
 
 	FOR_EACH_HDR_FIELD_FROM(field, end, req, TFW_HTTP_HDR_REGULAR) {

--- a/fw/http_limits.h
+++ b/fw/http_limits.h
@@ -165,6 +165,8 @@ struct frang_global_cfg_t {
  *			   code before client connection is closed.
  * @http_ct_required	- Header 'Content-Type:' is required;
  * @http_host_required	- Header 'Host:' is required;
+ * @http_trailer_split  - Allow the same header appear in both
+ *			  request header part and chunked trailer part;
  * @http_method_override - Allow method override in request headers.
  */
 struct frang_vhost_cfg_t {


### PR DESCRIPTION
Fix #1725 `http_trailer_split_allowed`  option logic: allow on enable, disallow by default.