### PR TITLE
Implement parsing Etag without double quotes

### DIFF
--- a/fw/http.h
+++ b/fw/http.h
@@ -313,6 +313,11 @@ enum {
 	TFW_HTTP_B_HDR_LMODIFIED,
 	/* Response is fully processed and ready to be forwarded to the client. */
 	TFW_HTTP_B_RESP_READY,
+	/*
+	 * Response has header 'Etag: ' and this header is
+	 * not enclosed in double quotes.
+	 */
+	TFW_HTTP_B_HDR_ETAG_HAS_NO_QOUTES,
 
 	_TFW_HTTP_FLAGS_NUM
 };

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -256,11 +256,14 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 
 	nlen = hdr_lens[client][id];
 	/*
-	 * Only Host header is allowed to be empty.
+	 * Only Host header is allowed to be empty but because
+	 * we don't follow RFC and allow Etag header to be not
+	 * enclosed in double quotes it also can be empty.
 	 * If header string is plain, it is always empty header.
 	 * Not empty headers are compound strings.
 	 */
-	BUG_ON(id == TFW_HTTP_HDR_HOST ? nlen > hdr->len : nlen >= hdr->len);
+	BUG_ON(id == TFW_HTTP_HDR_HOST
+	       || id == TFW_HTTP_HDR_ETAG ? nlen > hdr->len : nlen >= hdr->len);
 
 	*val = *hdr;
 

--- a/fw/str.h
+++ b/fw/str.h
@@ -237,8 +237,6 @@ basic_stricmp_fast(const BasicStr *s1, const BasicStr *s2)
 #define TFW_STR_HBH_HDR		0x10
 /* Not cachable due to configuration settings or no-cache/private directive */
 #define TFW_STR_NOCCPY_HDR	0x20
-/* Weak identifier was set for Etag value. */
-#define TFW_STR_ETAG_WEAK	0x40
 /*
  * The string/chunk is a header fully indexed in HPACK static
  * table (used only for HTTP/1.1=>HTTP/2 message transformation).

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -2809,7 +2809,7 @@ TEST(http1_parser, etag)
 	"\r\n"                     \
 	"0123456789"
 
-#define FOR_ETAG(header, expected, EXPECT_WEAK)				\
+#define FOR_ETAG(header, expected)				\
 	FOR_RESP(RESP_ETAG_START header "\r\n" RESP_ETAG_END)		\
 	{								\
 		TfwStr h_etag, s_etag;					\
@@ -2820,10 +2820,6 @@ TEST(http1_parser, etag)
 			TFW_HTTP_HDR_ETAG, &h_etag);			\
 		s_etag = tfw_str_next_str_val(&h_etag);			\
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);	\
-		if (!TFW_STR_EMPTY(&s_etag)) {				\
-			EXPECT_WEAK((TFW_STR_CHUNK(&s_etag, 0))->flags &\
-				TFW_STR_ETAG_WEAK);			\
-		}							\
 									\
 		s_etag = tfw_str_next_str_val(&s_etag);			\
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));			\
@@ -2832,12 +2828,12 @@ TEST(http1_parser, etag)
 #define ETAG_BLOCK(header)						\
 	EXPECT_BLOCK_RESP(RESP_ETAG_START header "\r\n" RESP_ETAG_END)
 
-	FOR_ETAG("ETag:   \"dummy\"  ",  "dummy\"", EXPECT_FALSE);
-	FOR_ETAG("ETag:   W/\"dummy\"  ", "dummy\"", EXPECT_TRUE);
-	FOR_ETAG("ETag: \"\" ", "\"", EXPECT_FALSE);
-	FOR_ETAG("ETag: W/\"\"", "\"", EXPECT_TRUE);
-	FOR_ETAG("ETag: \"" ETAG_ALPHABET "\"",  ETAG_ALPHABET "\"", EXPECT_FALSE);
-	FOR_ETAG("ETag: W/\"" ETAG_ALPHABET "\"",  ETAG_ALPHABET "\"", EXPECT_TRUE);
+	FOR_ETAG("ETag:   \"dummy\"  ",  "dummy\"");
+	FOR_ETAG("ETag:   W/\"dummy\"  ", "dummy\"");
+	FOR_ETAG("ETag: \"\" ", "\"");
+	FOR_ETAG("ETag: W/\"\"", "\"");
+	FOR_ETAG("ETag: \"" ETAG_ALPHABET "\"",  ETAG_ALPHABET "\"");
+	FOR_ETAG("ETag: W/\"" ETAG_ALPHABET "\"",  ETAG_ALPHABET "\"");
 
 	/* Same code is used to parse ETag header and If-None-Match header. */
 	ETAG_BLOCK("ETag: \"dummy1\", \"dummy2\"");
@@ -2866,10 +2862,6 @@ TEST(http1_parser, if_none_match)
 
 		s_etag = tfw_str_next_str_val(&h_inm);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
@@ -2885,10 +2877,6 @@ TEST(http1_parser, if_none_match)
 
 		s_etag = tfw_str_next_str_val(&h_inm);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
@@ -2905,17 +2893,9 @@ TEST(http1_parser, if_none_match)
 
 		s_etag = tfw_str_next_str_val(&h_inm);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_1, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_2, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
@@ -2933,24 +2913,12 @@ TEST(http1_parser, if_none_match)
 
 		s_etag = tfw_str_next_str_val(&h_inm);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_1, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_2, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_TRUE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				    & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_3, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -2836,8 +2836,10 @@ TEST(http1_parser, etag)
 	FOR_ETAG("ETag: W/\"" ETAG_ALPHABET "\"",  ETAG_ALPHABET "\"");
 
 	/* Same code is used to parse ETag header and If-None-Match header. */
+	ETAG_BLOCK("Etag: \"dum my\"");
+	ETAG_BLOCK("Etag: \"dummy \"");
+	ETAG_BLOCK("Etag:  *\"");
 	ETAG_BLOCK("ETag: \"dummy1\", \"dummy2\"");
-	ETAG_BLOCK("ETag: *\r\n");
 	COMMON_ETAG_BLOCK("ETag: ", ETAG_BLOCK);
 	ETAG_BLOCK("ETag: \"dummy\"\r\n"
 		       ": \"dummy\"");
@@ -2943,7 +2945,7 @@ TEST(http1_parser, if_none_match)
 	EXPECT_BLOCK_REQ_SIMPLE("If-None-Match: \"" ETAG_2 "\", * ");
 	EXPECT_BLOCK_REQ_SIMPLE("If-None-Match: *, \"" ETAG_2 "\" ");
 
-	COMMON_ETAG_BLOCK("If-None-Match: ", EXPECT_BLOCK_REQ_SIMPLE);
+	COMMON_IF_NON_MATCH_BLOCK("If-None-Match: ", EXPECT_BLOCK_REQ_SIMPLE);
 	EXPECT_BLOCK_REQ_SIMPLE("If-None-Match: \"dummy\"\r\n"
 					     ": \"dummy\"");
 

--- a/fw/t/unit/test_http2_parser.c
+++ b/fw/t/unit/test_http2_parser.c
@@ -1744,10 +1744,6 @@ TEST(http2_parser, if_none_match)
 
 		s_etag = tfw_str_next_str_val(&h_inm);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
@@ -1763,10 +1759,6 @@ TEST(http2_parser, if_none_match)
 
 		s_etag = tfw_str_next_str_val(&h_inm);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
@@ -1783,17 +1775,9 @@ TEST(http2_parser, if_none_match)
 
 		s_etag = tfw_str_next_str_val(&h_inm);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_1, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_2, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));
@@ -1811,24 +1795,12 @@ TEST(http2_parser, if_none_match)
 
 		s_etag = tfw_str_next_str_val(&h_inm);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_1, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_2, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_TRUE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				    & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_EQ(tfw_strcmpspn(&s_etag, &exp_etag_3, '"'), 0);
-		if (!TFW_STR_EMPTY(&s_etag)) {
-			EXPECT_FALSE((TFW_STR_CHUNK(&s_etag, 0))->flags
-				     & TFW_STR_ETAG_WEAK);
-		}
 
 		s_etag = tfw_str_next_str_val(&s_etag);
 		EXPECT_TRUE(TFW_STR_EMPTY(&s_etag));

--- a/fw/t/unit/test_http_parser_common.h
+++ b/fw/t/unit/test_http_parser_common.h
@@ -89,10 +89,9 @@ enum {
 	BLOCK_MACRO(head "4294967295" tail)
 
 /* For ETag and If-None-Match headers */
-#define COMMON_ETAG_BLOCK(head, BLOCK_MACRO)			\
+#define __COMMON_ETAG_IF_NONE_MATCH_BLOCK(head, BLOCK_MACRO)	\
 	BLOCK_MACRO(head "\"dummy");				\
 	BLOCK_MACRO(head "dummy\"");				\
-	BLOCK_MACRO(head "'dummy'");				\
 	BLOCK_MACRO(head "W/ \"dummy\"");			\
 	BLOCK_MACRO(head "w/\"dummy\"");			\
 	BLOCK_MACRO(head "\"\x00\"");				\
@@ -100,6 +99,13 @@ enum {
 	BLOCK_MACRO(head "\"\x7F\"");				\
 	BLOCK_MACRO(head "\" \"");				\
 	BLOCK_MACRO(head "\"\"\"")
+
+#define COMMON_ETAG_BLOCK(head, BLOCK_MACRO)			\
+	__COMMON_ETAG_IF_NONE_MATCH_BLOCK(head, BLOCK_MACRO)
+
+#define COMMON_IF_NON_MATCH_BLOCK(head, BLOCK_MACRO)		\
+	BLOCK_MACRO(head "'dummy'");				\
+	__COMMON_ETAG_IF_NONE_MATCH_BLOCK(head, BLOCK_MACRO)
 
 /**
  * Reference to a frame of bytes containing the request data to be parsed.


### PR DESCRIPTION
According to RFC #7232 Etag should be enclosed in
double quotes, but unfortunately many do not follow RFC and send Etag without double quotes (wordpress for example). Implement parsing of such Etag values.

Closes: #1813