### PR TITLE
Fix ulimited body parsing

### DIFF
--- a/fw/apm.h
+++ b/fw/apm.h
@@ -86,7 +86,8 @@ int tfw_apm_stats(void *apmref, TfwPrcntlStats *pstats);
 int tfw_apm_stats_bh(void *apmref, TfwPrcntlStats *pstats);
 int tfw_apm_pstats_verify(TfwPrcntlStats *pstats);
 void tfw_apm_hm_srv_rcount_update(TfwStr *uri_path, void *apmref);
-bool tfw_apm_hm_srv_alive(int status, TfwStr *body, void *apmref);
+bool tfw_apm_hm_srv_alive(int status, TfwStr *body, struct sk_buff *skb_head,
+			  void *apmref);
 bool tfw_apm_hm_srv_limit(int status, void *apmref);
 void tfw_apm_hm_enable_srv(TfwServer *srv, void *hmref);
 void tfw_apm_hm_disable_srv(TfwServer *srv);

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -1382,6 +1382,7 @@ tfw_cache_h2_copy_body(unsigned int *acc_len, char **p, TdbVRec **trec,
 		       TfwHttpResp *resp, size_t *tot_len)
 {
 	long n;
+	int r;
 	TfwMsgIter it;
 	TfwStr chunk;
 	TfwStr *body = &resp->body;
@@ -1396,7 +1397,8 @@ tfw_cache_h2_copy_body(unsigned int *acc_len, char **p, TdbVRec **trec,
 	it.frag = -1;
 
 	/* Move to the beginning of body. */
-	tfw_http_iter_set_at(&it, body->data);
+	if ((r = ss_skb_find_frag_by_offset(it.skb, body->data, &it.frag)))
+		return r;
 	chunk.data = body->data;
 
 	if (it.frag == -1) {
@@ -1438,6 +1440,8 @@ tfw_cache_h2_copy_body(unsigned int *acc_len, char **p, TdbVRec **trec,
 			chunk.len = skb_frag_size(f);
 		}
 	} while (true);
+
+	WARN_ON(*acc_len != body->len);
 
 	return 0;
 }

--- a/fw/http.c
+++ b/fw/http.c
@@ -1623,8 +1623,11 @@ tfw_http_hm_control(TfwHttpResp *resp)
 		return;
 
 	if (!tfw_srv_suspended(srv) ||
-	    !tfw_apm_hm_srv_alive(resp->status, &resp->body, srv->apmref))
+	    !tfw_apm_hm_srv_alive(resp->status, &resp->body, resp->msg.skb_head,
+				  srv->apmref))
+	{
 		return;
+	}
 
 	tfw_srv_mark_alive(srv);
 }

--- a/fw/http.h
+++ b/fw/http.h
@@ -412,8 +412,6 @@ struct tfw_http_msg_t {
 	TFW_HTTP_MSG_COMMON;
 };
 
-#define __MSG_STR_START(m)		(&(m)->crlf)
-
 #define TFW_HTTP_COND_IF_MSINCE		0x0001
 #define TFW_HTTP_COND_ETAG_ANY		0x0002
 #define TFW_HTTP_COND_ETAG_LIST		0x0004
@@ -495,9 +493,6 @@ struct tfw_http_req_t {
 	unsigned char		method;
 	unsigned char		method_override;
 };
-
-#define TFW_HTTP_REQ_STR_START(r)	__MSG_STR_START(r)
-#define TFW_HTTP_REQ_STR_END(r)		((&(r)->uri_path) + 1)
 
 #define TFW_IDX_BITS		12
 #define TFW_D_IDX_BITS		4
@@ -600,9 +595,6 @@ typedef struct {
 #define TFW_HDR_MAP_INIT_CNT		32
 #define TFW_HDR_MAP_SZ(cnt)		(sizeof(TfwHttpHdrMap)		\
 					 + sizeof(TfwHdrIndex) * (cnt))
-
-#define TFW_HTTP_RESP_STR_START(r)	__MSG_STR_START(r)
-#define TFW_HTTP_RESP_STR_END(r)	((&(r)->body) + 1)
 
 #define TFW_HTTP_RESP_CUT_BODY_SZ(r) 					\
 	(r)->stream ? 							\

--- a/fw/http.h
+++ b/fw/http.h
@@ -370,7 +370,8 @@ typedef struct {
  * @conn		- connection which the message was received on;
  * @destructor		- called when a connection is destroyed;
  * @crlf		- pointer to CRLF between headers and body;
- * @body		- pointer to the body of a message;
+ * @body		- contains start of the body of a message and length of
+ * 			  whole body. Do not use as regular TfwStr;
  *
  * TfwStr members must be the last for efficient scanning.
  *

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1705,7 +1705,8 @@ __FSM_STATE(Resp_BodyUnlimStart) {					\
 	/* fall through */						\
 }									\
 __FSM_STATE(Resp_BodyUnlimRead) {					\
-	__FSM_MOVE_nf(Resp_BodyUnlimRead, __data_remain(p), &msg->body); \
+	msg->body.len += __data_remain(p);				\
+	__FSM_MOVE_nofixup_n(Resp_BodyUnlimRead, __data_remain(p));	\
 }
 
 #define TFW_HTTP_PARSE_BODY(response, ...)				\


### PR DESCRIPTION
If the response doesn't have body tempesta parses the body until the connection is closed, in this case need to update overall body size and don't make chunks.

-Added error handling to `tfw_cache_h2_copy_body()`