### PR TITLE
Fix race with using parser fields.

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -2060,9 +2060,7 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 	ce->body = TDB_OFF(db->hdr, p);
 	if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags))
 		r = tfw_cache_h2_copy_chunked_body(&ce->body_len, &p, &trec,
-						   resp,
-						   &resp->stream->parser.cut,
-						   &tot_len);
+						   resp, &resp->cut, &tot_len);
 	else
 		r = tfw_cache_h2_copy_body(&ce->body_len, &p, &trec,
 					   resp, &tot_len);

--- a/fw/http.c
+++ b/fw/http.c
@@ -4840,14 +4840,14 @@ tfw_h2_frame_fwd_resp(TfwHttpResp *resp, unsigned int stream_id,
 		return -EPIPE;
 
 	if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags)) {
-		r = tfw_http_msg_cutoff_body_chunks((TfwHttpMsg*)resp);
+		r = tfw_http_msg_cutoff_body_chunks(resp);
 		if (unlikely(r))
 			return r;
 	}
 
 	if (b_len) {
 		if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags))
-			iter.skb = resp->stream->parser.body_start_skb;
+			iter.skb = resp->body_start_skb;
 		else
 			iter.skb = resp->body.skb;
 		tfw_msg_iter_set_skb_priv(&iter, stream_id,

--- a/fw/http.h
+++ b/fw/http.h
@@ -396,6 +396,7 @@ typedef struct {
 	TfwStr		crlf;						\
 	TfwStr		body;
 
+
 static inline void
 tfw_http_copy_flags(unsigned long *to, unsigned long *from)
 {
@@ -559,6 +560,13 @@ typedef struct {
  * @no_cache_tokens - tokens for cache-control directive e.g.
  *		      Cache-Control: no-cache="token1, token2"
  * @private_tokens  - similar to @no_cache_tokens but for private="tokens"
+ * @body_start_data - beginning of body used during HTTP1 to HTTP2 body
+ *		      transformation. Must be deprecated when new cutting
+ *		      strategy will be implemented (TODO #1852);
+ * @body_start_skb  - skb with start of the body;
+ * @cut 	    - descriptors of http chunked body to be cut during
+ *		      HTTP1 to HTTP2 transformation and ignored during
+ *		      caching;
  */
 struct tfw_http_resp_t {
 	TFW_HTTP_MSG_COMMON;
@@ -569,6 +577,9 @@ struct tfw_http_resp_t {
 	TfwHttpTransIter	mit;
 	TfwStr			no_cache_tokens;
 	TfwStr			private_tokens;
+	char			*body_start_data;
+	struct sk_buff		*body_start_skb;
+	TfwStr			cut;
 };
 
 /**
@@ -594,7 +605,7 @@ typedef struct {
 
 #define TFW_HTTP_RESP_CUT_BODY_SZ(r) 					\
 	(r)->stream ? 							\
-	(r)->body.len - (r)->stream->parser.cut.len : 			\
+	(r)->body.len - (r)->cut.len : 					\
 	(r)->body.len
 
 #define __FOR_EACH_HDR_FIELD(pos, end, msg, soff, eoff)			\

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -1022,17 +1022,17 @@ tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm)
  * WARNING: After this call TfwHttpMsg->body MUST not be used.
  */
 int
-tfw_http_msg_cutoff_body_chunks(TfwHttpMsg *hm)
+tfw_http_msg_cutoff_body_chunks(TfwHttpResp *resp)
 {
 	int r;
 
-	r = ss_skb_cutoff_data(hm->body.skb, &hm->stream->parser.cut, 0,
-			       tfw_str_eolen(&hm->body));
+	r = ss_skb_cutoff_data(resp->body.skb, &resp->cut, 0,
+			       tfw_str_eolen(&resp->body));
 	if (unlikely(r))
 		return r;
 
-	hm->msg.len -= hm->stream->parser.cut.len;
-	TFW_STR_INIT(&hm->body);
+	resp->msg.len -= resp->cut.len;
+	TFW_STR_INIT(&resp->body);
 
 	return 0;
 }
@@ -1419,10 +1419,8 @@ __tfw_http_msg_move_body(TfwHttpResp *resp, struct sk_buff *nskb)
 	char *p;
 
 	if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags)) {
-		TfwStream *stream = resp->stream;
-
-		p = stream->parser.body_start_data;
-		body = &stream->parser.body_start_skb;
+		p = resp->body_start_data;
+		body = &resp->body_start_skb;
 	} else {
 		p = TFW_STR_CHUNK(&resp->body, 0)->data;
 		body = &resp->body.skb;

--- a/fw/http_msg.h
+++ b/fw/http_msg.h
@@ -159,7 +159,7 @@ int tfw_http_msg_hdr_xfrm(TfwHttpMsg *hm, char *name, size_t n_len,
 
 int tfw_http_msg_del_str(TfwHttpMsg *hm, TfwStr *str);
 int tfw_http_msg_del_hbh_hdrs(TfwHttpMsg *hm);
-int tfw_http_msg_cutoff_body_chunks(TfwHttpMsg *hm);
+int tfw_http_msg_cutoff_body_chunks(TfwHttpResp *resp);
 
 int tfw_http_msg_setup(TfwHttpMsg *hm, TfwMsgIter *it, size_t data_len,
 		       unsigned int tx_flags);

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -103,11 +103,6 @@ typedef struct {
  * @_date	- currently parsed http date value;
  * @month_int	- accumulator for parsing of month;
  * @cc_dir_flag	- designates an uncommitted directive currently being processed.
- * @body_start_data - beginning of body used during HTTP1 to HTTP2 body
- * 		  transformation. Must be deprecated when new cutting strategy
- * 		  will be implemented;
- * @cut		- descriptors of http chunked body to be cutted during HTTP1 to
- *		  HTTP2 transformation and ignored during caching;
  */
 typedef struct {
 	unsigned short			to_go;
@@ -138,9 +133,6 @@ typedef struct {
 		unsigned int		month_int;
 		unsigned int		cc_dir_flag;
 	};
-	char				*body_start_data;
-	struct sk_buff			*body_start_skb;
-	TfwStr				cut;
 	TfwStr				_tmp_chunk;
 	TfwStr				hdr;
 	TfwHttpHbhHdrs			hbh_parser;

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -1894,7 +1894,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "0\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut.len, 8);
+		EXPECT_EQ(resp->cut.len, 8);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1908,7 +1908,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "Age: 1\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut.len, 8);
+		EXPECT_EQ(resp->cut.len, 8);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1921,7 +1921,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "0\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut.len, 5);
+		EXPECT_EQ(resp->cut.len, 5);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1935,7 +1935,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "Age: 1\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut.len, 6);
+		EXPECT_EQ(resp->cut.len, 6);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1948,7 +1948,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "0\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut.len, 16);
+		EXPECT_EQ(resp->cut.len, 16);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
@@ -1959,7 +1959,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "0\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut.len, 3);
+		EXPECT_EQ(resp->cut.len, 3);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 	/* Chunked response */
@@ -1969,7 +1969,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "000\r\n"
 		 "\r\n")
 	{
-		EXPECT_EQ(resp->stream->parser.cut.len, 5);
+		EXPECT_EQ(resp->cut.len, 5);
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 }


### PR DESCRIPTION
There were some fields in parser structure, which
can be used later in cache thread. But parser struture is one for the whole connection, so it can be race in this case. Move this fields to TfwHttpMsg struture to prevent this race.

Closes #1965