### PR TITLE
Backported fix for #1928

### DIFF
--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -586,6 +586,10 @@ frang_get_host_header(const TfwHttpReq *req, int hid, TfwStr *trimmed,
 	*name_only = hdr_name;
 }
 
+/**
+ * Fin vhost by authority, increment vhost reference counter.
+ * It is a caller responsibility to put vhost reference counter.
+ */
 static TfwVhost*
 __lookup_vhost_by_authority(TfwPool *pool, const TfwStr *authority)
 {
@@ -655,9 +659,11 @@ frang_http_domain_fronting_check(const TfwHttpReq *req, FrangAcc *ra)
 		frang_msg("vhost by SNI doesn't match vhost by authority",
 			  &FRANG_ACC2CLI(ra)->addr, " ('%.*s' vs '%.*s')\n",
 			  PR_TFW_STR(&tls_name), PR_TFW_STR(&req_name));
+		tfw_vhost_put(tls_vhost);
 		return TFW_BLOCK;
 	}
 
+	tfw_vhost_put(tls_vhost);
 	return TFW_PASS;
 }
 

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -452,8 +452,8 @@ __tfw_vhost_lookup(TfwVhostList *vh_list, const BasicStr *name,
 /**
  * Find vhost named @name in the _currently parsed and not yet applied_
  * configuration. The operation is safe to use in process context.
- * If vhost is found, an additional reference is taken. Caller is responsible to
- * release the reference after use.
+ * If vhost is found, an additional reference is taken. Caller is responsible
+ * to release the reference after use.
  */
 TfwVhost *
 tfw_vhost_lookup_reconfig(const char *name)
@@ -465,7 +465,8 @@ tfw_vhost_lookup_reconfig(const char *name)
 }
 
 /**
- * Lookup vhost by an SNI wildcard.
+ * Lookup vhost by an SNI wildcard. It is a caller responsibility to
+ * release the vhost reference after use.
  */
 TfwVhost *
 tfw_vhost_lookup_sni(const BasicStr *name)
@@ -494,6 +495,7 @@ tfw_vhost_lookup_sni(const BasicStr *name)
 /**
  * Get default vhost in the running configuration. Default vhost is special
  * entity that contains default policies if more precise vhost cannot be found.
+ * It is a caller responsibility to release the vhost reference after use.
  */
 TfwVhost *
 tfw_vhost_lookup_default(void)
@@ -1913,6 +1915,7 @@ tfw_vhost_add_sni_map(const BasicStr *cn, TfwVhost *vhost)
 	memcpy(svhm->sni, cn->data, cn->len);
 
 	hash_add(tfw_vhosts_reconfig->sni_vh_map, &svhm->hlist, key);
+	tfw_vhost_get(vhost);
 }
 
 static const TfwCfgEnum frang_http_methods_enum[] = {

--- a/fw/vhost.h
+++ b/fw/vhost.h
@@ -248,9 +248,15 @@ tfw_vhost_get(TfwVhost *vhost)
 static inline void
 tfw_vhost_put(TfwVhost *vhost)
 {
+	s64 refcnt;
+
 	if (unlikely(!vhost))
 		return;
-	if (likely(atomic64_dec_return(&vhost->refcnt)))
+
+	refcnt = atomic64_dec_return(&vhost->refcnt);
+	BUG_ON(refcnt < 0);
+
+	if (likely(refcnt))
 		return;
 	tfw_vhost_destroy(vhost);
 }


### PR DESCRIPTION
First of all we should check that vhost reference
count is always greater or equal to zero. Also we
should increment vhost reference count when we add vhost to sni map and we should decrement vhost
reference counter in `frang_http_domain_fronting_check` because we increment it in `__lookup_vhost_by_authority`.

Closes #1928