### PR TITLE
Fix invalid return code in `tfw_tls_add_cn`

### DIFF
--- a/fw/tls_conf.c
+++ b/fw/tls_conf.c
@@ -163,7 +163,7 @@ tfw_tls_add_cn(const ttls_x509_buf *sname, void *a_vhost)
 	 */
 	tfw_vhost_add_sni_map(&cn, vhost);
 
-	return T_BAD;
+	return r;
 }
 
 /**


### PR DESCRIPTION
Currently `tfw_tls_add_cn` always return T_BAD,
but it should return 0 if the wildcard CN matches
the host name.