### PR TITLE
Fixed caching response to POST request.

### DIFF
--- a/fw/http.h
+++ b/fw/http.h
@@ -203,6 +203,8 @@ typedef enum {
 	TFW_HTTP_HDR_REGULAR,
 	TFW_HTTP_HDR_HOST = TFW_HTTP_HDR_REGULAR,
 	TFW_HTTP_HDR_CONTENT_LENGTH,
+	/* This is only responce specific header. */
+	TFW_HTTP_HDR_CONTENT_LOCATION,
 	TFW_HTTP_HDR_CONTENT_TYPE,
 	TFW_HTTP_HDR_USER_AGENT,
 	TFW_HTTP_HDR_SERVER = TFW_HTTP_HDR_USER_AGENT,
@@ -602,14 +604,14 @@ tfw_h2_pseudo_index(unsigned short status)
 	}
 }
 
-/*
- * Currently the size of request header table is equal to size of
- * response header table. Don't forget to split this function in
- * two different functions in case of adding new header to request
- * or response header table.
- */
 static inline size_t
-tfw_http_msg_header_table_size(void)
+tfw_http_req_header_table_size(void)
+{
+	return TFW_HTTP_HDR_RAW - TFW_HTTP_HDR_REGULAR - 2;
+}
+
+static inline size_t
+tfw_http_resp_header_table_size(void)
 {
 	return TFW_HTTP_HDR_RAW - TFW_HTTP_HDR_REGULAR - 1;
 }

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -133,10 +133,11 @@ typedef struct {
 #define TfwStrDefV(v, id)	{{ .data = (v), SLEN(v), NULL, 0 }, (id) }
 
 static inline unsigned int
-__tfw_http_msg_spec_hid(const TfwStr *hdr, const TfwHdrDef array[])
+__tfw_http_msg_spec_hid(const TfwStr *hdr, const TfwHdrDef array[],
+			const size_t size)
 {
 	const TfwHdrDef *def;
-	size_t size = tfw_http_msg_header_table_size();
+
 	/* TODO: return error if @hdr can't be applied to response or client. */
 	def = (TfwHdrDef *)__tfw_http_msg_find_hdr(hdr, array, size,
 						   sizeof(TfwHdrDef));
@@ -154,6 +155,7 @@ tfw_http_msg_resp_spec_hid(const TfwStr *hdr)
 		TfwStrDefV("connection:",	TFW_HTTP_HDR_CONNECTION),
 		TfwStrDefV("content-encoding:", TFW_HTTP_HDR_CONTENT_ENCODING),
 		TfwStrDefV("content-length:",	TFW_HTTP_HDR_CONTENT_LENGTH),
+		TfwStrDefV("content-location:", TFW_HTTP_HDR_CONTENT_LOCATION),
 		TfwStrDefV("content-type:",	TFW_HTTP_HDR_CONTENT_TYPE),
 		TfwStrDefV("etag:",		TFW_HTTP_HDR_ETAG),
 		TfwStrDefV("forwarded:",	TFW_HTTP_HDR_FORWARDED),
@@ -167,11 +169,11 @@ tfw_http_msg_resp_spec_hid(const TfwStr *hdr)
 		TfwStrDefV("x-tempesta-cache:",	TFW_HTTP_HDR_X_TEMPESTA_CACHE),
 		TfwStrDefV("upgrade:",		TFW_HTTP_HDR_UPGRADE),
 	};
+	const size_t size = tfw_http_resp_header_table_size();
 
-	BUILD_BUG_ON(ARRAY_SIZE(resp_hdrs) !=
-		     tfw_http_msg_header_table_size());
+	BUILD_BUG_ON(ARRAY_SIZE(resp_hdrs) != size);
 
-	return __tfw_http_msg_spec_hid(hdr, resp_hdrs);
+	return __tfw_http_msg_spec_hid(hdr, resp_hdrs, size);
 }
 
 /**
@@ -197,11 +199,11 @@ tfw_http_msg_req_spec_hid(const TfwStr *hdr)
 		TfwStrDefV("x-tempesta-cache:",	TFW_HTTP_HDR_X_TEMPESTA_CACHE),
 		TfwStrDefV("upgrade:",		TFW_HTTP_HDR_UPGRADE),
 	};
+	const size_t size = tfw_http_req_header_table_size();
 
-	BUILD_BUG_ON(ARRAY_SIZE(req_hdrs) !=
-		     tfw_http_msg_header_table_size());
+	BUILD_BUG_ON(ARRAY_SIZE(req_hdrs) != size);
 
-	return __tfw_http_msg_spec_hid(hdr, req_hdrs);
+	return __tfw_http_msg_spec_hid(hdr, req_hdrs, size);
 }
 
 /**
@@ -220,6 +222,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 			[TFW_HTTP_HDR_HOST]		= SLEN("Host:"),
 			[TFW_HTTP_HDR_CONTENT_ENCODING]	= SLEN("Content-Encoding:"),
 			[TFW_HTTP_HDR_CONTENT_LENGTH]	= SLEN("Content-Length:"),
+			[TFW_HTTP_HDR_CONTENT_LOCATION] = SLEN("Content-Location:"),
 			[TFW_HTTP_HDR_CONTENT_TYPE]	= SLEN("Content-Type:"),
 			[TFW_HTTP_HDR_CONNECTION]	= SLEN("Connection:"),
 			[TFW_HTTP_HDR_X_FORWARDED_FOR]	= SLEN("X-Forwarded-For:"),

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1985,6 +1985,26 @@ __parse_content_length(TfwHttpMsg *hm, unsigned char *data, size_t len)
 	}
 }
 
+static int
+__parse_content_location(TfwHttpMsg *hm, unsigned char *data, size_t len)
+{
+	int r = CSTR_NEQ;
+	__FSM_DECLARE_VARS(hm);
+
+	__FSM_START(parser->_i_st);
+
+	__FSM_STATE(I_ContLocation) {
+		/* Do not validate this header, eat this as is. */
+		__FSM_I_MATCH_MOVE(ctext_vchar, I_ContLocation);
+		if (IS_CRLF(*(p + __fsm_sz)))
+			return __data_off(p + __fsm_sz);
+		return CSTR_NEQ;
+	}
+
+done:
+	return r;
+}
+
 /**
  * Parse Content-Type header value, RFC 7231 3.1.1.5.
  */
@@ -12244,7 +12264,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, unsigned int len,
 				{
 					__msg_hdr_chunk_fixup(data,
 							      __data_off(p + 8));
-					parser->_i_st = &&RGen_HdrOtherV;
+					parser->_i_st = &&Resp_HdrContent_LocationV;
 					__msg_hdr_set_hpack_index(29);
 					p += 8;
 					__FSM_MOVE_hdr_fixup(RGen_LWS, 1);
@@ -12310,6 +12330,11 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, unsigned int len,
 	TFW_HTTP_PARSE_SPECHDR_VAL(Resp_HdrContent_LengthV, msg,
 				   __parse_content_length,
 				   TFW_HTTP_HDR_CONTENT_LENGTH);
+
+	/* 'Content-Location:*OWS' is read, process field-value. */
+	TFW_HTTP_PARSE_SPECHDR_VAL(Resp_HdrContent_LocationV, msg,
+				   __parse_content_location,
+				   TFW_HTTP_HDR_CONTENT_LOCATION);
 
 	/* 'Content-Type:*OWS' is read, process field-value. */
 	TFW_HTTP_PARSE_SPECHDR_VAL(Resp_HdrContent_TypeV, msg,
@@ -12582,7 +12607,8 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, unsigned int len,
 	__FSM_TX_AF(Resp_HdrContent_Locat, 'i', Resp_HdrContent_Locati);
 	__FSM_TX_AF(Resp_HdrContent_Locati, 'o', Resp_HdrContent_Locatio);
 	__FSM_TX_AF(Resp_HdrContent_Locatio, 'n', Resp_HdrContent_Location);
-	__FSM_TX_AF_OWS_HP(Resp_HdrContent_Location, RGen_HdrOtherV, 29);
+	__FSM_TX_AF_OWS_HP(Resp_HdrContent_Location, Resp_HdrContent_LocationV,
+			   29);
 
 	/* Content-Range header processing. */
 	__FSM_TX_AF(Resp_HdrContent_R, 'a', Resp_HdrContent_Ra);

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -4012,6 +4012,7 @@ TEST(http1_parser, vchar)
 
 	/* Special headers */
 	TEST_VCHAR_HEADER("Content-Type", TFW_HTTP_HDR_CONTENT_TYPE, RESP);
+	TEST_VCHAR_HEADER("Content-Location", TFW_HTTP_HDR_CONTENT_LOCATION, RESP);
 	TEST_VCHAR_HEADER("Server", TFW_HTTP_HDR_SERVER, RESP);
 	TEST_VCHAR_HEADER("User-Agent", TFW_HTTP_HDR_USER_AGENT, REQ);
 
@@ -4022,7 +4023,6 @@ TEST(http1_parser, vchar)
 	TEST_RAW_RESP("Allow");
 	TEST_RAW_RESP("Content-Disposition");
 	TEST_RAW_RESP("Content-Language");
-	TEST_RAW_RESP("Content-Location");
 	TEST_RAW_RESP("Content-Range");
 	TEST_RAW_RESP("Link");
 	TEST_RAW_RESP("Location");


### PR DESCRIPTION
According to RFC 9110 9.3.3:
Responses to POST requests are only cacheable
when they include explicit freshness information
and a Content-Location header field that has the
same value as the POST's target URI. A cached POST response can be reused to satisfy a later GET or
HEAD request. In contrast, a POST request cannot
be satisfied by a cached POST response because
POST is potentially unsafe.

Part of #1995