### PR TITLE
Fix HTTP body copying

### DIFF
--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1503,7 +1503,9 @@ ss_skb_unroll(struct sk_buff **skb_head, struct sk_buff *skb)
  * The routine helps you to dump content of any skb.
  * It's supposed to be used for debugging purpose, so non-limited printing
  * is used.
- * BEWARE: don't call it too frequently.
+ *
+ * BEWARE: don't call it too frequently and use it ONLY FOR DEBUGGING to not
+ * to expose the kernel pointers.
  */
 void
 ss_skb_dump(struct sk_buff *skb)
@@ -1512,12 +1514,12 @@ ss_skb_dump(struct sk_buff *skb)
 	struct sk_buff *f_skb;
 	struct skb_shared_info *si = skb_shinfo(skb);
 
-	T_LOG_NL("SKB (%p) DUMP: len=%u data_len=%u truesize=%u users=%u\n",
+	T_LOG_NL("SKB (%px) DUMP: len=%u data_len=%u truesize=%u users=%u\n",
 		 skb, skb->len, skb->data_len, skb->truesize,
 		 refcount_read(&skb->users));
-	T_LOG_NL("  head=%p data=%p tail=%x end=%x\n",
+	T_LOG_NL("  head=%px data=%px tail=%x end=%x\n",
 		 skb->head, skb->data, skb->tail, skb->end);
-	T_LOG_NL("  nr_frags=%u frag_list=%p next=%p prev=%p\n",
+	T_LOG_NL("  nr_frags=%u frag_list=%px next=%px prev=%px\n",
 		 si->nr_frags, skb_shinfo(skb)->frag_list,
 		 skb->next, skb->prev);
 	T_LOG_NL("  head data (%u):\n", skb_headlen(skb));
@@ -1526,7 +1528,7 @@ ss_skb_dump(struct sk_buff *skb)
 
 	for (i = 0; i < si->nr_frags; ++i) {
 		const skb_frag_t *f = &si->frags[i];
-		T_LOG_NL("  frag %2d (addr=%p pg_off=%-4u size=%-4u pg_ref=%d):\n",
+		T_LOG_NL("  frag %2d (addr=%px pg_off=%-4u size=%-4u pg_ref=%d):\n",
 			 i, skb_frag_address(f), f->bv_offset,
 			 skb_frag_size(f), page_ref_count(skb_frag_page(f)));
 		print_hex_dump(KERN_INFO, "    ", DUMP_PREFIX_OFFSET, 16, 1,


### PR DESCRIPTION
Fix for #1970 and probably #1934.

If `curr` isn't within the current frag, then do not go to repeat on the same frag, do this only if we copied something. Otherwise we just skip the current frag (typically response headers).

If we fully copied the current frag until it's end, then this case is different from the case when the frag ends with a chunk descriptor. The second case also have 2 subcases: the next frag starts from the chunk descriptor prefix or data. The 3 cases are processed with `curr` == NULL, and `curr` == `prev_end` and an additional check for `stop` == `begin` correspondingly.

Make `ss_skb_dump()` to print real addresses (#1971).