### PR TITLE
Fixed bug when headers and body after our modifications became shuffled

### DIFF
--- a/fw/ss_skb.h
+++ b/fw/ss_skb.h
@@ -147,6 +147,23 @@ ss_skb_insert_after(struct sk_buff *skb, struct sk_buff *nskb)
 	nskb->next->prev = skb->next = nskb;
 }
 
+/*
+ * Insert @nskb in the list before @skb and update @skb_head.
+ */
+static inline void
+ss_skb_insert_before(struct sk_buff **skb_head, struct sk_buff *skb,
+		     struct sk_buff *nskb)
+{
+	/* The skb shouldn't be in any other queue. */
+	WARN_ON_ONCE(nskb->next || nskb->prev);
+	nskb->next = skb;
+	nskb->prev = skb->prev;
+	nskb->next->prev = nskb->prev->next = nskb;
+
+	if (*skb_head == skb)
+		*skb_head = nskb;
+}
+
 /**
  * Almost a copy of standard skb_dequeue() except it works with skb list
  * instead of sk_buff_head. Several crucial data include skb list and we don't

--- a/fw/t/unit/test_http_msg.c
+++ b/fw/t/unit/test_http_msg.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2023 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -84,7 +84,146 @@ TEST(http_msg, hdr_in_array)
 	EXPECT_NOT_NULL(tfw_http_msg_find_hdr(&dup_hdr, hdrs));
 }
 
+static TfwHttpResp *
+__test_resp_alloc(TfwStr *head_data, TfwStr *paged_data,
+		  unsigned short nr_frags)
+{
+	TfwMsgIter *it;
+	TfwHttpResp *hmresp;
+	struct sk_buff *skb;
+	struct page *page;
+	char *addr;
+	int i;
+
+	hmresp = (TfwHttpResp *)__tfw_http_msg_alloc(Conn_HttpSrv, true);
+	BUG_ON(!hmresp);
+
+	skb = ss_skb_alloc(head_data->len);
+	if (!skb)
+		return NULL;
+
+	skb->next = skb->prev = skb;
+	it = &hmresp->mit.iter;
+	it->skb = it->skb_head = skb;
+	it->frag = -1;
+
+	skb_put_data(skb, head_data->data, head_data->len);
+
+	if (nr_frags == 0)
+		return hmresp;
+
+	page = alloc_page(GFP_ATOMIC);
+	if (!page) {
+		kfree_skb(skb);
+		return NULL;
+	}
+
+	addr = page_address(page);
+	memcpy(addr, paged_data->data, paged_data->len);
+
+	for (i = 0; i < nr_frags; ++i) {
+		skb_fill_page_desc(skb, i, page, 0, paged_data->len);
+		ss_skb_adjust_data_len(skb, paged_data->len);
+	}
+
+	return hmresp;
+}
+
+/*
+ * Tests correctness of using SKBs with linear data during allocating memory
+ * using @tfw_http_msg_expand_from_pool().
+ */
+TEST(http_msg, expand_from_pool)
+{
+	static TfwStr frags[] = {
+		TFW_STR_STRING("headers"),
+		TFW_STR_STRING("linear_body"),
+		TFW_STR_STRING("paged_body")
+	};
+	TfwStr *hdr = &frags[0], *head = &frags[1], *pgd = &frags[2];
+	TfwHttpResp *resp = __test_resp_alloc(head, pgd, 1);
+	TfwMsgIter *it;
+	int i;
+
+	EXPECT_NOT_NULL(resp);
+	if (!resp)
+		return;
+
+	it = &resp->mit.iter;
+
+	EXPECT_FALSE(it->skb->data_len == head->len + hdr->len + pgd->len);
+	tfw_http_msg_expand_from_pool(resp, hdr);
+	/* Linear part MUST be moved to paged fragments */
+	EXPECT_TRUE(!skb_headlen(it->skb));
+
+	for (i = 0; i < ARRAY_SIZE(frags); i++) {
+		skb_frag_t *frag = &skb_shinfo(it->skb)->frags[i];
+		char* addr = skb_frag_address(frag);
+		unsigned int fragsz = skb_frag_size(frag);
+
+		EXPECT_ZERO(memcmp(addr, frags[i].data, fragsz));
+	}
+	tfw_http_msg_free((TfwHttpMsg *)resp);
+}
+
+/*
+ * Tests correctness of using SKBs with linear data and maximum fragments
+ * during allocating memory using @tfw_http_msg_expand_from_pool().
+ */
+TEST(http_msg, expand_from_pool_max_frags)
+{
+	TfwStr head = TFW_STR_STRING("linear_body");
+	TfwStr pgd = TFW_STR_STRING("paged_body");
+	TfwStr hdr = TFW_STR_STRING("headers");
+	TfwHttpResp *resp = __test_resp_alloc(&head, &pgd, MAX_SKB_FRAGS);
+	unsigned int skbsz = head.len + hdr.len + (pgd.len + MAX_SKB_FRAGS);
+	struct sk_buff *skb, *next;
+	TfwMsgIter *it;
+
+#define EXPECT_FRAGS_EQ_STR(skb, data)					\
+do {									\
+	int i;								\
+									\
+	for (i = 0; i < skb_shinfo(skb)->nr_frags; i++)	{		\
+		skb_frag_t *frag = &skb_shinfo(skb)->frags[i];		\
+		char* addr = skb_frag_address(frag);			\
+		unsigned int fragsz = skb_frag_size(frag);		\
+									\
+		EXPECT_ZERO(memcmp(addr, data, fragsz));		\
+	}								\
+} while (0)
+
+	EXPECT_NOT_NULL(resp);
+	if (!resp)
+		return;
+
+	it = &resp->mit.iter;
+
+	EXPECT_FALSE(it->skb->data_len == skbsz);
+	tfw_http_msg_expand_from_pool(resp, &hdr);
+	skb = it->skb;
+	next = it->skb->next;
+
+	/* Expected new skb without linear data. */
+	EXPECT_TRUE(!skb_headlen(skb));
+
+	/* Current SKB must contain only one frag with "headers" */
+	EXPECT_FRAGS_EQ_STR(skb, hdr.data);
+
+	/*
+	 * Next SKB must contain "linear_body" in linear data
+	 * and "paged_body" in each paged fragment.
+	 */
+	EXPECT_ZERO(memcmp(next->data, head.data, skb_headlen(next)));
+	EXPECT_FRAGS_EQ_STR(next, pgd.data);
+	tfw_http_msg_free((TfwHttpMsg *)resp);
+
+#undef EXPECT_FRAGS_EQ_STR
+}
+
 TEST_SUITE(http_msg)
 {
 	TEST_RUN(http_msg, hdr_in_array);
+	TEST_RUN(http_msg, expand_from_pool);
+	TEST_RUN(http_msg, expand_from_pool_max_frags);
 }


### PR DESCRIPTION
This happened when we added data to SKB with linear data, but don't moved linear part to paged fragment. We must move linear data to paged, because we insert data only to paged fragments and in such cases inserted data will be placed after linear part, however we expect that data will be inserted before linear data.

For instance: HTTP2 response. After cutting headers we got SKB with body in linear data and paged data. When we try to add headers to the SKB we insert headers between body from linear data and body from paged data.