### PR TITLE
Fix UBSAN warning

### DIFF
--- a/fw/main.c
+++ b/fw/main.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -346,13 +346,16 @@ tfw_ctlfn_state_io(struct ctl_table *ctl, int is_write,
 
 	if (is_write) {
 		char buf[T_SYSCTL_STBUF_LEN];
+		char start[T_SYSCTL_STBUF_LEN] = "start";
+		char stop[T_SYSCTL_STBUF_LEN] = "stop";
+
 		tmp.data = buf;
 		if ((r = proc_dostring(&tmp, is_write, user_buf, lenp, ppos)))
 			goto out;
 
 		r = tfw_ctlfn_state_change(buf);
 		strlcpy(new_state_buf,
-			tfw_runstate_is_started() ? "start" : "stop",
+			tfw_runstate_is_started() ? start : stop,
 			T_SYSCTL_STBUF_LEN);
 	} else {
 		tmp.data = new_state_buf;


### PR DESCRIPTION
If kernel was built with UBSAN support, during Tempesta unloading we got following warning:

```
UBSAN: object-size-mismatch in ./include/linux/string.h :320:29
load of address 00000000875726b7 with insufficient space
for an object of type 'const char'
CPU: 1 PID: 1488 Comm: sysctl Tainted: G           OE 5.10.35+ #82
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS Arch Linux 1.16.3-1-1 04/01/2014
Call Trace:
 dump_stack+0x72/0x8e
 ubsan_epilogue+0x9/0x43
 ubsan_type_mismatch_common.cold+0xc8/0xcd
 __ubsan_handle_type_mismatch_v1+0x42/0x50
 tfw_ctlfn_state_io+0x3d1/0x400 [tempesta_fw]
 ? tfw_cleanup+0x40/0x40 [tempesta_fw]
 proc_sys_call_handler+0x148/0x260
 proc_sys_write+0x13/0x20
 new_sync_write+0xcf/0x160
 vfs_write+0x1c3/0x270
 ksys_write+0x77/0xf0
 __x64_sys_write+0x19/0x20
 do_syscall_64+0x37/0x80
 entry_SYSCALL_64_after_hwframe+0x44/0xa9
```

This fix only statisfy UBSAN there is no error in code.