### PR TITLE
Safe handling of websockets drop

### DIFF
--- a/fw/connection.h
+++ b/fw/connection.h
@@ -4,7 +4,7 @@
  * Definitions for generic connection management at OSI level 6 (presentation).
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -215,7 +215,10 @@ enum {
 	TFW_CONN_B_ACTIVE,
 	/* Connection is disconnected and stopped. */
 	TFW_CONN_B_STOPPED,
-	/* Mark connection as unavailable to schedulers */
+	/*
+	 * Mark connection as unavailable to schedulers.
+	 * Used to steal server connections for websockets.
+	 */
 	TFW_CONN_B_UNSCHED
 };
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -6505,8 +6505,18 @@ tfw_http_websocket_upgrade(TfwSrvConn *srv_conn, TfwCliConn *cli_conn)
 
 	cli_conn->proto.type |= TFW_FSM_WEBSOCKET;
 
+	/*
+	 * At the moment we're under the ws_conn->sk->sk_lock, as the function
+	 * is called from tfw_http_resp_process(). ws_conn->refcnt = 1 as only
+	 * the client connection references it.
+	 *
+	 * The client connection can not be freed so far since the response is
+	 * still not forwarded to the client (see tfw_http_conn_cli_drop()), so
+	 * at this point we are safe to adjust the connection reference counter.
+	 */
 	cli_conn->pair = (TfwConn *)ws_conn;
 	ws_conn->pair = (TfwConn *)cli_conn;
+	tfw_connection_get(ws_conn->pair);
 
 	tfw_ws_cli_mod_timer(cli_conn);
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -2724,7 +2724,7 @@ tfw_http_conn_release(TfwConn *conn)
  *
  * If a response comes or gets ready to forward after @seq_list is
  * disintegrated, then both the request and the response are dropped at the
- *  sight of an empty list.
+ * sight of an empty list.
  *
  * Locking is necessary as @seq_list is constantly probed from server
  * connection threads.
@@ -6117,8 +6117,9 @@ next_msg:
 		/* Override shouldn't be combined with PURGE, that'd
 		 * probably break things */
 		req->method_override = _TFW_HTTP_METH_NONE;
-	} else
+	} else {
 		__clear_bit(TFW_HTTP_B_PURGE_GET, req->flags);
+	}
 
 	/*
 	 * Method override masks real request properties, non-idempotent methods
@@ -6495,7 +6496,7 @@ tfw_http_resp_terminate(TfwHttpMsg *hm)
  * @return zero on success and negative otherwise
  */
 static int
-tfw_http_websocket_upgrade(TfwSrvConn *srv_conn, TfwCliConn * cli_conn)
+tfw_http_websocket_upgrade(TfwSrvConn *srv_conn, TfwCliConn *cli_conn)
 {
 	TfwConn *ws_conn;
 
@@ -6546,7 +6547,7 @@ next_msg:
 	parsed = 0;
 	hmsib = NULL;
 	hmresp = (TfwHttpMsg *)stream->msg;
-	cli_conn = (TfwCliConn *) hmresp->req->conn;
+	cli_conn = (TfwCliConn *)hmresp->req->conn;
 
 	r = ss_skb_process(skb, tfw_http_parse_resp, hmresp, &chunks_unused,
 			   &parsed);
@@ -6733,10 +6734,9 @@ next_msg:
 	}
 
 next_resp:
-	if (skb && websocket) {
+	if (skb && websocket)
 		return tfw_ws_msg_process(cli_conn->pair, skb);
-	}
-	else if (hmsib) {
+	if (hmsib) {
 		/*
 		 * Switch the connection to the sibling message.
 		 * Data processing will continue with the new SKB.

--- a/fw/http.c
+++ b/fw/http.c
@@ -1455,10 +1455,9 @@ tfw_http_nip_req_resched_err(TfwSrvConn *srv_conn, TfwHttpReq *req,
 void
 tfw_http_send_err_resp(TfwHttpReq *req, int status, const char *reason)
 {
-	if (!(tfw_blk_flags & TFW_BLK_ERR_NOLOG)) {
+	if (!(tfw_blk_flags & TFW_BLK_ERR_NOLOG))
 		T_WARN_ADDR_STATUS(reason, &req->conn->peer->addr,
 				   TFW_NO_PORT, status);
-	}
 
 	if (TFW_MSG_H2(req))
 		tfw_h2_send_err_resp(req, status, 0);

--- a/fw/http.c
+++ b/fw/http.c
@@ -6486,44 +6486,6 @@ tfw_http_resp_terminate(TfwHttpMsg *hm)
 }
 
 /**
- * Does websocket upgrade procedure.
- *
- * Marks current client connection as websocket connection. Allocated new plain
- * TfwConn connection with websocket type and steal backend connection socket
- * into it. Starts reconnection for stealed from connection. Pairs websocket
- * connections with each other.
- *
- * @return zero on success and negative otherwise
- */
-static int
-tfw_http_websocket_upgrade(TfwSrvConn *srv_conn, TfwCliConn *cli_conn)
-{
-	TfwConn *ws_conn;
-
-	if (!(ws_conn = tfw_ws_srv_new_steal_sk(srv_conn)))
-		return TFW_BLOCK;
-
-	cli_conn->proto.type |= TFW_FSM_WEBSOCKET;
-
-	/*
-	 * At the moment we're under the ws_conn->sk->sk_lock, as the function
-	 * is called from tfw_http_resp_process(). ws_conn->refcnt = 1 as only
-	 * the client connection references it.
-	 *
-	 * The client connection can not be freed so far since the response is
-	 * still not forwarded to the client (see tfw_http_conn_cli_drop()), so
-	 * at this point we are safe to adjust the connection reference counter.
-	 */
-	cli_conn->pair = (TfwConn *)ws_conn;
-	ws_conn->pair = (TfwConn *)cli_conn;
-	tfw_connection_get(ws_conn->pair);
-
-	tfw_ws_cli_mod_timer(cli_conn);
-
-	return TFW_PASS;
-}
-
-/**
  * @return zero on success and negative value otherwise.
  * TODO enter the function depending on current GFSM state.
  */

--- a/fw/http.c
+++ b/fw/http.c
@@ -1832,9 +1832,7 @@ tfw_http_req_fwd_send(TfwSrvConn *srv_conn, TfwServer *srv, TfwHttpReq *req,
 		 *
 		 * This is theoretically possible on highly concurrent scenarios
 		 * the current function is called under tfw_http_conn_on_hold()
-		 * check. More likely it can happen on a just and quickly
-		 * recovered server connection, which didn't clear the
-		 * TFW_CONN_B_UNSCHED bit in tfw_ws_srv_new_steal_sk() yet.
+		 * check.
 		 */
 		return -EBADF;
 	}

--- a/fw/http.c
+++ b/fw/http.c
@@ -2007,7 +2007,7 @@ tfw_http_conn_treatnip(TfwSrvConn *srv_conn, struct list_head *eq)
 	TfwServer *srv = (TfwServer *)srv_conn->peer;
 	TfwHttpReq *req_sent = (TfwHttpReq *)srv_conn->msg_sent;
 
-	if (tfw_http_conn_on_hold(srv_conn)
+	if (req_sent && tfw_http_conn_on_hold(srv_conn)
 	    && !(srv->sg->flags & TFW_SRV_RETRY_NIP))
 	{
 		BUG_ON(list_empty(&req_sent->nip_list));

--- a/fw/t/unit/test_hpack.c
+++ b/fw/t/unit/test_hpack.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -23,11 +23,14 @@
 #include "http_frame.c"
 #include "http.c"
 
-TfwConn *tfw_ws_srv_new_steal_sk(TfwSrvConn *srv_conn)
+int
+tfw_http_websocket_upgrade(TfwSrvConn *srv_conn, TfwCliConn *cli_conn)
 {
 	(void)srv_conn;
-	return NULL;
+	(void)cli_conn;
+	return 0;
 }
+
 int tfw_ws_msg_process(TfwConn *conn, struct sk_buff *skb)
 {
 	(void)conn;

--- a/fw/websocket.c
+++ b/fw/websocket.c
@@ -137,7 +137,8 @@ tfw_ws_srv_new_steal_sk(TfwSrvConn *srv_conn)
 	if (!(conn = tfw_ws_conn_alloc())) {
 		T_WARN_ADDR("Can't create new connection for socket stealing",
 			    &srv->addr, TFW_NO_PORT);
-		goto err;
+		clear_bit(TFW_CONN_B_UNSCHED, &srv_conn->flags);
+		return NULL;
 	}
 	conn->peer = (TfwPeer *)srv;
 	conn->sk = srv_conn->sk;
@@ -153,8 +154,6 @@ tfw_ws_srv_new_steal_sk(TfwSrvConn *srv_conn)
 	srv_conn->sk = NULL;
 	if (srv_conn->destructor)
 		srv_conn->destructor(srv_conn);
-err:
-	clear_bit(TFW_CONN_B_UNSCHED, &srv_conn->flags);
 
 	return conn;
 }

--- a/fw/websocket.c
+++ b/fw/websocket.c
@@ -171,9 +171,8 @@ tfw_ws_msg_process(TfwConn *conn, struct sk_buff *skb)
 	}
 
 	/* When receiving data from client we consider client timeout */
-	if (TFW_CONN_TYPE(conn) & Conn_Clnt) {
+	if (TFW_CONN_TYPE(conn) & Conn_Clnt)
 		tfw_ws_cli_mod_timer((TfwCliConn *)conn);
-	}
 
 	return r;
 }

--- a/fw/websocket.h
+++ b/fw/websocket.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2022-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@
 typedef struct tfw_conn_t TfwConn;
 
 int tfw_ws_msg_process(TfwConn *conn, struct sk_buff *skb);
-TfwConn *tfw_ws_srv_new_steal_sk(TfwSrvConn *srv_conn);
+int tfw_http_websocket_upgrade(TfwSrvConn *srv_conn, TfwCliConn *cli_conn);
 void tfw_ws_cli_mod_timer(TfwCliConn *conn);
 
 #endif /* __TFW_WS_H__ */

--- a/fw/work_queue.c
+++ b/fw/work_queue.c
@@ -22,6 +22,7 @@
  * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 #include <linux/percpu.h>
+#include <linux/mm.h>
 #include <linux/slab.h>
 
 #include "work_queue.h"


### PR DESCRIPTION
Fix for #1647 (see commit messages). Now
```
for i in `seq 200`; do ./run_tests.py ws.test_ws_ping.CacheTest.test_ping_websockets; done
```
passes for local tests.