### PR TITLE
Add response with 308 status code to heuristically cacheable

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -454,7 +454,7 @@ tfw_cache_status_bydef(TfwHttpResp *resp)
 	 */
 	switch (resp->status) {
 	case 200: case 203: case 204:
-	case 300: case 301:
+	case 300: case 301: case 308:
 	case 404: case 405: case 410: case 414:
 	case 501:
 		return true;


### PR DESCRIPTION
According to new RFC 9110 15.4.9:
A 308 response is heuristically cacheable; i.e., unless otherwise indicated by the method definition or explicit cache controls.

Part of #1995