### PR TITLE
Fix BUG_ON in `tfw_h2_stream_process`.

### DIFF
--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -767,7 +767,7 @@ tfw_h2_stream_process(TfwH2Ctx *ctx, TfwStream *stream, unsigned char type)
 	 * closed queue.
 	 */
 	if (!stream->xmit.b_len) {
-		BUG_ON(stream->xmit.h_len);
+		WARN_ON_ONCE(stream->xmit.h_len);
 		queue = &ctx->closed_streams;
 		flags |= HTTP2_F_END_STREAM;
 	}


### PR DESCRIPTION
In case when we processed skb in `tfw_sk_prepare_xmit` and then something went wrong and this skb was not transmit to network, this skb would be passed to
`tfw_sk_prepare_xmit` again. We should not process such skb and only update limit according to previously processed bytes. Also change BUG_ON to WARN_ON in
`tfw_h2_stream_process` because such error is not
a reason to kernel panic.

Closes #1879