### PR TITLE
Fix warning in dmesg in case of error in frame processing

### DIFF
--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -1903,6 +1903,8 @@ next_msg:
 	}
 
 out:
+	if (r && r != T_POSTPONE)
+		tfw_h2_context_reinit(h2, false);
 	ss_skb_queue_purge(&h2->skb_head);
 	return r;
 }


### PR DESCRIPTION
It is necessary to reinit HTTP/2 framing context in case of error in frame processing.

Closes #1781 #1817