### PR TITLE
Fix `sk_free` security callback

### DIFF
--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -259,9 +259,6 @@ tfw_classify_conn_close(struct sock *sk)
 {
 	FrangAcc *ra = sk->sk_security;
 
-	if (unlikely(!sk->sk_user_data))
-		return;
-
 	BUG_ON(!ra);
 
 	spin_lock(&ra->lock);


### PR DESCRIPTION
We should deinitialize sk_security even if
sk->sk_user_data is equal to zero, because
we reset this pointer previously when we
drop connection. Also we don't need this
pointer in `sk_free` callback.

Closes #1740