### PR TITLE
Fix socket cpu migration

### DIFF
--- a/fw/http_sess.c
+++ b/fw/http_sess.c
@@ -677,7 +677,7 @@ tfw_http_sess_check_jsch(StickyVal *sv, TfwHttpReq* req)
 	 */
 	min_time = sv->ts + js_ch->delay_min
 			+ msecs_to_jiffies(sv->ts % js_ch->delay_range);
-	if (time_after(req->jrxtstamp, min_time))
+	if (time_after_eq(req->jrxtstamp, min_time))
 		return 0;
 
 	sess_warn("jsch redirect received too early",

--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -3,7 +3,7 @@
 # Tempesta FW service script.
 #
 # Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-# Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+# Copyright (C) 2015-2024 Tempesta Technologies, Inc.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -46,12 +46,12 @@ tls_mod=tempesta_tls
 tdb_mod=tempesta_db
 tfw_mod=tempesta_fw
 declare -r LONG_OPTS="help,load,unload,start,stop,restart,reload"
-
-# Exclude loopback interface since it needn't any tuning here: it hasn't RSS
-# while RPS just add unnecessary overhead for it (traffic redistribution, IPIs
-# introduction etc.).
-declare devs=$(ip addr show up | grep -P '^[0-9]+' | grep -Pv '\bLOOPBACK\b' \
-	       | awk '{ sub(/:/, "", $2); print $2}')
+# We should setup network queues for all existing network interfaces
+# to prevent socket CPU migration, which leads to response reordering
+# and broken HTTP1. Some network interfaces have some strange suffix
+# like @if14, and we should remove it from device name.
+declare devs=$(ip addr show up | grep -P '^[0-9]+' \
+	       | awk '{ sub(/:/, "", $2); split($2,a,"@"); print a[1] }')
 
 usage()
 {


### PR DESCRIPTION
Socket cpu migration can lead to two problems:
performance degradation and response reordering,
which leads to broken HTTP1.
Previously we use RSS and RPS to prevent it, but
there were several problems in our scripts:
- we exclude loopback interfaces from setup, because
  we don't take into account response reordering
  problem.
- we don't take into account that some interfaces
  have some suffix lile @if14, and we should remove
  it from device name in our scripts.
- we don't try to setup combined RSS queues, only
  RX queues, but there are a lot of cases when network
  interface has only combined queues.
- we don't take into account overflow when we calculate
  1 << x, when x is greater or equal then 64.
- When we setup RPS we use cpu_mask, which is calculated
  as $(perl -le 'printf("%x", (1 << '$CPUS_N') - 1)').
  But in this case we use all cpus, not only one.
- we don't setup RPS for network interface if, RSS setup
  fails.
This patch fix all this problems.

Closes #2075