### PR TITLE
Change WARNING with dump to error message.

### DIFF
--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -702,11 +702,7 @@ ht_small:
 				hp->curr -= shift;
 			}
 			else {
-				/*
-				 * @shift for short tables must be greater
-				 * than zero.
-				 */
-				WARN_ON_ONCE(1);
+				T_ERR("Decoding error. Short table shift less than zero.");
 				break;
 			}
 		}

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -702,7 +702,7 @@ ht_small:
 				hp->curr -= shift;
 			}
 			else {
-				T_ERR("Decoding error. Short table shift less than zero.");
+				T_WARN("Decoding error. Short table shift less than zero.");
 				break;
 			}
 		}


### PR DESCRIPTION
Because non-positive value of shift in short tables is a normal behaviour during decoding corrupted Huffman sequence we don't need detailed dump, short error message will be enough