### PR TITLE
Added restriction to specify DEBUG < 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,18 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+# if intcmp is supported use it
+ifeq ($(intcmp 1,0,,,y),y)
+test-gt = $(intcmp $(strip $1)0, $(strip $2)0,,,y)
+else
+test-gt = $(shell test $(strip $1)0 -gt $(strip $2)0 && echo y)
+endif
+
 TFW_CFLAGS = $(DEFINES) -Werror
 ifdef DEBUG
+	ifeq ($(call test-gt, 1, $(DEBUG)), y)
+		ERROR = "DEBUG must be greater than 0"
+	endif
 	TFW_CFLAGS += -DDEBUG=$(DEBUG)
 endif
 


### PR DESCRIPTION
DEBUG < 1 can cause problems. User can set DEBUG=0 thinking it will disable debugging, but in some places we have ifdef DEBUG that will be TRUE even for DEBUG=0 and project will be built with "partial" debugging, that lead to undefined behaviour.