### PR TITLE
Fix GPF when skb reused

### DIFF
--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -1668,6 +1668,9 @@ tfw_h2_msg_cutoff_headers(TfwHttpResp *resp, TfwHttpRespCleanup* cleanup)
 				if (unlikely(ret))
 					return ret;
 				break;
+			} else {
+				ss_skb_put(it->skb, -skb_headlen(it->skb));
+				it->skb->tail_lock = 1;
 			}
 		}
 

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -751,6 +751,12 @@ ss_tcp_process_skb(struct sock *sk, struct sk_buff *skb, int *processed)
 		WARN_ON_ONCE(skb_has_frag_list(skb));
 		WARN_ON_ONCE(skb->sk);
 
+		/*
+		 * Some SKBs may have dev, however tempesta uses dev to store
+		 * own flags, thus clear it.
+		 */
+		skb->dev = NULL;
+
 		if (unlikely(offset >= skb->len)) {
 			offset -= skb->len;
 			__kfree_skb(skb);

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1322,12 +1322,6 @@ ss_skb_init_for_xmit(struct sk_buff *skb)
 	}
 
 	skb->skb_mstamp_ns = 0;
-	/*
-	 * Do not clear skb->dev in case if it is used for private
-	 * tempesta data.
-	 */
-	if (!skb_tfw_is_present(skb))
-		skb->dev = NULL;
 	bzero_fast(skb->cb, sizeof(skb->cb));
 	nf_reset_ct(skb);
 	skb->mac_len = 0;


### PR DESCRIPTION
Remove tail part of skb because because it can be reused as `skb_head` of current response. If tail part will remain in skb we will have garbage in skb and `ss_skb_linear_transform()` will be applied twice.