### PR TITLE
fix: avoid duplicated chunking

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -10429,7 +10429,7 @@ tfw_h2_parse_req_hdr_val(unsigned char *data, unsigned long len, TfwHttpReq *req
 	case TFW_TAG_HDR_CONTENT_ENCODING:
 	TFW_H2_PARSE_HDR_VAL(Req_HdrContent_EncodingV, msg,
 			     __h2_req_parse_content_encoding,
-			     TFW_HTTP_HDR_CONTENT_ENCODING, 1);
+			     TFW_HTTP_HDR_CONTENT_ENCODING, 0);
 
 	/* 'content-length' is read, process field-value. */
 	case TFW_TAG_HDR_CONTENT_LENGTH:


### PR DESCRIPTION
Fix #2081

Some header value parsers like `__h2_req_parse_content_encoding()` call chunking explicitly (i.e. `__FSM_H2_I_MATCH_MOVE_fixup()`), which in turn call `tfw_http_msg_add_str_data()` as what `TFW_H2_PARSE_HDR_VAL()` does. As the comment of `TFW_H2_PARSE_HDR_VAL()` said, those parsers should set `saveval=0` to avoid duplicated chunk creations.

There is no test to validate the header value seen from the server side, so I add a new test case:
https://github.com/tempesta-tech/tempesta-test/compare/master...kingluo:tempesta-test:fix-2081

```
./run_tests.py http2_general.test_h2_responses.H2ResponsesTestCase.test_h2_duplicated_content_encoding
Root privileges are required: need access to module loading on localhost.

----------------------------------------------------------------------
Running functional tests...
----------------------------------------------------------------------

.
----------------------------------------------------------------------
Ran 1 test in 0.706s

OK
```

