### PR TITLE
Drop request sock in case when frang block new connection

### DIFF
--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -790,6 +790,23 @@ index 000000000..80de50693
 +
 +#endif /* __TEMPESTA_H__ */
 +
+diff --git a/include/net/inet_sock.h b/include/net/inet_sock.h
+index 89163ef8c..49ad1ddc9 100644
+--- a/include/net/inet_sock.h
++++ b/include/net/inet_sock.h
+@@ -87,7 +87,12 @@ struct inet_request_sock {
+ 				ecn_ok	   : 1,
+ 				acked	   : 1,
+ 				no_srccheck: 1,
++#ifdef CONFIG_SECURITY_TEMPESTA
++				smc_ok	   : 1,
++				aborted	   : 1;
++#else
+ 				smc_ok	   : 1;
++#endif
+ 	u32                     ir_mark;
+ 	union {
+ 		struct ip_options_rcu __rcu	*ireq_opt;
 diff --git a/include/net/sock.h b/include/net/sock.h
 index 261195598..456f6bd50 100644
 --- a/include/net/sock.h
@@ -2393,7 +2410,7 @@ index fac5c1469..f9f8000bf 100644
  		memcpy(nskb->cb, skb->cb, sizeof(skb->cb));
  #ifdef CONFIG_TLS_DEVICE
 diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
-index ab8ed0fc4..1a5c62ab7 100644
+index ab8ed0fc4..e8764cd36 100644
 --- a/net/ipv4/tcp_ipv4.c
 +++ b/net/ipv4/tcp_ipv4.c
 @@ -57,6 +57,7 @@
@@ -2434,13 +2451,30 @@ index ab8ed0fc4..1a5c62ab7 100644
 +	 * so there is no appropriate security hook.
 +	 */
 +	if (tempesta_new_clntsk(newsk, skb)) {
-+		tcp_v4_send_reset(newsk, skb);
++		ireq->aborted = true;
 +		goto put_and_exit;
 +	}
 +#endif
  	if (__inet_inherit_port(sk, newsk) < 0)
  		goto put_and_exit;
  	*own_req = inet_ehash_nolisten(newsk, req_to_sk(req_unhash),
+diff --git a/net/ipv4/tcp_minisocks.c b/net/ipv4/tcp_minisocks.c
+index f0f67b25c..58fbfb071 100644
+--- a/net/ipv4/tcp_minisocks.c
++++ b/net/ipv4/tcp_minisocks.c
+@@ -786,7 +786,12 @@ struct sock *tcp_check_req(struct sock *sk, struct sk_buff *skb,
+ 	return inet_csk_complete_hashdance(sk, child, req, own_req);
+ 
+ listen_overflow:
++#ifdef CONFIG_SECURITY_TEMPESTA
++	if (!sock_net(sk)->ipv4.sysctl_tcp_abort_on_overflow
++	    && !inet_rsk(req)->aborted) {
++#else
+ 	if (!sock_net(sk)->ipv4.sysctl_tcp_abort_on_overflow) {
++#endif
+ 		inet_rsk(req)->acked = 1;
+ 		return NULL;
+ 	}
 diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
 index f99494637..1a868b9aa 100644
 --- a/net/ipv4/tcp_output.c
@@ -2837,7 +2871,7 @@ index f99494637..1a868b9aa 100644
  		if (!err)
  			tcp_event_new_data_sent(sk, skb);
 diff --git a/net/ipv6/tcp_ipv6.c b/net/ipv6/tcp_ipv6.c
-index 3f9bb6dd1..af725b233 100644
+index 3f9bb6dd1..28e6539fa 100644
 --- a/net/ipv6/tcp_ipv6.c
 +++ b/net/ipv6/tcp_ipv6.c
 @@ -65,6 +65,7 @@
@@ -2859,7 +2893,7 @@ index 3f9bb6dd1..af725b233 100644
 +	 * so there is no appropriate security hook.
 +	 */
 +	if (tempesta_new_clntsk(newsk, skb)) {
-+		tcp_v6_send_reset(newsk, skb);
++		ireq->aborted = true;
 +		inet_csk_prepare_forced_close(newsk);
 +		tcp_done(newsk);
 +		goto out;


### PR DESCRIPTION
To understand this problem look at the tcp handshake: client sends SYN (and switched to TCP_SYN_SENT state) to server, after receiving SYN server (which is in TCP_LISTEN state) sends SYN_ACK to client. After
receiving SYN_ACK client send last ACK to server and switched to ESTABLISHED state. In this state client can send data to server. When server receives last ACK it use previously created request sock, and call tcp_check_req->syn_recv_sock->tempesta_new_clntsk. If we don't drop request sock after `tempesta_new_clntsk` fails, this request sock can be used later if client sends some data just after sending last ACK, or if client tries to retransmit last ACK.

Closes #2096