### PR TITLE
Backported fix of CCM tls encryption and decryption

### DIFF
--- a/tls/crypto.c
+++ b/tls/crypto.c
@@ -67,9 +67,6 @@ ttls_cipher_setup(TlsCipherCtx *ctx, const TlsCipherInfo *ci,
 		return r;
 	}
 
-	/* See IV definitions for all cipher suites at the below. */
-	WARN_ON_ONCE(crypto_aead_ivsize(ctx->cipher_ctx) != 12);
-
 	ctx->cipher_info = ci;
 
 	return 0;
@@ -108,7 +105,7 @@ static TlsCipherInfo aes_128_ccm_info = {
 	16,
 	"AES-128-CCM",
 	"ccm(aes)",
-	12,
+	16,
 };
 
 static TlsCipherInfo aes_192_ccm_info = {
@@ -117,7 +114,7 @@ static TlsCipherInfo aes_192_ccm_info = {
 	24,
 	"AES-192-CCM",
 	"ccm(aes)",
-	12,
+	16,
 };
 
 static TlsCipherInfo aes_256_ccm_info = {
@@ -126,7 +123,7 @@ static TlsCipherInfo aes_256_ccm_info = {
 	32,
 	"AES-256-CCM",
 	"ccm(aes)",
-	12,
+	16,
 };
 
 static TlsCipherDef ttls_ciphers[] = {

--- a/tls/ttls.h
+++ b/tls/ttls.h
@@ -307,7 +307,8 @@ typedef struct {
  * @keylen		- symmetric key length (bytes);
  * @minlen		- min. ciphertext length;
  * @ivlen		- IV length;
- * @fixed_ivlen		- fixed part of IV (AEAD);
+ * @fixed_ivlen 	- fixed part of IV (AEAD);
+ * @fixed_shift 	- fied shift to copy fixed IV;
  * @maclen		- MAC length;
  * @iv_enc		- IV for encryption;
  * @iv_dec		- IV for decryption;
@@ -322,6 +323,7 @@ typedef struct {
 	unsigned int			minlen;
 	unsigned char			ivlen;
 	unsigned char			fixed_ivlen;
+	unsigned char                   fixed_shift;
 	unsigned char			maclen;
 	unsigned char			iv_enc[16];
 	unsigned char			iv_dec[16];


### PR DESCRIPTION
In CCM first byte of IV is L parameter, so we
should copy fixed IV starting from the second
byte and set first byte to predefined value.