### PR TITLE
Rework stream state processing

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -4987,7 +4987,8 @@ tfw_h2_error_resp(TfwHttpReq *req, int status, bool reply, ErrorType type,
 		tfw_h2_conn_terminate_close(ctx, HTTP2_ECODE_PROTO,
 					    !on_req_recv_event);
 	} else {
-		if (tfw_h2_stream_fsm_ignore_err(stream, HTTP2_RST_STREAM, 0))
+		if (tfw_h2_stream_fsm_ignore_err(ctx, stream,
+						 HTTP2_RST_STREAM, 0))
 			return T_BAD;
 		tfw_h2_send_rst_stream(ctx, stream->id, HTTP2_ECODE_PROTO);
 	}

--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -430,8 +430,11 @@ tfw_sk_prepare_xmit(struct sock *sk, struct sk_buff *skb, unsigned int mss_now,
 
 	*nskbs = UINT_MAX;
 	h2_mode = TFW_CONN_PROTO(conn) == TFW_FSM_H2;
-	if (h2_mode)
-		return tfw_h2_sk_prepare_xmit(sk, skb, mss_now, limit, nskbs);
+	if (h2_mode) {
+		r = tfw_h2_sk_prepare_xmit(sk, skb, mss_now, limit, nskbs);
+		if (unlikely(r && r != -ENOMEM))
+			goto err_purge_tcp_write_queue;
+	}
 
 	return r;
 

--- a/fw/t/unit/test_http_parser_common.c
+++ b/fw/t/unit/test_http_parser_common.c
@@ -424,7 +424,7 @@ test_case_parse_prepare_h2(void)
 {
 	tfw_h2_context_init(&conn.h2);
 	conn.h2.hdr.type = HTTP2_HEADERS;
-	stream.state = HTTP2_STREAM_REM_HALF_CLOSED;
+	tfw_h2_set_stream_state(&stream, HTTP2_STREAM_REM_HALF_CLOSED);
 }
 
 /**


### PR DESCRIPTION
Previously we iplement two states for streams (which are not described in the RFC) for two special cases:
- we receive headers without END_HEADERS flag and without END_STREAM flag.
- we receive headers without END_HEADERS flag but with END_STREAM flag. But this states don't cover all possible cases, so in this patch i remove this two states, and add to pointers to the connection context to save streams, for which we receive or send headers without
END_HEADERS flags, we save flag to indicate whether we receive or sent END_STREAM for current stream.
Later when we send or receive frame, we check if
appropriate stream pointer in the connection context is not NULL, new frame should belongs to the same
stream and should be continuation frame.

Closes #1823