### PR TITLE
fix(1902): correct the skb len

### DIFF
--- a/fw/http.h
+++ b/fw/http.h
@@ -301,8 +301,7 @@ typedef struct {
 	TfwConn		*conn;						\
 	void (*destructor)(void *msg);					\
 	TfwStr		crlf;						\
-	TfwStr		body;						\
-	int		trailers_len;
+	TfwStr		body;
 
 
 static inline void
@@ -485,6 +484,7 @@ struct tfw_http_resp_t {
 	char			*body_start_data;
 	struct sk_buff		*body_start_skb;
 	TfwStr			cut;
+	int			trailers_len;
 };
 
 /**

--- a/fw/http.h
+++ b/fw/http.h
@@ -301,7 +301,8 @@ typedef struct {
 	TfwConn		*conn;						\
 	void (*destructor)(void *msg);					\
 	TfwStr		crlf;						\
-	TfwStr		body;
+	TfwStr		body;						\
+	int		trailers_len;
 
 
 static inline void

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -568,6 +568,7 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm)
 	/* Cumulate the trailer headers length */
 	if (parser->hdr.flags & TFW_STR_TRAILER) {
 		TfwHttpResp* resp = (TfwHttpResp*) hm;
+
 		resp->trailers_len += parser->hdr.len +
 			tfw_str_eolen(&parser->hdr);
 	}

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -565,6 +565,11 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm)
 	/* Close just parsed header. */
 	parser->hdr.flags |= TFW_STR_COMPLETE;
 
+	/* Cumulate the trailer headers length */
+	if (parser->hdr.flags & TFW_STR_TRAILER)
+		hm->trailers_len += parser->hdr.len +
+			tfw_str_eolen(&parser->hdr);
+
 	/*
 	 * We make this frang check here, because it is the earliest
 	 * place where we can determine that new added header is violating
@@ -1050,7 +1055,8 @@ tfw_http_msg_cutoff_body_chunks(TfwHttpResp *resp)
 	int r;
 
 	r = ss_skb_cutoff_data(resp->body.skb, &resp->cut, 0,
-			       tfw_str_eolen(&resp->body));
+			       tfw_str_eolen(&resp->body) +
+			       ((TfwHttpMsg*)resp)->trailers_len);
 	if (unlikely(r))
 		return r;
 

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -566,9 +566,11 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm)
 	parser->hdr.flags |= TFW_STR_COMPLETE;
 
 	/* Cumulate the trailer headers length */
-	if (parser->hdr.flags & TFW_STR_TRAILER)
-		hm->trailers_len += parser->hdr.len +
+	if (parser->hdr.flags & TFW_STR_TRAILER) {
+		TfwHttpResp* resp = (TfwHttpResp*) hm;
+		resp->trailers_len += parser->hdr.len +
 			tfw_str_eolen(&parser->hdr);
+	}
 
 	/*
 	 * We make this frang check here, because it is the earliest
@@ -1056,7 +1058,7 @@ tfw_http_msg_cutoff_body_chunks(TfwHttpResp *resp)
 
 	r = ss_skb_cutoff_data(resp->body.skb, &resp->cut, 0,
 			       tfw_str_eolen(&resp->body) +
-			       ((TfwHttpMsg*)resp)->trailers_len);
+			       resp->trailers_len);
 	if (unlikely(r))
 		return r;
 


### PR DESCRIPTION
Fix #1902

When we contruct frames for HTTP/2 response and
reuse the same skbs from the backend (HTTP/1), we forget to adjust the skb size according to the trailer headers (if exist) size, then it comes with extra partial HTTP/1 response to the client. Then, the client will send a `GOAWAY` to temepesta due to wrong frame size, and tempesta sends back the `TCP RESET`.