### PR TITLE
Fix cleaning not initialized http2 context.

### DIFF
--- a/fw/connection.h
+++ b/fw/connection.h
@@ -283,7 +283,17 @@ typedef struct {
 	TfwH2Ctx	h2;
 } TfwH2Conn;
 
-#define tfw_h2_context(conn)	((TfwH2Ctx *)(&((TfwH2Conn *)conn)->h2))
+/*
+ * Since we can accept both https and http2 connections on the same port,
+ * we initialize http2 context only after tls handshake is finished and
+ * we are sure that it is real http2 connection. There are two macros for
+ * accessing http2 context, when we are sure and not sure that tls handskare
+ * was finished.
+ */
+#define tfw_h2_context_unsafe(conn)	((TfwH2Ctx *)(&((TfwH2Conn *)conn)->h2))
+#define tfw_h2_context_safe(conn)	\
+	ttls_hs_done(tfw_tls_context(conn)) ? tfw_h2_context_unsafe(conn) : NULL;
+
 
 /* Callbacks used by l5-l7 protocols to operate on connection level. */
 typedef struct {

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -3558,7 +3558,7 @@ __tfw_hpack_encode(TfwHttpResp *__restrict resp, TfwStr *__restrict hdr,
 	TfwHPackInt idx;
 	bool st_full_index;
 	unsigned short st_index, index = 0;
-	TfwH2Ctx *ctx = tfw_h2_context(resp->req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context_unsafe(resp->req->conn);
 	TfwHPackETbl *tbl = &ctx->hpack.enc_tbl;
 	int r = HPACK_IDX_ST_NOT_FOUND;
 	bool name_indexed = true;

--- a/fw/http.c
+++ b/fw/http.c
@@ -1092,7 +1092,7 @@ void
 tfw_h2_resp_fwd(TfwHttpResp *resp)
 {
 	TfwHttpReq *req = resp->req;
-	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 
 	tfw_connection_get(req->conn);
 	do_access_log(resp);
@@ -1129,7 +1129,7 @@ static void
 tfw_h2_send_resp(TfwHttpReq *req, TfwStr *msg, int status,
 		 unsigned int stream_id)
 {
-	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 	TfwHttpResp *resp = tfw_http_msg_alloc_resp_light(req);
 	if (unlikely(!resp))
 		goto err;
@@ -2824,10 +2824,14 @@ tfw_http_conn_drop(TfwConn *conn)
 	T_DBG3("%s: conn=[%px]\n", __func__, conn);
 
 	if (TFW_CONN_TYPE(conn) & Conn_Clnt) {
-		if (h2_mode)
-			tfw_h2_conn_streams_cleanup(tfw_h2_context(conn));
-		else
+		if (h2_mode) {
+			TfwH2Ctx *ctx = tfw_h2_context_safe(conn);
+
+			if (ctx)
+				tfw_h2_conn_streams_cleanup(ctx);
+		} else {
 			tfw_http_conn_cli_drop((TfwCliConn *)conn);
+		}
 	}
 	else if (conn->stream.msg) { /* server connection */
 		if (!tfw_http_parse_terminate((TfwHttpMsg *)conn->stream.msg))
@@ -4992,7 +4996,7 @@ tfw_h2_error_resp(TfwHttpReq *req, int status, bool reply, ErrorType type,
 		  bool on_req_recv_event, TfwH2Err err_code)
 {
 	TfwStream *stream;
-	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 
 	/*
 	 * block_action attack/error drop - Tempesta FW must block message
@@ -5268,7 +5272,7 @@ tfw_h2_resp_adjust_fwd(TfwHttpResp *resp)
 	int r;
 	unsigned int stream_id;
 	TfwHttpReq *req = resp->req;
-	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 	TfwHttpTransIter *mit = &resp->mit;
 	TfwHttpRespCleanup cleanup = {};
 	TfwStr codings = {.data = *this_cpu_ptr(&g_te_buf), .len = 0};
@@ -5888,7 +5892,7 @@ next_msg:
 					HTTP2_ECODE_PROTO);
 		}
 		if (TFW_MSG_H2(req)) {
-			TfwH2Ctx *ctx = tfw_h2_context(conn);
+			TfwH2Ctx *ctx = tfw_h2_context_unsafe(conn);
 
 			/* Do not check the request validity until
 			 * it has been fully parsed.

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -10639,7 +10639,7 @@ tfw_h2_parse_body(char *data, unsigned int len, TfwHttpReq *req,
 		  unsigned int *parsed)
 {
 	unsigned int m_len;
-	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 	TfwHttpMsg *msg = (TfwHttpMsg *)req;
 	TfwHttpParser *parser = &msg->stream->parser;
 	int ret = T_POSTPONE;
@@ -10698,7 +10698,7 @@ tfw_h2_parse_req(void *req_data, unsigned char *data, unsigned int len,
 {
 	int r;
 	TfwHttpReq *req = (TfwHttpReq *)req_data;
-	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 
 	WARN_ON_ONCE(!len);
 	*parsed = 0;

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -767,7 +767,7 @@ int
 tfw_h2_stream_init_for_xmit(TfwHttpReq *req, unsigned long h_len,
 			    unsigned long b_len)
 {
-	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 	TfwStream *stream;
 
 	spin_lock(&ctx->lock);

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -427,4 +427,10 @@ frang_sticky_cookie_handler(TfwHttpReq *req)
 	return T_OK;
 }
 
+bool
+ttls_hs_done(TlsCtx *tls)
+{
+	return true;
+}
+
 unsigned int cache_default_ttl = 60;

--- a/fw/t/unit/test_http_parser_common.c
+++ b/fw/t/unit/test_http_parser_common.c
@@ -534,7 +534,7 @@ do_split_and_parse(int type, int chunk_mode)
 		}
 
 		if (type == FUZZ_REQ_H2) {
-			TfwH2Ctx *ctx = tfw_h2_context(req->conn);
+			TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 			ctx->hdr.type = frame->subtype;
 			ctx->plen = frame->len;
 		}


### PR DESCRIPTION
We initialize http2 context in `tfw_tls_over`, but
if this function was not called, because tls handshake
fails we clean uninitialized context, that can lead to
kernel BUG.