### PR TITLE
Validate stream_id from HEADERS frame

### DIFF
--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -1482,12 +1482,12 @@ tfw_h2_frame_type_process(TfwH2Ctx *ctx)
 			goto conn_term;
 		}
 
-		ctx->cur_stream = tfw_h2_find_stream(&ctx->sched,
-						     hdr->stream_id);
 		if (tfw_h2_stream_id_verify(ctx)) {
 			err_code = HTTP2_ECODE_PROTO;
 			goto conn_term;
 		}
+		ctx->cur_stream = tfw_h2_find_stream(&ctx->sched,
+						     hdr->stream_id);
 		/*
 		 * Endpoints must not exceed the limit set by their peer for
 		 * maximum number of concurrent streams (see RFC 7540 section

--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -1283,8 +1283,12 @@ tfw_h2_first_settings_verify(TfwH2Ctx *ctx)
 }
 
 static inline int
-tfw_h2_stream_id_verify(unsigned stream_id, unsigned lstream_id)
+tfw_h2_stream_id_verify(TfwH2Ctx *ctx)
 {
+	TfwFrameHdr *hdr = &ctx->hdr;
+
+	if (ctx->cur_stream && ctx->cur_stream->state < HTTP2_STREAM_REM_CLOSED)
+		return T_OK;
 	/*
 	 * If stream ID is not greater than last processed ID, there may be
 	 * two reasons for that:
@@ -1304,17 +1308,17 @@ tfw_h2_stream_id_verify(unsigned stream_id, unsigned lstream_id)
 	 * right away), streams in these states are temporary stored in special
 	 * queue @TfwStreamQueue.
 	 */
-	if (lstream_id >= stream_id) {
+	if (ctx->lstream_id >= hdr->stream_id) {
 		T_DBG("Invalid ID of new stream: %u stream is"
 		      " closed and removed, %u last initiated\n",
-		      stream_id, lstream_id);
+		      hdr->stream_id, ctx->lstream_id);
 		return T_DROP;
 	}
 	/*
 	 * Streams initiated by client must use odd-numbered
 	 * identifiers (see RFC 7540 section 5.1.1 for details).
 	 */
-	if (!(stream_id & 0x1)) {
+	if (!(hdr->stream_id & 0x1)) {
 		T_DBG("Invalid ID of new stream: initiated by"
 		      " server\n");
 		return T_DROP;
@@ -1478,12 +1482,12 @@ tfw_h2_frame_type_process(TfwH2Ctx *ctx)
 			goto conn_term;
 		}
 
-		if (tfw_h2_stream_id_verify(hdr->stream_id, ctx->lstream_id)) {
+		ctx->cur_stream = tfw_h2_find_stream(&ctx->sched,
+						     hdr->stream_id);
+		if (tfw_h2_stream_id_verify(ctx)) {
 			err_code = HTTP2_ECODE_PROTO;
 			goto conn_term;
 		}
-		ctx->cur_stream = tfw_h2_find_stream(&ctx->sched,
-						     hdr->stream_id);
 		/*
 		 * Endpoints must not exceed the limit set by their peer for
 		 * maximum number of concurrent streams (see RFC 7540 section

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -289,25 +289,13 @@ tfw_h2_stream_fsm(TfwStream *stream, unsigned char type, unsigned char flags,
 		if (type == HTTP2_PRIORITY)
 			break;
 
-		/* At this point we're likely being in a "half-closed (remote)" state
-		 * with response being sent to the client. This means that we need
-		 * to apply following RFC 9113 rules (sec 5.1)
-		 * 
-		 * If an endpoint receives additional frames, other than
-		 * WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is
-		 * in this state, it MUST respond with a stream error (Section 5.4.2)
-		 * of type STREAM_CLOSED. */
-		if (!send) {
-			switch (type) {
-			case HTTP2_WINDOW_UPDATE:
-			case HTTP2_RST_STREAM:
-				res = STREAM_FSM_RES_IGNORE;
-				break;
-			default:
-				res = STREAM_FSM_RES_TERM_CONN;
-				*err = HTTP2_ECODE_CLOSED;
-			}
+		if (type == HTTP2_CONTINUATION) {
+			*err = HTTP2_ECODE_PROTO;
+			res = STREAM_FSM_RES_TERM_CONN;
+			break;
 		}
+
+		res = STREAM_FSM_RES_IGNORE;
 
 		break;
 

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -289,37 +289,21 @@ tfw_h2_stream_fsm(TfwStream *stream, unsigned char type, unsigned char flags,
 		if (type == HTTP2_PRIORITY)
 			break;
 
+		/* At this point we're likely being in a "half-closed (remote)" state
+		 * with response being sent to the client. This means that we need
+		 * to apply following RFC 9113 rules (sec 5.1)
+		 * 
+		 * If an endpoint receives additional frames, other than
+		 * WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is
+		 * in this state, it MUST respond with a stream error (Section 5.4.2)
+		 * of type STREAM_CLOSED. */
 		if (!send) {
 			switch (type) {
 			case HTTP2_WINDOW_UPDATE:
 			case HTTP2_RST_STREAM:
 				res = STREAM_FSM_RES_IGNORE;
 				break;
-			case HTTP2_HEADERS:
-			case HTTP2_PUSH_PROMISE:
-				/* RFC 9113, sec 5.1.1:
-				 *
-				 * The identifier of a newly established stream MUST be
-				 * numerically greater than all streams that the initiating
-				 * endpoint has opened or reserved. This governs streams that
-				 * are opened using a HEADERS frame and streams that are
-				 * reserved using PUSH_PROMISE. An endpoint that receives an
-				 * unexpected stream identifier MUST respond with a connection
-				 * error (Section 5.4.1) of type PROTOCOL_ERROR.
-				 */
-				res = STREAM_FSM_RES_TERM_CONN;
-				*err = HTTP2_ECODE_PROTO;
-				break;
 			default:
-				/* At this point we're likely being in a "half-closed (remote)"
-				 * state with response being sent to the client. This means
-				 * that we need to apply RFC 9113 rule from sec 5.1:
-				 *
-				 * If an endpoint receives additional frames, other than
-				 * WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is
-				 * in this state, it MUST respond with a stream error
-				 * (Section 5.4.2) of type STREAM_CLOSED.
-				 */
 				res = STREAM_FSM_RES_TERM_CONN;
 				*err = HTTP2_ECODE_CLOSED;
 			}

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -289,13 +289,25 @@ tfw_h2_stream_fsm(TfwStream *stream, unsigned char type, unsigned char flags,
 		if (type == HTTP2_PRIORITY)
 			break;
 
-		if (type == HTTP2_CONTINUATION) {
-			*err = HTTP2_ECODE_PROTO;
-			res = STREAM_FSM_RES_TERM_CONN;
-			break;
+		/* At this point we're likely being in a "half-closed (remote)" state
+		 * with response being sent to the client. This means that we need
+		 * to apply following RFC 9113 rules (sec 5.1)
+		 * 
+		 * If an endpoint receives additional frames, other than
+		 * WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is
+		 * in this state, it MUST respond with a stream error (Section 5.4.2)
+		 * of type STREAM_CLOSED. */
+		if (!send) {
+			switch (type) {
+			case HTTP2_WINDOW_UPDATE:
+			case HTTP2_RST_STREAM:
+				res = STREAM_FSM_RES_IGNORE;
+				break;
+			default:
+				res = STREAM_FSM_RES_TERM_CONN;
+				*err = HTTP2_ECODE_CLOSED;
+			}
 		}
-
-		res = STREAM_FSM_RES_IGNORE;
 
 		break;
 


### PR DESCRIPTION
This validation existed in code but it was disabled due to setting `ctx->cur_stream` prior to actually validating stream_id for the HEADERS frame.

Related tempesta-test PR: https://github.com/tempesta-tech/tempesta-test/pull/479