### PR TITLE
Changed condition to met RFC requirement

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -586,7 +586,7 @@ tfw_cache_entry_is_live(TfwHttpReq *req, TfwCacheEntry *ce)
 	}
 #undef CC_LIFETIME_FRESH
 
-	return ce_lifetime > ce_age ? ce_lifetime : 0;
+	return ce_age > ce_lifetime ? 0 : ce_lifetime;
 }
 
 static bool


### PR DESCRIPTION
  The "max-age" request directive indicates that the client is
  unwilling to accept a response whose age is greater than the
  specified number of seconds. RFC 7234.