### PR TITLE
Fix HTTP2 empty frames processing

### DIFF
--- a/fw/http_frame.h
+++ b/fw/http_frame.h
@@ -300,7 +300,7 @@ tfw_h2_unpack_frame_header(TfwFrameHdr *hdr, const unsigned char *buf)
 }
 
 static inline void
-tf2_h2_conn_reset_stream_on_close(TfwH2Ctx *ctx, TfwStream *stream)
+tfw_h2_conn_reset_stream_on_close(TfwH2Ctx *ctx, TfwStream *stream)
 {
 	if (ctx->cur_send_headers == stream)
 		ctx->cur_send_headers = NULL;

--- a/fw/http_stream.h
+++ b/fw/http_stream.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -37,6 +37,7 @@
  * is just a stream that has not been created yet.
  */
 typedef enum {
+	HTTP2_STREAM_IDLE,
 	HTTP2_STREAM_LOC_RESERVED,
 	HTTP2_STREAM_REM_RESERVED,
 	HTTP2_STREAM_OPENED,
@@ -48,13 +49,14 @@ typedef enum {
 } TfwStreamState;
 
 enum {
-	HTTP2_STREAM_STATE_MASK = 0x7,
-	HTTP2_STREAM_FLAGS_OFFSET = 0x3,
+	HTTP2_STREAM_STATE_MASK = 0xF,
+	HTTP2_STREAM_FLAGS_OFFSET = 0x4,
 	HTTP2_STREAM_SEND_END_OF_STREAM = 0x1 << HTTP2_STREAM_FLAGS_OFFSET,
 	HTTP2_STREAM_RECV_END_OF_STREAM = 0x2 << HTTP2_STREAM_FLAGS_OFFSET,
 };
 
 static const char *__tfw_strm_st_names[] = {
+	[HTTP2_STREAM_IDLE]		= "HTTP2_STREAM_IDLE",
 	[HTTP2_STREAM_LOC_RESERVED]	= "HTTP2_STREAM_LOC_RESERVED",
 	[HTTP2_STREAM_REM_RESERVED]	= "HTTP2_STREAM_REM_RESERVED",
 	[HTTP2_STREAM_OPENED]	    	= "HTTP2_STREAM_OPENED",

--- a/lib/fsm.h
+++ b/lib/fsm.h
@@ -8,7 +8,7 @@
  * and make sense only if state lookup introduce significant overhead, e.g.
  * lookup a state for each input character as it is in HTTP parser.
  *
- * Copyright (C) 2018 Tempesta Technologies, INC.
+ * Copyright (C) 2018-2024 Tempesta Technologies, INC.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The main goal of current commit, it's prevent flooding by empty(zero payload length) frames. To achieve this was fixed handling of following empty frames: DATA, HEADERS, CONTINUATION.

All of these headers can be empty, but with exceptions:
 - Only first HEADERS frame can be empty(RFC doesn't have any direct prohibitions) and must be followed by CONTINUATION frame.
 - DATA frame MUST have END_STREAM flag.
 - CONTINUATION frame MUST have END_HEADERS.

Other empty frames are prohibited, because they are not described in protocol specification and there is not proper use cases. Handling of such frames leads to unreasonable CPU utilization thus potentially DOS.

Useage of allowed empty frames is described by protocol specification and receiving or sending them multiple times is prohibited by protocol. Thus we don't need any additional tracking.

Also added IDLE state to streams state machine. We should do it to follow specification and handle
streams states correctly.