### PR TITLE
Merge multiple cookie headers coming from HTTP/2 client into a single Cookie header for HTTP/1.1 backend

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -3624,7 +3624,8 @@ tfw_h2_req_set_loc_hdrs(TfwHttpReq *req)
 	return 0;
 }
 
-/** Fuse multiple cookie headers into one.
+/**
+ * Fuse multiple cookie headers into one.
  * Works only with TFW_STR_DUP strings. */
 static int
 write_merged_cookie_headers(TfwStr *hdr, TfwMsgIter *it)
@@ -3639,9 +3640,8 @@ write_merged_cookie_headers(TfwStr *hdr, TfwMsgIter *it)
 	TFW_STR_FOR_EACH_DUP(dup, hdr, dup_end) {
 		TfwStr *chunk, *chunk_end, hval = {};
 
-		if (unlikely(TFW_STR_PLAIN(dup))) {
+		if (unlikely(TFW_STR_PLAIN(dup)))
 			return -EINVAL;
-		}
 
 		hval.chunks = dup->chunks;
 		hval.nchunks = dup->nchunks;
@@ -3883,11 +3883,11 @@ tfw_h2_adjust_req(TfwHttpReq *req)
 			}
 			break;
 		case TFW_HTTP_HDR_COOKIE:
-			if (TFW_STR_DUP(field)) {
-				r |= write_merged_cookie_headers(&ht->tbl[TFW_HTTP_HDR_COOKIE], &it);
-				continue;
-			}
-			break;
+			if (!TFW_STR_DUP(field))
+				break;
+			r |= write_merged_cookie_headers(
+					&ht->tbl[TFW_HTTP_HDR_COOKIE], &it);
+			continue;
 		default:
 			break;
 		}


### PR DESCRIPTION
Also fix "strange" error codes coming from bitwise OR'ing or Exx error codes.

This PR is passing `http2_general.test_h2_headers.TestSplitCookies.test_split_cookies` test. I've also checked that calculated HTTP/1.1 header size (`h1_hdrs_sz`) is equal to actual  header length intercepted by wireshark.

PR with enabling tests: https://github.com/tempesta-tech/tempesta-test/pull/469