### PR TITLE
Validate vhost picked by SNI vs vhost picked by authority

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -5679,17 +5679,20 @@ tfw_http_extract_request_authority(TfwHttpReq *req)
 	TfwStr *hdrs = req->h_tbl->tbl;
 
 	if (TFW_MSG_H2(req)) {
-		/* RFC 9113, sec-8.3.1:
+		/*
+		 * RFC 9113, sec-8.3.1:
 		 * The recipient of an HTTP/2 request MUST NOT use
 		 * the Host header field to determine the target
-		 * URI if ":authority" is present.*/
+		 * URI if ":authority" is present.
+		 */
 		if (!TFW_STR_EMPTY(&hdrs[TFW_HTTP_HDR_H2_AUTHORITY]))
 			hid = TFW_HTTP_HDR_H2_AUTHORITY;
 		else
 			hid = TFW_HTTP_HDR_HOST;
 		__h2_msg_hdr_val(&hdrs[hid], &req->host);
 	} else {
-		/* req->host can be only filled by HTTP/1.x parser from
+		/*
+		 * req->host can be only filled by HTTP/1.x parser from
 		 * absoluteURI, so we act as described by RFC 9112, sec-3.2.2
 		 * (https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.2):
 		 * When an origin server receives a request with an
@@ -5697,11 +5700,10 @@ tfw_http_extract_request_authority(TfwHttpReq *req)
 		 * MUST ignore the received Host header field (if any)
 		 * and instead use the host information of the request-target.
 		 */
-		if (TFW_STR_EMPTY(&req->host)) {
+		if (TFW_STR_EMPTY(&req->host))
 			tfw_http_msg_clnthdr_val(req, &hdrs[TFW_HTTP_HDR_HOST],
 						 TFW_HTTP_HDR_HOST,
 						 &req->host);
-		}
 	}
 }
 
@@ -5858,17 +5860,19 @@ next_msg:
 
 	case TFW_PASS:
 		/*
-		 * The request is fully parsed,
-		 * fall through and process it.
+		 * The request is fully parsed, fall through and process it.
 		 */
-
 		if (WARN_ON_ONCE(!test_bit(TFW_HTTP_B_CHUNKED, req->flags)
 				 && (req->content_length != req->body.len)))
-		{
 			return TFW_BLOCK;
-		}
 	}
 
+	/*
+	 * XXX __check_authority_correctness() is called after parsing a whole
+	 * request, including body. For example: if we have a request with
+	 * invalid host/authority it will be dropped only after full parsing
+	 * while it's enough to parse only headers.
+	 */
 	if (!__check_authority_correctness(req)) {
 		tfw_http_req_parse_drop(req, 400, "Invalid authority");
 		return TFW_BLOCK;

--- a/fw/http.h
+++ b/fw/http.h
@@ -747,5 +747,6 @@ int tfw_h2_frame_local_resp(TfwHttpResp *resp, unsigned int stream_id,
 			    unsigned long h_len, const TfwStr *body);
 int tfw_http_resp_copy_encodings(TfwHttpResp *resp, TfwStr* dst,
 				 size_t max_len);
+void tfw_http_extract_request_authority(TfwHttpReq *req);
 
 #endif /* __TFW_HTTP_H__ */

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -603,6 +603,9 @@ frang_http_domain_fronting_check(const TfwHttpReq *req, FrangAcc *ra)
 	if ((TFW_CONN_TYPE(req->conn) & TFW_FSM_HTTPS) == 0)
 		return TFW_PASS;
 
+	if (tfw_tls_allow_any_sni)
+		return TFW_PASS;
+
 	tctx = tfw_tls_context(req->conn);
 
 	if (tctx->vhost != req->vhost) {

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -600,7 +600,8 @@ __lookup_vhost_by_authority(TfwPool *pool, const TfwStr *authority)
 		name.data = tfw_pool_alloc(pool, name.len + 1);
 		if (name.data == NULL) {
 			T_WARN("Can't allocate temporary buffer of %zu bytes for"
-				   " frang_http_domain_fronting_check()", name.len + 1);
+			       " HTTP domain fronting check",
+			       name.len + 1);
 			return NULL;
 		}
 	}
@@ -616,41 +617,46 @@ static int
 frang_http_domain_fronting_check(const TfwHttpReq *req, FrangAcc *ra)
 {
 	TlsCtx *tctx;
+	TfwVhost *tls_vhost;
+	BasicStr tls_name, req_name;
+	static BasicStr null_name = {"NULL", 4};
 
-	if ((TFW_CONN_TYPE(req->conn) & TFW_FSM_HTTPS) == 0)
+	if (!(TFW_CONN_TYPE(req->conn) & TFW_FSM_HTTPS))
 		return TFW_PASS;
 
-	/* Do not perform any SNI<=>authority validation if
-	 * tls_match_any_server_name is set */
+	/*
+	 * Do not perform any SNI<=>authority validation if
+	 * tls_match_any_server_name is set.
+	 */
 	if (tfw_tls_allow_any_sni)
 		return TFW_PASS;
 
 	tctx = tfw_tls_context(req->conn);
 	/* tfw_tls_sni() has to pick any existing vhost in order to proceed */
-	BUG_ON(tctx->vhost == NULL);
+	BUG_ON(!tctx->vhost);
 
-	if (tctx->vhost != req->vhost) {
-		TfwVhost *tls_vhost = tctx->vhost;
-		BasicStr tls_name, req_name;
-		static BasicStr null_name = {"NULL", 4};
+	if (tctx->vhost == req->vhost)
+		return TFW_PASS;
 
-		/* Special case of default vhosts */
-		if (req->vhost == NULL
-		    && tfw_vhost_is_default(tls_vhost))
-			return TFW_PASS;
+	/* Special case of default vhosts */
+	if (!req->vhost && tfw_vhost_is_default(tctx->vhost))
+		return TFW_PASS;
 
-		/* Last (and slowest case): we have to look for TLS certificate
-		 * by authority and make sure that req->vhost is reachable by
-		 * picked authority name */
-		if (tls_vhost != __lookup_vhost_by_authority(req->pool, &req->host)) {
-			tls_name = tctx->vhost ? tls_vhost->name : null_name;
-			req_name = req->vhost ? req->vhost->name : null_name;
-			frang_msg("vhost by SNI doesn't match vhost by authority",
-					  &FRANG_ACC2CLI(ra)->addr, " ('%.*s' vs '%.*s')\n",
-					  PR_TFW_STR(&tls_name), PR_TFW_STR(&req_name));
-			return TFW_BLOCK;
-		}
+	/*
+	 * Last (and slowest case): we have to look for TLS certificate
+	 * by authority and make sure that req->vhost is reachable by
+	 * picked authority name.
+	 */
+	tls_vhost = __lookup_vhost_by_authority(req->pool, &req->host);
+	if (tls_vhost != tctx->vhost) {
+		tls_name = tctx->vhost ? tctx->vhost->name : null_name;
+		req_name = req->vhost ? req->vhost->name : null_name;
+		frang_msg("vhost by SNI doesn't match vhost by authority",
+			  &FRANG_ACC2CLI(ra)->addr, " ('%.*s' vs '%.*s')\n",
+			  PR_TFW_STR(&tls_name), PR_TFW_STR(&req_name));
+		return TFW_BLOCK;
 	}
+
 	return TFW_PASS;
 }
 

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -616,7 +616,7 @@ frang_http_domain_fronting_check(const TfwHttpReq *req, FrangAcc *ra)
 			return TFW_PASS;
 		/* Special case of default vhosts */
 		if (req->vhost == NULL
-		    && tfw_vhost_is_default(tls_vhost))
+		    || tfw_vhost_is_default(tls_vhost))
 			return TFW_PASS;
 
 		tls_name = tctx->vhost ? tls_vhost->name : null_name;

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -612,8 +612,10 @@ frang_http_domain_fronting_check(const TfwHttpReq *req, FrangAcc *ra)
 
 		/* An exotic case where TLS connection hasn't assigned
 		 * any vhost to the TlsCtx */
-		if (unlikely(tls_vhost == NULL))
-			return TFW_PASS;
+		if (unlikely(tls_vhost == NULL)) {
+			frang_msg("client hasn't sent SNI", &FRANG_ACC2CLI(ra)->addr, "\n");
+			return TFW_BLOCK;
+		}
 		/* Special case of default vhosts */
 		if (req->vhost == NULL
 		    || tfw_vhost_is_default(tls_vhost))

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -699,12 +699,22 @@ frang_http_domain_fronting_check(const TfwHttpReq *req, FrangAcc *ra)
 	tctx = tfw_tls_context(req->conn);
 
 	if (tctx->vhost != req->vhost) {
+		BasicStr tls_name, req_name;
+		static BasicStr null_name = {"NULL", 4};
+
+		/* Special case of default vhosts */
+		if (req->vhost == NULL
+		    && tfw_vhost_is_default(tctx->vhost))
+			return TFW_PASS;
+
+		tls_name = tctx->vhost ? tctx->vhost->name : null_name;
+		req_name = req->vhost ? req->vhost->name : null_name;
 		frang_msg("vhost by SNI doesn't match vhost"
 		          " by authority",
 		          &FRANG_ACC2CLI(ra)->addr,
-		          "('%.*s' vs '%.*s')\n",
-		          PR_TFW_STR(&tctx->vhost->name),
-		          PR_TFW_STR(&req->vhost->name));
+		          " ('%.*s' vs '%.*s')\n",
+		          PR_TFW_STR(&tls_name),
+		          PR_TFW_STR(&req_name));
 		return TFW_BLOCK;
 	}
 	return TFW_PASS;

--- a/fw/http_limits.h
+++ b/fw/http_limits.h
@@ -169,6 +169,7 @@ struct frang_global_cfg_t {
  * @http_trailer_split  - Allow the same header appear in both
  *			  request header part and chunked trailer part;
  * @http_method_override - Allow method override in request headers.
+ * @http_allow_domain_fronting - Allow SNI/authority mismatch
  */
 struct frang_vhost_cfg_t {
 	unsigned long		http_methods_mask;
@@ -182,6 +183,7 @@ struct frang_vhost_cfg_t {
 
 	bool			http_ct_required;
 	bool			http_strict_host_checking;
+	bool			http_allow_domain_fronting;
 	bool			http_trailer_split;
 	bool			http_method_override;
 };

--- a/fw/http_limits.h
+++ b/fw/http_limits.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/http_limits.h
+++ b/fw/http_limits.h
@@ -169,7 +169,6 @@ struct frang_global_cfg_t {
  * @http_trailer_split  - Allow the same header appear in both
  *			  request header part and chunked trailer part;
  * @http_method_override - Allow method override in request headers.
- * @http_allow_domain_fronting - Allow SNI/authority mismatch
  */
 struct frang_vhost_cfg_t {
 	unsigned long		http_methods_mask;
@@ -183,7 +182,6 @@ struct frang_vhost_cfg_t {
 
 	bool			http_ct_required;
 	bool			http_strict_host_checking;
-	bool			http_allow_domain_fronting;
 	bool			http_trailer_split;
 	bool			http_method_override;
 };

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1597,6 +1597,7 @@ __FSM_STATE(RGen_BodyInit, cold) {					\
 	register TfwStr *tbl = msg->h_tbl->tbl;				\
 									\
 	__set_bit(TFW_HTTP_B_HEADERS_PARSED, msg->flags);		\
+	tfw_http_extract_request_authority(req);			\
 	T_DBG3("parse request body: flags=%#lx content_length=%lu\n",	\
 	       msg->flags[0], msg->content_length);			\
 									\

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -285,7 +285,7 @@ tfw_tls_cfg_configured(bool global)
 }
 
 void
-tfw_tls_match_any_sni_to_dflt(bool match)
+tfw_tls_set_allow_any_sni(bool match)
 {
 }
 

--- a/fw/t/unit/test_http_match.c
+++ b/fw/t/unit/test_http_match.c
@@ -847,14 +847,14 @@ TEST(http_match, choose_host)
 		 * host from uri must be matched.
 		 */
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_HOST] = hdr1;
-		extract_request_authority(test_req);
+		tfw_http_extract_request_authority(test_req);
 		match_id = test_chain_match();
 		EXPECT_EQ(1, match_id);
 
 		/* Host specified by Host header */
 		set_tfw_str(&test_req->host, "");
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_HOST] = hdr1;
-		extract_request_authority(test_req);
+		tfw_http_extract_request_authority(test_req);
 		match_id = test_chain_match();
 		EXPECT_EQ(2, match_id);
 
@@ -865,7 +865,7 @@ TEST(http_match, choose_host)
 		set_tfw_str(&test_req->host, "example.com");
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_HOST] = hdr1;
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_FORWARDED] = hdr4;
-		extract_request_authority(test_req);
+		tfw_http_extract_request_authority(test_req);
 		match_id = test_chain_match();
 		EXPECT_EQ(1, match_id);
 
@@ -876,7 +876,7 @@ TEST(http_match, choose_host)
 		set_tfw_str(&test_req->host, "");
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_HOST] = hdr2;
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_FORWARDED] = hdr4;
-		extract_request_authority(test_req);
+		tfw_http_extract_request_authority(test_req);
 		match_id = test_chain_match();
 		EXPECT_EQ(-1, match_id);
 
@@ -890,7 +890,7 @@ TEST(http_match, choose_host)
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_H2_AUTHORITY] = hdr5;
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_HOST] = hdr3;
 		test_req->h_tbl->tbl[TFW_HTTP_HDR_FORWARDED] = hdr4;
-		extract_request_authority(test_req);
+		tfw_http_extract_request_authority(test_req);
 		match_id = test_chain_match();
 		EXPECT_EQ(2, match_id);
 	}

--- a/fw/t/unit/test_http_parser_common.h
+++ b/fw/t/unit/test_http_parser_common.h
@@ -668,6 +668,4 @@ TfwStr get_next_str_val(TfwStr *str);
 void tfw_http_sess_redir_mark_enable(void);
 void tfw_http_sess_redir_mark_disable(void);
 
-void extract_request_authority(TfwHttpReq *req);
-
 #endif /* __TFW_HTTP_PARSER_COMMON_H__ */

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -817,9 +817,14 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 
 		if (unlikely(!vhost && !tfw_tls.allow_any_sni)) {
 			SNI_WARN("unknown server name '%.*s', reject connection.\n",
-				 PR_TFW_STR(&srv_name));
+				 (int)len, data);
 			return -ENOENT;
 		}
+		/* Save vhost that had been selected by SNI */
+		ctx->vhost = vhost;
+	} else {
+		/* No SNI => no vhost for later frang checks */
+		ctx->vhost = NULL;
 	}
 	/*
 	 * If accurate vhost is not found or client doesn't send sni extension,
@@ -851,8 +856,6 @@ found:
 	}
 	/* Save processed server name as hash. */
 	ctx->sni_hash = len ? hash_calc(data, len) : 0;
-	/* Save vhost that had been selected by SNI */
-	ctx->vhost = vhost;
 
 	return 0;
 }

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -37,16 +37,11 @@
 #include "vhost.h"
 #include "tcp.h"
 
-/**
- * Global level TLS configuration.
- *
- *			  vhost.
- */
-/** Common tls configuration for all vhosts; */
-static TlsCfg		tfw_tls_cfg;
-/** If set, all the unknown SNI are matched to default vhost. */
-bool		    tfw_tls_allow_any_sni;
+/* Common tls configuration for all vhosts. */
+static TlsCfg tfw_tls_cfg;
 
+/* If set, all the unknown SNI are matched to default vhost. */
+bool tfw_tls_allow_any_sni;
 /* Temporal value for reconfiguration stage. */
 static bool allow_any_sni_reconfig;
 
@@ -792,7 +787,7 @@ tfw_tls_find_vhost_by_name(BasicStr *srv_name)
 	 * lower domain.
 	 */
 	if (!vhost && !fw_tls_apply_sni_wildcard(srv_name)
-		&& (vhost = tfw_vhost_lookup_sni(srv_name)))
+	    && (vhost = tfw_vhost_lookup_sni(srv_name)))
 		return vhost;
 
 	return NULL;
@@ -817,8 +812,10 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 		return -EBUSY;
 
 	if (data && len) {
-		/* Data comes as a copy from temporary buffer tls_handshake_t::ext
-		 * See ttls_parse_client_hello() for details */
+		/*
+		 * Data comes as a copy from temporary buffer tls_handshake_t::ext
+		 * See ttls_parse_client_hello() for details.
+		 */
 		tfw_cstrtolower(srv_name.data, srv_name.data, len);
 
 		vhost = tfw_tls_find_vhost_by_name(&srv_name);
@@ -827,7 +824,8 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 				 (int)len, data);
 			return -ENOENT;
 		}
-	} else if (!tfw_tls_allow_any_sni) {
+	}
+	else if (!tfw_tls_allow_any_sni) {
 		SNI_WARN("missing server name, reject connection.\n");
 		return -ENOENT;
 	}

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -766,7 +766,7 @@ fw_tls_apply_sni_wildcard(BasicStr *name)
 	n = name->data + name->len - p;
 
 	/* The resulting name must be lower than a top level domain. */
-	if (n < 3 || !strnchr(p + 1, n, '.'))
+	if (n < 2)
 		return -ENOENT;
 
 	/*
@@ -810,8 +810,12 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 			return -ENOENT;
 		}
 
+		/* Look for non-wildcard SAN */
+		if (!vhost && (vhost = tfw_vhost_lookup_sni(&srv_name)))
+			goto found;
+
 		/*
-		 * Try wildcard SANs if the SNI requests 3rd-level or
+		 * Try wildcard SANs if the SNI requests 2nd-level or
 		 * lower domain.
 		 */
 		if (!vhost && !fw_tls_apply_sni_wildcard(&srv_name))

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -851,6 +851,8 @@ found:
 	}
 	/* Save processed server name as hash. */
 	ctx->sni_hash = len ? hash_calc(data, len) : 0;
+	/* Save vhost that had been selected by SNI */
+	ctx->vhost = vhost;
 
 	return 0;
 }

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -946,7 +946,7 @@ tfw_tls_cfg_configured(bool global)
 }
 
 void
-tfw_tls_match_any_sni_to_dflt(bool match)
+tfw_tls_set_allow_any_sni(bool match)
 {
 	allow_any_sni_reconfig = match;
 }

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -812,7 +812,10 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 
 		/* Look for non-wildcard SAN */
 		if (!vhost && (vhost = tfw_vhost_lookup_sni(&srv_name)))
+		{
+			ctx->vhost = vhost;
 			goto found;
+		}
 
 		/*
 		 * Try wildcard SANs if the SNI requests 2nd-level or
@@ -820,7 +823,10 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 		 */
 		if (!vhost && !fw_tls_apply_sni_wildcard(&srv_name))
 			if ((vhost = tfw_vhost_lookup_sni(&srv_name)))
+			{
+				ctx->vhost = vhost;
 				goto found;
+			}
 
 		if (unlikely(!vhost && !tfw_tls.allow_any_sni)) {
 			SNI_WARN("unknown server name '%.*s', reject connection.\n",

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -798,6 +798,9 @@ tfw_tls_sni(TlsCtx *ctx, const unsigned char *data, size_t len)
 		return -EBUSY;
 
 	if (data && len) {
+		/* Data comes as a copy from temporary buffer tls_handshake_t::ext
+		 * See ttls_parse_client_hello() for details */
+		tfw_cstrtolower(srv_name.data, srv_name.data, len);
 		vhost = tfw_vhost_lookup(&srv_name);
 
 		if (unlikely(vhost && tfw_vhost_is_default(vhost))) {

--- a/fw/tls.h
+++ b/fw/tls.h
@@ -22,6 +22,8 @@
 
 #include "ttls.h"
 
+extern bool tfw_tls_allow_any_sni;
+
 void tfw_tls_cfg_require(void);
 void tfw_tls_cfg_configured(bool global);
 void tfw_tls_match_any_sni_to_dflt(bool match);

--- a/fw/tls.h
+++ b/fw/tls.h
@@ -28,7 +28,7 @@ extern bool tfw_tls_allow_any_sni;
 
 void tfw_tls_cfg_require(void);
 void tfw_tls_cfg_configured(bool global);
-void tfw_tls_match_any_sni_to_dflt(bool match);
+void tfw_tls_set_allow_any_sni(bool match);
 int tfw_tls_cfg_alpn_protos(const char *cfg_str);
 int tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int mss_now,
 		    unsigned int limit, unsigned int nskbs);

--- a/fw/tls.h
+++ b/fw/tls.h
@@ -21,6 +21,8 @@
 #define __TFW_TLS_H__
 
 #include "ttls.h"
+#include "http_types.h"
+#include "str.h"
 
 extern bool tfw_tls_allow_any_sni;
 
@@ -33,5 +35,7 @@ int tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int mss_now,
 
 typedef struct tfw_conn_t TfwConn;
 int tfw_tls_connection_recv(TfwConn *conn, struct sk_buff *skb);
+
+TfwVhost* tfw_tls_find_vhost_by_name(BasicStr *srv_name);
 
 #endif /* __TFW_TLS_H__ */

--- a/fw/tls_conf.c
+++ b/fw/tls_conf.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/fw/tls_conf.c
+++ b/fw/tls_conf.c
@@ -125,13 +125,6 @@ tfw_tls_add_cn(const ttls_x509_buf *sname, void *a_vhost)
 
 
 	/*
-	 * Try exact name match.
-	 * SNI with this name will be resolved from the vhost hash table.
-	 */
-	if (sname->len == hlen && !strncasecmp(sname->p, hname, hlen))
-		return 0;
-
-	/*
 	 * Try wildcard match by RFC 2818 3.1:
 	 *
 	 *   Names may contain the wildcard character * which is considered to

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -2271,20 +2271,6 @@ tfw_cfgop_frang_strict_host_checking(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
-tfw_cfgop_frang_allow_domain_fronting(TfwCfgSpec *cs, TfwCfgEntry *ce)
-{
-	int r;
-	FrangVhostCfg *cfg = tfw_cfgop_frang_get_cfg();
-
-	if (ce->dflt_value && cfg->http_allow_domain_fronting)
-		return 0;
-	cs->dest = &cfg->http_allow_domain_fronting;
-	r = tfw_cfg_set_bool(cs, ce);
-	cs->dest = NULL;
-	return r;
-}
-
-static int
 tfw_cfgop_frang_ct_required(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
@@ -2884,12 +2870,6 @@ static TfwCfgSpec tfw_global_frang_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
-		.name = "http_allow_domain_fronting",
-		.deflt = "true",
-		.handler = tfw_cfgop_frang_allow_domain_fronting,
-		.allow_reconfig = true,
-	},
-	{
 		.name = "http_ct_required",
 		.deflt = "false",
 		.handler = tfw_cfgop_frang_ct_required,
@@ -3039,12 +3019,6 @@ static TfwCfgSpec tfw_vhost_frang_specs[] = {
 		.name = "http_strict_host_checking",
 		.deflt = "true",
 		.handler = tfw_cfgop_frang_strict_host_checking,
-		.allow_reconfig = true,
-	},
-	{
-		.name = "http_allow_domain_fronting",
-		.deflt = "true",
-		.handler = tfw_cfgop_frang_allow_domain_fronting,
 		.allow_reconfig = true,
 	},
 	{

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -2271,6 +2271,20 @@ tfw_cfgop_frang_strict_host_checking(TfwCfgSpec *cs, TfwCfgEntry *ce)
 }
 
 static int
+tfw_cfgop_frang_allow_domain_fronting(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	int r;
+	FrangVhostCfg *cfg = tfw_cfgop_frang_get_cfg();
+
+	if (ce->dflt_value && cfg->http_allow_domain_fronting)
+		return 0;
+	cs->dest = &cfg->http_allow_domain_fronting;
+	r = tfw_cfg_set_bool(cs, ce);
+	cs->dest = NULL;
+	return r;
+}
+
+static int
 tfw_cfgop_frang_ct_required(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
@@ -2867,6 +2881,12 @@ static TfwCfgSpec tfw_global_frang_specs[] = {
 		.name = "http_strict_host_checking",
 		.deflt = "true",
 		.handler = tfw_cfgop_frang_strict_host_checking,
+		.allow_reconfig = true,
+	},
+	{
+		.name = "http_allow_domain_fronting",
+		.deflt = "false",
+		.handler = tfw_cfgop_frang_allow_domain_fronting,
 		.allow_reconfig = true,
 	},
 	{

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -3042,6 +3042,12 @@ static TfwCfgSpec tfw_vhost_frang_specs[] = {
 		.allow_reconfig = true,
 	},
 	{
+		.name = "http_allow_domain_fronting",
+		.deflt = "true",
+		.handler = tfw_cfgop_frang_allow_domain_fronting,
+		.allow_reconfig = true,
+	},
+	{
 		.name = "http_ct_required",
 		.deflt = "false",
 		.handler = tfw_cfgop_frang_ct_required,

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -2429,7 +2429,7 @@ tfw_cfgop_tls_any_sni(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (r)
 		return r;
 
-	tfw_tls_match_any_sni_to_dflt(val);
+	tfw_tls_set_allow_any_sni(val);
 
 	return 0;
 }

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -2885,7 +2885,7 @@ static TfwCfgSpec tfw_global_frang_specs[] = {
 	},
 	{
 		.name = "http_allow_domain_fronting",
-		.deflt = "false",
+		.deflt = "true",
 		.handler = tfw_cfgop_frang_allow_domain_fronting,
 		.allow_reconfig = true,
 	},

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -273,7 +273,7 @@ TfwCaPolicy *tfw_capolicy_match(TfwLocation *loc, TfwStr *arg);
 TfwLocation *tfw_location_match(TfwVhost *vhost, TfwStr *arg);
 
 TfwVhost *tfw_vhost_new(const char *name);
-void tfw_vhost_add_sni_map(const BasicStr *cn, const char *hname, int hlen);
+void tfw_vhost_add_sni_map(const BasicStr *cn, TfwVhost *vhost);
 
 TfwVhost *tfw_vhost_lookup_reconfig(const char *name);
 TfwVhost *tfw_vhost_lookup(const BasicStr *name);

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -276,7 +276,6 @@ TfwVhost *tfw_vhost_new(const char *name);
 void tfw_vhost_add_sni_map(const BasicStr *cn, TfwVhost *vhost);
 
 TfwVhost *tfw_vhost_lookup_reconfig(const char *name);
-TfwVhost *tfw_vhost_lookup(const BasicStr *name);
 TfwVhost *tfw_vhost_lookup_sni(const BasicStr *name);
 TfwVhost *tfw_vhost_lookup_default(void);
 

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -37,6 +37,7 @@
 #include "x509_crl.h"
 #include "dhm.h"
 #include "ecdh.h"
+#include "fw/http_types.h"
 
 /* The requested feature is not available. */
 #define TTLS_ERR_FEATURE_UNAVAILABLE		-0x7080
@@ -540,6 +541,7 @@ typedef struct tls_handshake_t TlsHandshake;
  * @nb_zero	-  # of 0-length encrypted messages;
  * @client_auth	- flag for client authentication (client side only);
  * @hostname	- expected peer CN for verification (and SNI if available);
+ * @vhost	- vhost selected by SNI
  */
 typedef struct ttls_context {
 	struct sock		*sk;
@@ -560,6 +562,7 @@ typedef struct ttls_context {
 	unsigned int		nb_zero;
 	int			client_auth;
 	char			*hostname;
+	TfwVhost		*vhost;
 } TlsCtx;
 
 typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt);

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -4,7 +4,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,7 +37,6 @@
 #include "x509_crl.h"
 #include "dhm.h"
 #include "ecdh.h"
-#include "fw/http_types.h"
 
 /* The requested feature is not available. */
 #define TTLS_ERR_FEATURE_UNAVAILABLE		-0x7080
@@ -541,7 +540,7 @@ typedef struct tls_handshake_t TlsHandshake;
  * @nb_zero	-  # of 0-length encrypted messages;
  * @client_auth	- flag for client authentication (client side only);
  * @hostname	- expected peer CN for verification (and SNI if available);
- * @vhost	- vhost selected by SNI
+ * @vhost	- vhost selected by SNI (TfwVhost)
  */
 typedef struct ttls_context {
 	struct sock		*sk;
@@ -562,7 +561,7 @@ typedef struct ttls_context {
 	unsigned int		nb_zero;
 	int			client_auth;
 	char			*hostname;
-	TfwVhost		*vhost;
+	void			*vhost;
 } TlsCtx;
 
 typedef int ttls_send_cb_t(TlsCtx *tls, struct sg_table *sgt);

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -540,7 +540,8 @@ typedef struct tls_handshake_t TlsHandshake;
  * @nb_zero	-  # of 0-length encrypted messages;
  * @client_auth	- flag for client authentication (client side only);
  * @hostname	- expected peer CN for verification (and SNI if available);
- * @vhost	- vhost selected by SNI (TfwVhost)
+ * @vhost	- vhost selected by SNI (TfwVhost*), NULL if no SNI extension
+ *		  had been sent by the client
  */
 typedef struct ttls_context {
 	struct sock		*sk;

--- a/tls/x509_crt.c
+++ b/tls/x509_crt.c
@@ -15,7 +15,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tls/x509_crt.c
+++ b/tls/x509_crt.c
@@ -1792,8 +1792,8 @@ exit:
 
 int
 ttls_x509_process_san(const TlsX509Crt *crt,
-		      int (*process_cn)(const ttls_x509_buf *, const char *, int),
-		      const char *hname, int hlen)
+		      int (*process_cn)(const ttls_x509_buf *, void *arg),
+		      void *process_arg)
 {
 	int r = TTLS_X509_BADCERT_CN_MISMATCH;
 	const ttls_x509_name *name;
@@ -1806,14 +1806,14 @@ ttls_x509_process_san(const TlsX509Crt *crt,
 			/* Just skip non-dNSName records. */
 			if (san_type != TTLS_X509_SAN_DNS_NAME)
 				continue;
-			if (!process_cn(&cur->buf, hname, hlen))
+			if (!process_cn(&cur->buf, process_arg))
 				r = 0;
 		}
 	} else {
 		for (name = &crt->subject; name; name = name->next) {
 			if (TTLS_OID_CMP(TTLS_OID_AT_CN, &name->oid))
 				continue;
-			if (!process_cn(&name->val, hname, hlen))
+			if (!process_cn(&name->val, process_arg))
 				r = 0;
 		}
 	}

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -143,8 +143,8 @@ int ttls_x509_crt_check_extended_key_usage(const TlsX509Crt *crt,
 
 int ttls_x509_process_san(const TlsX509Crt *crt,
 			  int (*process_cn)(const ttls_x509_buf *,
-					    const char *, int),
-			  const char *name, int len);
+					    void *arg),
+			  void *process_arg);
 
 TlsX509Crt *ttls_x509_crt_alloc(void);
 void ttls_x509_crt_init(TlsX509Crt *crt);

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This is alternative implementation of #1688 that compares vhost pointers selected by `tfw_tls_sni()` and HTTP tables mechanism.

Related tempesta-test PR: https://github.com/tempesta-tech/tempesta-test/pull/456