### PR TITLE
Add sk_free callback handler.

### DIFF
--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -352,6 +352,9 @@ tfw_classify_conn_close(struct sock *sk)
 
 	spin_lock(&ra->lock);
 
+	if(ra == NULL)
+		return;
+
 	BUG_ON(!ra->conn_curr);
 	ra->conn_curr--;
 

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -1809,6 +1809,7 @@ tfw_http_limits_hooks_register(void)
 
 static TempestaOps tempesta_ops = {
 	.sk_alloc	= tfw_classify_conn_estab,
+	.sk_free        = tfw_classify_conn_close,
 	.sock_tcp_rcv	= tfw_classify_tcp,
 };
 

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -331,10 +331,8 @@ frang_conn_new(struct sock *sk, struct sk_buff *skb)
 	 * for a single client is absolutely straight-forward.
 	 */
 	r = frang_conn_limit(ra, dflt_vh->frang_gconf);
-	if (unlikely(r == T_BLOCK) && dflt_vh->frang_gconf->ip_block) {
+	if (unlikely(r == T_BLOCK) && dflt_vh->frang_gconf->ip_block)
 		tfw_filter_block_ip(cli);
-		tfw_client_put(cli);
-	}
 
 finish:
 	tfw_vhost_put(dflt_vh);

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -348,8 +348,6 @@ tfw_classify_conn_close(struct sock *sk)
 {
 	FrangAcc *ra = frang_acc_from_sk(sk);
 
-	BUG_ON(!ra);
-
 	assert_spin_locked(&sk->sk_lock.slock);
 
 	spin_lock(&ra->lock);
@@ -359,7 +357,8 @@ tfw_classify_conn_close(struct sock *sk)
 
 	spin_unlock(&ra->lock);
 
-	sk->sk_security = NULL;
+	if(sk)
+		sk->sk_security = NULL;
 
 	tfw_client_put(FRANG_ACC2CLI(ra));
 }

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -348,20 +348,19 @@ tfw_classify_conn_close(struct sock *sk)
 {
 	FrangAcc *ra = frang_acc_from_sk(sk);
 
+	if(ra == NULL)
+		return;
+
 	assert_spin_locked(&sk->sk_lock.slock);
 
 	spin_lock(&ra->lock);
 
-	if(ra == NULL)
-		return;
-
-	BUG_ON(!ra->conn_curr);
+	BUG_ON(ra->conn_curr == 0);
 	ra->conn_curr--;
 
 	spin_unlock(&ra->lock);
 
-	if(sk)
-		sk->sk_security = NULL;
+	sk->sk_security = NULL;
 
 	tfw_client_put(FRANG_ACC2CLI(ra));
 }

--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -732,10 +732,10 @@ index a828cf99c..59ebed976 100644
   *	@skb: buffer to check
 diff --git a/include/linux/tempesta.h b/include/linux/tempesta.h
 new file mode 100644
-index 000000000..80de50693
+index 000000000..90eedcba5
 --- /dev/null
 +++ b/include/linux/tempesta.h
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,55 @@
 +/**
 + * Linux interface for Tempesta FW.
 + *
@@ -776,6 +776,7 @@ index 000000000..80de50693
 +
 +/* Security hooks. */
 +int tempesta_new_clntsk(struct sock *newsk, struct sk_buff *skb);
++void tempesta_close_clntsk(struct sock *sk);
 +void tempesta_register_ops(TempestaOps *tops);
 +void tempesta_unregister_ops(TempestaOps *tops);
 +
@@ -2393,7 +2394,7 @@ index fac5c1469..f9f8000bf 100644
  		memcpy(nskb->cb, skb->cb, sizeof(skb->cb));
  #ifdef CONFIG_TLS_DEVICE
 diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
-index ab8ed0fc4..1a5c62ab7 100644
+index ab8ed0fc4..af34536fd 100644
 --- a/net/ipv4/tcp_ipv4.c
 +++ b/net/ipv4/tcp_ipv4.c
 @@ -57,6 +57,7 @@
@@ -2424,7 +2425,7 @@ index ab8ed0fc4..1a5c62ab7 100644
  	if (!md5sig)
  		return NULL;
  #if IS_ENABLED(CONFIG_IPV6)
-@@ -1582,6 +1581,16 @@ struct sock *tcp_v4_syn_recv_sock(const struct sock *sk, struct sk_buff *skb,
+@@ -1582,6 +1581,17 @@ struct sock *tcp_v4_syn_recv_sock(const struct sock *sk, struct sk_buff *skb,
  	}
  #endif
  
@@ -2435,6 +2436,7 @@ index ab8ed0fc4..1a5c62ab7 100644
 +	 */
 +	if (tempesta_new_clntsk(newsk, skb)) {
 +		tcp_v4_send_reset(newsk, skb);
++		tempesta_close_clntsk(newsk);
 +		goto put_and_exit;
 +	}
 +#endif
@@ -2837,7 +2839,7 @@ index f99494637..1a868b9aa 100644
  		if (!err)
  			tcp_event_new_data_sent(sk, skb);
 diff --git a/net/ipv6/tcp_ipv6.c b/net/ipv6/tcp_ipv6.c
-index 3f9bb6dd1..af725b233 100644
+index 3f9bb6dd1..72157170b 100644
 --- a/net/ipv6/tcp_ipv6.c
 +++ b/net/ipv6/tcp_ipv6.c
 @@ -65,6 +65,7 @@
@@ -2848,7 +2850,7 @@ index 3f9bb6dd1..af725b233 100644
  
  #include <trace/events/tcp.h>
  
-@@ -1376,7 +1377,18 @@ static struct sock *tcp_v6_syn_recv_sock(const struct sock *sk, struct sk_buff *
+@@ -1376,7 +1377,19 @@ static struct sock *tcp_v6_syn_recv_sock(const struct sock *sk, struct sk_buff *
  			       sk_gfp_mask(sk, GFP_ATOMIC));
  	}
  #endif
@@ -2860,6 +2862,7 @@ index 3f9bb6dd1..af725b233 100644
 +	 */
 +	if (tempesta_new_clntsk(newsk, skb)) {
 +		tcp_v6_send_reset(newsk, skb);
++		tempesta_close_clntsk(newsk);
 +		inet_csk_prepare_forced_close(newsk);
 +		tcp_done(newsk);
 +		goto out;
@@ -2996,10 +2999,10 @@ index 000000000..4c439ac0c
 +tempesta-y := tempesta_lsm.o
 diff --git a/security/tempesta/tempesta_lsm.c b/security/tempesta/tempesta_lsm.c
 new file mode 100644
-index 000000000..a65a79f30
+index 000000000..313101304
 --- /dev/null
 +++ b/security/tempesta/tempesta_lsm.c
-@@ -0,0 +1,120 @@
+@@ -0,0 +1,135 @@
 +/**
 + *		Tempesta FW
 + *
@@ -3082,6 +3085,21 @@ index 000000000..a65a79f30
 +	return r;
 +}
 +EXPORT_SYMBOL(tempesta_new_clntsk);
++
++void
++tempesta_close_clntsk(struct sock *sk)
++{
++	TempestaOps *tops;
++
++	rcu_read_lock();
++
++	tops = rcu_dereference(tempesta_ops);
++	if (likely(tops))
++		tops->sk_free(sk);
++
++	rcu_read_unlock();
++}
++EXPORT_SYMBOL(tempesta_close_clntsk);
 +
 +static int
 +tempesta_sock_tcp_rcv(struct sock *sk, struct sk_buff *skb)

--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -791,6 +791,23 @@ index 000000000..90eedcba5
 +
 +#endif /* __TEMPESTA_H__ */
 +
+diff --git a/include/net/inet_sock.h b/include/net/inet_sock.h
+index 89163ef8c..49ad1ddc9 100644
+--- a/include/net/inet_sock.h
++++ b/include/net/inet_sock.h
+@@ -87,7 +87,12 @@ struct inet_request_sock {
+ 				ecn_ok	   : 1,
+ 				acked	   : 1,
+ 				no_srccheck: 1,
++#ifdef CONFIG_SECURITY_TEMPESTA
++				smc_ok	   : 1,
++				aborted	   : 1;
++#else
+ 				smc_ok	   : 1;
++#endif
+ 	u32                     ir_mark;
+ 	union {
+ 		struct ip_options_rcu __rcu	*ireq_opt;
 diff --git a/include/net/sock.h b/include/net/sock.h
 index 261195598..456f6bd50 100644
 --- a/include/net/sock.h
@@ -2394,7 +2411,7 @@ index fac5c1469..f9f8000bf 100644
  		memcpy(nskb->cb, skb->cb, sizeof(skb->cb));
  #ifdef CONFIG_TLS_DEVICE
 diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
-index ab8ed0fc4..af34536fd 100644
+index ab8ed0fc4..7effbed4a 100644
 --- a/net/ipv4/tcp_ipv4.c
 +++ b/net/ipv4/tcp_ipv4.c
 @@ -57,6 +57,7 @@
@@ -2425,7 +2442,7 @@ index ab8ed0fc4..af34536fd 100644
  	if (!md5sig)
  		return NULL;
  #if IS_ENABLED(CONFIG_IPV6)
-@@ -1582,6 +1581,17 @@ struct sock *tcp_v4_syn_recv_sock(const struct sock *sk, struct sk_buff *skb,
+@@ -1582,6 +1581,18 @@ struct sock *tcp_v4_syn_recv_sock(const struct sock *sk, struct sk_buff *skb,
  	}
  #endif
  
@@ -2437,12 +2454,30 @@ index ab8ed0fc4..af34536fd 100644
 +	if (tempesta_new_clntsk(newsk, skb)) {
 +		tcp_v4_send_reset(newsk, skb);
 +		tempesta_close_clntsk(newsk);
++		ireq->aborted = true;
 +		goto put_and_exit;
 +	}
 +#endif
  	if (__inet_inherit_port(sk, newsk) < 0)
  		goto put_and_exit;
  	*own_req = inet_ehash_nolisten(newsk, req_to_sk(req_unhash),
+diff --git a/net/ipv4/tcp_minisocks.c b/net/ipv4/tcp_minisocks.c
+index f0f67b25c..58fbfb071 100644
+--- a/net/ipv4/tcp_minisocks.c
++++ b/net/ipv4/tcp_minisocks.c
+@@ -786,7 +786,12 @@ struct sock *tcp_check_req(struct sock *sk, struct sk_buff *skb,
+ 	return inet_csk_complete_hashdance(sk, child, req, own_req);
+ 
+ listen_overflow:
++#ifdef CONFIG_SECURITY_TEMPESTA
++	if (!sock_net(sk)->ipv4.sysctl_tcp_abort_on_overflow
++	    && !inet_rsk(req)->aborted) {
++#else
+ 	if (!sock_net(sk)->ipv4.sysctl_tcp_abort_on_overflow) {
++#endif
+ 		inet_rsk(req)->acked = 1;
+ 		return NULL;
+ 	}
 diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
 index f99494637..1a868b9aa 100644
 --- a/net/ipv4/tcp_output.c
@@ -2839,7 +2874,7 @@ index f99494637..1a868b9aa 100644
  		if (!err)
  			tcp_event_new_data_sent(sk, skb);
 diff --git a/net/ipv6/tcp_ipv6.c b/net/ipv6/tcp_ipv6.c
-index 3f9bb6dd1..72157170b 100644
+index 3f9bb6dd1..f9b137af9 100644
 --- a/net/ipv6/tcp_ipv6.c
 +++ b/net/ipv6/tcp_ipv6.c
 @@ -65,6 +65,7 @@
@@ -2850,7 +2885,7 @@ index 3f9bb6dd1..72157170b 100644
  
  #include <trace/events/tcp.h>
  
-@@ -1376,7 +1377,19 @@ static struct sock *tcp_v6_syn_recv_sock(const struct sock *sk, struct sk_buff *
+@@ -1376,7 +1377,20 @@ static struct sock *tcp_v6_syn_recv_sock(const struct sock *sk, struct sk_buff *
  			       sk_gfp_mask(sk, GFP_ATOMIC));
  	}
  #endif
@@ -2863,6 +2898,7 @@ index 3f9bb6dd1..72157170b 100644
 +	if (tempesta_new_clntsk(newsk, skb)) {
 +		tcp_v6_send_reset(newsk, skb);
 +		tempesta_close_clntsk(newsk);
++		ireq->aborted = true;
 +		inet_csk_prepare_forced_close(newsk);
 +		tcp_done(newsk);
 +		goto out;


### PR DESCRIPTION
In this way tfw_classify_conn_close() function called when connection closed on the socket level.
In this particular case we fix the situation when tfw_classify_conn_close() skipped when connection dropped by connections limiter (Issue #2084).