### PR TITLE
Fixed framing error for resposnses received from cache with header modification

### DIFF
--- a/db/core/main.c
+++ b/db/core/main.c
@@ -90,7 +90,7 @@ tdb_entry_get_room(TDB *db, TdbVRec **r, char *curr_ptr, size_t tail_len,
 	if (likely((*r)->data + (*r)->len - curr_ptr >= tail_len))
 		return curr_ptr;
 
-	(*r)->len -= curr_ptr - (*r)->data;
+	(*r)->len = curr_ptr - (*r)->data;
 
 	*r = tdb_htrie_extend_rec(db->hdr, *r, tot_size);
 	return *r ? (*r)->data : NULL;

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -189,6 +189,7 @@ __tfw_dbg_dump_ce(const TfwCacheEntry *ce)
  * @flags	- TFW_CSTR_DUPLICATE and TFW_CSTR_HPACK_IDX or zero;
  * @name_len	- Header name length. Used for raw headers;
  * @name_len_sz	- HPACK int size of @name_len;
+ * @len		- Total string length or number of duplicates;
  * @idx		- HPACK static index or index of special header;
  */
 typedef struct {

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -798,7 +798,6 @@ tfw_cache_skip_hdr(const TfwCStr *str, char *p, const TfwHdrMods *h_mods)
 	}
 
 	for (i = h_mods->spec_num; i < h_mods->sz; ++i) {
-		int cmplen;
 		char* mod_hdr_name;
 		size_t mod_hdr_len;
 
@@ -808,9 +807,8 @@ tfw_cache_skip_hdr(const TfwCStr *str, char *p, const TfwHdrMods *h_mods)
 			continue;
 
 		mod_hdr_name = TFW_STR_CHUNK(desc->hdr, 0)->data;
-		cmplen = min(hdr.len, mod_hdr_len);
 
-		if (!tfw_cstricmp(hdr.data, mod_hdr_name, cmplen))
+		if (!tfw_cstricmp(hdr.data, mod_hdr_name, hdr.len))
 			return true;
 	}
 

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -692,9 +692,7 @@ tfw_cache_h2_decode_write(TDB *db, TdbVRec **trec, TfwHttpResp *resp,
 		acc += m_len;
 		*data += m_len;
 		if (acc == len) {
-			bzero_fast(dc_iter->__off,
-				   sizeof(*dc_iter)
-				   - offsetof(TfwDecodeCacheIter, __off));
+			TFW_STR_INIT(&dc_iter->hdr_data);
 			break;
 		}
 

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -837,7 +837,7 @@ tfw_cache_build_resp_hdr(TDB *db, TfwHttpResp *resp, TfwHdrMods *hmods,
 	tfw_cache_write_actor_t *write_actor;
 	TfwCStr *s = (TfwCStr *)*p;
 	TfwHttpReq *req = resp->req;
-	TfwDecodeCacheIter dc_iter = { .h_mods = hmods, .skip = skip};
+	TfwDecodeCacheIter dc_iter = { .h_mods = hmods, .skip = skip };
 	int d, dn, r = 0;
 
 	BUG_ON(!req);

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -797,11 +797,19 @@ tfw_cache_skip_hdr(const TfwCStr *str, char *p, const TfwHdrMods *h_mods)
 	}
 
 	for (i = h_mods->spec_num; i < h_mods->sz; ++i) {
+		int cmplen;
+		char* mod_hdr_name;
+		size_t mod_hdr_len;
+
 		desc = &h_mods->hdrs[i];
-		if (desc->append)
+		mod_hdr_len = TFW_STR_CHUNK(desc->hdr, 0)->len;
+		if (desc->append || mod_hdr_len != hdr.len)
 			continue;
 
-		if (!__hdr_name_cmp(&hdr, desc->hdr))
+		mod_hdr_name = TFW_STR_CHUNK(desc->hdr, 0)->data;
+		cmplen = min(hdr.len, mod_hdr_len);
+
+		if (!tfw_cstricmp(hdr.data, mod_hdr_name, cmplen))
 			return true;
 	}
 

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -783,19 +783,10 @@ tfw_cache_skip_hdr(TfwCStr *str, char *p, const TfwHdrMods *h_mods)
 	if (str->idx) {
 		unsigned short hpack_idx = str->idx;
 
-		if (hpack_idx <= HPACK_S_TABLE_REGULAR)
+		if (hpack_idx <= HPACK_STATIC_TABLE_REGULAR)
 			return false;
 
-		for (i = h_mods->spec_num; i < h_mods->sz; ++i) {
-			desc = &h_mods->hdrs[i];
-			if (desc->append)
-				continue;
-
-			if (desc->hdr->hpack_idx == hpack_idx)
-				return true;
-		}
-
-		return false;
+		return test_bit(hpack_idx, h_mods->s_tbl);
 	}
 
 	p++;

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -192,7 +192,7 @@ tfw_hpack_find_hdr_idx(const TfwStr *hdr)
 	fc = tolower(*(unsigned char *)(TFW_STR_CHUNK(h, 0)->data));
 
 	while (start < end) {
-		unsigned short mid = start + (end - start) / 2;
+		unsigned short mid = (start + end) / 2;
 		const TfwStr *sh = static_table[mid].hdr;
 		int sc = *(unsigned char *)sh->chunks->data;
 

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -129,8 +129,6 @@ static const TfwHPackEntry static_table[] ____cacheline_aligned = {
 	HP_ENTRY_NAME("www-authenticate",	TFW_TAG_HDR_RAW)
 };
 
-#define HPACK_STATIC_ENTRIES (sizeof(static_table) / sizeof(static_table[0]))
-
 /*
  * Estimated overhead associated with an encoder/decoder index entry (see
  * RFC 7541 section 4.1 for details).
@@ -182,7 +180,7 @@ do {								\
 unsigned short
 tfw_hpack_find_hdr_idx(const TfwStr *hdr)
 {
-	unsigned short start = HPACK_S_TABLE_REGULAR,
+	unsigned short start = HPACK_STATIC_TABLE_REGULAR,
 		       end = ARRAY_SIZE(static_table);
 	int result, fc;
 	const TfwStr *h;
@@ -1101,6 +1099,8 @@ tfw_hpack_init(TfwHPack *__restrict hp, unsigned int htbl_sz)
 	TfwHPackETbl *et = &hp->enc_tbl;
 	TfwHPackDTbl *dt = &hp->dec_tbl;
 
+	BUILD_BUG_ON((sizeof(static_table) / sizeof(static_table[0])) !=
+		HPACK_STATIC_ENTRIES);
 	BUILD_BUG_ON(sizeof(TfwHPackNode) > HPACK_ENTRY_OVERHEAD
 		     || HPACK_ENC_TABLE_MAX_SIZE > SHRT_MAX);
 

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -219,7 +219,7 @@ tfw_hpack_find_hdr_idx(const TfwStr *hdr)
  * variable-length integer greater than defined limit, this is the malformed
  * request and we should drop the parsing process.
  */
-#define GET_FLEXIBLE_lambda(x, new_state, lambda)		\
+#define GET_FLEXIBLE(x, new_state)				\
 do {								\
 	unsigned int __m = 0;					\
 	unsigned int __c;					\
@@ -227,7 +227,6 @@ do {								\
 		if (src >= last) {				\
 			hp->shift = __m;			\
 			NEXT_STATE(new_state);			\
-			lambda;					\
 			goto out;				\
 		}						\
 		__c = *src++;					\
@@ -240,14 +239,11 @@ do {								\
 	} while (__c > 127);					\
 } while (0)
 
-#define GET_FLEXIBLE(x, new_state)				\
-	GET_FLEXIBLE_lambda(x, new_state, {})
-
 /* Continue decoding after interruption due to absence of the next fragment.
  * If the variable-length integer greater than defined limit, this is the
  * malformed request and we should drop the parsing process.
  */
-#define GET_CONTINUE_lambda(x, lambda)				\
+#define GET_CONTINUE(x)						\
 do {								\
 	unsigned int __m = hp->shift;				\
 	unsigned int __c = *src++;				\
@@ -261,7 +257,6 @@ do {								\
 	while (__c > 127) {					\
 		if (src >= last) {				\
 			hp->shift = __m;			\
-			lambda;					\
 			goto out;				\
 		}						\
 		__c = *src++;					\
@@ -272,11 +267,7 @@ do {								\
 			goto out;				\
 		}						\
 	}							\
-	lambda;							\
 } while (0)
-
-#define GET_CONTINUE(x)						\
-	GET_CONTINUE_lambda(x, {})
 
 #define SET_NEXT()						\
 do {								\

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -262,21 +262,15 @@ typedef struct {
  * @skip	- flag to skip particular cached data in order to switch
  *		  between HTTP/2 and HTTP/1.1 resulting representation during
  *		  decoding from HTTP/2-cache;
- * @__off	- offset to reinitialize the iterator non-persistent part;
- * @desc	- pointer to the found header configured to be changed;
  * @acc_len	- accumulated length of the resulting headers part of the
  *		  response;
  * @hdr_data	- header's data currently received from cache;
- * @h2_data	- HTTP/2-specific data currently received from cache.
  */
 typedef struct {
 	TfwHdrMods		*h_mods;
 	bool			skip;
-	char			__off[0];
-	TfwHdrModsDesc		*desc;
 	unsigned long		acc_len;
 	TfwStr			hdr_data;
-	TfwStr			h2_data;
 } TfwDecodeCacheIter;
 
 #define	BUFFER_GET(len, it)					\

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -33,8 +33,11 @@
 /* Limit for the HPACK variable-length integer. */
 #define HPACK_INT_LIMIT			(1 << 20)
 
+/* Static table size. Defined by RFC 7541. */
+#define HPACK_STATIC_ENTRIES		61
+
 /* Static table offset where starts regular headers (not pseudo-headers) */
-#define HPACK_S_TABLE_REGULAR		14
+#define HPACK_STATIC_TABLE_REGULAR	14
 /**
  * Red-black tree node representation in the ring buffer.
  * Note, the field @hdr_len use only 15 bits and the 16th bit of unsigned

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -326,26 +326,5 @@ tfw_hpack_int_size(unsigned long index, unsigned short max)
 
 	return size;
 }
-
-static inline int
-tfw_hpack_decode_int(char **p, const char *last, unsigned int *val)
-{
-	char *src = *p;
-	unsigned int c, m = 0;
-
-	do {
-		if (src >= last)
-			return 0;
-		c = *src++;
-		*val += (c & 127) << m;
-		m += 7;
-		if (*val > HPACK_INT_LIMIT)
-			return -EINVAL;
-	} while (c > 127);
-
-	*p = src;
-
-	return 0;
-}
 unsigned short tfw_hpack_find_hdr_idx(const TfwStr *hdr);
 #endif /* __TFW_HPACK_H__ */

--- a/fw/http.c
+++ b/fw/http.c
@@ -4622,12 +4622,15 @@ tfw_h2_hdr_sub(unsigned short hid, const TfwStr *hdr, const TfwHdrMods *h_mods)
 		return desc ? !desc->append : false;
 	}
 
-	for (idx = h_mods->spec_num; idx < h_mods->sz; ++idx) {
+	if (hdr->hpack_idx > 0) {
 		/* Don't touch pseudo-headers. */
-		if (hdr->hpack_idx > 0
-		    && hdr->hpack_idx <= HPACK_S_TABLE_REGULAR)
+		if (hdr->hpack_idx <= HPACK_STATIC_TABLE_REGULAR)
 			return false;
 
+		return test_bit(hdr->hpack_idx, h_mods->s_tbl);
+	}
+
+	for (idx = h_mods->spec_num; idx < h_mods->sz; ++idx) {
 		desc = &h_mods->hdrs[idx];
 		if (!desc->append && !__hdr_name_cmp(hdr, desc->hdr))
 			return true;

--- a/fw/http.c
+++ b/fw/http.c
@@ -3342,7 +3342,7 @@ tfw_h1_set_loc_hdrs(TfwHttpMsg *hm, bool is_resp, bool from_cache)
 			 * processed it during cache reading, or if the header
 			 * is configured for deletion (without value chunk).
 			 */
-			if (test_bit(i, mit->found) || h_mdf.nchunks < 3)
+			if (h_mdf.nchunks < 3)
 				continue;
 			/* h_mdf->eolen is ignored, add explicit CRLF. */
 			r = tfw_http_msg_expand_data(&mit->iter, skb_head,
@@ -4576,7 +4576,6 @@ tfw_h2_resp_add_loc_hdrs(TfwHttpResp *resp, const TfwHdrMods *h_mods,
 			 bool cache)
 {
 	unsigned int i;
-	TfwHttpTransIter *mit = &resp->mit;
 	TfwHttpHdrTbl *ht = resp->h_tbl;
 
 	if (!h_mods)
@@ -4588,8 +4587,7 @@ tfw_h2_resp_add_loc_hdrs(TfwHttpResp *resp, const TfwHdrMods *h_mods,
 		unsigned short hid = desc->hid;
 
 		/* FIXME: this is a temporary WA for GCC12, see #1695 for details */
-		if (test_bit(i, mit->found)
-		    || (TFW_STR_CHUNK(desc->hdr, 1) == NULL))
+		if (TFW_STR_CHUNK(desc->hdr, 1) == NULL)
 			continue;
 
 		if (unlikely(desc->append && !TFW_STR_EMPTY(&ht->tbl[hid])
@@ -4612,19 +4610,27 @@ static bool
 tfw_h2_hdr_sub(unsigned short hid, const TfwStr *hdr, const TfwHdrMods *h_mods)
 {
 	unsigned int idx;
+	const TfwHdrModsDesc *desc;
 
 	if (!h_mods)
 		return false;
 
-	for (idx = 0; idx < h_mods->sz; ++idx) {
-		TfwHdrModsDesc *desc = &h_mods->hdrs[idx];
+	/* Fast path for special headers */
+	if (hid >= TFW_HTTP_HDR_REGULAR && hid < TFW_HTTP_HDR_RAW) {
+		desc = h_mods->spec_hdrs[hid];
+		/* Skip only resp_hdr_set headers */
+		return desc ? !desc->append : false;
+	}
 
-		if (!desc->append && ((hid >= TFW_HTTP_HDR_RAW
-				       && !__hdr_name_cmp(hdr, desc->hdr))
-				      || hid == desc->hid))
-		{
+	for (idx = h_mods->spec_num; idx < h_mods->sz; ++idx) {
+		/* Don't touch pseudo-headers. */
+		if (hdr->hpack_idx > 0
+		    && hdr->hpack_idx <= HPACK_S_TABLE_REGULAR)
+			return false;
+
+		desc = &h_mods->hdrs[idx];
+		if (!desc->append && !__hdr_name_cmp(hdr, desc->hdr))
 			return true;
-		}
 	}
 
 	return false;

--- a/fw/http.c
+++ b/fw/http.c
@@ -3338,9 +3338,8 @@ tfw_h1_set_loc_hdrs(TfwHttpMsg *hm, bool is_resp, bool from_cache)
 			TfwHttpTransIter *mit = &resp->mit;
 			TfwStr crlf = { .data = S_CRLF, .len = SLEN(S_CRLF) };
 			/*
-			 * Skip the configured header if we have already
-			 * processed it during cache reading, or if the header
-			 * is configured for deletion (without value chunk).
+			 * Skip the configured header if the header is
+			 * configured for deletion (without value chunk).
 			 */
 			if (h_mdf.nchunks < 3)
 				continue;

--- a/fw/http.h
+++ b/fw/http.h
@@ -533,7 +533,6 @@ typedef struct {
  * @map		- indirection map for tracking headers order in skb;
  * @start_off	- initial offset during copying response data into
  *		  skb (for subsequent insertion of HTTP/2 frame header);
- * @found	- bit mask of configured headers found in the message.
  * @curr_ptr	- pointer in the skb to write the current header;
  * @frame_head	- pointer to reserved space for frame header. Used during
  * 		  http2 framing. Simplifies framing of paged SKBs.
@@ -544,7 +543,6 @@ typedef struct {
 typedef struct {
 	TfwHttpHdrMap	*map;
 	unsigned int	start_off;
-	DECLARE_BITMAP	(found, TFW_USRHDRS_ARRAY_SZ);
 	char		*curr_ptr;
 	char		*frame_head;
 	TfwMsgIter	iter;

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -32,6 +32,9 @@
 #include "hpack.h"
 #include "lib/str.h"
 
+/* Max length of http header name. */
+#define HTTP_MAX_HDR_NAME_LEN		1024
+
 /*
  * ------------------------------------------------------------------------
  *	Common HTTP parsing routines
@@ -1544,6 +1547,11 @@ __FSM_STATE(RGen_HdrOtherN) {						\
 			TFW_PARSER_BLOCK(RGen_HdrOtherN);		\
 		}							\
 		__msg_hdr_chunk_fixup(data, __data_off(p + __fsm_sz));	\
+		if (unlikely(parser->hdr.len > HTTP_MAX_HDR_NAME_LEN)) {\
+			T_WARN("Max header name length %u exceeded.",	\
+			       HTTP_MAX_HDR_NAME_LEN);			\
+			return TFW_BLOCK;				\
+		}							\
 		parser->_i_st = &&RGen_HdrOtherV;			\
 		p += __fsm_sz;						\
 		__FSM_MOVE_hdr_fixup(RGen_LWS, 1);			\
@@ -9621,6 +9629,12 @@ tfw_h2_parse_req_hdr(unsigned char *data, unsigned long len, TfwHttpReq *req,
 		 * previous states trying known header names.
 		 */
 		__msg_hdr_chunk_fixup(data, len);
+		if (unlikely(parser->hdr.len > HTTP_MAX_HDR_NAME_LEN)) {
+			T_WARN("Max header name length %u exceeded.",
+			       HTTP_MAX_HDR_NAME_LEN);
+			ret = T_DROP;
+			goto out;
+		}
 		if (unlikely(!fin))
 			__FSM_H2_POSTPONE(RGen_HdrOtherN);
 		it->tag = TFW_TAG_HDR_RAW;

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -19,6 +19,7 @@
  */
 #include <linux/hashtable.h>
 #include <linux/slab.h>
+#include <linux/sort.h>
 
 #undef DEBUG
 #if DBG_VHOST > 0
@@ -753,20 +754,33 @@ tfw_cfgop_mod_hdr_add(TfwLocation *loc, const char *name, const char *value,
 	TfwHdrMods *h_mods = &loc->mod_hdrs[mod_type];
 	TfwHdrModsDesc *desc = &h_mods->hdrs[h_mods->sz];
 
-	if (h_mods->sz == TFW_USRHDRS_ARRAY_SZ) {
+	if (unlikely(h_mods->sz == TFW_USRHDRS_ARRAY_SZ)) {
 		T_WARN_NL("Too lot of custom headers, %d supported.\n",
 			  TFW_USRHDRS_ARRAY_SZ);
 		return -EINVAL;
 	}
+
 	if (!(hdr = tfw_http_msg_make_hdr(loc->hdrs_pool, name, value))) {
 		T_WARN_NL("Can't create header.\n");
 		return -ENOMEM;
 	}
-	desc->hdr = hdr;
-	desc->append = append;
+
 	desc->hid = (mod_type == TFW_VHOST_HDRMOD_RESP)
 			? tfw_http_msg_resp_spec_hid(TFW_STR_CHUNK(hdr, 0))
 			: tfw_http_msg_req_spec_hid(TFW_STR_CHUNK(hdr, 0));
+
+	if (desc->hid < TFW_HTTP_HDR_RAW) {
+		if (h_mods->spec_hdrs[desc->hid]) {
+			T_WARN_NL("Duplicated header modification.\n");
+			return -EINVAL;
+		}
+		h_mods->spec_hdrs[desc->hid] = desc;
+		++h_mods->spec_num;
+	}
+
+	hdr->hpack_idx = tfw_hpack_find_hdr_idx(TFW_STR_CHUNK(hdr, 0));
+	desc->hdr = hdr;
+	desc->append = append;
 	++h_mods->sz;
 
 	return 0;
@@ -904,6 +918,28 @@ tfw_cfgop_out_resp_hdr_set(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	return tfw_cfgop_mod_hdr(cs, ce,
 				 tfw_vhosts_reconfig->vhost_dflt->loc_dflt,
 				 TFW_VHOST_HDRMOD_RESP, false);
+}
+
+static int
+tfw_mod_hdr_cmp(const void *l, const void *r)
+{
+	TfwHdrModsDesc *desc_l = (TfwHdrModsDesc *)l;
+	TfwHdrModsDesc *desc_r = (TfwHdrModsDesc *)r;
+
+	return (int)desc_l->hid - (int)desc_r->hid;
+}
+
+static void
+tfw_mod_hdr_sort(TfwLocation *loc)
+{
+	unsigned short type;
+
+	for (type = 0; type < TFW_VHOST_HDRMOD_NUM; type++) {
+		TfwHdrMods *h_mods = &loc->mod_hdrs[type];
+
+		sort(h_mods->hdrs, h_mods->sz, sizeof(h_mods->hdrs[0]),
+		     tfw_mod_hdr_cmp, NULL);
+	}
 }
 
 /*
@@ -1313,7 +1349,8 @@ tfw_location_init(TfwLocation *loc, tfw_match_t op, const char *arg,
 	size_t size = sizeof(FrangVhostCfg)
 		    + sizeof(TfwCaPolicy *) * TFW_CAPOLICY_ARRAY_SZ
 		    + sizeof(TfwNipDef *) * TFW_NIPDEF_ARRAY_SZ
-		    + sizeof(TfwHdrModsDesc) * TFW_USRHDRS_ARRAY_SZ * 2;
+		    + sizeof(TfwHdrModsDesc) * TFW_USRHDRS_ARRAY_SZ * 2
+		    + sizeof(TfwHdrModsDesc *) * TFW_HTTP_HDR_RAW * 2;
 
 	if ((argmem = kmalloc(len + 1, GFP_KERNEL)) == NULL)
 		return -ENOMEM;
@@ -1336,9 +1373,20 @@ tfw_location_init(TfwLocation *loc, tfw_match_t op, const char *arg,
 	loc->nipdef_sz = 0;
 	loc->hdrs_pool = pool;
 	loc->mod_hdrs[TFW_VHOST_HDRMOD_REQ].hdrs =
-			(TfwHdrModsDesc *)(loc->nipdef + TFW_NIPDEF_ARRAY_SZ);
+		(TfwHdrModsDesc *)(loc->nipdef + TFW_NIPDEF_ARRAY_SZ);
+
+	loc->mod_hdrs[TFW_VHOST_HDRMOD_REQ].spec_hdrs =
+		(TfwHdrModsDesc **)(loc->mod_hdrs[TFW_VHOST_HDRMOD_REQ].hdrs
+				    + TFW_USRHDRS_ARRAY_SZ);
+
 	loc->mod_hdrs[TFW_VHOST_HDRMOD_RESP].hdrs =
-			loc->mod_hdrs[TFW_VHOST_HDRMOD_REQ].hdrs + TFW_USRHDRS_ARRAY_SZ;
+		(TfwHdrModsDesc *)(loc->mod_hdrs[TFW_VHOST_HDRMOD_REQ].spec_hdrs
+				   + TFW_HTTP_HDR_RAW);
+
+	loc->mod_hdrs[TFW_VHOST_HDRMOD_RESP].spec_hdrs =
+		(TfwHdrModsDesc **)(loc->mod_hdrs[TFW_VHOST_HDRMOD_RESP].hdrs
+				    + TFW_USRHDRS_ARRAY_SZ);
+
 	memcpy((void *)loc->arg, (void *)arg, len + 1);
 
 	return 0;
@@ -1473,6 +1521,7 @@ tfw_cfgop_out_location_finish(TfwCfgSpec *cs)
 {
 	BUG_ON(tfw_vhost_entry);
 	BUG_ON(!tfwcfg_this_location);
+	tfw_mod_hdr_sort(tfwcfg_this_location);
 	tfwcfg_this_location = NULL;
 	return 0;
 }
@@ -2543,7 +2592,7 @@ tfw_cfgop_vhost_begin(TfwCfgSpec *cs, TfwCfgEntry *ce)
 static int
 tfw_cfgop_vhost_finish(TfwCfgSpec *cs)
 {
-	int r;
+	int r, i;
 
 	BUG_ON(!tfw_vhost_entry);
 	if (!tfw_vhost_entry->loc_dflt->main_sg) {
@@ -2553,6 +2602,12 @@ tfw_cfgop_vhost_finish(TfwCfgSpec *cs)
 			 tfw_vhost_entry->name.data);
 		return -EINVAL;
 	}
+
+	for (i = 0; i < tfw_vhost_entry->loc_sz; i++)
+		tfw_mod_hdr_sort(tfw_vhost_entry->loc + i);
+
+	tfw_mod_hdr_sort(tfw_vhost_entry->loc_dflt);
+
 	if ((r = tfw_tls_cert_cfg_finish(tfw_vhost_entry)))
 		return r;
 	if ((r = tfw_http_sess_cfg_finish(tfw_vhost_entry)))

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -782,6 +782,8 @@ tfw_cfgop_mod_hdr_add(TfwLocation *loc, const char *name, const char *value,
 	desc->hdr = hdr;
 	desc->append = append;
 	++h_mods->sz;
+	if (!append)
+		set_bit(hdr->hpack_idx, h_mods->s_tbl);
 
 	return 0;
 }

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -102,12 +102,15 @@ struct tfw_hdr_mods_desc_t {
  * @spec_num	- Number of special headers to modify;
  * @hdrs	- Headers to modify;
  * @spec_hdrs	- Lookup table of special headers;
+ * @s_tbl	- Bitmap of headers from static table. Static table index
+ * 		  equals to bit number of the bitmap;
  */
 struct tfw_hdr_mods_t {
 	size_t		sz;
 	size_t		spec_num;
 	TfwHdrModsDesc	*hdrs;
 	TfwHdrModsDesc	**spec_hdrs;
+	DECLARE_BITMAP	(s_tbl, HPACK_STATIC_ENTRIES);
 };
 
 enum {

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -98,12 +98,16 @@ struct tfw_hdr_mods_desc_t {
 /**
  * Headers modification before forwarding HTTP message.
  *
- * @sz		- Number of headers to modify;
+ * @sz		- Total number of headers to modify;
+ * @spec_num	- Number of special headers to modify;
  * @hdrs	- Headers to modify;
+ * @spec_hdrs	- Lookup table of special headers;
  */
 struct tfw_hdr_mods_t {
 	size_t		sz;
+	size_t		spec_num;
 	TfwHdrModsDesc	*hdrs;
+	TfwHdrModsDesc	**spec_hdrs;
 };
 
 enum {

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -106,8 +106,8 @@ struct tfw_hdr_mods_desc_t {
  * 		  equals to bit number of the bitmap;
  */
 struct tfw_hdr_mods_t {
-	size_t		sz;
-	size_t		spec_num;
+	unsigned int	sz;
+	unsigned int	spec_num;
 	TfwHdrModsDesc	*hdrs;
 	TfwHdrModsDesc	**spec_hdrs;
 	DECLARE_BITMAP	(s_tbl, HPACK_STATIC_ENTRIES);


### PR DESCRIPTION
tfw_hpack_cache_decode_expand: fixed http2 framing. However, function looks overcomplicated and combines http1 and http2 related logic.

tfw_cache_h2_decode_write: after decoding header part of `TfwDecodeCacheIter` was cleared including `acc_len` and
because of this caller of `tfw_cache_h2_decode_write` couldn't receive a total length of header. Fixed by clearing only `hdr_data` and `h2_data`.

Removed `__off` from `TfwDecodeCacheIter`, because we need to clear only two last members in this structure and it can be done via inner struct.

Removed `desc` from `TfwDecodeCacheIter`. It's not used.