### PR TITLE
Fix errors during Tempesta reload

### DIFF
--- a/fw/apm.c
+++ b/fw/apm.c
@@ -1744,6 +1744,9 @@ tfw_apm_cfgend(void)
 static void
 tfw_apm_cfgclean(void)
 {
+	if (tfw_runstate_is_reconfig())
+		return;
+
 	if (tfw_apm_global_data) {
 		tfw_apm_data_stop_timer(tfw_apm_global_data);
 		tfw_apm_data_destroy(tfw_apm_global_data);

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -1543,6 +1543,8 @@ frang_tls_handler(TlsCtx *tls, int state)
 	if (WARN_ON_ONCE(!dflt_vh))
 		return T_BLOCK_WITH_RST;
 
+	BUG_ON(!ra);
+
 	spin_lock(&ra->lock);
 
 	r = frang_tls_conn_limit(ra, dflt_vh->frang_gconf, state);

--- a/fw/main.c
+++ b/fw/main.c
@@ -352,10 +352,10 @@ tfw_ctlfn_state_io(struct ctl_table *ctl, int is_write,
 		if ((r = proc_dostring(&tmp, is_write, user_buf, lenp, ppos)))
 			goto out;
 
-		if ((r = tfw_ctlfn_state_change(buf)))
-			goto out;
-
-		strlcpy(new_state_buf, buf, T_SYSCTL_STBUF_LEN);
+		r = tfw_ctlfn_state_change(buf);
+		strlcpy(new_state_buf,
+			tfw_runstate_is_started() ? "start" : "stop",
+			T_SYSCTL_STBUF_LEN);
 	} else {
 		tmp.data = new_state_buf;
 		r = proc_dostring(&tmp, is_write, user_buf, lenp, ppos);

--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -241,11 +241,16 @@ start_tempesta_and_check()
 	# 'sysctl' does not indicate any problems and exits with zero code;
 	# so, stderr may return 'sysctl: setting key "net.tempesta.state"'
 	# followed by some error message or just empty string.
-	# The most reliable way to check Tempesta status is to check dmesg.
+	# The most reliable way to check Tempesta status is to check
+	# net.tempesta.state and if it is "start" check dmesg.
 	err=$(sysctl -w net.tempesta.state=start 2>&1 1>/dev/null)
-	if [[ -z "`check_dmesg 'Tempesta FW is ready'`" ]]; then
+	TFW_STATE=$(sysctl net.tempesta.state 2> /dev/null)
+	TFW_STATE=${TFW_STATE##* }
+
+	if [[ ${TFW_STATE} != "start" ]] || [[ -z "`check_dmesg 'Tempesta FW is ready'`" ]]; then
 		echo $err
 	fi
+
 	echo "0"
 }
 


### PR DESCRIPTION
- First of all Tempesta should stop listening old sockets and call `tfw_classifier_remove_inport` for appropriate ports before start listening new
sockets, otherwise if new sockets have same ports
as old one, such ports will be removed from import.
- Secondly we should check that tempesta reload is fail by cheking dmesg not by checking return code
of sysctl.

Closes #2043 #2017