### PR TITLE
Fix race in rsa implementation.

### DIFF
--- a/tls/bignum.c
+++ b/tls/bignum.c
@@ -44,6 +44,15 @@
 /* Maximum sliding window size in bits used for modular exponentiation. */
 #define MPI_W_SZ		6
 
+void
+ttls_mpi_precompute_RR(TlsMpi *X, const TlsMpi *N)
+{
+	ttls_mpi_alloc(X, N->used * 2 + 2);
+	ttls_mpi_lset(X, 1);
+	ttls_mpi_shift_l(X, X, N->used * 2 * BIL);
+	ttls_mpi_mod_mpi(X, X, N);
+}
+
 /**
  * Allocate an MPI on the stack and initialize it with the required limbs in
  * one shot.
@@ -1228,12 +1237,8 @@ ttls_mpi_exp_mod(TlsMpi *X, const TlsMpi *A, const TlsMpi *E, const TlsMpi *N,
 	 * If 1st call, pre-compute R^2 mod N
 	 */
 	BUG_ON(!RR);
-	if (unlikely(ttls_mpi_empty(RR))) {
-		ttls_mpi_alloc(RR, N->used * 2 + 2);
-		ttls_mpi_lset(RR, 1);
-		ttls_mpi_shift_l(RR, RR, N->used * 2 * BIL);
-		ttls_mpi_mod_mpi(RR, RR, N);
-	}
+	if (unlikely(ttls_mpi_empty(RR)))
+		ttls_mpi_precompute_RR(RR, N);
 
 	/* W[1] = A * R^2 * R^-1 mod N = A * R mod N */
 	if (ttls_mpi_cmp_mpi(A, N) >= 0)

--- a/tls/bignum.h
+++ b/tls/bignum.h
@@ -210,6 +210,7 @@ int ttls_mpi_exp_mod(TlsMpi *X, const TlsMpi *A, const TlsMpi *E,
 		     const TlsMpi *N, TlsMpi *_RR);
 void ttls_mpi_inv_mod(TlsMpi *X, const TlsMpi *A, const TlsMpi *N);
 void ttls_mpi_gcd(TlsMpi *G, const TlsMpi *A, const TlsMpi *B);
+void ttls_mpi_precompute_RR(TlsMpi *X, const TlsMpi *N);
 
 static inline bool
 ttls_mpi_empty(const TlsMpi *X)

--- a/tls/dhm.c
+++ b/tls/dhm.c
@@ -121,6 +121,8 @@ ttls_dhm_load(TlsDHMCtx *ctx)
 	ttls_mpi_read_binary(&ctx->G, ttls_dhm_rfc3526_modp_2048_g,
 			     sizeof(ttls_dhm_rfc3526_modp_2048_g));
 	ctx->len = ttls_mpi_size(&ctx->P);
+	ttls_mpi_alloc(&ctx->GX, ctx->P.used + 1);
+	ttls_mpi_alloc(&ctx->K, ctx->P.used + 1);
 }
 
 /*
@@ -394,10 +396,10 @@ ttls_dhm_calc_secret(TlsDHMCtx *ctx, unsigned char *output, size_t output_size,
 	if ((r = dhm_check_range(&ctx->GY, &ctx->P)))
 		return r;
 
-	GYb = ttls_mpi_alloc_stack_init(ctx->GY.used + ctx->Vi.used);
-
 	/* Blind peer's value */
 	MPI_CHK(dhm_update_blinding(ctx));
+
+	GYb = ttls_mpi_alloc_stack_init(ctx->GY.used + ctx->Vi.used);
 	ttls_mpi_mul_mpi(GYb, &ctx->GY, &ctx->Vi);
 	ttls_mpi_mod_mpi(GYb, GYb, &ctx->P);
 

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -1432,7 +1432,11 @@ ttls_write_server_key_exchange(TlsCtx *tls, struct sg_table *sgt,
 			TTLS_WARN(tls, "cannot make DHM params, %d\n", r);
 			return r;
 		}
-		WARN_ON_ONCE(len > 500);
+		/*
+		 * ttls_dhm_make_params write (256 + 2) + (1 + 2) + (256 + 2)
+		 * bytes.
+		 */
+		WARN_ON_ONCE(len > 519);
 		dig_signed = p;
 		sig_len = len;
 		p += len;
@@ -1512,8 +1516,11 @@ ttls_write_server_key_exchange(TlsCtx *tls, struct sg_table *sgt,
 	n += sig_len;
 	WARN_ON_ONCE(sig_len > 512);
 
-	/* Done with actual work; add handshake header and add the record. */
-	WARN_ON_ONCE(n > 1015);
+	/*
+	 * Done with actual work; add handshake header and add the record
+	 * (519 + 4 + 512).
+	 */
+	WARN_ON_ONCE(n > 1035);
 	io->msglen = TTLS_HS_HDR_LEN + n;
 	ttls_write_hshdr(TTLS_HS_SERVER_KEY_EXCHANGE, hdr + TLS_HEADER_SIZE,
 			 TTLS_HS_HDR_LEN + n);
@@ -2020,7 +2027,7 @@ ttls_handshake_server_hello(TlsCtx *tls, struct sg_table *sgt,
 	T_FSM_STATE(TTLS_SERVER_KEY_EXCHANGE) {
 		if ((r = ttls_write_server_key_exchange(tls, sgt, in_buf)))
 			T_FSM_EXIT();
-		CHECK_STATE(1024);
+		CHECK_STATE(1044);
 		/*
 		 * RFC 5246 Certificate Request is optional, so don't request
 		 * a certificate for now since we're unable to properly verify


### PR DESCRIPTION
We should initialize `ctx->RP` and `ctx->RQ`
when we initialize rsa context not during key
signition, because key signition can be called
on different CPUs for one ctx, which lead to race.

Closes #1779, #1892