### PR TITLE
Tempesta & backend servers health statistics

### DIFF
--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -1240,6 +1240,24 @@
 # Default: disabled.
 #
 
+# TAG: health_stat_server
+#
+# Counts the total amount of responses from an every server for each particular
+# response code.
+#
+# Syntax:
+#   health_stat_server RESPONSE_CODES
+#
+# RESPONSE_CODES is a list of space separated HTTP statuses.
+#
+# Example:
+#   health_stat_server 400 5*;
+#
+# Default:
+#   200 response code is always set (even if another codes are explicitly
+#   specified, as in the example).
+#
+
 # TAG: health
 #
 # Directive for health monitor specifying. Health monitor is specified

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -1220,6 +1220,26 @@
 #   Health monitor is disabled.
 #
 
+# TAG: health_stat
+#
+# Counts the total amount of responses from Tempesta for the each particular
+# response code.
+#
+# Syntax:
+#   health_stat RESPONSE_CODES
+#
+# RESPONSE_CODES is a list of space separated HTTP statuses.
+#
+# It counts amount of forwared responses, so 'Server messages forwarded' in the
+# perfstat equals the sum of health_stat, if all response codes were specified
+# (hypotetically).
+#
+# Example:
+#   health_stat 400 5*;
+#
+# Default: disabled.
+#
+
 # TAG: health
 #
 # Directive for health monitor specifying. Health monitor is specified

--- a/fw/apm.c
+++ b/fw/apm.c
@@ -1,7 +1,7 @@
 /*
  *		Tempesta FW
  *
- * Copyright (C) 2016-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/fw/apm.c
+++ b/fw/apm.c
@@ -969,6 +969,7 @@ tfw_apm_calc(TfwApmData *data)
 	rdidx = atomic_read(&data->stats.rdidx);			\
 	asent = &data->stats.asent[rdidx % 2];				\
 									\
+	pstats->ith = tfw_pstats_ith;					\
 	fn_lock(&asent->rwlock);					\
 	memcpy(pstats->val, asent->pstats.val,				\
 	       T_PSZ * sizeof(pstats->val[0]));				\
@@ -1002,23 +1003,6 @@ tfw_apm_stats_global(TfwPrcntlStats *pstats)
 	BUG_ON(!tfw_apm_global_data);
 	return __tfw_apm_stats_body(tfw_apm_global_data, pstats, read_lock_bh,
 				    read_unlock_bh);
-}
-
-/*
- * Verify that an APM Stats user using the same set of percentiles.
- *
- * Note: This module uses a single set of percentiles for all servers.
- * All APM Stats users must use the same set of percentiles.
- */
-int
-tfw_apm_pstats_verify(TfwPrcntlStats *pstats)
-{
-	int i;
-
-	for (i = 0; i < T_PSZ; ++i)
-		if (pstats->ith[i] != tfw_pstats_ith[i])
-			return 1;
-	return 0;
 }
 
 /*

--- a/fw/apm.c
+++ b/fw/apm.c
@@ -1698,12 +1698,9 @@ tfw_cfgop_apm_server_failover(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	TfwApmHMCfg *hm_entry;
 	int code, limit, tframe;
 
-	if (tfw_cfg_check_val_n(ce, 3))
-		return -EINVAL;
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+
+	TFW_CFG_CHECK_VAL_N(==, 3, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	if (tfw_cfgop_parse_http_status(ce->vals[0], &code)) {
 		T_ERR_NL("Unable to parse http code value: '%s'\n",
@@ -1759,12 +1756,8 @@ tfw_cfgop_begin_apm_hm(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	TfwApmHM *hm;
 	int r;
 
-	if (tfw_cfg_check_val_n(ce, 1))
-		return -EINVAL;
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(==, 1, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	list_for_each_entry(hm, &tfw_hm_list, list) {
 		if (!strcasecmp(hm->name, ce->vals[0])) {
@@ -1828,14 +1821,8 @@ tfw_cfgop_apm_hm_resp_code(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	int r, i, code;
 	const char *val;
 
-	if (!ce->val_n) {
-		T_ERR_NL("No arguments found.\n");
-		return -EINVAL;
-	}
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(>, 0, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	if ((r = tfw_cfgop_apm_alloc_hm_codes(tfw_hm_entry)))
 		return r;

--- a/fw/apm.c
+++ b/fw/apm.c
@@ -382,7 +382,7 @@ totals:
 #define HM_FREQ		10
 
 /*
- * Structure for health monitor settings.
+ * Structure for health monitor settings ('health_check').
  *
  * @list	- entry in list of all health monitors;
  * @name	- health monitor's name;
@@ -410,7 +410,8 @@ typedef struct {
 } TfwApmHM;
 
 /*
- * Structure for monitoring settings of particular HTTP code.
+ * Structure for monitoring settings of particular HTTP code
+ * ('server_failover_http' or 'health_stat_server').
  *
  * @list	- entry in list of all monitored codes;
  * @tframe	- Time frame in seconds for @code accounting;
@@ -1459,8 +1460,8 @@ bool
 tfw_apm_check_hm(const char *name)
 {
 	if (!tfw_hm_codes_cnt) {
-		T_ERR_NL("No response codes specified for server's health "
-			 "monitoring\n");
+		T_ERR_NL("No response 'server_failover_http' directives "
+			 "specified for server's health monitoring\n");
 		return false;
 	}
 

--- a/fw/apm.h
+++ b/fw/apm.h
@@ -62,18 +62,36 @@ static const unsigned int tfw_pstats_ith[] = {
 
 int tfw_apm_add_srv(TfwServer *srv);
 void tfw_apm_del_srv(TfwServer *srv);
+
+/*
+ * All blocks of the procedures listed below, separated by spaces, are not
+ * data-coupled. It can be said that these are independent submodules of the
+ * APM module.
+ */
+
+/* Procedures related to statistics (avg/min/max/percentiles).
+ * Configured by the 'apm_stats' directive.
+ */
 void tfw_apm_update(void *apmref, unsigned long jtstamp, unsigned long jrtime);
 int tfw_apm_stats(void *apmref, TfwPrcntlStats *pstats);
 int tfw_apm_stats_bh(void *apmref, TfwPrcntlStats *pstats);
 int tfw_apm_pstats_verify(TfwPrcntlStats *pstats);
+
+/*
+ * Although these procedures are used for health monitoring, they also collect
+ * overall statistics on responses from each server. Therefore, if health
+ * monitoring is not active for a server, these procedures are still executed.
+ */
+bool tfw_apm_hm_srv_limit(int status, void *apmref);
+TfwHMStats *tfw_apm_hm_stats(void *apmref);
+
+/* Health monitor procedures ('health_check' directive). */
 void tfw_apm_hm_srv_rcount_update(TfwStr *uri_path, void *apmref);
 bool tfw_apm_hm_srv_alive(int status, TfwStr *body, struct sk_buff *skb_head,
 			  void *apmref);
-bool tfw_apm_hm_srv_limit(int status, void *apmref);
 void tfw_apm_hm_enable_srv(TfwServer *srv, const char *hm_name);
 void tfw_apm_hm_disable_srv(TfwServer *srv);
 bool tfw_apm_hm_srv_eq(const char *name, TfwServer *srv);
-TfwHMStats *tfw_apm_hm_stats(void *apmref);
 bool tfw_apm_check_hm(const char *name);
 
 #endif /* __TFW_APM_H__ */

--- a/fw/apm.h
+++ b/fw/apm.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/fw/apm.h
+++ b/fw/apm.h
@@ -76,6 +76,9 @@ void tfw_apm_update(void *apmref, unsigned long jtstamp, unsigned long jrtime);
 int tfw_apm_stats(void *apmref, TfwPrcntlStats *pstats);
 int tfw_apm_stats_bh(void *apmref, TfwPrcntlStats *pstats);
 int tfw_apm_pstats_verify(TfwPrcntlStats *pstats);
+/* Displayed in the perfstat, not in a backend statistics. */
+void tfw_apm_update_global(unsigned long jtstamp, unsigned long jrtime);
+int tfw_apm_stats_global(TfwPrcntlStats *pstats);
 
 /*
  * Although these procedures are used for health monitoring, they also collect

--- a/fw/apm.h
+++ b/fw/apm.h
@@ -74,7 +74,6 @@ void tfw_apm_del_srv(TfwServer *srv);
  */
 void tfw_apm_update(void *apmref, unsigned long jtstamp, unsigned long jrtime);
 int tfw_apm_stats(void *apmref, TfwPrcntlStats *pstats);
-int tfw_apm_stats_bh(void *apmref, TfwPrcntlStats *pstats);
 /* Displayed in the perfstat, not in a backend statistics. */
 void tfw_apm_update_global(unsigned long jtstamp, unsigned long jrtime);
 int tfw_apm_stats_global(TfwPrcntlStats *pstats);

--- a/fw/apm.h
+++ b/fw/apm.h
@@ -67,6 +67,7 @@ static const unsigned int tfw_pstats_ith[] = {
 typedef struct {
 	int		code;
 	unsigned int	sum;
+	u64		total;	/* Another sum for total stats; can be unused. */
 } TfwHMCodeStats;
 
 /*
@@ -176,11 +177,10 @@ void tfw_apm_hm_srv_rcount_update(TfwStr *uri_path, void *apmref);
 bool tfw_apm_hm_srv_alive(int status, TfwStr *body, struct sk_buff *skb_head,
 			  void *apmref);
 bool tfw_apm_hm_srv_limit(int status, void *apmref);
-void tfw_apm_hm_enable_srv(TfwServer *srv, void *hmref);
+void tfw_apm_hm_enable_srv(TfwServer *srv, const char *hm_name);
 void tfw_apm_hm_disable_srv(TfwServer *srv);
 bool tfw_apm_hm_srv_eq(const char *name, TfwServer *srv);
 TfwHMStats *tfw_apm_hm_stats(void *apmref);
-void *tfw_apm_get_hm(const char *name);
 bool tfw_apm_check_hm(const char *name);
 
 #endif /* __TFW_APM_H__ */

--- a/fw/apm.h
+++ b/fw/apm.h
@@ -146,27 +146,6 @@ tfw_hm_stats_init_from_cfg_entry(TfwHMStats *s, TfwCfgEntry *ce)
 	return 0;
 }
 
-static inline void
-tfw_hm_stats_inc(TfwHMStats *s, int status)
-{
-	int i;
-
-	if (!s)
-		return;
-	/*
-	 * For faster access, alternative techniques like bitmask, binary search,
-	 * or other methods could be employed. However, a linear search is deemed
-	 * sufficient, given that the number of 'health_stat'/'health_stat_server'
-	 * codes is typically not high.
-	 */
-	for (i = 0; i < s->ccnt; ++i) {
-		if (tfw_http_status_eq(status, s->rsums[i].code)) {
-			++s->rsums[i].sum;
-			break;
-		}
-	}
-}
-
 int tfw_apm_add_srv(TfwServer *srv);
 void tfw_apm_del_srv(TfwServer *srv);
 void tfw_apm_update(void *apmref, unsigned long jtstamp, unsigned long jrtime);

--- a/fw/apm.h
+++ b/fw/apm.h
@@ -75,7 +75,6 @@ void tfw_apm_del_srv(TfwServer *srv);
 void tfw_apm_update(void *apmref, unsigned long jtstamp, unsigned long jrtime);
 int tfw_apm_stats(void *apmref, TfwPrcntlStats *pstats);
 int tfw_apm_stats_bh(void *apmref, TfwPrcntlStats *pstats);
-int tfw_apm_pstats_verify(TfwPrcntlStats *pstats);
 /* Displayed in the perfstat, not in a backend statistics. */
 void tfw_apm_update_global(unsigned long jtstamp, unsigned long jrtime);
 int tfw_apm_stats_global(TfwPrcntlStats *pstats);

--- a/fw/apm.h
+++ b/fw/apm.h
@@ -20,6 +20,7 @@
 #ifndef __TFW_APM_H__
 #define __TFW_APM_H__
 
+#include "http.h"
 #include "pool.h"
 #include "server.h"
 #include "str.h"
@@ -69,7 +70,8 @@ typedef struct {
 } TfwHMCodeStats;
 
 /*
- * @rtime	- time until next server health checking;
+ * @rtime	- time until next server health checking (can be unused if not
+ *		  required);
  * @ccnt	- count of @rsums elements;
  * @rsums	- array of counters for separate HTTP codes;
  */
@@ -78,6 +80,91 @@ typedef struct {
 	unsigned int	ccnt;
 	TfwHMCodeStats	*rsums;
 } TfwHMStats;
+
+/**
+ * The real size of TfwHMStats, used for memory allocation.
+ *
+ * TfwHMCodeStats is located monolithically in memory with TfwHMStats,
+ * just after it.
+ */
+static inline size_t
+tfw_hm_stats_size(int ccnt)
+{
+	return sizeof(TfwHMStats) + sizeof(TfwHMCodeStats) * ccnt;
+}
+
+/**
+ * Use it right after memory allocation.
+ *
+ * Rsums content stays unitinitialized.
+ */
+static inline void
+tfw_hm_stats_init(TfwHMStats *s, int ccnt)
+{
+	s->ccnt = ccnt;
+	s->rsums = (TfwHMCodeStats *)(s + 1);
+}
+
+static inline void
+tfw_hm_stats_clone(TfwHMStats *dest, TfwHMStats *src)
+{
+	if (!src)
+		return;
+
+	memcpy_fast(dest, src, tfw_hm_stats_size(src->ccnt));
+	dest->rsums = (TfwHMCodeStats *)(dest + 1);
+}
+
+/**
+ * The config entry @ce must be a list of HTTP codes, such as:
+ * 'some_directive 403 404 5*'.
+ *
+ * Use it right after memory allocation.
+ */
+static inline int
+tfw_hm_stats_init_from_cfg_entry(TfwHMStats *s, TfwCfgEntry *ce)
+{
+	int i, code;
+	const char *val;
+	tfw_hm_stats_init(s, ce->val_n);
+
+	TFW_CFG_ENTRY_FOR_EACH_VAL(ce, i, val) {
+		BUG_ON(i >= s->ccnt);
+
+		if (tfw_cfgop_parse_http_status(val, &code)
+		    || (code > HTTP_STATUS_5XX
+			&& tfw_cfg_check_range(code, HTTP_CODE_MIN,
+					       HTTP_CODE_MAX)))
+		{
+			T_ERR_NL("Unable to parse http code value: '%s'\n",
+				 val);
+			return -EINVAL;
+		}
+		s->rsums[i].code = code;
+	}
+	return 0;
+}
+
+static inline void
+tfw_hm_stats_inc(TfwHMStats *s, int status)
+{
+	int i;
+
+	if (!s)
+		return;
+	/*
+	 * For faster access, alternative techniques like bitmask, binary search,
+	 * or other methods could be employed. However, a linear search is deemed
+	 * sufficient, given that the number of 'health_stat'/'health_stat_server'
+	 * codes is typically not high.
+	 */
+	for (i = 0; i < s->ccnt; ++i) {
+		if (tfw_http_status_eq(status, s->rsums[i].code)) {
+			++s->rsums[i].sum;
+			break;
+		}
+	}
+}
 
 int tfw_apm_add_srv(TfwServer *srv);
 void tfw_apm_del_srv(TfwServer *srv);

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -4,7 +4,7 @@
  * HTTP cache (RFC 7234).
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -34,6 +34,7 @@
 
 #include "tdb.h"
 
+#include "apm.h"
 #include "lib/str.h"
 #include "tempesta_fw.h"
 #include "vhost.h"
@@ -2880,6 +2881,7 @@ cache_req_process_node(TfwHttpReq *req, tfw_http_cache_cb_t action)
 	}
 
 	resp = tfw_cache_build_resp(req, ce, lifetime, id);
+
 	/*
 	 * The stream of HTTP/2-request should be closed here since we have
 	 * successfully created the resulting response from cache and will

--- a/fw/cache.h
+++ b/fw/cache.h
@@ -23,7 +23,6 @@
 
 #include "http.h"
 
-bool tfw_cache_msg_cacheable(TfwHttpReq *req);
 int tfw_cache_process(TfwHttpMsg *msg, tfw_http_cache_cb_t action);
 
 extern unsigned int cache_default_ttl;

--- a/fw/cache.h
+++ b/fw/cache.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/cfg.h
+++ b/fw/cfg.h
@@ -191,6 +191,21 @@ typedef struct {
 	     (idx) < (e)->val_n;		\
 	     (v) = (e)->vals[++(idx)])
 
+#define TFW_CFG_CHECK_NO_ATTRS(spec, entry)				\
+	if ((entry)->attr_n) {						\
+		T_ERR_NL("%s: Arguments may not have the '=' sign\n",	\
+			 (spec)->name);					\
+		return -EINVAL;						\
+	}
+
+#define TFW_CFG_CHECK_VAL_N(op, req, spec, entry)				\
+	if (! ((entry)->val_n op (req)) ) {				\
+		T_ERR_NL("%s: Invalid number of arguments: %zu, must "	\
+			 "be %s %d\n", (spec)->name, (entry)->val_n,	\
+			 #op, (req));					\
+		return -EINVAL;						\
+	}
+
 /**
  * TfwCfgSpec{} is a single instruction for the configuration parser.
  * It specifies a @handler which is executed when the parser meets

--- a/fw/cfg.h
+++ b/fw/cfg.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/http.c
+++ b/fw/http.c
@@ -1093,6 +1093,7 @@ tfw_h2_resp_fwd(TfwHttpResp *resp)
 	}
 	else {
 		TFW_INC_STAT_BH(serv.msgs_forwarded);
+		tfw_inc_global_hm_stats(resp->status);
 	}
 
 	tfw_connection_put(req->conn);
@@ -4135,9 +4136,10 @@ __tfw_http_resp_fwd(TfwCliConn *cli_conn, struct list_head *ret_queue)
 			tfw_connection_close((TfwConn *)cli_conn, true);
 			return;
 		}
+		TFW_INC_STAT_BH(serv.msgs_forwarded);
+		tfw_inc_global_hm_stats(req->resp->status);
 		list_del_init(&req->msg.seq_list);
 		tfw_http_resp_pair_free(req);
-		TFW_INC_STAT_BH(serv.msgs_forwarded);
 	}
 }
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -6133,6 +6133,10 @@ next_msg:
 }
 
 /**
+ * Process the cached response from tfw_cache_process() or the original
+ * response from a backend if it wasn't cached due to certain circumstances
+ * or conditions.
+ *
  * This is the second half of tfw_http_resp_process().
  * tfw_http_resp_process() runs in SoftIRQ whereas tfw_http_resp_cache_cb()
  * runs in cache thread that is scheduled at an appropriate TDB node.

--- a/fw/http.c
+++ b/fw/http.c
@@ -6951,10 +6951,7 @@ tfw_cfgop_block_action(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		T_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
 		return -EINVAL;
 	}
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	if (!strcasecmp(ce->vals[0], "error")) {
 		if (tfw_cfgop_define_block_action(ce->vals[1],
@@ -7273,13 +7270,8 @@ tfw_cfgop_resp_body(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int code;
 
-	if (tfw_cfg_check_val_n(ce, 2))
-		return -EINVAL;
-
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(==, 2, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	if (tfw_cfgop_parse_http_status(ce->vals[0], &code)) {
 		T_ERR_NL("Unable to parse HTTP code value in '%s' directive: "
@@ -7296,14 +7288,8 @@ tfw_cfgop_whitelist_mark(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	unsigned int i;
 	const char *val;
 
-	if (!ce->val_n) {
-		T_ERR_NL("%s: At least one argument is required", cs->name);
-		return -EINVAL;
-	}
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(>, 0, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	tfw_wl_marks.sz = ce->val_n;
 	if (!(tfw_wl_marks.mrks = kmalloc(ce->val_n * sizeof(unsigned int),
@@ -7338,14 +7324,8 @@ __cfgop_brange_hndl(TfwCfgSpec *cs, TfwCfgEntry *ce, unsigned char *a)
 	unsigned int i;
 	const char *val;
 
-	if (!ce->val_n) {
-		T_ERR_NL("%s: At least one argument is required", cs->name);
-		return -EINVAL;
-	}
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(>, 0, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	TFW_CFG_ENTRY_FOR_EACH_VAL(ce, i, val) {
 		unsigned long i0 = 0, i1 = 0;

--- a/fw/http.c
+++ b/fw/http.c
@@ -6288,6 +6288,7 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 	TfwHttpReq *req = hmresp->req;
 	TfwFsmData data;
 	long timestamp = tfw_current_timestamp();
+	unsigned long jrtime;
 
 	/*
 	 * The time the response was received is used in cache
@@ -6314,8 +6315,10 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 	 * a fast and simple algorithm for that? Keep in mind, that the
 	 * value of RTT has an upper boundary in the APM.
 	 */
+	jrtime = resp->jrxtstamp - req->jtxtstamp;
 	tfw_apm_update(((TfwServer *)resp->conn->peer)->apmref,
-		       resp->jrxtstamp, resp->jrxtstamp - req->jtxtstamp);
+		       resp->jrxtstamp, jrtime);
+	tfw_apm_update_global(resp->jrxtstamp, jrtime);
 	/*
 	 * Health monitor request means that its response need not to
 	 * send anywhere.

--- a/fw/http.c
+++ b/fw/http.c
@@ -1601,11 +1601,16 @@ static bool
 tfw_http_hm_suspend(TfwHttpResp *resp, TfwServer *srv)
 {
 	unsigned long old_flags, flags = READ_ONCE(srv->flags);
+	/*
+	 * We need to count a total response statistics in
+	 * tfw_apm_hm_srv_limit(), even if health monitor is disabled.
+	 * In this case limit calculation won't be accounted.
+	 */
+	bool lim_exceeded = tfw_apm_hm_srv_limit(resp->status, srv->apmref);
 
 	if (!(flags & TFW_SRV_F_HMONITOR))
 		return true;
-
-	if (!tfw_apm_hm_srv_limit(resp->status, srv->apmref))
+	if (!lim_exceeded)
 		return false;
 
 	do {

--- a/fw/http.h
+++ b/fw/http.h
@@ -258,19 +258,19 @@ typedef struct {
  * @msg			- the base data of an HTTP message;
  * @pool		- message's memory allocation pool;
  * @h_tbl		- table of message's HTTP headers in internal form;
- * @httperr		- HTTP error data used to form an error response;
  * @pair		- the message paired with this one;
  * @req			- the request paired with this response;
  * @resp		- the response paired with this request;
  * @stream		- stream which the message is linked with;
+ * @httperr		- HTTP error data used to form an error response;
  * @cache_ctl		- cache control data for a message;
  * @version		- HTTP version (1.0 and 1.1 are only supported);
+ * @keep_alive		- the value of timeout specified in Keep-Alive header;
+ * @content_length	- the value of Content-Length header field;
  * @flags		- message related flags. The flags are tested
  *			  concurrently, but concurrent updates aren't
  *			  allowed. Use atomic operations if concurrent
  *			  updates are possible;
- * @content_length	- the value of Content-Length header field;
- * @keep_alive		- the value of timeout specified in Keep-Alive header;
  * @conn		- connection which the message was received on;
  * @destructor		- called when a connection is destroyed;
  * @crlf		- pointer to CRLF between headers and body;

--- a/fw/http.h
+++ b/fw/http.h
@@ -686,6 +686,20 @@ tfw_body_iter_next(TfwMsgIter* it, TfwStr* chunk)
 #define TFW_BODY_ITER_WALK(it, c)					\
 	for (; (c)->data; tfw_body_iter_next((it), (c)))
 
+/**
+ * Compare the HTTP status with the code parsed from
+ * tfw_cfgop_parse_http_status().
+ *
+ * Wildcarded HTTP code values (of type 4*, 5* etc.) are allowed during
+ * configuration, so these values also must be checked via
+ * dividing by 100.
+ */
+static inline bool
+tfw_http_status_eq(int status, int code)
+{
+	return status == code || status / 100 == code;
+}
+
 typedef void (*tfw_http_cache_cb_t)(TfwHttpMsg *);
 
 /**

--- a/fw/http.h
+++ b/fw/http.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -11827,7 +11827,8 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, unsigned int len,
 				__set_bit(TFW_HTTP_B_VOID_BODY, resp->flags);
 			}
 
-			if (resp->status < 100 || resp->status > 599)
+			if (resp->status < HTTP_CODE_MIN
+			    || resp->status > HTTP_CODE_MAX)
 				T_WARN("Unknown response code: %hu", resp->status);
 
 			__FSM_MOVE_n(Resp_ReasonPhrase, __fsm_n);

--- a/fw/http_sched_ratio.c
+++ b/fw/http_sched_ratio.c
@@ -456,10 +456,7 @@ __tfw_sched_ratio_get_rtt(size_t si, TfwRatio *ratio, TfwRatioData *rtodata)
 {
 	unsigned int recalc;
 	unsigned int val[T_PSZ] = { 0 };
-	TfwPrcntlStats pstats = {
-		.ith = tfw_pstats_ith,
-		.val = val,
-	};
+	TfwPrcntlStats pstats = {.val = val};
 	TfwRatioSrvData *srvdata = rtodata->srvdata;
 	TfwRatioSrvDesc *srvdesc = ratio->srvdesc;
 

--- a/fw/http_sched_ratio.c
+++ b/fw/http_sched_ratio.c
@@ -1,7 +1,7 @@
 /**
  *              Tempesta FW
  *
- * Copyright (C) 2017-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2017-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/fw/http_sess_conf.c
+++ b/fw/http_sess_conf.c
@@ -646,7 +646,7 @@ tfw_cfgop_jsch_parse_resp_code(TfwCfgSpec *cs, TfwCfgJsCh *js_ch,
 		T_ERR_NL("%s: can't parse key 'resp_code'\n", cs->name);
 		return r;
 	}
-	if ((r = tfw_cfg_check_range(int_val, 100, 599)))
+	if ((r = tfw_cfg_check_range(int_val, HTTP_CODE_MIN, HTTP_CODE_MAX)))
 		return r;
 	js_ch->st_code = int_val;
 

--- a/fw/http_sess_conf.c
+++ b/fw/http_sess_conf.c
@@ -474,14 +474,8 @@ tfw_cfgop_sticky_sess_set(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	unsigned long *flags;
 
-	if (ce->attr_n) {
-		T_ERR_NL("Arguments may not have the '=' sign\n");
-		return -EINVAL;
-	}
-	if (ce->val_n > 1) {
-		T_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+	TFW_CFG_CHECK_VAL_N(<=, 1, cs, ce);
 
 	if (cur_vhost) {
 		flags =  &cur_vhost->flags;

--- a/fw/http_sess_conf.c
+++ b/fw/http_sess_conf.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/fw/http_tbl.c
+++ b/fw/http_tbl.c
@@ -306,14 +306,8 @@ tfw_cfgop_http_tbl_chain_begin(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	T_DBG("http_tbl: begin http_chain\n");
 
-	if (ce->val_n > 1) {
-		T_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
-		return -EINVAL;
-	}
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(<=, 1, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	chain = list_first_entry_or_null(&tfw_table_reconfig->head,
 					 TfwHttpChain, list);
@@ -400,12 +394,8 @@ tfw_cfgop_http_rule(TfwCfgSpec *cs, TfwCfgEntry *e)
 	TfwVhost *vhost = NULL;
 
 	BUG_ON(!tfw_chain_entry);
-	if ((r = tfw_cfg_check_val_n(e, 0)))
-		return r;
-	if (e->attr_n) {
-		T_ERR_NL("Attributes count must be zero\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(==, 0, cs, e);
+	TFW_CFG_CHECK_NO_ATTRS(cs, e);
 
 	invert = cfg_rule->inv;
 	in_field = cfg_rule->fst;

--- a/fw/http_tbl.c
+++ b/fw/http_tbl.c
@@ -83,7 +83,7 @@
  *   - Extended string matching operators: "regex", "substring".
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -106,6 +106,7 @@ static int
 tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 {
 #define SPRNE(m, e)	seq_printf(seq, m": %llu\n", e)
+#define SPRNED(m, e)	seq_printf(seq, m": %dms\n", e)
 #define SPRN(m, c)	seq_printf(seq, m": %llu\n", stat.c)
 
 	int i;
@@ -113,6 +114,12 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	u64 serv_conn_active, serv_conn_sched;
 	SsStat *ss_stat = kmalloc(sizeof(SsStat) * num_online_cpus(),
 				  GFP_KERNEL);
+	unsigned int val[ARRAY_SIZE(tfw_pstats_ith)] = { 0 };
+	TfwPrcntlStats pstats = {
+		.ith = tfw_pstats_ith,
+		.val = val,
+	};
+
 	if (!ss_stat)
 		T_WARN("Cannot allocate sync sockets statistics\n");
 
@@ -128,6 +135,16 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	}
 
 	tfw_perfstat_collect(&stat);
+	tfw_apm_stats_global(&pstats);
+
+	SPRNED("Minimal response time\t\t", pstats.val[TFW_PSTATS_IDX_MIN]);
+	SPRNED("Average response time\t\t", pstats.val[TFW_PSTATS_IDX_AVG]);
+	SPRNED("Median  response time\t\t", pstats.val[TFW_PSTATS_IDX_P50]);
+	SPRNED("Maximum response time\t\t", pstats.val[TFW_PSTATS_IDX_MAX]);
+	seq_printf(seq, "Percentiles\n");
+	for (i = TFW_PSTATS_IDX_ITH; i < ARRAY_SIZE(tfw_pstats_ith); ++i)
+		seq_printf(seq, "%02d%%:\t%dms\n",
+				pstats.ith[i], pstats.val[i]);
 
 	/* Ss statistics. */
 	SPRN("SS work queue full\t\t\t", ss.wq_full);

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -191,7 +191,7 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	if (stat.hm) {
 		seq_printf(seq, "Tempesta health statistics:\n");
 		for (i = 0; i < stat.hm->ccnt; ++i) {
-			seq_printf(seq, "\tHTTP '%d' codes\t: %u\n",
+			seq_printf(seq, "\tHTTP '%d' code\t: %u\n",
 				   stat.hm->rsums[i].code,
 				   stat.hm->rsums[i].sum);
 		}
@@ -218,12 +218,12 @@ tfw_srvstats_seq_show(struct seq_file *seq, void *off)
 	TfwSrvConn *srv_conn;
 	TfwServer *srv = seq->private;
 	unsigned int *qsize;
-	bool hm = test_bit(TFW_SRV_B_HMONITOR, &srv->flags);
 	unsigned int val[ARRAY_SIZE(tfw_pstats_ith)] = { 0 };
 	TfwPrcntlStats pstats = {
 		.ith = tfw_pstats_ith,
 		.val = val,
 	};
+	TfwHMStats *hm_stats;
 
 	if (!(qsize = kmalloc(sizeof(int) * srv->conn_n, GFP_KERNEL)))
 		return -ENOMEM;
@@ -256,21 +256,19 @@ tfw_srvstats_seq_show(struct seq_file *seq, void *off)
 	seq_printf(seq, "Total schedulable connections\t: %zd\n",
 			srv->conn_n - rc);
 
-	seq_printf(seq, "HTTP health monitor is enabled\t: %d\n", hm);
-	if (hm) {
-		TfwHMStats *hm_stats;
-		seq_printf(seq, "HTTP availability\t: %d\n",
-				!tfw_srv_suspended(srv));
-		if ((hm_stats = tfw_apm_hm_stats(srv->apmref))) {
-			seq_printf(seq, "\tTime until next health"
-					" checking\t: %u\n",
-					hm_stats->rtime);
-			for (i = 0; i < hm_stats->ccnt; ++i)
-				seq_printf(seq, "\tHTTP '%d' codes\t: %u\n",
-						hm_stats->rsums[i].code,
-						hm_stats->rsums[i].sum);
-			kfree(hm_stats);
-		}
+	seq_printf(seq, "HTTP health monitor is enabled\t: %d\n",
+		   test_bit(TFW_SRV_B_HMONITOR, &srv->flags));
+	seq_printf(seq, "HTTP availability\t\t: %d\n",
+			!tfw_srv_suspended(srv));
+	if ((hm_stats = tfw_apm_hm_stats(srv->apmref))) {
+		seq_printf(seq, "\tTime until next health check\t: %u\n",
+			   hm_stats->rtime);
+		for (i = 0; i < hm_stats->ccnt; ++i)
+			seq_printf(seq, "\tHTTP '%d' code\t: %u (%llu total)"
+				   "\n", hm_stats->rsums[i].code,
+				   hm_stats->rsums[i].sum,
+				   hm_stats->rsums[i].total);
+		kfree(hm_stats);
 	}
 
 	seq_printf(seq, "Maximum forwarding queue size\t: %u\n",

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -114,11 +114,8 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	u64 serv_conn_active, serv_conn_sched;
 	SsStat *ss_stat = kmalloc(sizeof(SsStat) * num_online_cpus(),
 				  GFP_KERNEL);
-	unsigned int val[ARRAY_SIZE(tfw_pstats_ith)] = { 0 };
-	TfwPrcntlStats pstats = {
-		.ith = tfw_pstats_ith,
-		.val = val,
-	};
+	unsigned int val[T_PSZ] = { 0 };
+	TfwPrcntlStats pstats = {.val = val};
 
 	if (!ss_stat)
 		T_WARN("Cannot allocate sync sockets statistics\n");
@@ -235,11 +232,8 @@ tfw_srvstats_seq_show(struct seq_file *seq, void *off)
 	TfwSrvConn *srv_conn;
 	TfwServer *srv = seq->private;
 	unsigned int *qsize;
-	unsigned int val[ARRAY_SIZE(tfw_pstats_ith)] = { 0 };
-	TfwPrcntlStats pstats = {
-		.ith = tfw_pstats_ith,
-		.val = val,
-	};
+	unsigned int val[T_PSZ] = { 0 };
+	TfwPrcntlStats pstats = {.val = val};
 	TfwHMStats *hm_stats;
 
 	if (!(qsize = kmalloc(sizeof(int) * srv->conn_n, GFP_KERNEL)))
@@ -379,14 +373,6 @@ tfw_procfs_sg_create(TfwSrvGroup *sg)
 static int
 tfw_procfs_cfgend(void)
 {
-	TfwPrcntlStats pstats = {
-		.ith = tfw_pstats_ith,
-	};
-
-	if (tfw_runstate_is_reconfig())
-		return 0;
-	if (tfw_apm_pstats_verify(&pstats))
-		return -EINVAL;
 	return 0;
 }
 

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -110,7 +110,7 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 #define SPRN(m, c)	seq_printf(seq, m": %llu\n", stat.c)
 
 	int i;
-	TfwPerfStat stat;
+	TfwPerfStat stat = {0};
 	u64 serv_conn_active, serv_conn_sched;
 	SsStat *ss_stat = kmalloc(sizeof(SsStat) * num_online_cpus(),
 				  GFP_KERNEL);
@@ -120,15 +120,11 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	if (!ss_stat)
 		T_WARN("Cannot allocate sync sockets statistics\n");
 
-	memset(&stat, 0, sizeof(stat));
-
 	if (health_stat_codes) {
 		stat.hm = kmalloc(tfw_hm_stats_size(health_stat_codes->ccnt),
 				  GFP_KERNEL);
 		if (stat.hm)
 			tfw_hm_stats_clone(stat.hm, health_stat_codes);
-	} else {
-		stat.hm = NULL;
 	}
 
 	tfw_perfstat_collect(&stat);
@@ -277,7 +273,7 @@ tfw_srvstats_seq_show(struct seq_file *seq, void *off)
 		for (i = 0; i < hm_stats->ccnt; ++i)
 			seq_printf(seq, "\tHTTP '%d' code\t: %u (%llu total)"
 				   "\n", hm_stats->rsums[i].code,
-				   hm_stats->rsums[i].sum,
+				   hm_stats->rsums[i].tf_total,
 				   hm_stats->rsums[i].total);
 		kfree(hm_stats);
 	}

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -95,8 +95,8 @@ tfw_perfstat_collect(TfwPerfStat *stat)
 			for (i = 0; i < stat->hm->ccnt; ++i) {
 				BUG_ON(stat->hm->rsums[i].code !=
 				       pcp_stat->hm->rsums[i].code);
-				stat->hm->rsums[i].sum +=
-					pcp_stat->hm->rsums[i].sum;
+				stat->hm->rsums[i].total +=
+					pcp_stat->hm->rsums[i].total;
 			}
 	}
 #undef SADD
@@ -191,9 +191,9 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	if (stat.hm) {
 		seq_printf(seq, "Tempesta health statistics:\n");
 		for (i = 0; i < stat.hm->ccnt; ++i) {
-			seq_printf(seq, "\tHTTP '%d' code\t: %u\n",
+			seq_printf(seq, "\tHTTP '%d' code\t: %llu\n",
 				   stat.hm->rsums[i].code,
-				   stat.hm->rsums[i].sum);
+				   stat.hm->rsums[i].total);
 		}
 	}
 
@@ -410,7 +410,7 @@ tfw_cfgop_health_stat(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	health_stat_codes = kzalloc(tfw_hm_stats_size(ce->val_n),
 				    GFP_KERNEL);
 	if (!health_stat_codes)
-		return -EINVAL;
+		return -ENOMEM;
 	if (tfw_hm_stats_init_from_cfg_entry(health_stat_codes, ce)) {
 		kfree(health_stat_codes);
 		health_stat_codes = NULL;
@@ -422,7 +422,7 @@ tfw_cfgop_health_stat(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		pcp_stat->hm = kmalloc_node(tfw_hm_stats_size(ce->val_n),
 					    GFP_KERNEL, cpu_to_node(cpu));
 		if (!pcp_stat->hm)
-			return -EINVAL;
+			return -ENOMEM;
 		tfw_hm_stats_clone(pcp_stat->hm, health_stat_codes);
 	}
 	return 0;

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -239,7 +239,7 @@ tfw_srvstats_seq_show(struct seq_file *seq, void *off)
 	if (!(qsize = kmalloc(sizeof(int) * srv->conn_n, GFP_KERNEL)))
 		return -ENOMEM;
 
-	tfw_apm_stats_bh(srv->apmref, &pstats);
+	tfw_apm_stats(srv->apmref, &pstats);
 
 	SPRNE("Minimal response time\t\t", pstats.val[TFW_PSTATS_IDX_MIN]);
 	SPRNE("Average response time\t\t", pstats.val[TFW_PSTATS_IDX_AVG]);

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -360,6 +360,12 @@ tfw_procfs_stop(void)
 }
 
 static TfwCfgSpec tfw_procfs_specs[] = {
+/*	{
+		.name       = "health_stat",
+		.handler    = tfw_cfgop_apm_stats,
+		.cleanup    = tfw_cfgop_cleanup_apm,
+	},
+*/
 	{ 0 },
 };
 

--- a/fw/procfs.h
+++ b/fw/procfs.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2017 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/fw/procfs.h
+++ b/fw/procfs.h
@@ -21,6 +21,7 @@
 #define __TFW_PROCFS_H__
 
 #include "tempesta_fw.h"
+#include "apm.h"
 
 /*
  * @wq_full		- How many times we faced work queue full.
@@ -89,11 +90,17 @@ typedef struct {
 	u64	misses;
 } TfwCacheStat;
 
+/*
+ * @hm	- Total responses for each HTTP code specified in 'health_stat'.
+ * 	  Accounts for all responses, whether served from the backend or the
+ *	  cache.
+ */
 typedef struct {
 	TfwSsStat	ss;
 	TfwClntStat	clnt;
 	TfwSrvStat	serv;
 	TfwCacheStat	cache;
+	TfwHMStats	*hm;
 } TfwPerfStat;
 
 DECLARE_PER_CPU_ALIGNED(TfwPerfStat, tfw_perfstat);
@@ -108,5 +115,27 @@ DECLARE_PER_CPU_ALIGNED(TfwPerfStat, tfw_perfstat);
 #define TFW_DEC_STAT_BH(...)	this_cpu_dec(tfw_perfstat.__VA_ARGS__)
 #define TFW_ADD_STAT_BH(val, ...)	\
 		this_cpu_add(tfw_perfstat.__VA_ARGS__, val)
+
+static inline void
+tfw_inc_global_hm_stats(int status)
+{
+	TfwPerfStat *this_stat = this_cpu_ptr(&tfw_perfstat);
+	TfwHMStats *hm = this_stat->hm;
+
+	if (!hm)
+		return;
+        /*
+         * For faster access, alternative techniques like bitmask, binary search,
+         * or other methods could be employed. However, a linear search is deemed
+         * sufficient, given that the number of 'health_stat'/'health_stat_server'
+         * codes is typically not high.
+         */
+        for (i = 0; i < hm->ccnt; ++i) {
+                if (tfw_http_status_eq(status, hm->rsums[i].code)) {
+                        ++hm->rsums[i].total;
+                        break;
+                }
+        }
+}
 
 #endif /* __TFW_PROCFS_H__ */

--- a/fw/procfs.h
+++ b/fw/procfs.h
@@ -119,6 +119,7 @@ DECLARE_PER_CPU_ALIGNED(TfwPerfStat, tfw_perfstat);
 static inline void
 tfw_inc_global_hm_stats(int status)
 {
+	int i;
 	TfwPerfStat *this_stat = this_cpu_ptr(&tfw_perfstat);
 	TfwHMStats *hm = this_stat->hm;
 

--- a/fw/procfs.h
+++ b/fw/procfs.h
@@ -21,7 +21,7 @@
 #define __TFW_PROCFS_H__
 
 #include "tempesta_fw.h"
-#include "apm.h"
+#include "stat.h"
 
 /*
  * @wq_full		- How many times we faced work queue full.

--- a/fw/server.h
+++ b/fw/server.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/server.h
+++ b/fw/server.h
@@ -82,8 +82,8 @@ enum {
 	TFW_SRV_B_SUSPEND
 };
 
-#define	TFW_SRV_F_HMONITOR	(1 << TFW_SRV_B_HMONITOR)
-#define	TFW_SRV_F_SUSPEND	(1 << TFW_SRV_B_SUSPEND)
+#define	TFW_SRV_F_HMONITOR		(1 << TFW_SRV_B_HMONITOR)
+#define	TFW_SRV_F_SUSPEND		(1 << TFW_SRV_B_SUSPEND)
 
 /**
  * The servers group with the same load balancing, failovering and eviction

--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -937,13 +937,12 @@ tfw_cfgop_keepalive_timeout(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	int r;
 
-	if ((r = tfw_cfg_check_val_n(ce, 1)))
-		return -EINVAL;
+	TFW_CFG_CHECK_VAL_N(==, 1, cs, ce);
 
 	if ((r = tfw_cfg_parse_int(ce->vals[0], &tfw_cli_cfg_ka_timeout))) {
 		T_ERR_NL("Unable to parse 'keepalive_timeout' value: '%s'\n",
 			 ce->vals[0] ? : "No value specified");
-		return -EINVAL;
+		return r;
 	}
 
 	if (tfw_cli_cfg_ka_timeout < 0) {

--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -4,7 +4,7 @@
  * TCP/IP stack hooks and socket routines to handle client traffic.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/sock_srv.c
+++ b/fw/sock_srv.c
@@ -4,7 +4,7 @@
  * Handling server connections.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/sock_srv.c
+++ b/fw/sock_srv.c
@@ -1085,14 +1085,8 @@ tfw_cfgop_update_srv_health(TfwSrvGroup *sg, TfwServer *srv, void *data)
 static int
 tfw_cfgop_intval(TfwCfgSpec *cs, TfwCfgEntry *ce, int *intval)
 {
-	if (ce->val_n != 1) {
-		T_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
-			return -EINVAL;
-	}
-	if (ce->attr_n) {
-		T_ERR_NL("Arguments may not have the '=' sign\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(==, 1, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	cs->dest = intval;
 	return tfw_cfg_set_int(cs, ce);
@@ -1173,10 +1167,8 @@ tfw_cfgop_retry_nip(TfwCfgSpec *cs, TfwCfgEntry *ce, unsigned int *sg_flags)
 {
 	unsigned int retry_nip;
 
-	if (ce->attr_n) {
-		T_ERR_NL("Arguments may not have the '=' sign\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+
 	if (tfw_cfg_is_dflt_value(ce)) {
 		retry_nip = 0;
 	} else if (!ce->val_n) {
@@ -1328,10 +1320,7 @@ tfw_cfgop_server(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwCfgSrvGroup *sg_cfg)
 	bool has_conns_n = false, has_weight = false;
 	const char *key, *val;
 
-	if (ce->val_n != 1) {
-		T_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(==, 1, cs, ce);
 	if (ce->attr_n > 3) {
 		T_ERR_NL("Invalid number of key=value pairs: %zu\n",
 			 ce->attr_n);
@@ -1483,14 +1472,8 @@ tfw_cfgop_begin_srv_group(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	unsigned int nlen;
 
 	BUILD_BUG_ON(TFW_CFG_ENTRY_VAL_MAX < sizeof(TFW_CFG_SG_DFT_NAME));
-	if (ce->val_n != 1) {
-		T_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
-		return -EINVAL;
-	}
-	if (ce->attr_n) {
-		T_ERR_NL("Invalid number of key=value pairs: %zu\n", ce->attr_n);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(==, 1, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	nlen = strlen(ce->vals[0]);
 	if (tfw_cfgop_lookup_sg_cfg(ce->vals[0], nlen)) {
@@ -1813,10 +1796,7 @@ tfw_cfgop_sched(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwScheduler **sched_val,
 {
 	TfwScheduler *sched;
 
-	if (!ce->val_n) {
-		T_ERR_NL("Invalid number of arguments: %zu\n", ce->val_n);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(>, 0, cs, ce);
 
 	if (!(sched = tfw_sched_lookup(ce->vals[0]))) {
 		T_ERR_NL("Unrecognized scheduler: '%s'\n", ce->vals[0]);

--- a/fw/stat.h
+++ b/fw/stat.h
@@ -1,0 +1,117 @@
+/**
+ *		Tempesta kernel library
+ *
+ * Copyright (C) 2019 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_STAT_H__
+#define __TFW_STAT_H__
+
+#include "http.h"
+
+/* Shared structures used for statistics. */
+
+/*
+ * Structures for health monitoring statistics accountings in procfs.
+ *
+ * @code	- HTTP code for which the statistics is collected.
+ * @sum		- Amount of responses for the period, limited by a time frame.
+ * @total	- Amount of responses for the overall period.
+ */
+typedef struct {
+	int		code;
+	unsigned int	sum;
+	u64		total;
+} TfwHMCodeStats;
+
+/*
+ * @rtime	- time until next server health checking (can be unused if not
+ *		  required);
+ * @ccnt	- count of @rsums elements;
+ * @rsums	- array of counters for separate HTTP codes;
+ */
+typedef struct {
+	unsigned int	rtime;
+	unsigned int	ccnt;
+	TfwHMCodeStats	*rsums;
+} TfwHMStats;
+
+/**
+ * The real size of TfwHMStats, used for memory allocation.
+ *
+ * TfwHMCodeStats is located monolithically in memory with TfwHMStats,
+ * just after it.
+ */
+static inline size_t
+tfw_hm_stats_size(int ccnt)
+{
+	return sizeof(TfwHMStats) + sizeof(TfwHMCodeStats) * ccnt;
+}
+
+/**
+ * Use it right after memory allocation.
+ *
+ * Rsums content stays unitinitialized.
+ */
+static inline void
+tfw_hm_stats_init(TfwHMStats *s, int ccnt)
+{
+	s->ccnt = ccnt;
+	s->rsums = (TfwHMCodeStats *)(s + 1);
+}
+
+static inline void
+tfw_hm_stats_clone(TfwHMStats *dest, TfwHMStats *src)
+{
+	if (!src)
+		return;
+
+	memcpy_fast(dest, src, tfw_hm_stats_size(src->ccnt));
+	dest->rsums = (TfwHMCodeStats *)(dest + 1);
+}
+
+/**
+ * The config entry @ce must be a list of HTTP codes, such as:
+ * 'some_directive 403 404 5*'.
+ *
+ * Use it right after memory allocation.
+ */
+static inline int
+tfw_hm_stats_init_from_cfg_entry(TfwHMStats *s, TfwCfgEntry *ce)
+{
+	int i, code;
+	const char *val;
+	tfw_hm_stats_init(s, ce->val_n);
+
+	TFW_CFG_ENTRY_FOR_EACH_VAL(ce, i, val) {
+		BUG_ON(i >= s->ccnt);
+
+		if (tfw_cfgop_parse_http_status(val, &code)
+		    || (code > HTTP_STATUS_5XX
+		    && tfw_cfg_check_range(code, HTTP_CODE_MIN,
+					   HTTP_CODE_MAX)))
+		{
+			T_ERR_NL("Unable to parse http code value: '%s'\n",
+				 val);
+			return -EINVAL;
+		}
+		s->rsums[i].code = code;
+	}
+	return 0;
+}
+
+
+#endif /* __TFW_STAT_H__ */

--- a/fw/stat.h
+++ b/fw/stat.h
@@ -28,12 +28,12 @@
  * Structures for health monitoring statistics accountings in procfs.
  *
  * @code	- HTTP code for which the statistics is collected.
- * @sum		- Amount of responses for the period, limited by a time frame.
+ * @tf_total	- Amount of responses for the period, limited by a time frame.
  * @total	- Amount of responses for the overall period.
  */
 typedef struct {
 	int		code;
-	unsigned int	sum;
+	unsigned int	tf_total;
 	u64		total;
 } TfwHMCodeStats;
 
@@ -97,13 +97,7 @@ tfw_hm_stats_init_from_cfg_entry(TfwHMStats *s, TfwCfgEntry *ce)
 	tfw_hm_stats_init(s, ce->val_n);
 
 	TFW_CFG_ENTRY_FOR_EACH_VAL(ce, i, val) {
-		BUG_ON(i >= s->ccnt);
-
-		if (tfw_cfgop_parse_http_status(val, &code)
-		    || (code > HTTP_STATUS_5XX
-		    && tfw_cfg_check_range(code, HTTP_CODE_MIN,
-					   HTTP_CODE_MAX)))
-		{
+		if (tfw_cfgop_parse_http_status(val, &code)) {
 			T_ERR_NL("Unable to parse http code value: '%s'\n",
 				 val);
 			return -EINVAL;

--- a/fw/stat.h
+++ b/fw/stat.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta kernel library
  *
- * Copyright (C) 2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/str.c
+++ b/fw/str.c
@@ -80,6 +80,7 @@ bool custom_ctext_vchar_enabled = false;
 bool custom_xff_enabled = false;
 bool custom_cookie_enabled = false;
 bool custom_etag_enabled = false;
+bool custom_token_lc_enabled = false;
 
 unsigned char custom_uri[256] ____cacheline_aligned __read_mostly;
 unsigned char custom_token[256] ____cacheline_aligned __read_mostly;
@@ -249,7 +250,7 @@ size_t tfw_match_##a_name(const char *str, size_t len)			\
 }									\
 
 #define TFW_INIT_CUSTOM_A(a_name)					\
-void tfw_init_custom_##a_name(const unsigned char a[256])		\
+void tfw_init_custom_##a_name(const unsigned char *a)			\
 {									\
 	custom_##a_name##_enabled = !!a;				\
 	if (!!a)							\
@@ -266,7 +267,7 @@ TFW_MATCH(cookie);
 TFW_MATCH(etag);
 TFW_MATCH(token_lc);
 
-void tfw_init_custom_token(const unsigned char a[256])
+void tfw_init_custom_token(const unsigned char *a)
 {
 	custom_token_enabled = !!a;
 

--- a/fw/str.c
+++ b/fw/str.c
@@ -6,7 +6,7 @@
  * configuration phase.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -15,7 +15,7 @@
  * and generic testing functions/macros are located in test.c/test.h
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -131,8 +131,7 @@ void
 tfw_apm_update(void *apmref, unsigned long jtstamp, unsigned long jrtt)
 {
 }
-
-bool
+ bool
 ss_active(void)
 {
 	return true;

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -131,7 +131,13 @@ void
 tfw_apm_update(void *apmref, unsigned long jtstamp, unsigned long jrtt)
 {
 }
- bool
+
+void
+tfw_apm_update_global(unsigned long jtstamp, unsigned long jrtime)
+{
+}
+
+bool
 ss_active(void)
 {
 	return true;

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -637,15 +637,8 @@ tfw_cfgop_nonidempotent(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 	BUILD_BUG_ON(sizeof(tfw_method_enum[0].value) * BITS_PER_BYTE
 		     < _TFW_HTTP_METH_COUNT);
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			 cs->name);
-		return -EINVAL;
-	}
-	if (ce->val_n != 3) {
-		T_ERR_NL("%s: Invalid number of arguments.\n", cs->name);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+	TFW_CFG_CHECK_VAL_N(==, 3, cs, ce);
 
 	/* The method: one of GET, PUT, POST, etc. in form of a bitmask. */
 	in_method = ce->vals[0];
@@ -772,11 +765,8 @@ tfw_cfgop_mod_hdr(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc,
 	const char *name;
 	const char *value = NULL;
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			 cs->name);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+
 	switch (ce->val_n)
 	{
 	case 2:
@@ -971,16 +961,8 @@ tfw_cfgop_capolicy(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc, int cmd)
 
 	BUG_ON((cmd != TFW_D_CACHE_BYPASS) && (cmd != TFW_D_CACHE_FULFILL));
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			 cs->name);
-		return -EINVAL;
-	}
-	if (ce->val_n < 2) {
-		T_ERR_NL("%s: Invalid number of arguments: %d\n",
-			 cs->name, (int)ce->val_n);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+	TFW_CFG_CHECK_VAL_N(>=, 2, cs, ce);
 
 	in_op = ce->vals[0];	/* Match operator. */
 
@@ -1095,16 +1077,8 @@ tfw_cfgop_capo_hdr_del(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 	size_t total_size;
 	TfwCaToken *new_tokens;
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			 cs->name);
-		return -EINVAL;
-	}
-	if (ce->val_n < 1) {
-		T_ERR_NL("%s: Arguments required\n",
-			 cs->name);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+	TFW_CFG_CHECK_VAL_N(>=, 1, cs, ce);
 	if (ce->val_n > TFW_CAPOLICY_HDR_DEL_LIMIT) {
 		T_ERR_NL("%s: Too many headers\n",
 			 cs->name);
@@ -1183,16 +1157,8 @@ const struct {
 	size_t i, len;
 	const char *arg;
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			 cs->name);
-		return -EINVAL;
-	}
-	if (ce->val_n < 1) {
-		T_ERR_NL("%s: Arguments required\n",
-			 cs->name);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+	TFW_CFG_CHECK_VAL_N(>=, 1, cs, ce);
 
 	for (i = 0; i < ce->val_n; ++i) {
 		int map_idx;
@@ -1398,16 +1364,8 @@ tfw_cfgop_location_begin(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwVhost *vhost)
 	tfw_match_t op;
 	const char *in_op, *arg;
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			   cs->name);
-		return -EINVAL;
-	}
-	if (ce->val_n != 2) {
-		T_ERR_NL("%s: Invalid number of arguments: %d\n",
-			   cs->name, (int)ce->val_n);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+	TFW_CFG_CHECK_VAL_N(==, 2, cs, ce);
 
 	/* Get the values of the 'location' directive. */
 	in_op = ce->vals[0];	/* Match operator. */
@@ -1579,11 +1537,7 @@ tfw_cfgop_cache_purge_acl(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	size_t i;
 	const char *val;
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			cs->name);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 
 	TFW_CFG_ENTRY_FOR_EACH_VAL(ce, i, val) {
 		TfwAddr addr = { 0 };
@@ -1621,11 +1575,8 @@ tfw_cfgop_cache_purge(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	size_t i;
 	const char *val;
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			 cs->name);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+
 	if (!ce->val_n) {
 		/* Default value for the cache_purge directive. */
 		tfw_global.cache_purge_mode = TFW_D_CACHE_PURGE_INVALIDATE;
@@ -1655,16 +1606,8 @@ tfw_cfgop_hdr_via(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	size_t len;
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s: Arguments may not have the '=' sign\n",
-			 cs->name);
-		return -EINVAL;
-	}
-	if (ce->val_n != 1) {
-		T_ERR_NL("%s: Invalid number of arguments: %d\n",
-			 cs->name, (int)ce->val_n);
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+	TFW_CFG_CHECK_VAL_N(==, 1, cs, ce);
 
 	/*
 	 * If a value is specified in the configuration file, then
@@ -1726,11 +1669,9 @@ err:
 static inline int
 tfw_cfgop_proxy_pass(TfwCfgSpec *cs, TfwCfgEntry *ce, TfwLocation *loc)
 {
-	int r;
 	const char *in_main_sg, *in_backup_sg;
 
-	if ((r = tfw_cfg_check_val_n(ce, 1)))
-		return r;
+	TFW_CFG_CHECK_VAL_N(==, 1, cs, ce);
 
 	in_main_sg = ce->vals[0];
 	in_backup_sg = tfw_cfg_get_attr(ce, "backup", NULL);
@@ -2047,12 +1988,7 @@ __tfw_cfgop_frang_rsp_code_block(TfwCfgSpec *cs, TfwCfgEntry *ce,
 	static const char *error_msg_begin = "frang: http_resp_code_block:";
 	int n, i;
 
-	if (ce->attr_n) {
-		T_ERR_NL("%s arguments may not have the '=' sign\n",
-			 error_msg_begin);
-		return -EINVAL;
-	}
-
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
 	if (ce->val_n < 3) {
 		T_ERR_NL("%s too few arguments\n", error_msg_begin);
 		return -EINVAL;
@@ -2522,12 +2458,9 @@ tfw_cfgop_vhost_begin(TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	BUG_ON(tfw_vhost_entry);
 
-	if (tfw_cfg_check_val_n(ce, 1))
-		return -EINVAL;
-	if (ce->attr_n) {
-		T_ERR_NL("Unexpected attributes\n");
-		return -EINVAL;
-	}
+	TFW_CFG_CHECK_VAL_N(==, 1, cs, ce);
+	TFW_CFG_CHECK_NO_ATTRS(cs, ce);
+
 	hash_for_each(tfw_vhosts_reconfig->vh_hash, i, vhost, hlist) {
 		if (!strcasecmp(vhost->name.data, ce->vals[0])) {
 			T_ERR_NL("Duplicate vhost entry: '%s'\n",

--- a/fw/vhost.c
+++ b/fw/vhost.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Pay attention to tfw_apm_global_data. Here, existing code is effectively reused,
but we use the same synchronization primitives as for the backend (which makes
sense as the data structure is the same). I'm uncertain about the performance
implications of this since the rest of the global Tempesta statistics work with
percpu variables.

Cache misses for Tempesta and backends differ: for Tempesta, a miss is
considered when a request doesn't hit the cache, while for the backend, it's
considered at the time of response delivery (uncached).

Is the use of for_each_possible_cpu correct?

Any ideas regarding code smells are appreciated.

There's an optional refactoring left after the commit rework, but I decided to
keep it, as it seems good on its own.