### PR TITLE
Validate SNI against authority information from HTTP request

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -5624,31 +5624,9 @@ __extract_request_authority(TfwHttpReq *req)
 	}
 }
 
-static char*
-__get_sni_from_tls_ctx(TlsCtx *tctx)
-{
-	return likely(tctx->sni_len <= sizeof(tctx->sni_buf))
-		? tctx->sni_buf
-		: tctx->sni;
-}
-
 static bool
 __check_authority_correctness(TfwHttpReq *req)
 {
-	int conn_type = TFW_CONN_TYPE(req->conn)
-			& (TFW_FSM_HTTPS | TFW_FSM_WEBSOCKET);
-	if (conn_type == TFW_FSM_HTTPS) {
-		TlsCtx *tctx = tfw_tls_context(req->conn);
-
-		if (likely(tctx->sni_len != 0) &&
-		    unlikely(!tfw_str_eq_cstr(&req->host,
-		                              __get_sni_from_tls_ctx(tctx),
-		                              tctx->sni_len,
-		                              TFW_STR_EQ_CASEI))) {
-			return false;
-		}
-	}
-
 	switch (req->version) {
 	case TFW_HTTP_VER_11:
 		/* https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.2

--- a/fw/http.c
+++ b/fw/http.c
@@ -5643,7 +5643,8 @@ __check_authority_correctness(TfwHttpReq *req)
 		if (likely(tctx->sni_len != 0) &&
 		    unlikely(!tfw_str_eq_cstr(&req->host,
 		                              __get_sni_from_tls_ctx(tctx),
-					      tctx->sni_len, 0))) {
+		                              tctx->sni_len,
+		                              TFW_STR_EQ_CASEI))) {
 			return false;
 		}
 	}

--- a/fw/http_limits.h
+++ b/fw/http_limits.h
@@ -166,6 +166,7 @@ struct frang_global_cfg_t {
  * @http_ct_required	- Header 'Content-Type:' is required;
  * @http_strict_host_checking - Enforce equality of absolute_uri,
  *			  Host and :authority;
+ * @http_allow_domain_fronting - Allow SNI/authority mismatch
  * @http_trailer_split  - Allow the same header appear in both
  *			  request header part and chunked trailer part;
  * @http_method_override - Allow method override in request headers.
@@ -182,6 +183,7 @@ struct frang_vhost_cfg_t {
 
 	bool			http_ct_required;
 	bool			http_strict_host_checking;
+	bool			http_allow_domain_fronting;
 	bool			http_trailer_split;
 	bool			http_method_override;
 };

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -564,7 +564,7 @@ tfw_tls_conn_dtor(void *c)
 		tfw_h2_context_clear(tfw_h2_context(c));
 
 	if (tls) {
-		if (tls->sni && tls->sni != tls->sni_buf)
+		if (tls->sni_len > sizeof(tls->sni_buf))
 			kfree(tls->sni);
 		while ((skb = ss_skb_dequeue(&tls->io_in.skb_list)))
 			kfree_skb(skb);
@@ -829,7 +829,7 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 			ctx->sni = ctx->sni_buf;
 			memcpy_fast(ctx->sni_buf, data, len);
 		} else {
-			ctx->sni = kmalloc(len, GFP_KERNEL | GFP_NOWAIT);
+			ctx->sni = kmalloc(len, GFP_ATOMIC);
 			if (unlikely(ctx->sni == NULL)) {
 				/* this is non-fatal, just warn about it */
 				SNI_WARN("Unable to allocate %zu bytes for server_name", len);

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -2220,6 +2220,20 @@ tfw_cfgop_frang_strict_host_checking(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
+tfw_cfgop_frang_allow_domain_fronting(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	int r;
+	FrangVhostCfg *cfg = tfw_cfgop_frang_get_cfg();
+
+	if (ce->dflt_value && cfg->http_allow_domain_fronting)
+		return 0;
+	cs->dest = &cfg->http_allow_domain_fronting;
+	r = tfw_cfg_set_bool(cs, ce);
+	cs->dest = NULL;
+	return r;
+}
+
+static int
 tfw_cfgop_frang_ct_required(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
@@ -2810,6 +2824,12 @@ static TfwCfgSpec tfw_global_frang_specs[] = {
 		.name = "http_strict_host_checking",
 		.deflt = "true",
 		.handler = tfw_cfgop_frang_strict_host_checking,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "http_allow_domain_fronting",
+		.deflt = "false",
+		.handler = tfw_cfgop_frang_allow_domain_fronting,
 		.allow_reconfig = true,
 	},
 	{

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -516,6 +516,9 @@ typedef struct {
 /* Declarations of internal TLS data structures. */
 typedef struct tls_handshake_t TlsHandshake;
 
+/* Maximum allowed length of the server name */
+#define MAX_SNI_LEN 4096
+
 /**
  * TLS context.
  *

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -540,6 +540,10 @@ typedef struct tls_handshake_t TlsHandshake;
  * @nb_zero	-  # of 0-length encrypted messages;
  * @client_auth	- flag for client authentication (client side only);
  * @hostname	- expected peer CN for verification (and SNI if available);
+ * @sni		- stored name from SNI extension. Could be NULL, dynamically
+ *		  allocated or point to static buffer. Not NUL-terminated.
+ * @sni_len	- length of the SNI string
+ * @sni_buf	- static buffer for server name
  */
 typedef struct ttls_context {
 	struct sock		*sk;
@@ -550,6 +554,7 @@ typedef struct ttls_context {
 	const ttls_alpn_proto	*alpn_chosen;
 
 	unsigned int		state;
+	unsigned int		sni_len;
 
 	TlsIOCtx		io_in;
 	TlsIOCtx		io_out;
@@ -560,6 +565,8 @@ typedef struct ttls_context {
 	unsigned int		nb_zero;
 	int			client_auth;
 	char			*hostname;
+	char			*sni;
+	char			sni_buf[64];
 } TlsCtx;
 
 typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt);

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -554,6 +554,7 @@ typedef struct ttls_context {
 	const ttls_alpn_proto	*alpn_chosen;
 
 	unsigned int		state;
+	/* Invariant: if sni_len > sizeof(sni_buf), then sni != NULL */
 	unsigned int		sni_len;
 
 	TlsIOCtx		io_in;
@@ -565,8 +566,10 @@ typedef struct ttls_context {
 	unsigned int		nb_zero;
 	int			client_auth;
 	char			*hostname;
-	char			*sni;
-	char			sni_buf[64];
+	union {
+		char		*sni;
+		char		sni_buf[4];
+	};
 } TlsCtx;
 
 typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt);

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -571,7 +571,7 @@ typedef struct ttls_context {
 	char			*hostname;
 	union {
 		char		*sni;
-		char		sni_buf[4];
+		char		sni_buf[32];
 	};
 } TlsCtx;
 


### PR DESCRIPTION
- server name is stored inside statically allocated buffer up to 64 bytes
- if server name is longer than 64 bytes, it is allocated dynamically with kmalloc
- if allocation fails, no validation is performed for requests in that connection. This opens up exploit for host names larger than 1 page (according to kernel manuals, kmalloc may fail if more than 1 page of memory is requested)