### PR TITLE
HTTP2: account for :status headers field when sending 304 response

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -850,6 +850,7 @@ tfw_cache_send_304(TfwHttpReq *req, TfwCacheEntry *ce)
 					     true);
 		if (unlikely(r))
 			goto err_setup;
+		h_len++;	/* account for :status field itself */
 	}
 
 	/* Put 304 headers */


### PR DESCRIPTION
We were missing on updating `h_len` variable (which accounts for total headers block length) in `tfw_cache_send_304` function. The fix isn't elegant, but would do the work.
I couldn't figure out if interface of `tfw_h2_resp_status_write` should be updated in order to handle externally passed length field.

I would also be grateful if someone could inspect following uses of `tfw_h2_resp_status_write` to make sure if said code needs related updates too:
- https://github.com/tempesta-tech/tempesta/blob/dp-1814-malformed-http-304/fw/http.c#L585
- https://github.com/tempesta-tech/tempesta/blob/dp-1814-malformed-http-304/fw/http.c#L5417