### PR TITLE
En/fix 2033

### DIFF
--- a/db/core/htrie.c
+++ b/db/core/htrie.c
@@ -11,7 +11,7 @@
  * and shutdown are performed in process context.
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2021 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/db/core/htrie.c
+++ b/db/core/htrie.c
@@ -918,7 +918,7 @@ tdb_htrie_init(void *p, size_t db_size, unsigned int rec_len)
 		TDB_ERR("cannot allocate per-cpu data\n");
 		return NULL;
 	}
-	for_each_possible_cpu(cpu) {
+	for_each_online_cpu(cpu) {
 		TdbPerCpu *p = per_cpu_ptr(hdr->pcpu, cpu);
 		p->i_wcl = tdb_alloc_blk(hdr);
 		p->d_wcl = tdb_alloc_blk(hdr);

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -341,6 +341,9 @@ tfw_release_node_cpus(void)
 {
 	int node;
 
+	if(!c_nodes)
+		return;
+
 	for(node = 0; node < nr_online_nodes; node++) {
 		if(c_nodes[node].cpu)
 			kfree(c_nodes[node].cpu);

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -234,7 +234,7 @@ enum {
 };
 
 typedef struct {
-	int* cpu;
+	int 		*cpu;
 	atomic_t	cpu_idx;
 	unsigned int	nr_cpus;
 	TDB		*db;
@@ -341,10 +341,9 @@ tfw_release_node_cpus(void)
 {
 	int i;
 
-	for (i = 0; i < MAX_NUMNODES; i++)
-	{
+	for (i = 0; i < MAX_NUMNODES; i++) {
 		if(!c_nodes[i].cpu) {
-			T_ERR("%s c_node deallocation interrupted on node %i\n", __func__, i);
+			T_WARN("%s c_node deallocation interrupted on node %i\n", __func__, i);
 			break;
 		}
 		kfree(c_nodes[i].cpu);
@@ -363,7 +362,7 @@ tfw_init_node_cpus(void)
 	nr_cpus = num_online_cpus();
 
 	for (i = 0; i < MAX_NUMNODES; i++) {
-		c_nodes[i].cpu = kmalloc(nr_cpus*sizeof(int), GFP_KERNEL);
+		c_nodes[i].cpu = kmalloc(nr_cpus * sizeof(int), GFP_KERNEL);
 		if(!c_nodes[i].cpu) {
 			T_ERR("%s Failed to allocate c_nodes[%i] cpu\n", __func__, i);
 			tfw_release_node_cpus();

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -333,8 +333,7 @@ tfw_cache_key_node(unsigned long key)
 }
 
 /**
- * Release memory dynamically allocated
- * for every node cpus
+ * Release memory dynamically allocated for every node cpus
  */
 static void
 tfw_release_node_cpus(void)
@@ -359,18 +358,14 @@ tfw_init_node_cpus(void)
 	nr_cpus = num_online_cpus();
 
 	for_each_online_cpu(cpu) {
-
-
 		node = cpu_to_node(cpu);
-
-		pr_err("node.nr_cpus %u",c_nodes[node].nr_cpus);
-
+		T_DBG("node.nr_cpus %u",c_nodes[node].nr_cpus);
 		c_nodes[node].cpu = kmalloc(nr_cpus * sizeof(int), GFP_KERNEL);
-		if(!c_nodes[node].cpu) {
-			T_ERR("%s Failed to allocate c_nodes[%i] cpu\n", __func__, node);
+		if (!c_nodes[node].cpu) {
+			//T_ERR("Failed to allocate c_nodes[%i] cpu\n", __func__, node);
+			T_ERR( "Failed to allocate a CPU %i for cache work scheduler", cpu);
 			return -ENOMEM;
 		}
-
 		c_nodes[node].cpu[c_nodes[node].nr_cpus++] = cpu;
 	}
 	return 0;

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -363,8 +363,7 @@ tfw_init_node_cpus(void)
 			T_ERR( "Failed to allocate nodes map for cache work scheduler");
 			return -ENOMEM;
 	}
-
-	for_each_online_node(node) {
+	for_each_node_with_cpus(node) {
 		nr_cpus = nr_cpus_node(node);
 		c_nodes[node].cpu = kmalloc(nr_cpus * sizeof(int), GFP_KERNEL);
 		if (!c_nodes[node].cpu) {
@@ -3207,7 +3206,7 @@ tfw_cache_start(void)
 	if (!(cache_cfg.cache || g_vhost->cache_purge))
 		return 0;
 
-	if (r = tfw_init_node_cpus())
+	if ((r = tfw_init_node_cpus()))
 		goto close_db;
 
 	for(i = 0; i < nr_online_nodes; i++) {

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -364,10 +364,11 @@ tfw_init_node_cpus(void)
 	T_DBG2("nr_online_nodes: %d", nr_online_nodes);
 
 	c_nodes = kzalloc(nr_online_nodes * sizeof(CaNode), GFP_KERNEL);
-		if(!c_nodes) {
-			T_ERR("Failed to allocate nodes map for cache work scheduler");
-			return -ENOMEM;
+	if(!c_nodes) {
+		T_ERR("Failed to allocate nodes map for cache work scheduler");
+		return -ENOMEM;
 	}
+
 	for_each_node_with_cpus(node) {
 		nr_cpus = nr_cpus_node(node);
 		T_DBG2("node: %d  nr_cpus: %d",node, nr_cpus);

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -358,6 +358,8 @@ tfw_init_node_cpus(void)
 {
 	int nr_cpus, cpu, node;
 
+	T_DBG2("nr_online_nodes: %d", nr_online_nodes);
+
 	c_nodes = kzalloc(nr_online_nodes * sizeof(CaNode), GFP_KERNEL);
 		if (!c_nodes) {
 			T_ERR( "Failed to allocate nodes map for cache work scheduler");
@@ -365,6 +367,7 @@ tfw_init_node_cpus(void)
 	}
 	for_each_node_with_cpus(node) {
 		nr_cpus = nr_cpus_node(node);
+		T_DBG2("node: %d  nr_cpus: %d",node, nr_cpus);
 		c_nodes[node].cpu = kmalloc(nr_cpus * sizeof(int), GFP_KERNEL);
 		if (!c_nodes[node].cpu) {
 			T_ERR( "Failed to allocate a CPU %i for cache work scheduler", cpu);
@@ -375,7 +378,7 @@ tfw_init_node_cpus(void)
 
 	for_each_online_cpu(cpu) {
 		node = cpu_to_node(cpu);
-		T_DBG2("node - nr_cpus %i - %i",node, nr_cpus);
+		T_DBG2("node: %d  cpu: %d",node, cpu);
 		c_nodes[node].cpu[c_nodes[node].nr_cpus++] = cpu;
 	}
 

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -3207,7 +3207,7 @@ tfw_cache_start(void)
 		return 0;
 
 	if ((r = tfw_init_node_cpus()))
-		goto close_db;
+		goto node_cpus_alloc_err;
 
 	for(i = 0; i < nr_online_nodes; i++) {
 		c_nodes[i].db = tdb_open(cache_cfg.db_path,
@@ -3261,6 +3261,8 @@ dbg_buf_free:
 close_db:
 	for_each_node_with_cpus(i)
 		tdb_close(c_nodes[i].db);
+
+node_cpus_alloc_err:
 	return r;
 }
 

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -364,22 +364,24 @@ tfw_init_node_cpus(void)
 			return -ENOMEM;
 	}
 
-	for_each_online_cpu(cpu) {
-		node = cpu_to_node(cpu);
+	for_each_online_node(node) {
 		nr_cpus = nr_cpus_node(node);
-		T_DBG("node - nr_cpus %i - %i",node, nr_cpus);
 		c_nodes[node].cpu = kmalloc(nr_cpus * sizeof(int), GFP_KERNEL);
 		if (!c_nodes[node].cpu) {
 			T_ERR( "Failed to allocate a CPU %i for cache work scheduler", cpu);
 			tfw_release_node_cpus();
 			return -ENOMEM;
 		}
+	}
+
+	for_each_online_cpu(cpu) {
+		node = cpu_to_node(cpu);
+		T_DBG("node - nr_cpus %i - %i",node, nr_cpus);
 		c_nodes[node].cpu[c_nodes[node].nr_cpus++] = cpu;
 	}
+
 	return 0;
 }
-
-
 
 static TDB *
 node_db(void)

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -332,20 +332,25 @@ tfw_cache_key_node(unsigned long key)
 	return key % num_online_nodes();
 }
 
+/**
+ * Release memory dynamically allocated
+ * for every node cpus
+ */
 static void
 tfw_release_node_cpus(void)
 {
 	int i;
 
-	for (i = 0; i < MAX_NUMNODES; i++) {
-		//T_LOG("node %i\n", i);
-		//if(!c_nodes[i].cpu) {
-		//	T_ERR("%s c_node deallocation interrupted on node %i\n", __func__, i);
-		//	break;
-		//}
+	for (i = 0; i < MAX_NUMNODES; i++)
+	{
+		if(!c_nodes[i].cpu) {
+			T_ERR("%s c_node deallocation interrupted on node %i\n", __func__, i);
+			break;
+		}
 		kfree(c_nodes[i].cpu);
 	}
 }
+
 /**
  * Just choose any CPU for each node to use queue_work_on() for
  * nodes scheduling. Reserve 0th CPU for other tasks.
@@ -359,10 +364,9 @@ tfw_init_node_cpus(void)
 
 	for (i = 0; i < MAX_NUMNODES; i++) {
 		c_nodes[i].cpu = kmalloc(nr_cpus*sizeof(int), GFP_KERNEL);
-		//T_LOG("node %i\n", i);
 		if(!c_nodes[i].cpu) {
 			T_ERR("%s Failed to allocate c_nodes[%i] cpu\n", __func__, i);
-			//tfw_release_node_cpus();
+			tfw_release_node_cpus();
 			return;
 		}
 	}
@@ -371,7 +375,7 @@ tfw_init_node_cpus(void)
 		node = cpu_to_node(cpu);
 		c_nodes[node].cpu[c_nodes[node].nr_cpus++] = cpu;
 	}
-	tfw_release_node_cpus();}
+}
 
 
 static TDB *

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -361,16 +361,17 @@ tfw_init_node_cpus(void)
 	T_DBG2("nr_online_nodes: %d", nr_online_nodes);
 
 	c_nodes = kzalloc(nr_online_nodes * sizeof(CaNode), GFP_KERNEL);
-		if (!c_nodes) {
-			T_ERR( "Failed to allocate nodes map for cache work scheduler");
+		if(!c_nodes) {
+			T_ERR("Failed to allocate nodes map for cache work scheduler");
 			return -ENOMEM;
 	}
 	for_each_node_with_cpus(node) {
 		nr_cpus = nr_cpus_node(node);
 		T_DBG2("node: %d  nr_cpus: %d",node, nr_cpus);
 		c_nodes[node].cpu = kmalloc(nr_cpus * sizeof(int), GFP_KERNEL);
-		if (!c_nodes[node].cpu) {
-			T_ERR("Failed to allocate CPU array for node %d for cache work scheduler", node);
+		if(!c_nodes[node].cpu) {
+			T_ERR("Failed to allocate CPU array for node %d for cache work scheduler",
+				node);
 			return -ENOMEM;
 		}
 	}

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -363,7 +363,7 @@ tfw_init_node_cpus(void)
 	c_nodes = kzalloc(nr_online_nodes * sizeof(CaNode), GFP_KERNEL);
 		if (!c_nodes) {
 			T_ERR( "Failed to allocate nodes map for cache work scheduler");
-			//return -ENOMEM;
+			return -ENOMEM;
 	}
 
 	return 0;
@@ -3223,7 +3223,7 @@ tfw_cache_start(void)
 		goto close_db;
 	}
 #endif
-	if (tfw_init_node_cpus() == -ENOMEM)
+	if (!tfw_init_node_cpus())
 		goto close_db;
 
 	TFW_WQ_CHECKSZ(TfwCWork);

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -3207,14 +3207,16 @@ tfw_cache_start(void)
 	if (!(cache_cfg.cache || g_vhost->cache_purge))
 		return 0;
 
-	if (!tfw_init_node_cpus())
+	if (r = tfw_init_node_cpus())
 		goto close_db;
 
 	for(i = 0; i < nr_online_nodes; i++) {
 		c_nodes[i].db = tdb_open(cache_cfg.db_path,
 					 cache_cfg.db_size, 0, i);
-		if (!c_nodes[i].db)
+		if (!c_nodes[i].db) {
+			r = -ENOMEM;
 			goto close_db;
+		}
 	}
 #if 0
 	cache_mgr_thr = kthread_run(tfw_cache_mgr, NULL, "tfw_cache_mgr");

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -371,7 +371,6 @@ tfw_init_node_cpus(void)
 		c_nodes[node].cpu = kmalloc(nr_cpus * sizeof(int), GFP_KERNEL);
 		if (!c_nodes[node].cpu) {
 			T_ERR("Failed to allocate CPU array for node %d for cache work scheduler", node);
-			tfw_release_node_cpus();
 			return -ENOMEM;
 		}
 	}
@@ -3266,6 +3265,7 @@ close_db:
 		tdb_close(c_nodes[i].db);
 
 node_cpus_alloc_err:
+	tfw_release_node_cpus();
 	return r;
 }
 

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -375,7 +375,7 @@ tfw_init_node_cpus(void)
 
 	for_each_online_cpu(cpu) {
 		node = cpu_to_node(cpu);
-		T_DBG("node - nr_cpus %i - %i",node, nr_cpus);
+		T_DBG2("node - nr_cpus %i - %i",node, nr_cpus);
 		c_nodes[node].cpu[c_nodes[node].nr_cpus++] = cpu;
 	}
 

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -3210,8 +3210,10 @@ tfw_cache_start(void)
 		goto close_db;
 	}
 #endif
-	if(tfw_init_node_cpus() == -ENOMEM) 
+	if (tfw_init_node_cpus() == -ENOMEM) {
+		tfw_release_node_cpus();
 		goto close_db;
+	}
 
 	TFW_WQ_CHECKSZ(TfwCWork);
 	for_each_online_cpu(i) {

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -370,7 +370,7 @@ tfw_init_node_cpus(void)
 		T_DBG2("node: %d  nr_cpus: %d",node, nr_cpus);
 		c_nodes[node].cpu = kmalloc(nr_cpus * sizeof(int), GFP_KERNEL);
 		if (!c_nodes[node].cpu) {
-			T_ERR( "Failed to allocate a CPU %i for cache work scheduler", cpu);
+			T_ERR("Failed to allocate CPU array for node %d for cache work scheduler", node);
 			tfw_release_node_cpus();
 			return -ENOMEM;
 		}

--- a/fw/work_queue.c
+++ b/fw/work_queue.c
@@ -5,7 +5,7 @@
  * complicated MPMC case at http://www.linuxjournal.com/content/lock-free- \
  * multi-producer-multi-consumer-queue-ring-buffer .
  *
- * Copyright (C) 2016-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/fw/work_queue.c
+++ b/fw/work_queue.c
@@ -36,7 +36,7 @@ tfw_wq_init(TfwRBQueue *q, size_t qsize, int node)
 	if (!q->heads)
 		return -ENOMEM;
 
-	for_each_possible_cpu(cpu) {
+	for_each_online_cpu(cpu) {
 		atomic64_t *local_head = per_cpu_ptr(q->heads, cpu);
 		atomic64_set(local_head, LLONG_MAX);
 	}

--- a/ktest/linux/percpu.h
+++ b/ktest/linux/percpu.h
@@ -33,7 +33,7 @@
 #define alloc_percpu(t)			calloc(NR_CPUS, sizeof(t))
 #define __alloc_percpu(s, a)		calloc(NR_CPUS, (s))
 #define free_percpu(p)			free(p)
-#define for_each_possible_cpu(c)	for (c = 0; c < NR_CPUS; ++c)
+#define for_each_online_cpu(c)		for (c = 0; c < NR_CPUS; ++c)
 
 #if NR_CPUS == 1
 

--- a/ktest/linux/percpu.h
+++ b/ktest/linux/percpu.h
@@ -1,7 +1,7 @@
 /**
  *	Tempesta kernel emulation unit testing framework.
  *
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -1911,7 +1911,7 @@ index 1301ea694..02ff44569 100644
  {
 +#ifdef CONFIG_SECURITY_TEMPESTA
 +	int cpu, l;
-+	for_each_possible_cpu(cpu)
++	for_each_online_cpu(cpu)
 +		for (l = 0; l < PG_LISTS_N; ++l) {
 +			TfwSkbMemPool *pool = per_cpu_ptr(&pg_mpool[l], cpu);
 +			INIT_LIST_HEAD(&pool->lh);

--- a/tls/mpool.c
+++ b/tls/mpool.c
@@ -397,7 +397,7 @@ ttls_mpool_exit(void)
 	int i;
 	TlsMpiPool *mp;
 
-	for_each_possible_cpu(i) {
+	for_each_online_cpu(i) {
 		mp = per_cpu(g_tmp_mpool, i);
 		ttls_bzero_safe(MPI_POOL_DATA(mp), mp->curr - sizeof(*mp));
 		free_pages((unsigned long)mp, mp->order);
@@ -409,7 +409,7 @@ ttls_mpool_init(void)
 {
 	int cpu;
 
-	for_each_possible_cpu(cpu) {
+	for_each_online_cpu(cpu) {
 		TlsMpiPool **mp = per_cpu_ptr(&g_tmp_mpool, cpu);
 		if (!(*mp = ttls_mpi_pool_create(__MPOOL_STACK_ORDER,
 						 GFP_KERNEL)))

--- a/tls/rsa.c
+++ b/tls/rsa.c
@@ -133,7 +133,7 @@ __rsa_setup_ctx(TlsRSACtx *ctx)
 	 * Generate blinding values.
 	 * Unblinding value: Vf = random number, invertible mod N.
 	 */
-	for_each_possible_cpu(cpu) {
+	for_each_online_cpu(cpu) {
 		int count = 0;
 
 		TlsMpi *vi = per_cpu_ptr(ctx->Vi, cpu);

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -2824,7 +2824,7 @@ ttls_exit(void)
 
 	kmem_cache_destroy(ttls_hs_cache);
 
-	for_each_possible_cpu(cpu) {
+	for_each_online_cpu(cpu) {
 		struct aead_request **req = per_cpu_ptr(&g_req, cpu);
 		kfree(*req);
 	}
@@ -2852,7 +2852,7 @@ ttls_init(void)
 	if ((r = ttls_tickets_init()))
 		goto err_free;
 
-	for_each_possible_cpu(cpu) {
+	for_each_online_cpu(cpu) {
 		struct aead_request **req = per_cpu_ptr(&g_req, cpu);
 		*req = kmalloc(ttls_aead_reqsize(), GFP_KERNEL);
 		if (!*req)


### PR DESCRIPTION
According to issue 2033
1. `for_each_possible_cpu()` changed to `each_online_cpu()`
2. Static array with size `NR_CPUS` changed to dynamic one with size `num_online_cpu()`
3. Updated kernel patch with the same changes.