### PR TITLE
Fix incorrect msg->len calculation during redirect preparation.

### DIFF
--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -983,6 +983,8 @@
 # 'delay_range' - Allowed time period to receive and accept client's session.
 # 'resp_code'   - Status code for response with JS challenge. Optional
 #                 parameter, default is "503".
+#                 Allowed codes: 200, 301, 302, 303, 307, 308, 400, 403, 404,
+#                                412, 500, 502, 503, 504
 # <SCRIPT_TEMPLATE> - path to JS challenge script.. Optional parameter, default
 #                 is "/etc/tempesta/js_challenge.conf".
 #

--- a/fw/http.c
+++ b/fw/http.c
@@ -533,7 +533,7 @@ tfw_http_prep_date(char *buf)
 	tfw_http_prep_date_from(buf, tfw_current_timestamp());
 }
 
-static inline char *
+char *
 tfw_http_resp_status_line(int status, size_t *len)
 {
 	switch(status) {
@@ -780,10 +780,8 @@ do { 								\
 	p += len;						\
 } while (0)
 
-	if (!status_line) {
-		T_WARN("Unexpected response error code: [%d]\n", status);
-		status_line = S_500;
-	}
+	/* Checked early during Tempesta FW config parsing. */
+	BUG_ON(!status_line);
 
 	tfw_http_prep_date(date_val);
 	cl_len = tfw_ultoa(body_len, cl_val, RESP_BUF_LEN - SLEN(S_V_DATE));
@@ -1531,6 +1529,9 @@ tfw_http_req_redir(TfwHttpReq *req, int status, TfwHttpRedir *redir)
 	size_t status_line_len;
 	char *status_line = tfw_http_resp_status_line(status, &status_line_len);
 	size_t i = 0;
+
+	/* Checked early during Tempesta FW config parsing. */
+	BUG_ON(!status_line);
 
 	tfw_http_prep_date(date_val);
 

--- a/fw/http.h
+++ b/fw/http.h
@@ -762,5 +762,6 @@ int tfw_http_resp_copy_encodings(TfwHttpResp *resp, TfwStr* dst,
 				 size_t max_len);
 void tfw_http_extract_request_authority(TfwHttpReq *req);
 bool tfw_http_mark_is_in_whitlist(unsigned int mark);
+char *tfw_http_resp_status_line(int status, size_t *len);
 
 #endif /* __TFW_HTTP_H__ */

--- a/fw/http_sess_conf.c
+++ b/fw/http_sess_conf.c
@@ -640,13 +640,17 @@ tfw_cfgop_jsch_parse_resp_code(TfwCfgSpec *cs, TfwCfgJsCh *js_ch,
 			       const char *val)
 {
 	int r, int_val;
+	size_t len;
 
 	if ((r = tfw_cfg_parse_int(val, &int_val))) {
 		T_ERR_NL("%s: can't parse key 'resp_code'\n", cs->name);
 		return r;
 	}
-	if ((r = tfw_cfg_check_range(int_val, HTTP_CODE_MIN, HTTP_CODE_MAX)))
-		return r;
+	if (!tfw_http_resp_status_line(int_val, &len)) {
+		T_ERR_NL("%d is disallowed js challenge resp status code",
+			 int_val);
+		return -EINVAL;
+	}
 	js_ch->st_code = int_val;
 
 	return 0;


### PR DESCRIPTION
msg len calculation was totally wrong: we should adjust status line len instead of length of S_301, because we can use different status codes, also we should adjust S_F_SET_COOKIE length.