### PR TITLE
Correctly set TFW_HTTP_B_ACCEPT_HTML bit in req->flags from hpack

### DIFF
--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1306,6 +1306,12 @@ done:
 		break;
 	case TFW_TAG_HDR_IF_NONE_MATCH:
 		parser->_hdr_tag = TFW_HTTP_HDR_IF_NONE_MATCH;
+		/* Prefer IF_NONE_MATCH over IF_MSINCE like in
+		 * __h2_req_parse_if_nmatch */
+		if (req->cond.flags & TFW_HTTP_COND_IF_MSINCE) {
+			req->cond.m_date = 0;
+			req->cond.flags &= ~TFW_HTTP_COND_IF_MSINCE;
+		}
 		break;
 	case TFW_TAG_HDR_PRAGMA:
 		parser->_hdr_tag = TFW_HTTP_HDR_RAW;

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1312,6 +1312,7 @@ done:
 			req->cond.m_date = 0;
 			req->cond.flags &= ~TFW_HTTP_COND_IF_MSINCE;
 		}
+		h2_set_hdr_if_nmatch(req, &entry->cstate);
 		break;
 	case TFW_TAG_HDR_PRAGMA:
 		parser->_hdr_tag = TFW_HTTP_HDR_RAW;

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1301,7 +1301,8 @@ done:
 		break;
 	case TFW_TAG_HDR_IF_MODIFIED_SINCE:
 		parser->_hdr_tag = TFW_HTTP_HDR_RAW;
-		h2_set_hdr_if_mod_since(req, &entry->cstate);
+		if (h2_set_hdr_if_mod_since(req, &entry->cstate))
+			return T_DROP;
 		break;
 	case TFW_TAG_HDR_IF_NONE_MATCH:
 		parser->_hdr_tag = TFW_HTTP_HDR_IF_NONE_MATCH;
@@ -1361,6 +1362,7 @@ tfw_hpack_decode(TfwHPack *__restrict hp, unsigned char *__restrict src,
 		case HPACK_STATE_READY:
 		{
 			unsigned char c = *src++;
+			req->stream->parser.cstate.is_set = 0;
 
 			if (c & 0x80) { /* RFC 7541 6.1 */
 				T_DBG3("%s: > Indexed Header Field\n", __func__);

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1179,6 +1179,7 @@ tfw_hpack_hdr_set(TfwHPack *__restrict hp, TfwHttpReq *__restrict req,
 		  const TfwHPackEntry *__restrict entry)
 {
 	char *data;
+	unsigned int i;
 	unsigned long d_size;
 	TfwMsgParseIter *it = &req->pit;
 	const TfwStr *s, *end, *s_hdr = entry->hdr;
@@ -1269,6 +1270,13 @@ done:
 		break;
 	case TFW_TAG_HDR_ACCEPT:
 		parser->_hdr_tag = TFW_HTTP_HDR_RAW;
+		for (i = 1, d = d_hdr->chunks; i < d_hdr->nchunks; i++) {
+			if (d[i].len == sizeof("text/html") - 1
+			    && memcmp_fast(d[i].data, "text/html",
+					   sizeof("text/html") - 1) == 0) {
+				__set_bit(TFW_HTTP_B_ACCEPT_HTML, req->flags);
+			}
+		}
 		break;
 	case TFW_TAG_HDR_AUTHORIZATION:
 		parser->_hdr_tag = TFW_HTTP_HDR_RAW;

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1265,6 +1265,7 @@ done:
 		break;
 	case TFW_TAG_HDR_H2_AUTHORITY:
 		parser->_hdr_tag = TFW_HTTP_HDR_H2_AUTHORITY;
+		h2_set_hdr_authority(req, &entry->cstate);
 		break;
 	case TFW_TAG_HDR_H2_PATH:
 		parser->_hdr_tag = TFW_HTTP_HDR_H2_PATH;
@@ -1296,10 +1297,7 @@ done:
 		break;
 	case TFW_TAG_HDR_HOST:
 		parser->_hdr_tag = TFW_HTTP_HDR_HOST;
-		/* We need to parse port part of the header again
-		 * to fill @req->host_port
-		 */
-		tfw_idx_hdr_parse_host_port(req, entry->hdr);
+		h2_set_hdr_authority(req, &entry->cstate);
 		break;
 	case TFW_TAG_HDR_IF_MODIFIED_SINCE:
 		parser->_hdr_tag = TFW_HTTP_HDR_RAW;

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1303,10 +1303,7 @@ done:
 		break;
 	case TFW_TAG_HDR_IF_MODIFIED_SINCE:
 		parser->_hdr_tag = TFW_HTTP_HDR_RAW;
-		/* When 'if-modified-since' hdr is taken from HPACK dyn table,
-		 * we need to parse date once again to fill @req->cond.m_date.
-		 */
-		tfw_idx_hdr_parse_if_mod_since(req, entry->hdr);
+		h2_set_hdr_if_mod_since(req, &entry->cstate);
 		break;
 	case TFW_TAG_HDR_IF_NONE_MATCH:
 		parser->_hdr_tag = TFW_HTTP_HDR_IF_NONE_MATCH;

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -150,6 +150,24 @@ typedef enum {
 } TfwHPackTag;
 
 /**
+ * This strucutre holds reusable parsed information from different HTTP
+ * headers.
+ *
+ * @is_set	- boolean flag indicating that the state is set
+ */
+typedef struct {
+	union {
+		struct {
+			unsigned char	    text_html;
+		} hdr_accept;
+		struct {
+			long		    date;
+		} hdr_if_msince;
+	};
+	unsigned char		is_set;
+} TfwCachedHeaderState;
+
+/**
  * Representation of the entry in HPack decoder index.
  *
  * @hdr		- pointer to the header data descriptor;
@@ -158,6 +176,8 @@ typedef enum {
  * @tag		- tag of the indexed header;
  * @last	- flag bit indicating that corresponding header is the last on
  *		  the page.
+ * @cstate	- part of the parser state for reusage with headers
+ *		  stored in hpack dynamic table without re-parsing them.
  */
 typedef struct {
 	TfwStr			*hdr;
@@ -165,6 +185,7 @@ typedef struct {
 	unsigned long		name_num;
 	unsigned int		tag;
 	unsigned char		last : 1;
+	TfwCachedHeaderState	cstate;
 } TfwHPackEntry;
 
 /**

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -163,6 +163,9 @@ typedef struct {
 		struct {
 			long		    date;
 		} hdr_if_msince;
+		struct {
+			unsigned long	    port;
+		} hdr_authority;
 	};
 	unsigned char		is_set;
 } TfwCachedHeaderState;

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -157,15 +157,10 @@ typedef enum {
  */
 typedef struct {
 	union {
-		struct {
-			unsigned char	    text_html;
-		} hdr_accept;
-		struct {
-			long		    date;
-		} hdr_if_msince;
-		struct {
-			unsigned long	    port;
-		} hdr_authority;
+		unsigned char	    accept_text_html;
+		long		    if_msince_date;
+		unsigned long	    authority_port;
+		unsigned char	    ifnmatch_etag_any;
 	};
 	unsigned char		is_set;
 } TfwCachedHeaderState;

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -163,5 +163,6 @@ bool tfw_http_parse_is_done(TfwHttpMsg *hm);
 void tfw_idx_hdr_parse_host_port(TfwHttpReq *req, TfwStr *hdr);
 void h2_set_hdr_accept(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_if_mod_since(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
+void h2_set_hdr_authority(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 unsigned char tfw_http_meth_str2id(const TfwStr *m_hdr);
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -164,5 +164,6 @@ void tfw_idx_hdr_parse_host_port(TfwHttpReq *req, TfwStr *hdr);
 void h2_set_hdr_accept(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 int h2_set_hdr_if_mod_since(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_authority(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
+void h2_set_hdr_if_nmatch(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 unsigned char tfw_http_meth_str2id(const TfwStr *m_hdr);
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -162,6 +162,6 @@ bool tfw_http_parse_is_done(TfwHttpMsg *hm);
 
 void tfw_idx_hdr_parse_host_port(TfwHttpReq *req, TfwStr *hdr);
 void h2_set_hdr_accept(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
-void tfw_idx_hdr_parse_if_mod_since(TfwHttpReq *req, TfwStr *hdr);
+void h2_set_hdr_if_mod_since(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 unsigned char tfw_http_meth_str2id(const TfwStr *m_hdr);
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -162,7 +162,7 @@ bool tfw_http_parse_is_done(TfwHttpMsg *hm);
 
 void tfw_idx_hdr_parse_host_port(TfwHttpReq *req, TfwStr *hdr);
 void h2_set_hdr_accept(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
-void h2_set_hdr_if_mod_since(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
+int h2_set_hdr_if_mod_since(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_authority(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 unsigned char tfw_http_meth_str2id(const TfwStr *m_hdr);
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -22,6 +22,7 @@
 
 #include "str.h"
 #include "http_types.h"
+#include "hpack.h"
 
 typedef struct {
 	unsigned int	size;	/* number of elements in the table */
@@ -113,6 +114,7 @@ typedef struct {
 	const void			*state;
 	const void			*_i_st;
 	long				to_read;
+	TfwCachedHeaderState		cstate;
 	union {
 		unsigned long		_acc;
 		struct {
@@ -159,6 +161,7 @@ int tfw_http_parse_terminate(TfwHttpMsg *hm);
 bool tfw_http_parse_is_done(TfwHttpMsg *hm);
 
 void tfw_idx_hdr_parse_host_port(TfwHttpReq *req, TfwStr *hdr);
+void h2_set_hdr_accept(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void tfw_idx_hdr_parse_if_mod_since(TfwHttpReq *req, TfwStr *hdr);
 unsigned char tfw_http_meth_str2id(const TfwStr *m_hdr);
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/fw/t/unit/test_hpack.c
+++ b/fw/t/unit/test_hpack.c
@@ -76,6 +76,7 @@ do {								\
 
 static TfwH2Ctx ctx;
 static TfwHttpReq *test_req;
+static TfwCachedHeaderState dummy_cstate;
 
 static inline TfwHttpReq *
 test_hpack_req_alloc(void)
@@ -237,21 +238,21 @@ TEST(hpack, dec_table_dynamic)
 	it->nm_len = h_name.len;
 	it->tag = TFW_TAG_HDR_RAW;
 	*it->parsed_hdr = *s1;
-	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 	test_h2_hdr_name(s2, &h_name);
 	it->nm_num = h_name.nchunks;
 	it->nm_len = h_name.len;
 	it->tag = TFW_TAG_HDR_X_FORWARDED_FOR;
 	*it->parsed_hdr = *s2;
-	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 	test_h2_hdr_name(s3, &h_name);
 	it->nm_num = h_name.nchunks;
 	it->nm_len = h_name.len;
 	it->tag = TFW_TAG_HDR_RAW;
 	*it->parsed_hdr = *s3;
-	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 	entry = tfw_hpack_find_index(&hp->dec_tbl, 64);
 	EXPECT_NOT_NULL(entry);
@@ -306,14 +307,14 @@ TEST(hpack, dec_table_dynamic_inc)
 	it->nm_len = h_name.len;
 	it->tag = TFW_TAG_HDR_RAW;
 	*it->parsed_hdr = *s1;
-	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 	test_h2_hdr_name(s2, &h_name);
 	it->nm_num = h_name.nchunks;
 	it->nm_len = h_name.len;
 	it->tag = TFW_TAG_HDR_RAW;
 	*it->parsed_hdr = *s2;
-	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 	entry = tfw_hpack_find_index(&hp->dec_tbl, 62);
 	EXPECT_NOT_NULL(entry);
@@ -330,14 +331,14 @@ TEST(hpack, dec_table_dynamic_inc)
 	it->nm_len = h_name.len;
 	it->tag = TFW_TAG_HDR_CACHE_CONTROL;
 	*it->parsed_hdr = *s3;
-	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 	test_h2_hdr_name(s4, &h_name);
 	it->nm_num = h_name.nchunks;
 	it->nm_len = h_name.len;
 	it->tag = TFW_TAG_HDR_RAW;
 	*it->parsed_hdr = *s4;
-	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 	entry = tfw_hpack_find_index(&hp->dec_tbl, 62);
 	EXPECT_NOT_NULL(entry);
@@ -354,7 +355,7 @@ TEST(hpack, dec_table_dynamic_inc)
 	it->nm_len = h_name.len;
 	it->tag = TFW_TAG_HDR_RAW;
 	*it->parsed_hdr = *s5;
-	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+	EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 	/* Verify the correctness of the indexes order. */
 	entry = tfw_hpack_find_index(&hp->dec_tbl, 66);
@@ -426,7 +427,7 @@ TEST(hpack, dec_table_wrap)
 			HDR_COMPOUND_STR(s, hdr, s_value);
 
 			*it->parsed_hdr = *s;
-			EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it));
+			EXPECT_OK(tfw_hpack_add_index(&hp->dec_tbl, it, &dummy_cstate));
 
 		}
 


### PR DESCRIPTION
Architecture:
- `TfwCachedHeaderState` is added to `TfwHPackEntry` and `TfwHttpParser`.
- Initially this structure is filled from parser-related routines into `parser->cstate` and then it is copied from `TfwHttpParser` into `TfwHPackEntry` before header is added into hpack dynamic table.
- `cstate->is_set` is only set/reset from routines related to headers that are using this mechanism, so no extra performance penalties are implied to other headers