### PR TITLE
Added small hacks to work around tests disabled by #1630

### DIFF
--- a/db/libtdb/handler.cc
+++ b/db/libtdb/handler.cc
@@ -189,7 +189,7 @@ TdbHndl::msg_send(std::function<void (nlmsghdr *)> msg_build_cb)
  * ------------------------------------------------------------------------
  */
 void
-TdbHndl::alloc_trx_frame() noexcept
+TdbHndl::alloc_trx_frame()
 {
 	trx_.init();
 

--- a/db/libtdb/libtdb.h
+++ b/db/libtdb/libtdb.h
@@ -103,7 +103,7 @@ public:
 private:
 	void advance_frame_offset(unsigned int &off) noexcept;
 	void lazy_buffer_alloc();
-	void alloc_trx_frame() noexcept;
+	void alloc_trx_frame();
 	void send_to_kernel();
 
 	void msg_recv(std::function<bool (nlmsghdr *)> msg_cb);

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -1025,7 +1025,7 @@
 #       http_header_cnt NUM;
 #       http_header_chunk_cnt NUM;
 #       http_body_chunk_cnt NUM;
-#       http_host_required true|false;
+#       http_strict_host_checking true|false;
 #       http_methods [METHOD]...;
 #       http_ct_required true|false;
 #       http_method_override_allowed true|false;

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1556,7 +1556,14 @@ get_value:
 
 			if (unlikely(!hp->length)) {
 				T_DBG3("%s: zero-length value\n", __func__);
-				r = T_DROP;
+				switch (req->pit.tag) {
+				case TFW_TAG_HDR_HOST:
+				case TFW_TAG_HDR_H2_AUTHORITY:
+					r = T_BAD;
+					break;
+				default:
+					r = T_DROP;
+				}
 				goto out;
 			}
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -5644,7 +5644,7 @@ check_authority_correctness(TfwHttpReq *req)
 		 * A client MUST send a Host header field in an HTTP/1.1
 		 * request even if the request-target is in the absolute-form
 		 */
-		return req->uri_host ||
+		return test_bit(TFW_HTTP_B_ABSOLUTE_URI, req->flags) ||
 			!TFW_STR_EMPTY(&req->h_tbl->tbl[TFW_HTTP_HDR_HOST]);
 	case TFW_HTTP_VER_20: {
 		TfwStr authority, host;

--- a/fw/http.c
+++ b/fw/http.c
@@ -5654,10 +5654,11 @@ validate_authority_rfc9113(TfwHttpReq *req)
 	 * a Host header field that identifies an entity that differs
 	 * from the entity in the ":authority" pseudo-header field.
 	 * */
-	TfwStr *authority = &req->h_tbl->tbl[TFW_HTTP_HDR_H2_AUTHORITY];
-	TfwStr *host = &req->h_tbl->tbl[TFW_HTTP_HDR_HOST];
-	return TFW_STR_EMPTY(authority) || TFW_STR_EMPTY(host)
-		|| tfw_strcmp(authority, host) == 0;
+	TfwStr authority, host;
+	__h2_msg_hdr_val(&req->h_tbl->tbl[TFW_HTTP_HDR_H2_AUTHORITY], &authority);
+	__h2_msg_hdr_val(&req->h_tbl->tbl[TFW_HTTP_HDR_HOST], &host);
+	return TFW_STR_EMPTY(&authority) || TFW_STR_EMPTY(&host)
+		|| tfw_strcmp(&authority, &host) == 0;
 }
 
 /**

--- a/fw/http.c
+++ b/fw/http.c
@@ -756,21 +756,7 @@ do { 								\
 	if (!cl_len)
 		return TFW_BLOCK;
 
-	if (req->host.len) {
-		host = req->host;
-	} else {
-		/* Invalid id value */
-		unsigned id = TFW_HTTP_HDR_NUM;
-
-		if (!TFW_STR_EMPTY(&req->h_tbl->tbl[TFW_HTTP_HDR_H2_AUTHORITY]))
-			id = TFW_HTTP_HDR_H2_AUTHORITY;
-		else if (!TFW_STR_EMPTY(&req->h_tbl->tbl[TFW_HTTP_HDR_HOST]))
-			id = TFW_HTTP_HDR_HOST;
-
-		if (id != TFW_HTTP_HDR_NUM)
-			tfw_http_msg_clnthdr_val(req, &req->h_tbl->tbl[id],
-						 id, &host);
-	}
+	host = req->host;
 
 	remaining = RESP_BUF_LEN - SLEN(S_V_DATE) - cl_len;
 	len = host.len + req->uri_path.len + body_len;
@@ -1501,8 +1487,6 @@ tfw_http_req_redir(TfwHttpReq *req, int status, TfwHttpRedir *redir)
 	TfwStr *c, *end, *c2, *end2;
 	char *status_line;
 	size_t i = 0;
-	TfwStr *hdr;
-	TfwStr hdr_val;
 
 	tfw_http_prep_date(date_val);
 
@@ -1541,16 +1525,7 @@ do {									\
 			TFW_STRCPY(&req->uri_path);
 			break;
 		case TFW_HTTP_REDIR_HOST:
-			if (req->host.len) {
-				hdr_val = req->host;
-			} else {
-				hdr = &req->h_tbl->tbl[TFW_HTTP_HDR_HOST];
-				tfw_http_msg_clnthdr_val(req, hdr,
-							 TFW_HTTP_HDR_HOST,
-							 &hdr_val);
-			}
-
-			TFW_STRCPY(&hdr_val);
+			TFW_STRCPY(&req->host);
 			break;
 		default:
 			BUG();
@@ -5645,6 +5620,7 @@ tfw_http_req_process(TfwConn *conn, TfwStream *stream, struct sk_buff *skb)
 	TfwHttpActionResult res;
 
 	BUG_ON(!stream->msg);
+	pr_info(">>> tfw_http_req_process");
 
 	T_DBG2("Received %u client data bytes on conn=%p msg=%p\n",
 	       skb->len, conn, stream->msg);

--- a/fw/http.c
+++ b/fw/http.c
@@ -5627,7 +5627,6 @@ extract_req_host(TfwHttpReq *req)
 		 * and instead use the host information of the request-target.
 		 */
 		if (TFW_STR_EMPTY(&req->host)) {
-			hid = TFW_HTTP_HDR_HOST;
 			tfw_http_msg_clnthdr_val(req, &hdrs[TFW_HTTP_HDR_HOST],
 						 TFW_HTTP_HDR_HOST,
 						 &req->host);

--- a/fw/http.c
+++ b/fw/http.c
@@ -5683,6 +5683,10 @@ next_msg:
 		TFW_INC_STAT_BH(clnt.msgs_parserr);
 		tfw_http_req_parse_drop(req, 400, "failed to parse request");
 		return TFW_BAD;
+	case TFW_BAD:
+		tfw_http_req_parse_block(req, 403,
+			"frang: Request authority is unknown");
+		return TFW_BLOCK;
 	case TFW_POSTPONE:
 		if (WARN_ON_ONCE(parsed != data_up.skb->len)) {
 			/*

--- a/fw/http.c
+++ b/fw/http.c
@@ -5684,7 +5684,7 @@ next_msg:
 		tfw_http_req_parse_drop(req, 400, "failed to parse request");
 		return TFW_BAD;
 	case TFW_BAD:
-		tfw_http_req_parse_block(req, 403,
+		tfw_http_req_parse_drop(req, 403,
 			"frang: Request authority is unknown");
 		return TFW_BLOCK;
 	case TFW_POSTPONE:

--- a/fw/http.c
+++ b/fw/http.c
@@ -5619,7 +5619,7 @@ extract_req_host(TfwHttpReq *req)
 		__h2_msg_hdr_val(&hdrs[hid], &req->host);
 	} else {
 		/* req->host can be only filled by HTTP/1.x parser from
-		 * absoluteURI, so we act as describen by RFC 9112, sec-3.2.2
+		 * absoluteURI, so we act as described by RFC 9112, sec-3.2.2
 		 * (https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.2):
 		 * When an origin server receives a request with an
 		 * absolute-form of request-target, the origin server
@@ -5633,6 +5633,31 @@ extract_req_host(TfwHttpReq *req)
 						 &req->host);
 		}
 	}
+}
+
+static bool
+validate_authority_rfc9112(TfwHttpReq *req)
+{
+	/* https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.2
+	 * A client MUST send a Host header field in an HTTP/1.1
+	 * request even if the request-target is in the absolute-form
+	 */
+	return req->uri_host ||
+		!TFW_STR_EMPTY(&req->h_tbl->tbl[TFW_HTTP_HDR_HOST]);
+}
+
+static bool
+validate_authority_rfc9113(TfwHttpReq *req)
+{
+	/* https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
+	 * A server SHOULD treat a request as malformed if it contains
+	 * a Host header field that identifies an entity that differs
+	 * from the entity in the ":authority" pseudo-header field.
+	 * */
+	TfwStr *authority = &req->h_tbl->tbl[TFW_HTTP_HDR_H2_AUTHORITY];
+	TfwStr *host = &req->h_tbl->tbl[TFW_HTTP_HDR_HOST];
+	return TFW_STR_EMPTY(authority) || TFW_STR_EMPTY(host)
+		|| tfw_strcmp(authority, host) == 0;
 }
 
 /**
@@ -5779,6 +5804,23 @@ next_msg:
 	}
 
 	extract_req_host(req);
+	switch (req->version) {
+	case TFW_HTTP_VER_11:
+		if (!validate_authority_rfc9112(req)) {
+			tfw_http_req_parse_drop(req, 400,
+						"Missing Host header");
+			return TFW_BLOCK;
+		}
+		break;
+	case TFW_HTTP_VER_20:
+		if (!validate_authority_rfc9113(req)) {
+			tfw_http_req_parse_drop(req, 400,
+		                                ":authority and Host headers"
+		                                " are not equal");
+			return TFW_BLOCK;
+		}
+		break;
+	}
 	/*
 	 * The message is fully parsed, the rest of the data in the
 	 * stream may represent another request or its part.

--- a/fw/http.c
+++ b/fw/http.c
@@ -6749,8 +6749,6 @@ cleanup:
 unsigned long
 tfw_http_req_key_calc(TfwHttpReq *req)
 {
-	TfwStr host;
-
 	if (req->hash)
 		return req->hash;
 
@@ -6759,10 +6757,8 @@ tfw_http_req_key_calc(TfwHttpReq *req)
 	if (test_bit(TFW_HTTP_B_HMONITOR, req->flags))
 		return req->hash;
 
-	tfw_http_msg_clnthdr_val(req, &req->h_tbl->tbl[TFW_HTTP_HDR_HOST],
-				 TFW_HTTP_HDR_HOST, &host);
-	if (!TFW_STR_EMPTY(&host))
-		req->hash ^= tfw_hash_str(&host);
+	if (!TFW_STR_EMPTY(&req->host))
+		req->hash ^= tfw_hash_str(&req->host);
 
 	return req->hash;
 }

--- a/fw/http.c
+++ b/fw/http.c
@@ -5712,8 +5712,8 @@ next_msg:
 		tfw_http_req_parse_drop(req, 400, "failed to parse request");
 		return TFW_BAD;
 	case TFW_BAD:
-		tfw_http_req_parse_drop(req, 403,
-			"frang: Request authority is unknown");
+		tfw_http_req_parse_drop(req, 400,
+			"Invalid authority");
 		return TFW_BLOCK;
 	case TFW_POSTPONE:
 		if (WARN_ON_ONCE(parsed != data_up.skb->len)) {

--- a/fw/http.c
+++ b/fw/http.c
@@ -5608,18 +5608,22 @@ static void
 extract_req_host(TfwHttpReq *req)
 {
 	int hid = 0;
-	TfwHttpHdrTbl *ht = req->h_tbl;
+	TfwStr *hdrs = req->h_tbl->tbl;
+
 	if (TFW_MSG_H2(req)) {
-		if (!TFW_STR_EMPTY(&ht->tbl[TFW_HTTP_HDR_H2_AUTHORITY]))
+		if (!TFW_STR_EMPTY(&hdrs[TFW_HTTP_HDR_H2_AUTHORITY]))
 			hid = TFW_HTTP_HDR_H2_AUTHORITY;
 		else
 			hid = TFW_HTTP_HDR_HOST;
+		__h2_msg_hdr_val(&hdrs[hid], &req->host);
 	} else {
-		if (TFW_STR_EMPTY(&req->host))
+		if (TFW_STR_EMPTY(&req->host)) {
 			hid = TFW_HTTP_HDR_HOST;
+			tfw_http_msg_clnthdr_val(req, &hdrs[TFW_HTTP_HDR_HOST],
+						 TFW_HTTP_HDR_HOST,
+						 &req->host);
+		}
 	}
-	if (hid)
-		__h2_msg_hdr_val(&ht->tbl[hid], &req->host);
 }
 
 /**

--- a/fw/http.c
+++ b/fw/http.c
@@ -5619,8 +5619,12 @@ extract_req_host(TfwHttpReq *req)
 		__h2_msg_hdr_val(&hdrs[hid], &req->host);
 	} else {
 		/* req->host can be only filled by HTTP/1.x parser from
-		 * absoluteURI, so we act as RFC 7230, sec-5.4 says:
-		 * Host header must be ignored when URI is absolute.
+		 * absoluteURI, so we act as describen by RFC 9112, sec-3.2.2
+		 * (https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.2):
+		 * When an origin server receives a request with an
+		 * absolute-form of request-target, the origin server
+		 * MUST ignore the received Host header field (if any)
+		 * and instead use the host information of the request-target.
 		 */
 		if (TFW_STR_EMPTY(&req->host)) {
 			hid = TFW_HTTP_HDR_HOST;

--- a/fw/http.h
+++ b/fw/http.h
@@ -320,6 +320,8 @@ enum {
 	 * not enclosed in double quotes.
 	 */
 	TFW_HTTP_B_HDR_ETAG_HAS_NO_QOUTES,
+	/* Request URI is absolute (HTTP/1.x only) */
+	TFW_HTTP_B_ABSOLUTE_URI,
 
 	_TFW_HTTP_FLAGS_NUM
 };
@@ -441,8 +443,6 @@ typedef struct {
  * @userinfo	- userinfo in URI, not mandatory;
  * @host	- host that was picked from request URI, Host or HTTP/2
  *		  authority header;
- * @uri_host	- points to host if request URI contained hostname, NULL
- *		  otherwise;
  * @uri_path	- path + query + fragment from URI (RFC3986.3);
  * @mark	- special hash mark for redirects handling in session module;
  * @multipart_boundary_raw - multipart boundary as is, maybe with escaped chars;
@@ -473,7 +473,6 @@ struct tfw_http_req_t {
 	TfwHttpCond		cond;
 	TfwMsgParseIter		pit;
 	TfwStr			userinfo;
-	TfwStr			*uri_host;
 	TfwStr			host;
 	TfwStr			uri_path;
 	TfwStr			mark;

--- a/fw/http.h
+++ b/fw/http.h
@@ -439,7 +439,10 @@ typedef struct {
  * @pit		- iterator for tracking transformed data allocation (applicable
  *		  for HTTP/2 mode only);
  * @userinfo	- userinfo in URI, not mandatory;
- * @host	- host in URI, may differ from Host header;
+ * @host	- host that was picked from request URI, Host or HTTP/2
+ *		  authority header;
+ * @uri_host	- points to host if request URI contained hostname, NULL
+ *		  otherwise;
  * @uri_path	- path + query + fragment from URI (RFC3986.3);
  * @mark	- special hash mark for redirects handling in session module;
  * @multipart_boundary_raw - multipart boundary as is, maybe with escaped chars;
@@ -470,6 +473,7 @@ struct tfw_http_req_t {
 	TfwHttpCond		cond;
 	TfwMsgParseIter		pit;
 	TfwStr			userinfo;
+	TfwStr			*uri_host;
 	TfwStr			host;
 	TfwStr			uri_path;
 	TfwStr			mark;

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -638,6 +638,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 	TfwAddr addr;
 	unsigned short port;
 	unsigned short real_port;
+	TfwStr authority, host;
 	TfwStr prim_trim = { 0 }, prim_name = { 0 }, /* primary source */
 	       fwd_trim = { 0 },  fwd_name = { 0 };
 
@@ -645,8 +646,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 	BUG_ON(!req->h_tbl);
 
 	switch (req->version) {
-	case TFW_HTTP_VER_20: {
-		TfwStr authority, host;
+	case TFW_HTTP_VER_20:
 		__h2_msg_hdr_val(&req->h_tbl->tbl[TFW_HTTP_HDR_H2_AUTHORITY],
 		                 &authority);
 		__h2_msg_hdr_val(&req->h_tbl->tbl[TFW_HTTP_HDR_HOST], &host);
@@ -659,7 +659,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
                  * at least one of :authority or Host headers are not empty.
 		 */
 		if (!TFW_STR_EMPTY(&authority) && !TFW_STR_EMPTY(&host)
-                    && tfw_strcmp(&authority, &host) != 0)
+                    && tfw_strcmp(&authority, &host) != 0) {
 			frang_msg("Request :authority differs from Host",
 				  &FRANG_ACC2CLI(ra)->addr, "\n");
                         return TFW_BLOCK;

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -658,8 +658,8 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
                  * Note: check_authority_correctness() already ensures that
                  * at least one of :authority or Host headers are not empty.
 		 */
-		if (TFW_STR_EMPTY(&authority) || TFW_STR_EMPTY(&host)
-                    || tfw_strcmp(&authority, &host) != 0)
+		if (!TFW_STR_EMPTY(&authority) && !TFW_STR_EMPTY(&host)
+                    && tfw_strcmp(&authority, &host) != 0)
 			frang_msg("Request :authority differs from Host",
 				  &FRANG_ACC2CLI(ra)->addr, "\n");
                         return TFW_BLOCK;

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -679,6 +679,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 		 * Also this MUST be removed after #1870 is complete*/
 		if (test_bit(TFW_HTTP_B_ABSOLUTE_URI, req->flags)) {
 			TfwStr host;
+
 			tfw_http_msg_clnthdr_val(req,
 						&req->h_tbl->tbl[TFW_HTTP_HDR_HOST],
 						TFW_HTTP_HDR_HOST, &host);

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -645,8 +645,6 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 	BUG_ON(!req->h_tbl);
 
 	switch (req->version) {
-	/* Note: host/authority equality is enforced in
-         * check_authority_correctness() */
 	case TFW_HTTP_VER_20: {
 		TfwStr authority, host;
 		__h2_msg_hdr_val(&req->h_tbl->tbl[TFW_HTTP_HDR_H2_AUTHORITY],
@@ -677,7 +675,8 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 			return TFW_BLOCK;
 		}
 		/* This is pure HTTP/1.1 check, that would never trigger for
-		 * HTTP/2 because it cannot have an absolute URI */
+		 * HTTP/2 because it cannot have an absolute URI.
+		 * Also this MUST be removed after #1870 is complete*/
 		if (test_bit(TFW_HTTP_B_ABSOLUTE_URI, req->flags)) {
 			TfwStr host;
 			tfw_http_msg_clnthdr_val(req,

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -1093,7 +1093,7 @@ frang_http_req_process(FrangAcc *ra, TfwConn *conn, TfwFsmData *data,
 		*/
 
 		/* Ensure presence and the value of Host: header field. */
-		if (f_cfg->http_host_required
+		if (f_cfg->http_strict_host_checking
 		    && (r = frang_http_host_check(req, ra)))
 		{
 			T_FSM_EXIT();

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -685,7 +685,7 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 			if (tfw_strcmp(&req->host, &host) != 0) {
 				frang_msg("Request host from absolute URI differs"
 					  " from Host header",
-					&FRANG_ACC2CLI(ra)->addr, "\n");
+					  &FRANG_ACC2CLI(ra)->addr, "\n");
 				return TFW_BLOCK;
 			}
 		}

--- a/fw/http_limits.h
+++ b/fw/http_limits.h
@@ -164,7 +164,8 @@ struct frang_global_cfg_t {
  * @http_resp_code_block - Response status codes and maximum number of each
  *			   code before client connection is closed.
  * @http_ct_required	- Header 'Content-Type:' is required;
- * @http_host_required	- Header 'Host:' is required;
+ * @http_strict_host_checking - Enforce equality of absolute_uri,
+ *			  Host and :authority;
  * @http_trailer_split  - Allow the same header appear in both
  *			  request header part and chunked trailer part;
  * @http_method_override - Allow method override in request headers.
@@ -180,7 +181,7 @@ struct frang_vhost_cfg_t {
 	FrangHttpRespCodeBlock	*http_resp_code_block;
 
 	bool			http_ct_required;
-	bool			http_host_required;
+	bool			http_strict_host_checking;
 	bool			http_trailer_split;
 	bool			http_method_override;
 };

--- a/fw/http_match.c
+++ b/fw/http_match.c
@@ -231,18 +231,16 @@ match_host_forwarded(const TfwHttpReq *req, const TfwHttpMatchRule *rule)
 static bool
 match_host(const TfwHttpReq *req, const TfwHttpMatchRule *rule)
 {
-	const TfwStr *host = &req->host;
-
 	/*
 	 * TODO #1630: replace with a single condition
 	 * on the authority special header.
 	 */
-	if (host->len > 0) {
+	if (req->uri_host && req->uri_host->len > 0) {
 		/*
 		 * RFC 7230 5.4: Host header must
 		 * be ignored when URI is absolute.
 		 */
-		return host_val_eq(host, rule);
+		return host_val_eq(req->uri_host, rule);
 	} else if (req->h_tbl->tbl[TFW_HTTP_HDR_H2_AUTHORITY].len > 0) {
 		return hdr_val_eq(req, rule, TFW_HTTP_HDR_H2_AUTHORITY);
 	}

--- a/fw/http_match.c
+++ b/fw/http_match.c
@@ -241,7 +241,7 @@ match_host(const TfwHttpReq *req, const TfwHttpMatchRule *rule)
 	 * RFC 7230 5.4: Host header must
 	 * be ignored when URI is absolute.
 	 */
-	if (req->uri_host)
+	if (test_bit(TFW_HTTP_B_ABSOLUTE_URI, req->flags))
 		return false;
 	/* For non-absolute URI also check Forwarded header */
 	return match_host_forwarded(req, rule);

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -5870,7 +5870,7 @@ Req_Method_1CharStep: __attribute__((cold))
 	 */
 	__FSM_STATE(Req_UriAuthorityStart, cold) {
 		if (likely(isalnum(c) || c == '.' || c == '-')) {
-			req->uri_host = &req->host;
+			__set_bit(TFW_HTTP_B_ABSOLUTE_URI, req->flags);
 			__msg_field_open(&req->host, p);
 			__FSM_MOVE_f(Req_UriAuthority, &req->host);
 		} else if (likely(c == '/')) {
@@ -5884,7 +5884,7 @@ Req_Method_1CharStep: __attribute__((cold))
 			req->host.flags |= TFW_STR_COMPLETE;
 			__FSM_JMP(Req_UriMark);
 		} else if (c == '[') {
-			req->uri_host = &req->host;
+			__set_bit(TFW_HTTP_B_ABSOLUTE_URI, req->flags);
 			__msg_field_open(&req->host, p);
 			__FSM_MOVE_f(Req_UriAuthorityIPv6, &req->host);
 		}

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -10684,12 +10684,6 @@ tfw_h2_parse_req_finish(TfwHttpReq *req)
 	req->body.flags |= TFW_STR_COMPLETE;
 	__set_bit(TFW_HTTP_B_FULLY_PARSED, req->flags);
 
-	if (!TFW_STR_EMPTY(&ht->tbl[TFW_HTTP_HDR_H2_AUTHORITY]))
-		__h2_msg_hdr_val(&ht->tbl[TFW_HTTP_HDR_H2_AUTHORITY],
-				&req->host);
-	else
-		__h2_msg_hdr_val(&ht->tbl[TFW_HTTP_HDR_HOST],
-				&req->host);
 	__h2_msg_hdr_val(&ht->tbl[TFW_HTTP_HDR_H2_PATH],
 			 &req->uri_path);
 

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -2206,14 +2206,14 @@ tfw_cfgop_frang_hdr_cnt(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
-tfw_cfgop_frang_host_required(TfwCfgSpec *cs, TfwCfgEntry *ce)
+tfw_cfgop_frang_strict_host_checking(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
 	FrangVhostCfg *cfg = tfw_cfgop_frang_get_cfg();
 
-	if (ce->dflt_value && cfg->http_host_required)
+	if (ce->dflt_value && cfg->http_strict_host_checking)
 		return 0;
-	cs->dest = &cfg->http_host_required;
+	cs->dest = &cfg->http_strict_host_checking;
 	r = tfw_cfg_set_bool(cs, ce);
 	cs->dest = NULL;
 	return r;
@@ -2807,9 +2807,9 @@ static TfwCfgSpec tfw_global_frang_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
-		.name = "http_host_required",
+		.name = "http_strict_host_checking",
 		.deflt = "true",
-		.handler = tfw_cfgop_frang_host_required,
+		.handler = tfw_cfgop_frang_strict_host_checking,
 		.allow_reconfig = true,
 	},
 	{
@@ -2959,9 +2959,9 @@ static TfwCfgSpec tfw_vhost_frang_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
-		.name = "http_host_required",
+		.name = "http_strict_host_checking",
 		.deflt = "true",
-		.handler = tfw_cfgop_frang_host_required,
+		.handler = tfw_cfgop_frang_strict_host_checking,
 		.allow_reconfig = true,
 	},
 	{


### PR DESCRIPTION
Current (27.04.2023) state of PR:
`req->host` aka `picked_authority` is selected from request data in the following priority:
- from `absoluteURI` (HTTP/1.1 and earlier versions)
- from `:authority` header (HTTP/2)
- from `Host` header (all version)

`req->host` is now used for cache key calculation.

Hard-coded checks (`check_authority_correctness()`):
- `Host` header MUST be present even when request comes in form of an absolute-URI (HTTP/1.1)
- authority information MUST be supplied (ie non-empty) for HTTP/1.1 and HTTP/2

Frang check had been update accordingly:
- `:authority == Host` (HTTP/2) or (`host_from_absolute_uri == Host`) (HTTP/1.1)
- `host_from_forwarded_header == picked_authority` (both HTTP/1.1 and HTTP/2)

