### PR TITLE
Fix cleaning not initialized http2 context.

### DIFF
--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -121,7 +121,7 @@ tfw_cli_conn_free(TfwCliConn *cli_conn)
 	 * Free POSTPONED SKBs. This is necessary when h2 context has
 	 * postponed frames and connection closing initiated.
 	 */
-	if (TFW_FSM_TYPE(TFW_FSM_TYPE(cli_conn->proto.type) == TFW_FSM_H2))
+	if (TFW_CONN_PROTO((TfwConn *)cli_conn) == TFW_FSM_H2)
 		ss_skb_queue_purge(&tfw_h2_context(cli_conn)->skb_head);
 
 	/* Check that all nested resources are freed. */


### PR DESCRIPTION
We initialize http2 context in `tfw_tls_over`, but if this function was not called, because tls handshake fails we clean uninitialized context, that can lead to kernel BUG. Move initialization of h2 context back to `tfw_tls_conn_init` and make it for h2 and negotiable connections.