### PR TITLE
Fixed chunked body parsing error

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -2090,7 +2090,7 @@ te_codings_size(TfwHttpResp *resp)
 
 	TFW_STR_FOR_EACH_DUP(dup, te_hdr, end_dup) {
 		TFW_STR_FOR_EACH_CHUNK(chunk, dup, end) {
-			if (!(chunk->flags & TFW_STR_CUT))
+			if (!(chunk->flags & TFW_STR_NAME))
 				continue;
 
 			if (!first)

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -1186,7 +1186,7 @@ tfw_cache_h2_copy_chunked_body(unsigned int *acc_len, char **p, TdbVRec **trec,
 	BUG_ON(TFW_STR_DUP(body));
 
 	/* Body has only zero chunk. */
-	if (unlikely(!body->len))
+	if (unlikely(!body->len || body->len == cut->len))
 		return 0;
 
 	if (unlikely(!cut->len))

--- a/fw/http.c
+++ b/fw/http.c
@@ -2530,6 +2530,9 @@ tfw_http_req_destruct(void *msg)
 
 	if (req->peer)
 		tfw_client_put(req->peer);
+
+	if (req->old_head)
+		ss_skb_queue_purge(&req->old_head);
 }
 
 /**
@@ -3922,6 +3925,7 @@ tfw_h2_adjust_req(TfwHttpReq *req)
 	T_DBG3("%s: req [%p] converted to http1.1\n", __func__, req);
 
 	old_head = req->msg.skb_head;
+	req->old_head = old_head;
 	req->msg.skb_head = new_head;
 
 	/* Http chains might add a mark for the message, keep it. */
@@ -3960,7 +3964,6 @@ tfw_h2_adjust_req(TfwHttpReq *req)
 			ss_skb_queue_append(&old_head, trailer);
 		}
 	}
-	ss_skb_queue_purge(&old_head);
 
 	return 0;
 err:

--- a/fw/http.c
+++ b/fw/http.c
@@ -4859,7 +4859,7 @@ tfw_h2_make_frames(TfwHttpResp *resp, unsigned int stream_id,
 	tfw_h2_pack_frame_header(mit->frame_head, &frame_hdr);
 
 	/* Add first DATA frame */
-	if (!local_response && b_len) {
+	if (!local_response) {
 		if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags)) {
 			TfwHttpMsg *hm = (TfwHttpMsg*)resp;
 
@@ -4868,16 +4868,18 @@ tfw_h2_make_frames(TfwHttpResp *resp, unsigned int stream_id,
 				return r;
 		}
 
-		frame_hdr.length = min(max_sz, b_len);
-		frame_hdr.type = HTTP2_DATA;
-		frame_hdr.flags = (frame_hdr.length == b_len)
-				   ? HTTP2_F_END_STREAM : 0;
-		tfw_h2_pack_frame_header(buf, &frame_hdr);
+		if (b_len > 0) {
+			frame_hdr.length = min(max_sz, b_len);
+			frame_hdr.type = HTTP2_DATA;
+			frame_hdr.flags = (frame_hdr.length == b_len)
+					   ? HTTP2_F_END_STREAM : 0;
+			tfw_h2_pack_frame_header(buf, &frame_hdr);
 
-		r = tfw_http_msg_expand_from_pool(mit, resp->pool,
-						  &frame_hdr_str);
-		if (unlikely(r))
-			return r;
+			r = tfw_http_msg_expand_from_pool(mit, resp->pool,
+							  &frame_hdr_str);
+			if (unlikely(r))
+				return r;
+		}
 	}
 
 	/* Add CONTINATION frames. */

--- a/fw/http.c
+++ b/fw/http.c
@@ -4863,13 +4863,7 @@ tfw_h2_make_frames(TfwHttpResp *resp, unsigned int stream_id,
 		if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags)) {
 			TfwHttpMsg *hm = (TfwHttpMsg*)resp;
 
-			/* Save beginning of body before modifying */
-			if (b_len > max_sz) {
-				h2_body = __tfw_h2_get_body_start(resp);
-				BUG_ON(!h2_body);
-			}
-
-			r = tfw_http_msg_del_flagged_body(hm);
+			r = tfw_http_msg_cutoff_body_chunks(hm);
 			if (unlikely(r))
 				return r;
 		}

--- a/fw/http.h
+++ b/fw/http.h
@@ -434,6 +434,8 @@ typedef struct {
  * @peer	- end-to-end peer. The peer is not set if
  *		  hop-by-hop peer (TfwConnection->peer) and end-to-end peer are
  *		  the same;
+ * @old_head	- Original request head. Required for keep request data until
+ * 		  the response is sent to the client;
  * @pit		- iterator for tracking transformed data allocation (applicable
  *		  for HTTP/2 mode only);
  * @userinfo	- userinfo in URI, not mandatory;
@@ -464,6 +466,7 @@ struct tfw_http_req_t {
 	TfwLocation		*location;
 	TfwHttpSess		*sess;
 	TfwClient		*peer;
+	struct sk_buff		*old_head;
 	TfwHttpCond		cond;
 	TfwMsgParseIter		pit;
 	TfwStr			userinfo;

--- a/fw/http.h
+++ b/fw/http.h
@@ -590,7 +590,7 @@ typedef struct {
 
 #define TFW_HTTP_RESP_CUT_BODY_SZ(r) 					\
 	(r)->stream ? 							\
-	(r)->body.len - (r)->stream->parser.cut_len : 			\
+	(r)->body.len - (r)->stream->parser.cut.len : 			\
 	(r)->body.len
 
 #define __FOR_EACH_HDR_FIELD(pos, end, msg, soff, eoff)			\

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -1021,12 +1021,12 @@ tfw_http_msg_del_flagged_body(TfwHttpMsg *hm)
 {
 	int r;
 
-	r = ss_skb_cutoff_data_flagged(hm->msg.skb_head, &hm->body,
-				       TFW_STR_CUT, tfw_str_eolen(&hm->body));
+	r = ss_skb_cutoff_data(hm->body.skb, &hm->stream->parser.cut, 0,
+			       tfw_str_eolen(&hm->body));
 	if (unlikely(r))
 		return r;
 
-	hm->msg.len -= hm->stream->parser.cut_len;
+	hm->msg.len -= hm->stream->parser.cut.len;
 	TFW_STR_INIT(&hm->body);
 
 	return 0;

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -1017,7 +1017,7 @@ tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm)
  * WARNING: After this call TfwHttpMsg->body MUST not be used.
  */
 int
-tfw_http_msg_del_flagged_body(TfwHttpMsg *hm)
+tfw_http_msg_cutoff_body_chunks(TfwHttpMsg *hm)
 {
 	int r;
 

--- a/fw/http_msg.h
+++ b/fw/http_msg.h
@@ -160,7 +160,7 @@ int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 
 int tfw_http_msg_del_str(TfwHttpMsg *hm, TfwStr *str);
 int tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm);
-int tfw_http_msg_del_flagged_body(TfwHttpMsg *hm);
+int tfw_http_msg_cutoff_body_chunks(TfwHttpMsg *hm);
 
 int tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len,
 		       unsigned int tx_flags);

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2018-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2018-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -103,9 +103,11 @@ typedef struct {
  * @_date	- currently parsed http date value;
  * @month_int	- accumulator for parsing of month;
  * @cc_dir_flag	- designates an uncommitted directive currently being processed.
- * @cut_len	- the length of all data in http chunked body to be cutted
- *		  during HTTP1 to HTTP2 transformation and ignored during
- *		  caching;
+ * @body_start_data - beginning of body used during HTTP1 to HTTP2 body
+ * 		  transformation. Must be deprecated when new cutting strategy
+ * 		  will be implemented;
+ * @cut		- descriptors of http chunked body to be cutted during HTTP1 to
+ *		  HTTP2 transformation and ignored during caching;
  */
 typedef struct {
 	unsigned short			to_go;
@@ -136,7 +138,9 @@ typedef struct {
 		unsigned int		month_int;
 		unsigned int		cc_dir_flag;
 	};
-	unsigned long			cut_len;
+	char *body_start_data;
+	struct sk_buff *body_start_skb;
+	TfwStr				cut;
 	TfwStr				_tmp_chunk;
 	TfwStr				hdr;
 	TfwHttpHbhHdrs			hbh_parser;

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1087,6 +1087,7 @@ ss_skb_cutoff_data_flagged(struct sk_buff *skb_head, const TfwStr *str,
 				 -c->len, &it, &_);
 		if (r < 0)
 			return r;
+		WARN_ON(r != c->len);
 	}
 
 	BUG_ON(it.data == NULL);

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1061,45 +1061,6 @@ ss_skb_cutoff_data(struct sk_buff *skb_head, const TfwStr *str, int skip,
 	return 0;
 }
 
-/**
- * Cut off @str->len data bytes from underlying skbs skipping chunks
- * that doesn't have @flag, and also cut off @tail bytes after @str.
- * @str can be an HTTP header or other parsed part of HTTP message
- * ('uri_path', 'host' etc).
- */
-int
-ss_skb_cutoff_data_flagged(struct sk_buff *skb_head, const TfwStr *str,
-			   unsigned short flag, int tail)
-{
-	int r;
-	TfwStr it = {};
-	const TfwStr *c, *end;
-	int _;
-
-	BUG_ON(tail < 0);
-
-	TFW_STR_FOR_EACH_CHUNK(c, str, end) {
-		if (!(c->flags & flag))
-			continue;
-
-		bzero_fast(&it, sizeof(TfwStr));
-		r = skb_fragment(skb_head, c->skb, c->data,
-				 -c->len, &it, &_);
-		if (r < 0)
-			return r;
-		WARN_ON(r != c->len);
-	}
-
-	BUG_ON(it.data == NULL);
-	BUG_ON(it.skb == NULL);
-
-	/* Cut off the tail. */
-	if (tail > 0)
-		return __ss_skb_cutoff(skb_head, it.skb, it.data, tail);
-
-	return 0;
-}
-
 int
 skb_next_data(struct sk_buff *skb, char *last_ptr, TfwStr *it)
 {

--- a/fw/ss_skb.h
+++ b/fw/ss_skb.h
@@ -274,9 +274,6 @@ int ss_skb_chop_head_tail(struct sk_buff *skb_head, struct sk_buff *skb,
 int
 ss_skb_list_chop_head_tail(struct sk_buff **skb_list_head,
                            size_t head, size_t trail);
-int
-ss_skb_cutoff_data_flagged(struct sk_buff *skb_head, const TfwStr *str,
-			   unsigned short flag, int tail);
 int ss_skb_cutoff_data(struct sk_buff *skb_head, const TfwStr *hdr,
 		       int skip, int tail);
 int skb_next_data(struct sk_buff *skb, char *last_ptr, TfwStr *it);

--- a/fw/str.h
+++ b/fw/str.h
@@ -229,8 +229,6 @@ basic_stricmp_fast(const BasicStr *s1, const BasicStr *s2)
 #define TFW_STR_COMPLETE	0x02
 /* Some name starts at the string chunk. */
 #define TFW_STR_NAME		0x04
-/* The chunk contains cut-part that using while stripping chunked body. */
-#define TFW_STR_CUT		0x04
 /* Some value starts at the string chunk. */
 #define TFW_STR_VALUE		0x08
 /* The string represents hop-by-hop header, not end-to-end one */

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -1894,7 +1894,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "0\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut_len, 8);
+		EXPECT_EQ(resp->stream->parser.cut.len, 8);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1908,7 +1908,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "Age: 1\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut_len, 8);
+		EXPECT_EQ(resp->stream->parser.cut.len, 8);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1921,7 +1921,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "0\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut_len, 5);
+		EXPECT_EQ(resp->stream->parser.cut.len, 5);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1935,7 +1935,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "Age: 1\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut_len, 6);
+		EXPECT_EQ(resp->stream->parser.cut.len, 6);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1948,7 +1948,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "0\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut_len, 16);
+		EXPECT_EQ(resp->stream->parser.cut.len, 16);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1959,7 +1959,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "0\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut_len, 3);
+		EXPECT_EQ(resp->stream->parser.cut.len, 3);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 	/* Chunked response */
@@ -1969,7 +1969,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "000\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut_len, 5);
+		EXPECT_EQ(resp->stream->parser.cut.len, 5);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 }


### PR DESCRIPTION
In our implementation of parsing chunked body we try to make as less TfwStr's chunks as possible, merging continuous memory TfwStr's chunks in single chunk. However, we didn't take into account that continuous memory can be used by different SKBs.

Body chunk "\r\n8fb1" can be located in continuous memory, but first part of chunk - "\r\n" can be used by one skb and second part "8fb1" by another.