### PR TITLE
Fix invalid deinitialization of tls connection

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -926,7 +926,7 @@ tfw_cache_send_304(TfwHttpReq *req, TfwCacheEntry *ce)
 		if (unlikely(r))
 			goto err_setup;
 	} else {
-		stream_id = tfw_h2_stream_id(req);
+		stream_id = tfw_h2_req_stream_id(req);
 		if (unlikely(!stream_id))
 			goto err_setup;
 
@@ -977,7 +977,7 @@ tfw_cache_send_304(TfwHttpReq *req, TfwCacheEntry *ce)
 	if (tfw_h2_frame_local_resp(resp, stream_id, h_len, NULL))
 		goto err_setup;
 
-	tfw_h2_stream_unlink_from_req(req);
+	tfw_h2_req_unlink_stream(req);
 	tfw_h2_resp_fwd(resp);
 
 	return;
@@ -2875,7 +2875,7 @@ cache_req_process_node(TfwHttpReq *req, tfw_http_cache_cb_t action)
 	 * forward request to the server.
 	 */
 	if (TFW_MSG_H2(req)) {
-		id = tfw_h2_stream_id(req);
+		id = tfw_h2_req_stream_id(req);
 		if (unlikely(!id)) {
 			tfw_http_conn_msg_free((TfwHttpMsg *)req);
 			goto put;
@@ -2890,13 +2890,13 @@ cache_req_process_node(TfwHttpReq *req, tfw_http_cache_cb_t action)
 	 * the backend), thus the stream will be finished.
 	 */
 	if (resp && TFW_MSG_H2(req)) {
-		id = tfw_h2_stream_id(req);
+		id = tfw_h2_req_stream_id(req);
 		if (unlikely(!id)) {
 			tfw_http_msg_free((TfwHttpMsg *)resp);
 			tfw_http_conn_msg_free((TfwHttpMsg *)req);
 			goto put;
 		}
-		tfw_h2_stream_unlink_from_req(req);
+		tfw_h2_req_unlink_stream(req);
 	}
 out:
 	if (!resp && (req->cache_ctl.flags & TFW_HTTP_CC_OIFCACHED))

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -312,9 +312,10 @@ void write_int(unsigned long index, unsigned short max, unsigned short mask,
 	       TfwHPackInt *__restrict res_idx);
 int tfw_hpack_init(TfwHPack *__restrict hp, unsigned int htbl_sz);
 void tfw_hpack_clean(TfwHPack *__restrict hp);
-int tfw_hpack_transform(TfwHttpResp *__restrict resp, TfwStr *__restrict hdr);
+int tfw_hpack_transform(TfwHttpResp *__restrict resp, TfwStr *__restrict hdr,
+			unsigned int stream_id);
 int tfw_hpack_encode(TfwHttpResp *__restrict resp, TfwStr *__restrict hdr,
-		     bool use_pool, bool dyn_indexing);
+		     bool use_pool, bool dyn_indexing, unsigned int stream_id);
 void tfw_hpack_set_rbuf_size(TfwHPackETbl *__restrict tbl,
 			     unsigned short new_size);
 int tfw_hpack_decode(TfwHPack *__restrict hp, unsigned char *__restrict src,

--- a/fw/http.c
+++ b/fw/http.c
@@ -581,7 +581,7 @@ tfw_h2_prep_resp(TfwHttpResp *resp, unsigned short status, TfwStr *msg,
 
 	BUG_ON(!resp->req);
 	if (!stream_id) {
-		stream_id = tfw_h2_stream_id(resp->req);
+		stream_id = tfw_h2_req_stream_id(resp->req);
 		if (unlikely(!stream_id))
 			return -EPIPE;
 	}
@@ -659,9 +659,9 @@ tfw_h2_prep_resp(TfwHttpResp *resp, unsigned short status, TfwStr *msg,
 
 out:
 	if (r)
-		tfw_h2_stream_unlink_from_req_with_rst(req);
+		tfw_h2_req_unlink_stream_with_rst(req);
 	else
-		tfw_h2_stream_unlink_from_req(req);
+		tfw_h2_req_unlink_stream(req);
 
 	return r;
 }
@@ -954,7 +954,7 @@ static inline void
 tfw_http_conn_req_clean(TfwHttpReq *req)
 {
 	if (TFW_MSG_H2(req)) {
-		tfw_h2_stream_unlink_from_req_with_rst(req);
+		tfw_h2_req_unlink_stream_with_rst(req);
 	} else {
 		spin_lock_bh(&((TfwCliConn *)req->conn)->seq_qlock);
 		if (likely(!list_empty(&req->msg.seq_list)))
@@ -2711,7 +2711,7 @@ tfw_http_conn_release(TfwConn *conn)
 	list_for_each_entry_safe(req, tmp, &zap_queue, fwd_list) {
 		list_del_init(&req->fwd_list);
 		if (TFW_MSG_H2(req)) {
-			tfw_h2_stream_unlink_from_req_with_rst(req);
+			tfw_h2_req_unlink_stream_with_rst(req);
 		}
 		else if (unlikely(!list_empty_careful(&req->msg.seq_list))) {
 			spin_lock_bh(&((TfwCliConn *)req->conn)->seq_qlock);
@@ -4929,7 +4929,7 @@ tfw_h2_error_resp(TfwHttpReq *req, int status, bool reply, ErrorType type,
 	if (!reply) {
 		if (!on_req_recv_event)
 			tfw_connection_abort(req->conn);
-		tfw_h2_stream_unlink_from_req_with_rst(req);
+		tfw_h2_req_unlink_stream_with_rst(req);
 		goto free_req;
 	}
 
@@ -5180,7 +5180,7 @@ tfw_h2_resp_adjust_fwd(TfwHttpResp *resp)
 							  req->vhost,
 							  TFW_VHOST_HDRMOD_RESP);
 
-	stream_id = tfw_h2_stream_id(req);
+	stream_id = tfw_h2_req_stream_id(req);
 	if (unlikely(!stream_id))
 		goto out;
 
@@ -5284,7 +5284,7 @@ tfw_h2_resp_adjust_fwd(TfwHttpResp *resp)
 	       req, resp);
 	SS_SKB_QUEUE_DUMP(&resp->msg.skb_head);
 
-	tfw_h2_stream_unlink_from_req(req);
+	tfw_h2_req_unlink_stream(req);
 	tfw_h2_resp_fwd(resp);
 
 	__tfw_h2_resp_cleanup(&cleanup);

--- a/fw/http.h
+++ b/fw/http.h
@@ -702,12 +702,13 @@ int tfw_http_expand_hbh(TfwHttpResp *resp, unsigned short status);
 int tfw_http_expand_hdr_via(TfwHttpResp *resp);
 void tfw_h2_resp_fwd(TfwHttpResp *resp);
 int tfw_h2_hdr_map(TfwHttpResp *resp, const TfwStr *hdr, unsigned int id);
-int tfw_h2_add_hdr_date(TfwHttpResp *resp, bool cache);
-int tfw_h2_set_stale_warn(TfwHttpResp *resp);
+int tfw_h2_add_hdr_date(TfwHttpResp *resp, bool cache, unsigned int stream_id);
+int tfw_h2_set_stale_warn(TfwHttpResp *resp, unsigned int stream_id);
 int tfw_h2_resp_add_loc_hdrs(TfwHttpResp *resp, const TfwHdrMods *h_mods,
-			     bool cache);
+			     bool cache, unsigned int stream_id);
 int tfw_h2_resp_status_write(TfwHttpResp *resp, unsigned short status,
-			     bool use_pool, bool cache);
+			     bool use_pool, bool cache,
+			     unsigned int stream_id);
 /*
  * Functions to send an HTTP error response to a client.
  */

--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -565,134 +565,11 @@ tfw_h2_headers_pri_process(TfwH2Ctx *ctx)
 	return T_OK;
 }
 
-/*
- * Create a new stream and add it to the streams storage and to the dependency
- * tree. Note, that we do not need to protect the streams storage in @sched from
- * concurrent access, since all operations with it (adding, searching and
- * deletion) are done only in receiving flow of Frame layer.
- */
-static TfwStream *
-tfw_h2_stream_create(TfwH2Ctx *ctx, unsigned int id)
-{
-	TfwStream *stream, *dep = NULL;
-	TfwFramePri *pri = &ctx->priority;
-	bool excl = pri->exclusive;
-
-	if (tfw_h2_find_stream_dep(&ctx->sched, pri->stream_id, &dep))
-		return NULL;
-
-	stream = tfw_h2_add_stream(&ctx->sched, id, pri->weight,
-				   ctx->lsettings.wnd_sz,
-				   ctx->rsettings.wnd_sz);
-	if (!stream)
-		return NULL;
-
-	tfw_h2_add_stream_dep(&ctx->sched, stream, dep, excl);
-
-	++ctx->streams_num;
-
-	T_DBG3("%s: ctx [%p] (streams_num %lu, dep strm id %u, dep strm [%p], excl %u)\n"
-	       "added strm [%p] id %u weight %u\n",
-	       __func__, ctx, ctx->streams_num, pri->stream_id, dep, pri->exclusive,
-	       stream, id, stream->weight);
-
-	return stream;
-}
-
-static inline void
-tfw_h2_stream_clean(TfwH2Ctx *ctx, TfwStream *stream)
-{
-	T_DBG3("%s: strm [%p] id %u state %d(%s) weight %u, ctx "
-	       "streams num %lu\n",  __func__, stream, stream->id,
-	       tfw_h2_get_stream_state(stream), __h2_strm_st_n(stream),
-	       stream->weight, ctx->streams_num);
-	tfw_h2_stop_stream(&ctx->sched, stream);
-	tfw_h2_delete_stream(stream);
-	--ctx->streams_num;
-}
-
-/*
- * Del stream from queue.
- *
- * NOTE: call to this procedure should be protected by special lock for
- * Stream linkage protection.
- */
-static inline void
-__tfw_h2_stream_del_from_queue(TfwStream *stream)
-{
-	if(list_empty(&stream->hcl_node))
-		return;
-
-	BUG_ON(!stream->queue);
-	BUG_ON(!stream->queue->num);
-
-	list_del_init(&stream->hcl_node);
-	--stream->queue->num;
-	stream->queue = NULL;
-}
-
-/*
- * Add stream to queue.
- *
- * NOTE: call to this procedure should be protected by special lock for
- * Stream linkage protection.
- */
-static inline void
-__tfw_h2_stream_add_to_queue(TfwStreamQueue *queue, TfwStream *stream)
-{
-	if (!list_empty(&stream->hcl_node))
-		return;
-
-	list_add_tail(&stream->hcl_node, &queue->list);
-	stream->queue = queue;
-	++stream->queue->num;
-}
-
-/*
- * Unlink the stream from a corresponding request (if linked) and from special
- * queue of closed streams (if it is contained there).
- *
- * NOTE: call to this procedure should be protected by special lock for
- * Stream linkage protection.
- */
-static void
-__tfw_h2_stream_unlink(TfwH2Ctx *ctx, TfwStream *stream)
-{
-	TfwHttpMsg *hmreq = (TfwHttpMsg *)stream->msg;
-
-	__tfw_h2_stream_del_from_queue(stream);
-
-	if (hmreq) {
-		hmreq->stream = NULL;
-		/*
-		 * If the request is linked with a stream, but not complete yet,
-		 * it must be deleted right here to avoid leakage, because in
-		 * this case it is not used anywhere yet. When request is
-		 * assembled and complete, it will be removed (due to some
-		 * processing error) in @tfw_http_req_process(), or in other
-		 * cases controlled by server connection side (after adding to
-		 * @fwd_queue): successful response sending, eviction etc.
-		 */
-		if (!test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags))
-			tfw_http_conn_msg_free(hmreq);
-	}
-}
-
-static inline void
-tfw_h2_stream_unlink(TfwH2Ctx *ctx, TfwStream *stream)
-{
-	spin_lock(&ctx->lock);
-
-	__tfw_h2_stream_unlink(ctx, stream);
-
-	spin_unlock(&ctx->lock);
-}
-
 static inline void
 tfw_h2_current_stream_remove(TfwH2Ctx *ctx)
 {
 	T_DBG3("%s: ctx [%p] ctx->cur_stream %p\n", __func__, ctx, ctx->cur_stream);
-	tfw_h2_stream_unlink(ctx, ctx->cur_stream);
+	tfw_h2_stream_unlink_lock(ctx, ctx->cur_stream);
 	tfw_h2_stream_clean(ctx, ctx->cur_stream);
 	ctx->cur_stream = NULL;
 }
@@ -709,7 +586,7 @@ tfw_h2_conn_streams_cleanup(TfwH2Ctx *ctx)
 	T_DBG3("%s: ctx [%p] conn %p sched %p\n", __func__, ctx, conn, sched);
 
 	rbtree_postorder_for_each_entry_safe(cur, next, &sched->streams, node) {
-		tfw_h2_stream_unlink(ctx, cur);
+		tfw_h2_stream_unlink_lock(ctx, cur);
 
 		/* The streams tree is about to be destroyed and
 		 * we don't want to trigger rebalancing.
@@ -722,74 +599,11 @@ tfw_h2_conn_streams_cleanup(TfwH2Ctx *ctx)
 	sched->streams = RB_ROOT;
 }
 
-void
-tfw_h2_stream_add_closed(TfwH2Ctx *ctx, TfwStream *stream)
-{
-	spin_lock(&ctx->lock);
-	__tfw_h2_stream_add_to_queue(&ctx->closed_streams, stream);
-	spin_unlock(&ctx->lock);
-}
-
-TfwStreamFsmRes
-tfw_h2_stream_send_process(TfwH2Ctx *ctx, TfwStream *stream, unsigned char type)
-{
-	TfwStreamFsmRes r;
-	unsigned char flags = 0;
-
-	BUG_ON(stream->xmit.h_len && stream->xmit.b_len);
-
-	if (!stream->xmit.h_len && type != HTTP2_DATA)
-		flags |= HTTP2_F_END_HEADERS;
-
-	if (!stream->xmit.b_len)
-		flags |= HTTP2_F_END_STREAM;
-
-	r = tfw_h2_stream_fsm_ignore_err(ctx, stream, type, flags);
-	if (tfw_h2_get_stream_state(stream) > HTTP2_STREAM_REM_HALF_CLOSED)
-		tfw_h2_stream_add_closed(ctx, stream);
-
-	return r != STREAM_FSM_RES_IGNORE ? r : STREAM_FSM_RES_OK;
-}
-
-/*
- * Stream closing procedure: move the stream into special queue of closed
- * streams and send RST_STREAM frame to peer. This procedure is intended
- * for usage only in receiving flow of Framing layer, thus the stream is
- * definitely alive here and we need not any unlinking operations since
- * all the unlinking and cleaning work will be made later, during shrinking
- * the queue of closed streams; thus, we just move the stream into the
- * closed queue here.
- * We also reset the current stream of the H2 context here.
- */
-static int
-tfw_h2_stream_close(TfwH2Ctx *ctx, unsigned int id, TfwStream **stream,
-		    TfwH2Err err_code)
-{
-	if (stream && *stream) {
-		T_DBG3("%s: ctx [%p] strm %p id %d err %u\n", __func__,
-			ctx, *stream, id, err_code);
-		tf2_h2_conn_reset_stream_on_close(ctx, *stream);
-		if (tfw_h2_get_stream_state(*stream) >
-		    HTTP2_STREAM_REM_HALF_CLOSED) {
-			tfw_h2_stream_add_closed(ctx, *stream);
-		} else {
-			/*
-			 * This function is always called after processing
-			 * RST STREAM or stream error.
-			 */
-			BUG();
-		}
-		*stream = NULL;
-	}
-
-	return tfw_h2_send_rst_stream(ctx, id, err_code);
-}
-
 /*
  * Get stream ID for upper layer to create frames info.
  */
 unsigned int
-tfw_h2_stream_id(TfwHttpReq *req)
+tfw_h2_req_stream_id(TfwHttpReq *req)
 {
 	unsigned int id = 0;
 	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
@@ -804,35 +618,11 @@ tfw_h2_stream_id(TfwHttpReq *req)
 	return id;
 }
 
-int
-tfw_h2_stream_init_for_xmit(TfwHttpReq *req, unsigned long h_len,
-			    unsigned long b_len)
-{
-	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
-	TfwStream *stream;
-
-	spin_lock(&ctx->lock);
-
-	stream = req->stream;
-	if (!stream) {
-		spin_unlock(&ctx->lock);
-		return -EPIPE;
-	}
-
-	stream->xmit.h_len = h_len;
-	stream->xmit.b_len = b_len;
-	tfw_h2_stream_xmit_reinit(&stream->xmit);
-
-	spin_unlock(&ctx->lock);
-
-	return 0;
-}
-
 /*
  * Unlink request from corresponding stream (if linked).
  */
 void
-tfw_h2_stream_unlink_from_req(TfwHttpReq *req)
+tfw_h2_req_unlink_stream(TfwHttpReq *req)
 {
 	TfwStream *stream;
 	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
@@ -856,7 +646,7 @@ tfw_h2_stream_unlink_from_req(TfwHttpReq *req)
  * send RST STREAM and add stream to closed queue.
  */
 void
-tfw_h2_stream_unlink_from_req_with_rst(TfwHttpReq *req)
+tfw_h2_req_unlink_stream_with_rst(TfwHttpReq *req)
 {
 	TfwStreamFsmRes r;
 	TfwStream *stream;
@@ -876,7 +666,7 @@ tfw_h2_stream_unlink_from_req_with_rst(TfwHttpReq *req)
 	r = tfw_h2_stream_fsm_ignore_err(ctx, stream, HTTP2_RST_STREAM, 0);
 	WARN_ON_ONCE(r != STREAM_FSM_RES_OK && r != STREAM_FSM_RES_IGNORE);
 
-	__tfw_h2_stream_add_to_queue(&ctx->closed_streams, stream);
+	tfw_h2_stream_add_to_queue_nolock(&ctx->closed_streams, stream);
 
 	spin_unlock(&ctx->lock);
 }
@@ -908,7 +698,7 @@ tfw_h2_closed_streams_shrink(TfwH2Ctx *ctx)
 		BUG_ON(list_empty(&closed_streams->list));
 		cur = list_first_entry(&closed_streams->list, TfwStream,
 				       hcl_node);
-		__tfw_h2_stream_unlink(ctx, cur);
+		tfw_h2_stream_unlink_nolock(ctx, cur);
 
 		spin_unlock(&ctx->lock);
 
@@ -933,7 +723,7 @@ tfw_h2_check_closed_stream(TfwH2Ctx *ctx)
 }
 
 static inline int
-tfw_h2_stream_state_process(TfwH2Ctx *ctx)
+tfw_h2_current_stream_state_process(TfwH2Ctx *ctx)
 {
 	TfwFrameHdr *hdr = &ctx->hdr;
 
@@ -982,7 +772,7 @@ tfw_h2_headers_process(TfwH2Ctx *ctx)
 	 * HEADERS frame), we should process its state here - when frame is
 	 * fully received and new stream is created.
 	 */
-	return tfw_h2_stream_state_process(ctx);
+	return tfw_h2_current_stream_state_process(ctx);
 }
 
 static int
@@ -1261,7 +1051,7 @@ tfw_h2_first_settings_verify(TfwH2Ctx *ctx)
 }
 
 static inline int
-tfw_h2_stream_id_verify(TfwH2Ctx *ctx)
+tfw_h2_current_stream_id_verify(TfwH2Ctx *ctx)
 {
 	TfwFrameHdr *hdr = &ctx->hdr;
 
@@ -1467,7 +1257,7 @@ tfw_h2_frame_type_process(TfwH2Ctx *ctx)
 		ctx->cur_stream =
 			tfw_h2_find_not_closed_stream(ctx, hdr->stream_id,
 						      true);
-		if (tfw_h2_stream_id_verify(ctx)) {
+		if (tfw_h2_current_stream_id_verify(ctx)) {
 			err_code = HTTP2_ECODE_PROTO;
 			goto conn_term;
 		}
@@ -1866,7 +1656,7 @@ tfw_h2_frame_recv(void *data, unsigned char *buf, unsigned int len,
 	T_FSM_STATE(HTTP2_RECV_DATA) {
 		FRAME_FSM_READ_PYLD();
 
-		if ((ret = tfw_h2_stream_state_process(ctx)))
+		if ((ret = tfw_h2_current_stream_state_process(ctx)))
 			FRAME_FSM_EXIT(ret);
 
 		if (unlikely(ctx->to_read)) {
@@ -1892,7 +1682,7 @@ tfw_h2_frame_recv(void *data, unsigned char *buf, unsigned int len,
 	T_FSM_STATE(HTTP2_RECV_CONT) {
 		FRAME_FSM_READ_PYLD();
 
-		if ((ret = tfw_h2_stream_state_process(ctx)))
+		if ((ret = tfw_h2_current_stream_state_process(ctx)))
 			FRAME_FSM_EXIT(ret);
 
 		if (unlikely(ctx->to_read)) {

--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -804,6 +804,30 @@ tfw_h2_stream_id(TfwHttpReq *req)
 	return id;
 }
 
+int
+tfw_h2_stream_init_for_xmit(TfwHttpReq *req, unsigned long h_len,
+			    unsigned long b_len)
+{
+	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwStream *stream;
+
+	spin_lock(&ctx->lock);
+
+	stream = req->stream;
+	if (!stream) {
+		spin_unlock(&ctx->lock);
+		return -EPIPE;
+	}
+
+	stream->xmit.h_len = h_len;
+	stream->xmit.b_len = b_len;
+	tfw_h2_stream_xmit_reinit(&stream->xmit);
+
+	spin_unlock(&ctx->lock);
+
+	return 0;
+}
+
 /*
  * Unlink request from corresponding stream (if linked).
  */

--- a/fw/http_frame.h
+++ b/fw/http_frame.h
@@ -234,6 +234,8 @@ void tfw_h2_conn_streams_cleanup(TfwH2Ctx *ctx);
 TfwStream *tfw_h2_find_not_closed_stream(TfwH2Ctx *ctx, unsigned int id,
 					 bool recv);
 unsigned int tfw_h2_stream_id(TfwHttpReq *req);
+int tfw_h2_stream_init_for_xmit(TfwHttpReq *req, unsigned long h_len,
+				unsigned long b_len);
 void tfw_h2_stream_unlink_from_req(TfwHttpReq *req);
 void tfw_h2_stream_unlink_from_req_with_rst(TfwHttpReq *req);
 void tfw_h2_stream_add_closed(TfwH2Ctx *ctx, TfwStream *stream);

--- a/fw/http_frame.h
+++ b/fw/http_frame.h
@@ -233,14 +233,9 @@ int tfw_h2_frame_process(TfwConn *c, struct sk_buff *skb,
 void tfw_h2_conn_streams_cleanup(TfwH2Ctx *ctx);
 TfwStream *tfw_h2_find_not_closed_stream(TfwH2Ctx *ctx, unsigned int id,
 					 bool recv);
-unsigned int tfw_h2_stream_id(TfwHttpReq *req);
-int tfw_h2_stream_init_for_xmit(TfwHttpReq *req, unsigned long h_len,
-				unsigned long b_len);
-void tfw_h2_stream_unlink_from_req(TfwHttpReq *req);
-void tfw_h2_stream_unlink_from_req_with_rst(TfwHttpReq *req);
-void tfw_h2_stream_add_closed(TfwH2Ctx *ctx, TfwStream *stream);
-TfwStreamFsmRes tfw_h2_stream_send_process(TfwH2Ctx *ctx, TfwStream *stream,
-					   unsigned char type);
+unsigned int tfw_h2_req_stream_id(TfwHttpReq *req);
+void tfw_h2_req_unlink_stream(TfwHttpReq *req);
+void tfw_h2_req_unlink_stream_with_rst(TfwHttpReq *req);
 void tfw_h2_conn_terminate_close(TfwH2Ctx *ctx, TfwH2Err err_code, bool close);
 int tfw_h2_send_rst_stream(TfwH2Ctx *ctx, unsigned int id, TfwH2Err err_code);
 

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -311,7 +311,7 @@ finish:
 /**
  * Just update current connection count for a user.
  */
-static void
+void
 tfw_classify_conn_close(struct sock *sk)
 {
 	FrangAcc *ra = frang_acc_from_sk(sk);
@@ -1696,7 +1696,6 @@ tfw_http_limits_hooks_register(void)
 
 static TempestaOps tempesta_ops = {
 	.sk_alloc	= tfw_classify_conn_estab,
-	.sk_free	= tfw_classify_conn_close,
 	.sock_tcp_rcv	= tfw_classify_tcp,
 };
 

--- a/fw/http_limits.h
+++ b/fw/http_limits.h
@@ -47,6 +47,7 @@ typedef struct { char _[TFW_CLASSIFIER_ACCSZ]; } TfwClassifierPrvt;
 void tfw_classifier_add_inport(__be16 port);
 void tfw_classifier_remove_inport(__be16 port);
 void tfw_classifier_cleanup_inport(void);
+void tfw_classify_conn_close(struct sock *sk);
 
 /*
  * ------------------------------------------------------------------------

--- a/fw/http_msg.h
+++ b/fw/http_msg.h
@@ -122,7 +122,7 @@ tfw_h2_msg_transform_setup(TfwHttpTransIter *mit, struct sk_buff *skb,
 
 static inline int
 tfw_h2_msg_hdr_add(TfwHttpResp *resp, char *name, size_t nlen, char *val,
-		   size_t vlen, unsigned short idx)
+		   size_t vlen, unsigned short idx, unsigned int stream_id)
 {
 	TfwStr hdr = {
 		.chunks = (TfwStr []){
@@ -134,7 +134,7 @@ tfw_h2_msg_hdr_add(TfwHttpResp *resp, char *name, size_t nlen, char *val,
 		.hpack_idx = idx
 	};
 
-	return tfw_hpack_encode(resp, &hdr, true, true);
+	return tfw_hpack_encode(resp, &hdr, true, true, stream_id);
 }
 
 int __must_check __tfw_http_msg_add_str_data(TfwHttpMsg *hm, TfwStr *str,
@@ -179,8 +179,8 @@ int __http_hdr_lookup(TfwHttpMsg *hm, const TfwStr *hdr);
 int tfw_h2_msg_cutoff_headers(TfwHttpResp *resp, TfwHttpRespCleanup* cleanup);
 int tfw_http_msg_insert(TfwMsgIter *it, char **off, const TfwStr *data);
 
-#define TFW_H2_MSG_HDR_ADD(hm, name, val, idx)				\
+#define TFW_H2_MSG_HDR_ADD(hm, name, val, idx, stream_id)		\
 	tfw_h2_msg_hdr_add(hm, name, sizeof(name) - 1, val,		\
-			   sizeof(val) - 1, idx)
+			   sizeof(val) - 1, idx, stream_id)
 
 #endif /* __TFW_HTTP_MSG_H__ */

--- a/fw/http_sess.c
+++ b/fw/http_sess.c
@@ -393,7 +393,7 @@ tfw_http_sticky_calc(TfwHttpReq *req, StickyVal *sv)
  * to the HTTP response' header block.
  */
 static int
-tfw_http_sticky_add(TfwHttpResp *resp, bool cache)
+tfw_http_sticky_add(TfwHttpResp *resp, bool cache, unsigned int stream_id)
 {
 	int r;
 	static const unsigned int len = sizeof(StickyVal) * 2;
@@ -426,7 +426,8 @@ tfw_http_sticky_add(TfwHttpResp *resp, bool cache)
 
 	if (to_h2) {
 		set_cookie.hpack_idx = 55;
-		r = tfw_hpack_encode(resp, &set_cookie, !cache, !cache);
+		r = tfw_hpack_encode(resp, &set_cookie, !cache, !cache,
+				     stream_id);
 	}
 	else if (cache) {
 		TfwHttpTransIter *mit = &resp->mit;
@@ -836,7 +837,8 @@ tfw_http_sess_req_process(TfwHttpReq *req)
  * Add Tempesta sticky cookie to an HTTP response if needed.
  */
 int
-tfw_http_sess_resp_process(TfwHttpResp *resp, bool cache)
+tfw_http_sess_resp_process(TfwHttpResp *resp, bool cache,
+			   unsigned int stream_id)
 {
 	TfwHttpReq *req = resp->req;
 	TfwStickyCookie *sticky = req->vhost->cookie;
@@ -857,7 +859,7 @@ tfw_http_sess_resp_process(TfwHttpResp *resp, bool cache)
 	 */
 	if (test_bit(TFW_HTTP_B_HAS_STICKY, req->flags))
 		return 0;
-	return tfw_http_sticky_add(resp, cache);
+	return tfw_http_sticky_add(resp, cache, stream_id);
 }
 
 /**

--- a/fw/http_sess.h
+++ b/fw/http_sess.h
@@ -176,7 +176,8 @@ enum {
 int tfw_http_sess_obtain(TfwHttpReq *req);
 void tfw_http_sess_learn(TfwHttpResp *resp);
 int tfw_http_sess_req_process(TfwHttpReq *req);
-int tfw_http_sess_resp_process(TfwHttpResp *resp, bool cache);
+int tfw_http_sess_resp_process(TfwHttpResp *resp, bool cache,
+                               unsigned int stream_id);
 void tfw_http_sess_put(TfwHttpSess *sess);
 void tfw_http_sess_pin_vhost(TfwHttpSess *sess, TfwVhost *vhost);
 

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -24,6 +24,7 @@
 #define DEBUG DBG_HTTP_STREAM
 #endif
 #include "http_frame.h"
+#include "http.h"
 
 #define HTTP2_DEF_WEIGHT	16
 
@@ -44,6 +45,221 @@ void
 tfw_h2_stream_cache_destroy(void)
 {
 	kmem_cache_destroy(stream_cache);
+}
+
+static int
+tfw_h2_find_stream_dep(TfwStreamSched *sched, unsigned int id, TfwStream **dep)
+{
+	/*
+	 * TODO: implement dependency/priority logic (according to RFC 7540
+	 * section 5.3) in context of #1196.
+	 */
+	return 0;
+}
+
+static void
+tfw_h2_add_stream_dep(TfwStreamSched *sched, TfwStream *stream, TfwStream *dep,
+		      bool excl)
+{
+	/*
+	 * TODO: implement dependency/priority logic (according to RFC 7540
+	 * section 5.3) in context of #1196.
+	 */
+}
+
+static void
+tfw_h2_remove_stream_dep(TfwStreamSched *sched, TfwStream *stream)
+{
+	/*
+	 * TODO: implement dependency/priority logic (according to RFC 7540
+	 * section 5.3) in context of #1196.
+	 */
+}
+
+static void
+tfw_h2_stop_stream(TfwStreamSched *sched, TfwStream *stream)
+{
+	TfwH2Ctx *ctx = container_of(sched, TfwH2Ctx, sched);
+
+	tf2_h2_conn_reset_stream_on_close(ctx, stream);
+	tfw_h2_remove_stream_dep(sched, stream);
+	rb_erase(&stream->node, &sched->streams);
+}
+
+static inline void
+tfw_h2_init_stream(TfwStream *stream, unsigned int id, unsigned short weight,
+		   long int loc_wnd, long int rem_wnd)
+{
+	RB_CLEAR_NODE(&stream->node);
+	INIT_LIST_HEAD(&stream->hcl_node);
+	spin_lock_init(&stream->st_lock);
+	stream->id = id;
+	stream->state = HTTP2_STREAM_OPENED;
+	stream->loc_wnd = loc_wnd;
+	stream->rem_wnd = rem_wnd;
+	stream->weight = weight ? weight : HTTP2_DEF_WEIGHT;
+}
+
+static TfwStream *
+tfw_h2_add_stream(TfwStreamSched *sched, unsigned int id, unsigned short weight,
+		  long int loc_wnd, long int rem_wnd)
+{
+	TfwStream *new_stream;
+	struct rb_node **new = &sched->streams.rb_node;
+	struct rb_node *parent = NULL;
+
+	while (*new) {
+		TfwStream *stream = rb_entry(*new, TfwStream, node);
+
+		parent = *new;
+		if (id < stream->id) {
+			new = &parent->rb_left;
+		} else if (id > stream->id) {
+			new = &parent->rb_right;
+		} else {
+			WARN_ON_ONCE(1);
+			return NULL;
+		}
+	}
+
+	new_stream = kmem_cache_alloc(stream_cache, GFP_ATOMIC | __GFP_ZERO);
+	if (unlikely(!new_stream))
+		return NULL;
+
+	tfw_h2_init_stream(new_stream, id, weight, loc_wnd, rem_wnd);
+
+	rb_link_node(&new_stream->node, parent, new);
+	rb_insert_color(&new_stream->node, &sched->streams);
+
+	return new_stream;
+}
+
+/*
+ * Create a new stream and add it to the streams storage and to the dependency
+ * tree. Note, that we do not need to protect the streams storage in @sched from
+ * concurrent access, since all operations with it (adding, searching and
+ * deletion) are done only in receiving flow of Frame layer.
+ */
+TfwStream *
+tfw_h2_stream_create(TfwH2Ctx *ctx, unsigned int id)
+{
+	TfwStream *stream, *dep = NULL;
+	TfwFramePri *pri = &ctx->priority;
+	bool excl = pri->exclusive;
+
+	if (tfw_h2_find_stream_dep(&ctx->sched, pri->stream_id, &dep))
+		return NULL;
+
+	stream = tfw_h2_add_stream(&ctx->sched, id, pri->weight,
+				   ctx->lsettings.wnd_sz,
+				   ctx->rsettings.wnd_sz);
+	if (!stream)
+		return NULL;
+
+	tfw_h2_add_stream_dep(&ctx->sched, stream, dep, excl);
+
+	++ctx->streams_num;
+
+	T_DBG3("%s: ctx [%p] (streams_num %lu, dep strm id %u, dep strm [%p], excl %u)\n"
+	       "added strm [%p] id %u weight %u\n",
+	       __func__, ctx, ctx->streams_num, pri->stream_id, dep, pri->exclusive,
+	       stream, id, stream->weight);
+
+	return stream;
+}
+
+void
+tfw_h2_stream_clean(TfwH2Ctx *ctx, TfwStream *stream)
+{
+	T_DBG3("%s: strm [%p] id %u state %d(%s) weight %u, ctx "
+	       "streams num %lu\n",  __func__, stream, stream->id,
+	       tfw_h2_get_stream_state(stream), __h2_strm_st_n(stream),
+	       stream->weight, ctx->streams_num);
+	tfw_h2_stop_stream(&ctx->sched, stream);
+	tfw_h2_delete_stream(stream);
+	--ctx->streams_num;
+}
+
+/*
+ * Unlink the stream from a corresponding request (if linked) and from special
+ * queue of closed streams (if it is contained there).
+ *
+ * NOTE: call to this procedure should be protected by special lock for
+ * Stream linkage protection.
+ */
+void
+tfw_h2_stream_unlink_nolock(TfwH2Ctx *ctx, TfwStream *stream)
+{
+	TfwHttpMsg *hmreq = (TfwHttpMsg *)stream->msg;
+
+	tfw_h2_stream_del_from_queue_nolock(stream);
+
+	if (hmreq) {
+		hmreq->stream = NULL;
+		/*
+		 * If the request is linked with a stream, but not complete yet,
+		 * it must be deleted right here to avoid leakage, because in
+		 * this case it is not used anywhere yet. When request is
+		 * assembled and complete, it will be removed (due to some
+		 * processing error) in @tfw_http_req_process(), or in other
+		 * cases controlled by server connection side (after adding to
+		 * @fwd_queue): successful response sending, eviction etc.
+		 */
+		if (!test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags))
+			tfw_http_conn_msg_free(hmreq);
+	}
+}
+
+void
+tfw_h2_stream_unlink_lock(TfwH2Ctx *ctx, TfwStream *stream)
+{
+	spin_lock(&ctx->lock);
+
+	tfw_h2_stream_unlink_nolock(ctx, stream);
+
+	spin_unlock(&ctx->lock);
+}
+
+void
+tfw_h2_stream_add_closed(TfwH2Ctx *ctx, TfwStream *stream)
+{
+	spin_lock(&ctx->lock);
+	tfw_h2_stream_add_to_queue_nolock(&ctx->closed_streams, stream);
+	spin_unlock(&ctx->lock);
+}
+
+/*
+ * Stream closing procedure: move the stream into special queue of closed
+ * streams and send RST_STREAM frame to peer. This procedure is intended
+ * for usage only in receiving flow of Framing layer, thus the stream is
+ * definitely alive here and we need not any unlinking operations since
+ * all the unlinking and cleaning work will be made later, during shrinking
+ * the queue of closed streams; thus, we just move the stream into the
+ * closed queue here.
+ * We also reset the current stream of the H2 context here.
+ */
+int
+tfw_h2_stream_close(TfwH2Ctx *ctx, unsigned int id, TfwStream **stream,
+		    TfwH2Err err_code)
+{
+	if (stream && *stream) {
+		T_DBG3("%s: ctx [%p] strm %p id %d err %u\n", __func__,
+			ctx, *stream, id, err_code);
+		tf2_h2_conn_reset_stream_on_close(ctx, *stream);
+		if (tfw_h2_get_stream_state(*stream) >
+		    HTTP2_STREAM_REM_HALF_CLOSED) {
+			tfw_h2_stream_add_closed(ctx, *stream);
+		} else {
+			/*
+			 * This function is always called after processing
+			 * RST STREAM or stream error.
+			 */
+			BUG();
+		}
+		*stream = NULL;
+	}
+
+	return tfw_h2_send_rst_stream(ctx, id, err_code);
 }
 
 /*
@@ -402,20 +618,6 @@ finish:
 #undef TFW_H2_FSM_STREAM_CHECK
 }
 
-static inline void
-tfw_h2_init_stream(TfwStream *stream, unsigned int id, unsigned short weight,
-		   long int loc_wnd, long int rem_wnd)
-{
-	RB_CLEAR_NODE(&stream->node);
-	INIT_LIST_HEAD(&stream->hcl_node);
-	spin_lock_init(&stream->st_lock);
-	stream->id = id;
-	stream->state = HTTP2_STREAM_OPENED;
-	stream->loc_wnd = loc_wnd;
-	stream->rem_wnd = rem_wnd;
-	stream->weight = weight ? weight : HTTP2_DEF_WEIGHT;
-}
-
 TfwStream *
 tfw_h2_find_stream(TfwStreamSched *sched, unsigned int id)
 {
@@ -435,64 +637,10 @@ tfw_h2_find_stream(TfwStreamSched *sched, unsigned int id)
 	return NULL;
 }
 
-TfwStream *
-tfw_h2_add_stream(TfwStreamSched *sched, unsigned int id, unsigned short weight,
-		  long int loc_wnd, long int rem_wnd)
-{
-	TfwStream *new_stream;
-	struct rb_node **new = &sched->streams.rb_node;
-	struct rb_node *parent = NULL;
-
-	while (*new) {
-		TfwStream *stream = rb_entry(*new, TfwStream, node);
-
-		parent = *new;
-		if (id < stream->id) {
-			new = &parent->rb_left;
-		} else if (id > stream->id) {
-			new = &parent->rb_right;
-		} else {
-			WARN_ON_ONCE(1);
-			return NULL;
-		}
-	}
-
-	new_stream = kmem_cache_alloc(stream_cache, GFP_ATOMIC | __GFP_ZERO);
-	if (unlikely(!new_stream))
-		return NULL;
-
-	tfw_h2_init_stream(new_stream, id, weight, loc_wnd, rem_wnd);
-
-	rb_link_node(&new_stream->node, parent, new);
-	rb_insert_color(&new_stream->node, &sched->streams);
-
-	return new_stream;
-}
-
 void
 tfw_h2_delete_stream(TfwStream *stream)
 {
 	kmem_cache_free(stream_cache, stream);
-}
-
-int
-tfw_h2_find_stream_dep(TfwStreamSched *sched, unsigned int id, TfwStream **dep)
-{
-	/*
-	 * TODO: implement dependency/priority logic (according to RFC 7540
-	 * section 5.3) in context of #1196.
-	 */
-	return 0;
-}
-
-void
-tfw_h2_add_stream_dep(TfwStreamSched *sched, TfwStream *stream, TfwStream *dep,
-		      bool excl)
-{
-	/*
-	 * TODO: implement dependency/priority logic (according to RFC 7540
-	 * section 5.3) in context of #1196.
-	 */
 }
 
 void
@@ -506,21 +654,47 @@ tfw_h2_change_stream_dep(TfwStreamSched *sched, unsigned int stream_id,
 	 */
 }
 
-static void
-tfw_h2_remove_stream_dep(TfwStreamSched *sched, TfwStream *stream)
+int
+tfw_h2_stream_init_for_xmit(TfwHttpReq *req, unsigned long h_len,
+			    unsigned long b_len)
 {
-	/*
-	 * TODO: implement dependency/priority logic (according to RFC 7540
-	 * section 5.3) in context of #1196.
-	 */
+	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwStream *stream;
+
+	spin_lock(&ctx->lock);
+
+	stream = req->stream;
+	if (!stream) {
+		spin_unlock(&ctx->lock);
+		return -EPIPE;
+	}
+
+	stream->xmit.h_len = h_len;
+	stream->xmit.b_len = b_len;
+	tfw_h2_stream_xmit_reinit(&stream->xmit);
+
+	spin_unlock(&ctx->lock);
+
+	return 0;
 }
 
-void
-tfw_h2_stop_stream(TfwStreamSched *sched, TfwStream *stream)
+TfwStreamFsmRes
+tfw_h2_stream_send_process(TfwH2Ctx *ctx, TfwStream *stream, unsigned char type)
 {
-	TfwH2Ctx *ctx = container_of(sched, TfwH2Ctx, sched);
+	TfwStreamFsmRes r;
+	unsigned char flags = 0;
 
-	tf2_h2_conn_reset_stream_on_close(ctx, stream);
-	tfw_h2_remove_stream_dep(sched, stream);
-	rb_erase(&stream->node, &sched->streams);
+	BUG_ON(stream->xmit.h_len && stream->xmit.b_len);
+
+	if (!stream->xmit.h_len && type != HTTP2_DATA)
+		flags |= HTTP2_F_END_HEADERS;
+
+	if (!stream->xmit.b_len)
+		flags |= HTTP2_F_END_STREAM;
+
+	r = tfw_h2_stream_fsm_ignore_err(ctx, stream, type, flags);
+	if (tfw_h2_get_stream_state(stream) > HTTP2_STREAM_REM_HALF_CLOSED)
+		tfw_h2_stream_add_closed(ctx, stream);
+
+	return r != STREAM_FSM_RES_IGNORE ? r : STREAM_FSM_RES_OK;
 }

--- a/fw/http_stream.h
+++ b/fw/http_stream.h
@@ -234,15 +234,6 @@ tfw_h2_stream_xmit_reinit(TfwHttpXmit *xmit)
 	bzero_fast(xmit->__off, sizeof(*xmit) - offsetof(TfwHttpXmit, __off));
 }
 
-static inline void
-tfw_h2_stream_init_for_xmit(TfwStream *stream, unsigned long h_len,
-			    unsigned long b_len)
-{
-	stream->xmit.h_len = h_len;
-	stream->xmit.b_len = b_len;
-	tfw_h2_stream_xmit_reinit(&stream->xmit);
-}
-
 static inline bool
 tfw_h2_strm_req_is_compl(TfwStream *stream)
 {

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -37,6 +37,7 @@
 #include "sync_socket.h"
 #include "tempesta_fw.h"
 #include "work_queue.h"
+#include "http_limits.h"
 
 typedef enum {
 	SS_SEND,
@@ -194,6 +195,8 @@ static void
 ss_conn_drop_guard_exit(struct sock *sk)
 {
 	SS_CALL(connection_drop, sk);
+	if (sk->sk_security)
+		tfw_classify_conn_close(sk);
 	ss_active_guard_exit(SS_V_ACT_LIVECONN);
 }
 

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -620,7 +620,7 @@ tfw_tls_conn_init(TfwConn *c)
 
 	return 0;
 err_cleanup:
-	tfw_tls_conn_dtor(c);
+	ttls_ctx_clear(tls);
 	return r;
 }
 

--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -732,7 +732,7 @@ index a828cf99c..59ebed976 100644
   *	@skb: buffer to check
 diff --git a/include/linux/tempesta.h b/include/linux/tempesta.h
 new file mode 100644
-index 000000000..08350e4ad
+index 000000000..80de50693
 --- /dev/null
 +++ b/include/linux/tempesta.h
 @@ -0,0 +1,54 @@
@@ -740,7 +740,7 @@ index 000000000..08350e4ad
 + * Linux interface for Tempesta FW.
 + *
 + * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by
@@ -2948,15 +2948,15 @@ index 000000000..4c439ac0c
 +tempesta-y := tempesta_lsm.o
 diff --git a/security/tempesta/tempesta_lsm.c b/security/tempesta/tempesta_lsm.c
 new file mode 100644
-index 000000000..c25f0a8ac
+index 000000000..a65a79f30
 --- /dev/null
 +++ b/security/tempesta/tempesta_lsm.c
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,120 @@
 +/**
 + *		Tempesta FW
 + *
 + * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by
@@ -3035,23 +3035,6 @@ index 000000000..c25f0a8ac
 +}
 +EXPORT_SYMBOL(tempesta_new_clntsk);
 +
-+static void
-+tempesta_sk_free(struct sock *sk)
-+{
-+	TempestaOps *tops;
-+
-+	if (!sk->sk_security)
-+		return;
-+
-+	rcu_read_lock();
-+
-+	tops = rcu_dereference(tempesta_ops);
-+	if (likely(tops))
-+		tops->sk_free(sk);
-+
-+	rcu_read_unlock();
-+}
-+
 +static int
 +tempesta_sock_tcp_rcv(struct sock *sk, struct sk_buff *skb)
 +{
@@ -3072,7 +3055,6 @@ index 000000000..c25f0a8ac
 +}
 +
 +static struct security_hook_list tempesta_hooks[] __read_mostly = {
-+	LSM_HOOK_INIT(sk_free_security, tempesta_sk_free),
 +	LSM_HOOK_INIT(socket_sock_rcv_skb, tempesta_sock_tcp_rcv),
 +};
 +


### PR DESCRIPTION
Fix #1982 : We should only clear previosly inited tls context
but not release connection in case of error in
`tfw_tls_conn_init` function