### PR TITLE
Cache information from cache-control header

### DIFF
--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1313,6 +1313,7 @@ done:
 		break;
 	case TFW_TAG_HDR_CONTENT_LENGTH:
 		parser->_hdr_tag = TFW_HTTP_HDR_CONTENT_LENGTH;
+		h2_set_hdr_content_length(req, &entry->cstate);
 		break;
 	case TFW_TAG_HDR_CONTENT_TYPE:
 		parser->_hdr_tag = TFW_HTTP_HDR_CONTENT_TYPE;

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1354,9 +1354,15 @@ done:
 	case TFW_TAG_HDR_TRANSFER_ENCODING:
 		parser->_hdr_tag = TFW_HTTP_HDR_TRANSFER_ENCODING;
 		break;
-	case TFW_TAG_HDR_X_METHOD_OVERRIDE:
-	case TFW_TAG_HDR_AUTHORIZATION:
 	case TFW_TAG_HDR_CACHE_CONTROL:
+		parser->_hdr_tag = TFW_HTTP_HDR_RAW;
+		h2_set_hdr_cache_control(req, &entry->cstate);
+		break;
+	case TFW_TAG_HDR_AUTHORIZATION:
+		parser->_hdr_tag = TFW_HTTP_HDR_RAW;
+		h2_set_hdr_authorization(req, &entry->cstate);
+		break;
+	case TFW_TAG_HDR_X_METHOD_OVERRIDE:
 	case TFW_TAG_HDR_PRAGMA:
 	case TFW_TAG_HDR_RAW:
 		parser->_hdr_tag = TFW_HTTP_HDR_RAW;

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -172,6 +172,7 @@ typedef struct {
 			unsigned int max_stale;
 			unsigned int min_fresh;
 		} cache_ctl;
+		unsigned long	content_length;
 	};
 	unsigned char		is_set;
 } TfwCachedHeaderState;

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -166,6 +166,12 @@ typedef struct {
 		long		if_msince_date;
 		unsigned long	authority_port;
 		unsigned char	ifnmatch_etag_any;
+		struct {
+			unsigned int flags;
+			unsigned int max_age;
+			unsigned int max_stale;
+			unsigned int min_fresh;
+		} cache_ctl;
 	};
 	unsigned char		is_set;
 } TfwCachedHeaderState;

--- a/fw/http.c
+++ b/fw/http.c
@@ -5837,7 +5837,7 @@ next_msg:
 				if (likely(!tfw_h2_parse_req_finish(req)))
 					break;
 				TFW_INC_STAT_BH(clnt.msgs_otherr);
-				return	tfw_http_req_parse_drop_with_fin(req, 500,
+				return	tfw_http_req_parse_drop_with_fin(req, 400,
 						"Request parsing inconsistency");
 			}
 		}

--- a/fw/http.h
+++ b/fw/http.h
@@ -270,6 +270,8 @@ enum {
 	TFW_HTTP_B_CT_MULTIPART,
 	/* Multipart/form-data request has a boundary parameter. */
 	TFW_HTTP_B_CT_MULTIPART_HAS_BOUNDARY,
+	/* Content-length header was parsed. */
+	TFW_HTTP_B_REQ_CONTENT_LENGTH_PARSED,
 	/* Singular header presents more than once. */
 	TFW_HTTP_B_FIELD_DUPENTRY,
 	/* Message headers are fully parsed */

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -163,5 +163,9 @@ void h2_set_hdr_accept(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 int h2_set_hdr_if_mod_since(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_authority(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_if_nmatch(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
+void h2_set_hdr_cache_control(TfwHttpReq *req,
+                              const TfwCachedHeaderState *cstate);
+void h2_set_hdr_authorization(TfwHttpReq *req,
+                              const TfwCachedHeaderState *cstate);
 unsigned char tfw_http_meth_str2id(const TfwStr *m_hdr);
 #endif /* __TFW_HTTP_PARSER_H__ */

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -167,5 +167,7 @@ void h2_set_hdr_cache_control(TfwHttpReq *req,
                               const TfwCachedHeaderState *cstate);
 void h2_set_hdr_authorization(TfwHttpReq *req,
                               const TfwCachedHeaderState *cstate);
+void h2_set_hdr_content_length(TfwHttpReq *req,
+                               const TfwCachedHeaderState *cstate);
 unsigned char tfw_http_meth_str2id(const TfwStr *m_hdr);
 #endif /* __TFW_HTTP_PARSER_H__ */


### PR DESCRIPTION
We need to cache information from cache-control header in hpack table entry same as we do it for :authority and other headers.

Closes #1901