### PR TITLE
Fix finding place to insertion frame header

### DIFF
--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -205,7 +205,7 @@ tfw_sk_fill_write_queue(struct sock *sk, unsigned int mss_now, int ss_action)
 		return 0;
 	}
 
-	snd_wnd = tfw_tcp_calc_snd_wnd(sk, mss_now); //TRY ULONG MAX ALSO
+	snd_wnd = tfw_tcp_calc_snd_wnd(sk, mss_now);
 
 	r = tfw_h2_make_frames(sk, h2, snd_wnd, ss_action, &data_is_available);
 	if (unlikely(r < 0))

--- a/fw/ss_skb.h
+++ b/fw/ss_skb.h
@@ -421,7 +421,7 @@ ss_skb_data_ptr_by_offset(struct sk_buff *skb, unsigned int off)
 		end = begin + skb_frag_size(f);
 		d = end - begin;
 
-		if (off >= d) {
+		if (off > d) {
 			off -= d;
 			continue;
 		}


### PR DESCRIPTION
Fix `ss_skb_data_ptr_by_offset` function, return
pointer to data if offset is equal to skb->len.
Also free empty skbs before insertion frame header, not before pushing to socket write queue.