### PR TITLE
Fix accesing connection after Tempesta unload

### DIFF
--- a/fw/connection.c
+++ b/fw/connection.c
@@ -100,12 +100,15 @@ tfw_connection_close(TfwConn *conn, bool sync)
 void
 tfw_connection_abort(TfwConn *conn)
 {
+	int r;
+
 	/*
 	 * Same as for tfw_connection_close() we should increment connection
 	 * reference counter here.
 	 */
 	tfw_connection_get(conn);
-	TFW_CONN_HOOK_CALL(conn, conn_abort);
+	r = TFW_CONN_HOOK_CALL(conn, conn_abort);
+	WARN_ON(r);
 	tfw_connection_put(conn);
 }
 

--- a/fw/connection.h
+++ b/fw/connection.h
@@ -275,7 +275,7 @@ typedef struct {
 	 * This is rough connection closing without any notifications like TLS
 	 * alerts, probably with TCP RST or just silent connection termination.
 	 */
-	void (*conn_abort)(TfwConn *conn);
+	int (*conn_abort)(TfwConn *conn);
 
 	/*
 	 * Called when closing a connection (client or server,
@@ -421,6 +421,8 @@ tfw_connection_put(TfwConn *conn)
 		return;
 
 	rc = atomic_dec_return(&conn->refcnt);
+	BUG_ON(rc < TFW_CONN_DEATHCNT);
+
 	if (likely(rc && rc != TFW_CONN_DEATHCNT))
 		return;
 	if (conn->destructor)

--- a/fw/http.c
+++ b/fw/http.c
@@ -2671,10 +2671,10 @@ tfw_http_conn_close(TfwConn *conn, bool sync)
 	return ss_close(conn->sk, sync ? SS_F_SYNC : 0);
 }
 
-static void
+static int
 tfw_http_conn_abort(TfwConn *c)
 {
-	ss_close(c->sk, SS_F_ABORT_FORCE);
+	return ss_close(c->sk, SS_F_ABORT_FORCE);
 }
 
 /*

--- a/fw/server.h
+++ b/fw/server.h
@@ -219,6 +219,7 @@ tfw_server_put(TfwServer *srv)
 		return;
 
 	rc = atomic64_dec_return(&srv->refcnt);
+	BUG_ON(rc < 0);
 	if (likely(rc))
 		return;
 	tfw_server_destroy(srv);
@@ -322,9 +323,14 @@ tfw_sg_get(TfwSrvGroup *sg)
 static inline void
 tfw_sg_put(TfwSrvGroup *sg)
 {
+	long rc;
+
 	if (unlikely(!sg))
 		return;
-	if (likely(atomic64_dec_return(&sg->refcnt)))
+	rc = atomic64_dec_return(&sg->refcnt);
+	BUG_ON(rc < 0);
+
+	if (likely(rc))
 		return;
 	tfw_sg_destroy(sg);
 }

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -1399,7 +1399,8 @@ static void
 __sk_close_locked(struct sock *sk, int flags)
 {
 	ss_do_close(sk, flags);
-	if (!sk_stream_closing(sk)) {
+	if (!sk_stream_closing(sk) ||
+	    (flags & SS_F_ABORT_FORCE) == SS_F_ABORT_FORCE) {
 		ss_conn_drop_guard_exit(sk);
 	} else {
 		BUG_ON(!sock_flag(sk, SOCK_DEAD));

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -732,10 +732,10 @@ tfw_tls_conn_close(TfwConn *c, bool sync)
 	return r;
 }
 
-static void
+static int
 tfw_tls_conn_abort(TfwConn *c)
 {
-	ss_close(c->sk, SS_F_ABORT_FORCE);
+	return ss_close(c->sk, SS_F_ABORT_FORCE);
 }
 
 static void

--- a/fw/websocket.c
+++ b/fw/websocket.c
@@ -288,12 +288,16 @@ tfw_ws_conn_close(TfwConn *conn, bool sync)
 	return r;
 }
 
-static void
+static int
 tfw_ws_conn_abort(TfwConn *conn)
 {
+	int r;
+
 	T_DBG("%s cpu/%d: conn=%p\n", __func__, smp_processor_id(), conn);
 
-	tfw_conn_hook_call(TFW_CONN_HTTP_TYPE(conn), conn, conn_abort);
+	r = tfw_conn_hook_call(TFW_CONN_HTTP_TYPE(conn), conn, conn_abort);
+
+	return r;
 }
 
 /**


### PR DESCRIPTION
During applying new configuration, we delete old
server groups, servers and their connections.
We should immediately close and drop connection
in this case, because we may not receive FIN from
the peer and connection hung. Moreover we don't
need to be shure that backend receive FIN from
our side and closed gracefully because we stop
work with such server and don't expect any
response from it.

Closes #2010