### PR TITLE
Fix setting mark for tempesta sockets.

### DIFF
--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -740,7 +740,7 @@ index 000000000..80de50693
 + * Linux interface for Tempesta FW.
 + *
 + * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by
@@ -1035,7 +1035,7 @@ index 000000000..7ee3ead54
 +/**
 + *		Tempesta Memory Reservation
 + *
-+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by
@@ -2144,7 +2144,7 @@ index 45fb450b4..48da5be43 100644
  
  	offset++;
 diff --git a/net/ipv4/ip_output.c b/net/ipv4/ip_output.c
-index 97975bed4..672f21290 100644
+index 97975bed4..3d195228e 100644
 --- a/net/ipv4/ip_output.c
 +++ b/net/ipv4/ip_output.c
 @@ -82,6 +82,9 @@
@@ -2157,7 +2157,23 @@ index 97975bed4..672f21290 100644
  
  static int
  ip_fragment(struct net *net, struct sock *sk, struct sk_buff *skb,
-@@ -702,7 +705,31 @@ struct sk_buff *ip_frag_next(struct sk_buff *skb, struct ip_frag_state *state)
+@@ -527,6 +530,15 @@ int __ip_queue_xmit(struct sock *sk, struct sk_buff *skb, struct flowi *fl,
+ 
+ 	/* TODO : should we use skb->sk here instead of sk ? */
+ 	skb->priority = sk->sk_priority;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/*
++	 * Tempesta can set skb->mark for some skbs. And moreover
++	 * sk_mark is never set for Tempesta sockets.
++	 */
++	if (sock_flag(sk, SOCK_TEMPESTA))
++		WARN_ON_ONCE(sk->sk_mark);
++	else
++#endif
+ 	skb->mark = sk->sk_mark;
+ 
+ 	res = ip_local_out(net, sk, skb);
+@@ -702,7 +714,31 @@ struct sk_buff *ip_frag_next(struct sk_buff *skb, struct ip_frag_state *state)
  	}
  
  	/* Allocate buffer */
@@ -2189,7 +2205,7 @@ index 97975bed4..672f21290 100644
  	if (!skb2)
  		return ERR_PTR(-ENOMEM);
  
-@@ -711,7 +738,11 @@ struct sk_buff *ip_frag_next(struct sk_buff *skb, struct ip_frag_state *state)
+@@ -711,7 +747,11 @@ struct sk_buff *ip_frag_next(struct sk_buff *skb, struct ip_frag_state *state)
  	 */
  
  	ip_copy_metadata(skb2, skb);
@@ -2426,7 +2442,7 @@ index ab8ed0fc4..1a5c62ab7 100644
  		goto put_and_exit;
  	*own_req = inet_ehash_nolisten(newsk, req_to_sk(req_unhash),
 diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
-index f99494637..d3c0ba7cd 100644
+index f99494637..1a868b9aa 100644
 --- a/net/ipv4/tcp_output.c
 +++ b/net/ipv4/tcp_output.c
 @@ -39,6 +39,9 @@
@@ -2573,7 +2589,17 @@ index f99494637..d3c0ba7cd 100644
  		return -ENOMEM;
  
  	/* Get a new skb... force flag on. */
-@@ -1670,7 +1706,7 @@ int tcp_trim_head(struct sock *sk, struct sk_buff *skb, u32 len)
+@@ -1575,6 +1611,9 @@ int tcp_fragment(struct sock *sk, enum tcp_queue tcp_queue,
+ 	nlen = skb->len - len - nsize;
+ 	buff->truesize += nlen;
+ 	skb->truesize -= nlen;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	buff->mark = skb->mark;
++#endif
+ 
+ 	/* Correct the sequence numbers. */
+ 	TCP_SKB_CB(buff)->seq = TCP_SKB_CB(skb)->seq + len;
+@@ -1670,7 +1709,7 @@ int tcp_trim_head(struct sock *sk, struct sk_buff *skb, u32 len)
  {
  	u32 delta_truesize;
  
@@ -2582,7 +2608,7 @@ index f99494637..d3c0ba7cd 100644
  		return -ENOMEM;
  
  	delta_truesize = __pskb_trim_head(skb, len);
-@@ -1848,6 +1884,7 @@ unsigned int tcp_current_mss(struct sock *sk)
+@@ -1848,6 +1887,7 @@ unsigned int tcp_current_mss(struct sock *sk)
  
  	return mss_now;
  }
@@ -2590,7 +2616,7 @@ index f99494637..d3c0ba7cd 100644
  
  /* RFC2861, slow part. Adjust cwnd, after it was not full during one rto.
   * As additional protections, we do not touch cwnd in retransmission phases,
-@@ -2108,8 +2145,8 @@ static bool tcp_snd_wnd_test(const struct tcp_sock *tp,
+@@ -2108,8 +2148,8 @@ static bool tcp_snd_wnd_test(const struct tcp_sock *tp,
   * know that all the data is in scatter-gather pages, and that the
   * packet has never been sent out before (and thus is not cloned).
   */
@@ -2601,7 +2627,17 @@ index f99494637..d3c0ba7cd 100644
  {
  	int nlen = skb->len - len;
  	struct sk_buff *buff;
-@@ -2159,6 +2196,7 @@ static int tso_fragment(struct sock *sk, struct sk_buff *skb, unsigned int len,
+@@ -2129,6 +2169,9 @@ static int tso_fragment(struct sock *sk, struct sk_buff *skb, unsigned int len,
+ 	sk_mem_charge(sk, buff->truesize);
+ 	buff->truesize += nlen;
+ 	skb->truesize -= nlen;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	buff->mark = skb->mark;
++#endif
+ 
+ 	/* Correct the sequence numbers. */
+ 	TCP_SKB_CB(buff)->seq = TCP_SKB_CB(skb)->seq + len;
+@@ -2159,6 +2202,7 @@ static int tso_fragment(struct sock *sk, struct sk_buff *skb, unsigned int len,
  
  	return 0;
  }
@@ -2609,19 +2645,22 @@ index f99494637..d3c0ba7cd 100644
  
  /* Try to defer sending, if possible, in order to minimize the amount
   * of TSO splitting we do.  View it as a kind of TSO Nagle test.
-@@ -2303,6 +2341,11 @@ static bool tcp_can_coalesce_send_queue_head(struct sock *sk, int len)
+@@ -2303,6 +2347,14 @@ static bool tcp_can_coalesce_send_queue_head(struct sock *sk, int len)
  
  		if (unlikely(TCP_SKB_CB(skb)->eor) || tcp_has_tx_tstamp(skb))
  			return false;
 +#ifdef CONFIG_SECURITY_TEMPESTA
-+		/* Do not coalesce tempesta and not tempesta skbs. */
-+		if (skb_tfw_tls_type(skb))
++		/* Do not coalesce tempesta skbs with tls type or set mark. */
++		if ((next != ((struct sk_buff *)&(sk)->sk_write_queue))
++		    && ((skb_tfw_tls_type(skb) != skb_tfw_tls_type(next))
++			|| (sock_flag(sk, SOCK_TEMPESTA)
++			    && (skb->mark != next->mark))))
 +			return false;
 +#endif
  
  		len -= skb->len;
  	}
-@@ -2577,6 +2620,62 @@ void tcp_chrono_stop(struct sock *sk, const enum tcp_chrono type)
+@@ -2577,6 +2629,62 @@ void tcp_chrono_stop(struct sock *sk, const enum tcp_chrono type)
  		tcp_chrono_set(tp, TCP_CHRONO_BUSY);
  }
  
@@ -2684,7 +2723,7 @@ index f99494637..d3c0ba7cd 100644
  /* This routine writes packets to the network.  It advances the
   * send_head.  This happens as incoming acks open up the remote
   * window for us.
-@@ -2601,6 +2700,9 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
+@@ -2601,6 +2709,9 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
  	int result;
  	bool is_cwnd_limited = false, is_rwnd_limited = false;
  	u32 max_segs;
@@ -2694,7 +2733,7 @@ index f99494637..d3c0ba7cd 100644
  
  	sent_pkts = 0;
  
-@@ -2666,7 +2768,15 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
+@@ -2666,7 +2777,15 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
  							  cwnd_quota,
  							  max_segs),
  						    nonagle);
@@ -2711,7 +2750,7 @@ index f99494637..d3c0ba7cd 100644
  		if (skb->len > limit &&
  		    unlikely(tso_fragment(sk, skb, limit, mss_now, gfp)))
  			break;
-@@ -2681,7 +2791,14 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
+@@ -2681,7 +2800,14 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
  		 */
  		if (TCP_SKB_CB(skb)->end_seq == TCP_SKB_CB(skb)->seq)
  			break;
@@ -2727,7 +2766,7 @@ index f99494637..d3c0ba7cd 100644
  		if (unlikely(tcp_transmit_skb(sk, skb, 1, gfp)))
  			break;
  
-@@ -2866,6 +2983,7 @@ void __tcp_push_pending_frames(struct sock *sk, unsigned int cur_mss,
+@@ -2866,6 +2992,7 @@ void __tcp_push_pending_frames(struct sock *sk, unsigned int cur_mss,
  			   sk_gfp_mask(sk, GFP_ATOMIC)))
  		tcp_check_probe_timer(sk);
  }
@@ -2735,7 +2774,7 @@ index f99494637..d3c0ba7cd 100644
  
  /* Send _single_ skb sitting at the send head. This function requires
   * true push pending frames to setup probe timer etc.
-@@ -3183,7 +3301,7 @@ int __tcp_retransmit_skb(struct sock *sk, struct sk_buff *skb, int segs)
+@@ -3183,7 +3310,7 @@ int __tcp_retransmit_skb(struct sock *sk, struct sk_buff *skb, int segs)
  				 cur_mss, GFP_ATOMIC))
  			return -ENOMEM; /* We'll try again later. */
  	} else {
@@ -2744,7 +2783,7 @@ index f99494637..d3c0ba7cd 100644
  			return -ENOMEM;
  
  		diff = tcp_skb_pcount(skb);
-@@ -3421,6 +3539,7 @@ void tcp_send_fin(struct sock *sk)
+@@ -3421,6 +3548,7 @@ void tcp_send_fin(struct sock *sk)
  	}
  	__tcp_push_pending_frames(sk, tcp_current_mss(sk), TCP_NAGLE_OFF);
  }
@@ -2752,7 +2791,7 @@ index f99494637..d3c0ba7cd 100644
  
  /* We get here when a process closes a file descriptor (either due to
   * an explicit close() or as a byproduct of exit()'ing) and there
-@@ -3454,6 +3573,7 @@ void tcp_send_active_reset(struct sock *sk, gfp_t priority)
+@@ -3454,6 +3582,7 @@ void tcp_send_active_reset(struct sock *sk, gfp_t priority)
  	 */
  	trace_tcp_send_reset(sk, NULL);
  }
@@ -2760,7 +2799,7 @@ index f99494637..d3c0ba7cd 100644
  
  /* Send a crossed SYN-ACK during socket establishment.
   * WARNING: This routine must only be called when we have already sent
-@@ -4030,6 +4150,9 @@ int tcp_write_wakeup(struct sock *sk, int mib)
+@@ -4030,6 +4159,9 @@ int tcp_write_wakeup(struct sock *sk, int mib)
  
  	skb = tcp_send_head(sk);
  	if (skb && before(TCP_SKB_CB(skb)->seq, tcp_wnd_end(tp))) {
@@ -2770,7 +2809,7 @@ index f99494637..d3c0ba7cd 100644
  		int err;
  		unsigned int mss = tcp_current_mss(sk);
  		unsigned int seg_size = tcp_wnd_end(tp) - TCP_SKB_CB(skb)->seq;
-@@ -4037,6 +4160,12 @@ int tcp_write_wakeup(struct sock *sk, int mib)
+@@ -4037,6 +4169,12 @@ int tcp_write_wakeup(struct sock *sk, int mib)
  		if (before(tp->pushed_seq, TCP_SKB_CB(skb)->end_seq))
  			tp->pushed_seq = TCP_SKB_CB(skb)->end_seq;
  
@@ -2783,7 +2822,7 @@ index f99494637..d3c0ba7cd 100644
  		/* We are probing the opening of a window
  		 * but the window size is != 0
  		 * must have been a result SWS avoidance ( sender )
-@@ -4052,6 +4181,13 @@ int tcp_write_wakeup(struct sock *sk, int mib)
+@@ -4052,6 +4190,13 @@ int tcp_write_wakeup(struct sock *sk, int mib)
  			tcp_set_skb_tso_segs(skb, mss);
  
  		TCP_SKB_CB(skb)->tcp_flags |= TCPHDR_PSH;
@@ -2965,7 +3004,7 @@ index 000000000..a65a79f30
 + *		Tempesta FW
 + *
 + * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Kernel set skb->mark in `__ip_queue_xmit` using
sk->sk_mark, but for Tempesta sockets we can't
rely on this mechanizm. Tempesta can set skb->mark for some skbs. And moreover sk_mark is never set
for Tempesta sockets. Also we should copy skb->mark when we split skb in tso_fragment/tcp_fragment,
because skb can contain mark which was set by Tempesta.

Closes #1987