### PR TITLE
Remove unnecessary BUG_ON

### DIFF
--- a/fw/websocket.c
+++ b/fw/websocket.c
@@ -3,7 +3,7 @@
  *
  * Websocket proxy protocol implementation for Tempesta FW.
  *
- * Copyright (C) 2022-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2022-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -197,7 +197,7 @@ tfw_http_websocket_upgrade(TfwSrvConn *srv_conn, TfwCliConn *cli_conn)
 	 */
 	cli_conn->pair = (TfwConn *)ws_conn;
 	tfw_connection_get(cli_conn->pair);
-	BUG_ON(atomic_read(&cli_conn->refcnt) < 2);
+	BUG_ON(atomic_read(&cli_conn->refcnt) < 1);
 
 	ws_conn->pair = (TfwConn *)cli_conn;
 	tfw_connection_get(ws_conn->pair);


### PR DESCRIPTION
This BUG_ON can be removed, because `cli_conn->refcnt` can be below then two at this place. For instance in case when socket was stolen and after it client connection was aborted. Therefore server connection will be upgraded for invalid client connection. It's not a good case for us but not critical. We can add check that client connection is still alive in `tfw_ws_srv_new_steal_sk()`, but it will not fix the problem completely.

Details:
When the second request is received by Tempesta `tfw_http_msg_process_generic()` checks whether the client already sent upgrade request or not, if upgrade request was received as the first request and response to this request still not sent, Tempesta drops the connection with the client and decrements ref counter of client connection. However in parallel Tempesta processes response to the first upgrade request and at this moment might happen a race between connection closing in `tfw_http_msg_process_generic()` and `tfw_http_websocket_upgrade()`. In this case, decrement of reference counter may happen right after socket stealing `tfw_ws_srv_new_steal_sk()`, therefore ref counter of `cli_conn` in `tfw_http_websocket_upgrade()` will be equal to 1. Then Tempesta will try to forward response to closed connection, but in the function `tfw_h1_resp_adjust_fwd()` response will be dropped, because in this function we have condition that checks the state of the client connection.