### PR TITLE
Remove unnecessary BUG_ON

### DIFF
--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -1900,7 +1900,6 @@ next_msg:
 	 */
 	if (APP_FRAME(h2) && likely(h2->cur_stream))
 	{
-		BUG_ON(TFW_CONN_TYPE(c) & Conn_Stop);
 		/* This chopping algorithm could be replaced with a call
 		 * of ss_skb_list_chop_head_tail(). We refrain of it
 		 * to proccess a special case !h2->skb_head below.


### PR DESCRIPTION
Conn_Stop flag can be set not only from softirq
under socket lock, but also from user context,
when lock is not hold. There is no problem if
we process any data, after connection is closed,
this already happens, for example, when we process a lot of data in parallel under load and an error
occurs. We don't send response for such request,
because socket will be DEAD. Next incoming frames, except WINDOW_UPDATE frames will be ignored.

Closes #2071