### PR TITLE
Fix request parsing when using different values in the Forwarded header

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -6431,6 +6431,7 @@ __FSM_STATE(st_curr) {							\
 		}							\
 		parser->_i_st = NULL;					\
 		parser->_hdr_tag = hid;					\
+		parser->_acc = 0;					\
 		__FSM_H2_HDR_COMPLETE(st_curr);				\
 	case CSTR_POSTPONE:						\
 		__FSM_H2_POSTPONE(st_curr);				\


### PR DESCRIPTION
The problem was that after processing the value from the Forwarded header we set the corresponding flag in the parser->flags field, then when processing next value, we check that this flag has been set and return an error. But we must reset the flags field after processing the value from the header. Actually must reset the parser->_acc value in the TFW_H2_PARSE_HDR_VAL macro same as we do it in the __TFW_HTTP_PARSE_SPECHDR_VAL macro. Because the _acc field is part of the union, we also reset all other values ​​in that union, including the flags field.

Closes #1718