### PR TITLE
Fix x509 certificate parsing

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -7246,7 +7246,7 @@ __tfw_http_msg_body_dup(const char *filename, TfwStr *c_len, size_t *len,
 		tfw_str_to_cstr(c_len, res, t_sz);
 		b_start += c_len->len;
 	}
-	memcpy_fast(b_start, body, b_sz);
+	memcpy(b_start, body, b_sz);
 
 	*len = t_sz;
 	*body_offset = b_start - res;

--- a/fw/tls_conf.c
+++ b/fw/tls_conf.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2019-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -121,8 +121,8 @@ tfw_tls_add_cn(const ttls_x509_buf *sname, void *a_vhost)
 	TfwVhost *vhost = a_vhost;
 	const char *hname = vhost->name.data;
 	int hlen = vhost->name.len;
-	BasicStr cn = {.data = sname->p, .len = sname->len};
-
+	/* cn-pointed data isn't modified, so just a type compatibility. */
+	BasicStr cn = {.data = (char *)sname->p, .len = sname->len};
 
 	/*
 	 * Try wildcard match by RFC 2818 3.1:
@@ -153,7 +153,7 @@ tfw_tls_add_cn(const ttls_x509_buf *sname, void *a_vhost)
 		 * Add the chopped (w/o leading '*') wildcard to
 		 * the SNI mapping.
 		 */
-		cn.data = sname->p + 1;
+		cn.data = (char *)sname->p + 1;
 		cn.len = sname->len - 1;
 	}
 

--- a/fw/tls_conf.c
+++ b/fw/tls_conf.c
@@ -186,8 +186,6 @@ tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 	if (tfw_cfg_check_single_val(ce))
 		return -EINVAL;
 
-	ttls_x509_crt_init(&conf->crt);
-	/* Preserve 3 bytes for the certificate length. */
 	crt_data = tfw_cfg_read_file(ce->vals[0], &crt_size);
 	if (!crt_data) {
 		T_ERR_NL("%s: Can't read certificate file '%s'\n",
@@ -195,6 +193,7 @@ tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 		return -EINVAL;
 	}
 
+	ttls_x509_crt_init(&conf->crt);
 	r = ttls_x509_crt_parse(&conf->crt, crt_data, crt_size);
 	if (r) {
 		T_ERR_NL("%s: Invalid certificate specified, err=%x\n",

--- a/fw/tls_conf.c
+++ b/fw/tls_conf.c
@@ -197,7 +197,7 @@ tfw_tls_set_cert(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce)
 
 	r = ttls_x509_crt_parse(&conf->crt, crt_data, crt_size);
 	if (r) {
-		T_ERR_NL("%s: Invalid certificate specified (%x)\n",
+		T_ERR_NL("%s: Invalid certificate specified, err=%x\n",
 			 cs->name, -r);
 		goto err;
 	}

--- a/tls/asn1.h
+++ b/tls/asn1.h
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -102,8 +102,7 @@
 do {									\
 	if ((ret = f) < 0)						\
 		return ret;						\
-	else								\
-		g += ret;						\
+	g += ret;							\
 } while (0)
 
 /**
@@ -114,22 +113,20 @@ do {									\
  * @p		- ASN1 data, e.g. in ASCII.
  */
 typedef struct {
-	int		tag;
-	size_t		len;
-	unsigned char	*p;
+	int			tag;
+	size_t			len;
+	const unsigned char	*p;
 } ttls_asn1_buf;
 
 /**
  * Container for ASN1 bit strings.
  *
  * @len		- ASN1 length, in octets;
- * @unused_bits	- Number of unused bits at the end of the string;
  * @p		- Raw ASN1 data for the bit string.
  */
 typedef struct {
-	size_t		len;
-	unsigned char	unused_bits;
-	unsigned char	*p;
+	size_t			len;
+	const unsigned char	*p;
 } ttls_asn1_bitstring;
 
 /**
@@ -140,7 +137,7 @@ typedef struct {
  */
 typedef struct ttls_asn1_sequence
 {
-	ttls_asn1_buf	buf;
+	ttls_asn1_buf		buf;
 	struct ttls_asn1_sequence *next;
 } ttls_asn1_sequence;
 
@@ -160,21 +157,25 @@ typedef struct ttls_asn1_named_data
 	unsigned char	next_merged;
 } ttls_asn1_named_data;
 
-int ttls_asn1_get_len(unsigned char **p, const unsigned char *end, size_t *len);
-int ttls_asn1_get_tag(unsigned char **p, const unsigned char *end, size_t *len,
-		      int tag);
-int ttls_asn1_get_bool(unsigned char **p, const unsigned char *end, int *val);
-int ttls_asn1_get_int(unsigned char **p, const unsigned char *end, int *val);
-int ttls_asn1_get_mpi(unsigned char **p, const unsigned char *end, TlsMpi *X);
-int ttls_asn1_get_bitstring(unsigned char **p, const unsigned char *end,
+int ttls_asn1_get_len(const unsigned char **p, const unsigned char *end,
+		      size_t *len);
+int ttls_asn1_get_tag(const unsigned char **p, const unsigned char *end,
+		      size_t *len, int tag);
+int ttls_asn1_get_bool(const unsigned char **p, const unsigned char *end,
+		       int *val);
+int ttls_asn1_get_int(const unsigned char **p, const unsigned char *end,
+		      int *val);
+int ttls_asn1_get_mpi(const unsigned char **p, const unsigned char *end,
+		      TlsMpi *X);
+int ttls_asn1_get_bitstring(const unsigned char **p, const unsigned char *end,
 			    ttls_asn1_bitstring *bs);
-int ttls_asn1_get_bitstring_null(unsigned char **p, const unsigned char *end,
-				 size_t *len);
-int ttls_asn1_get_sequence_of(unsigned char **p, const unsigned char *end,
+int ttls_asn1_get_bitstring_null(const unsigned char **p,
+				 const unsigned char *end, size_t *len);
+int ttls_asn1_get_sequence_of(const unsigned char **p, const unsigned char *end,
 			      ttls_asn1_sequence *cur, int tag);
-int ttls_asn1_get_alg(unsigned char **p, const unsigned char *end,
+int ttls_asn1_get_alg(const unsigned char **p, const unsigned char *end,
 		      ttls_asn1_buf *alg, ttls_asn1_buf *params);
-int ttls_asn1_get_alg_null(unsigned char **p, const unsigned char *end,
+int ttls_asn1_get_alg_null(const unsigned char **p, const unsigned char *end,
 			   ttls_asn1_buf *alg);
 int ecdsa_signature_to_asn1(const TlsMpi *r, const TlsMpi *s,
 			    unsigned char *sig, size_t *slen);

--- a/tls/oid.h
+++ b/tls/oid.h
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2019 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,21 +40,27 @@
 /*
  * Top level OID tuples
  */
-#define TTLS_OID_ISO_MEMBER_BODIES		   "\x2a"		  /* {iso(1) member-body(2)} */
-#define TTLS_OID_ISO_IDENTIFIED_ORG		  "\x2b"		  /* {iso(1) identified-organization(3)} */
-#define TTLS_OID_ISO_CCITT_DS				"\x55"		  /* {joint-iso-ccitt(2) ds(5)} */
-#define TTLS_OID_ISO_ITU_COUNTRY			 "\x60"		  /* {joint-iso-itu-t(2) country(16)} */
+/* {iso(1) member-body(2)} */
+#define TTLS_OID_ISO_MEMBER_BODIES	"\x2a"
+/* {iso(1) identified-organization(3)} */
+#define TTLS_OID_ISO_IDENTIFIED_ORG	"\x2b"
+/* {joint-iso-ccitt(2) ds(5)} */
+#define TTLS_OID_ISO_CCITT_DS		"\x55"
+/* {joint-iso-itu-t(2) country(16)} */
+#define TTLS_OID_ISO_ITU_COUNTRY	"\x60"
 
 /*
  * ISO Member bodies OID parts
  */
-#define TTLS_OID_COUNTRY_US				  "\x86\x48"	  /* {us(840)} */
-#define TTLS_OID_ORG_RSA_DATA_SECURITY	   "\x86\xf7\x0d"  /* {rsadsi(113549)} */
-#define TTLS_OID_RSA_COMPANY				 TTLS_OID_ISO_MEMBER_BODIES TTLS_OID_COUNTRY_US \
-				TTLS_OID_ORG_RSA_DATA_SECURITY /* {iso(1) member-body(2) us(840) rsadsi(113549)} */
-#define TTLS_OID_ORG_ANSI_X9_62			  "\xce\x3d" /* ansi-X9-62(10045) */
-#define TTLS_OID_ANSI_X9_62				  TTLS_OID_ISO_MEMBER_BODIES TTLS_OID_COUNTRY_US \
-				TTLS_OID_ORG_ANSI_X9_62
+#define TTLS_OID_COUNTRY_US		"\x86\x48" /* {us(840)} */
+#define TTLS_OID_ORG_RSA_DATA_SECURITY	"\x86\xf7\x0d"  /* {rsadsi(113549)} */
+/* {iso(1) member-body(2) us(840) rsadsi(113549)} */
+#define TTLS_OID_RSA_COMPANY		TTLS_OID_ISO_MEMBER_BODIES	\
+					TTLS_OID_COUNTRY_US		\
+					TTLS_OID_ORG_RSA_DATA_SECURITY
+#define TTLS_OID_ORG_ANSI_X9_62		"\xce\x3d" /* ansi-X9-62(10045) */
+#define TTLS_OID_ANSI_X9_62		TTLS_OID_ISO_MEMBER_BODIES	\
+					TTLS_OID_COUNTRY_US TTLS_OID_ORG_ANSI_X9_62
 
 /*
  * ISO Identified organization OID parts
@@ -259,7 +265,7 @@
 
 /* secp256r1 OBJECT IDENTIFIER ::= {
  *   iso(1) member-body(2) us(840) ansi-X9-62(10045) curves(3) prime(1) 7 } */
-#define TTLS_OID_EC_GRP_SECP256R1		TTLS_OID_ANSI_X9_62 "\x03\x01\x07"
+#define TTLS_OID_EC_GRP_SECP256R1	TTLS_OID_ANSI_X9_62 "\x03\x01\x07"
 
 /*
  * SEC1 C.1
@@ -301,13 +307,18 @@
 #define TTLS_OID_ECDSA_SHA512			TTLS_OID_ANSI_X9_62_SIG_SHA2 "\x04"
 
 /**
- * \brief Base OID descriptor structure
+ * Base OID descriptor structure.
+ *
+ * @asn1	- OID ASN.1 representation;
+ * @asn1_len	- length of asn1;
+ * @name	- official name (e.g. from RFC);
+ * @description	- human friendly description.
  */
 typedef struct {
-	const char *asn1;			   /*!< OID ASN.1 representation	   */
-	size_t asn1_len;				/*!< length of asn1				 */
-	const char *name;			   /*!< official name (e.g. from RFC)  */
-	const char *description;		/*!< human friendly description	 */
+	const char		*asn1;
+	size_t			asn1_len;
+	const char		*name;
+	const char		*description;
 } ttls_oid_descriptor_t;
 
 /**

--- a/tls/pem.c
+++ b/tls/pem.c
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -126,6 +126,7 @@ ttls_base64_decode(unsigned char *dst, size_t dlen, size_t *olen,
 
 /**
  * @return length of decoded data or negative value on error.
+ * @use_len returns the effective length of unencoded data.
  */
 int
 ttls_pem_read_buffer(const char *header, const char *footer,

--- a/tls/pk.c
+++ b/tls/pk.c
@@ -10,7 +10,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -129,7 +129,7 @@ ecdsa_verify_wrap(void *ctx, ttls_md_type_t md_alg __attribute__((unused)),
 		  const unsigned char *sig, size_t sig_len)
 {
 	TlsEcpKeypair *eck = ctx;
-	unsigned char *p = (unsigned char *)sig;
+	const unsigned char *p = sig;
 	const unsigned char *end = sig + sig_len;
 	size_t len;
 	TlsMpi *r, *s;

--- a/tls/pk.h
+++ b/tls/pk.h
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -125,7 +125,7 @@ int ttls_pk_sign(TlsPkCtx *ctx, ttls_md_type_t md_alg,
 ttls_pk_type_t ttls_pk_get_type(const TlsPkCtx *ctx);
 
 int ttls_pk_parse_key(TlsPkCtx *ctx, unsigned char *key, size_t keylen);
-int ttls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
+int ttls_pk_parse_subpubkey(const unsigned char **p, const unsigned char *end,
 			    TlsPkCtx *pk);
 
 /**

--- a/tls/pkparse.c
+++ b/tls/pkparse.c
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,34 +41,31 @@
  *   -- implicitCurve   NULL
  * }
  */
-static int pk_get_ecparams(unsigned char **p, const unsigned char *end,
-				ttls_asn1_buf *params)
+static int
+pk_get_ecparams(const unsigned char **p, const unsigned char *end,
+		ttls_asn1_buf *params)
 {
 	int ret;
 
 	if (end - *p < 1)
-		return(TTLS_ERR_PK_KEY_INVALID_FORMAT +
-				TTLS_ERR_ASN1_OUT_OF_DATA);
+		return TTLS_ERR_PK_KEY_INVALID_FORMAT
+			+ TTLS_ERR_ASN1_OUT_OF_DATA;
 
 	/* Tag may be either OID or SEQUENCE */
 	params->tag = **p;
 	if (params->tag != TTLS_ASN1_OID)
-	{
-		return(TTLS_ERR_PK_KEY_INVALID_FORMAT +
-				TTLS_ERR_ASN1_UNEXPECTED_TAG);
-	}
+		return TTLS_ERR_PK_KEY_INVALID_FORMAT
+			+ TTLS_ERR_ASN1_UNEXPECTED_TAG;
 
-	if ((ret = ttls_asn1_get_tag(p, end, &params->len, params->tag)) != 0)
-	{
-		return(TTLS_ERR_PK_KEY_INVALID_FORMAT + ret);
-	}
+	if ((ret = ttls_asn1_get_tag(p, end, &params->len, params->tag)))
+		return TTLS_ERR_PK_KEY_INVALID_FORMAT + ret;
 
 	params->p = *p;
 	*p += params->len;
 
 	if (*p != end)
-		return(TTLS_ERR_PK_KEY_INVALID_FORMAT +
-				TTLS_ERR_ASN1_LENGTH_MISMATCH);
+		return TTLS_ERR_PK_KEY_INVALID_FORMAT
+			+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	return 0;
 }
@@ -118,15 +115,15 @@ pk_use_ecparams(const ttls_asn1_buf *params, const TlsEcpGrp **grp)
  * return code of ttls_ecp_point_read_binary() and leave p in a usable state.
  */
 static int
-pk_get_ecpubkey(unsigned char **p, const unsigned char *end, TlsEcpKeypair *key)
+pk_get_ecpubkey(const unsigned char **p, const unsigned char *end,
+		TlsEcpKeypair *key)
 {
 	int r;
 
-	r = ttls_ecp_point_read_binary(key->grp, &key->Q,
-				       (const unsigned char *)*p, end - *p);
+	r = ttls_ecp_point_read_binary(key->grp, &key->Q, *p, end - *p);
 	/* We know ttls_ecp_point_read_binary consumed all bytes or failed. */
 	if (!r)
-		*p = (unsigned char *)end;
+		*p = end;
 
 	return r;
 }
@@ -138,7 +135,7 @@ pk_get_ecpubkey(unsigned char **p, const unsigned char *end, TlsEcpKeypair *key)
  *  }
  */
 static int
-pk_get_rsapubkey(unsigned char **p, const unsigned char *end, TlsRSACtx *rsa)
+pk_get_rsapubkey(const unsigned char **p, const unsigned char *end, TlsRSACtx *rsa)
 {
 	int r;
 	size_t len;
@@ -180,36 +177,36 @@ pk_get_rsapubkey(unsigned char **p, const unsigned char *end, TlsRSACtx *rsa)
 	return 0;
 }
 
-/* Get a PK algorithm identifier
+/**
+ * Get a PK algorithm identifier
  *
- *  AlgorithmIdentifier  ::=  SEQUENCE  {
- *	   algorithm			   OBJECT IDENTIFIER,
- *	   parameters			  ANY DEFINED BY algorithm OPTIONAL  }
+ * AlgorithmIdentifier ::= SEQUENCE {
+ *	algorithm		OBJECT IDENTIFIER,
+ *	parameters		ANY DEFINED BY algorithm OPTIONAL
+ * }
  */
-static int pk_get_pk_alg(unsigned char **p,
-			  const unsigned char *end,
-			  ttls_pk_type_t *pk_alg, ttls_asn1_buf *params)
+static int
+pk_get_pk_alg(const unsigned char **p, const unsigned char *end,
+	      ttls_pk_type_t *pk_alg, ttls_asn1_buf *params)
 {
 	int ret;
 	ttls_asn1_buf alg_oid;
 
 	memset(params, 0, sizeof(ttls_asn1_buf));
 
-	if ((ret = ttls_asn1_get_alg(p, end, &alg_oid, params)) != 0)
-		return(TTLS_ERR_PK_INVALID_ALG + ret);
+	if ((ret = ttls_asn1_get_alg(p, end, &alg_oid, params)))
+		return TTLS_ERR_PK_INVALID_ALG + ret;
 
-	if (ttls_oid_get_pk_alg(&alg_oid, pk_alg) != 0)
+	if (ttls_oid_get_pk_alg(&alg_oid, pk_alg))
 		return(TTLS_ERR_PK_UNKNOWN_PK_ALG);
 
 	/*
 	 * No parameters with RSA (only for EC)
 	 */
 	if (*pk_alg == TTLS_PK_RSA &&
-			((params->tag != TTLS_ASN1_NULL && params->tag != 0) ||
-				params->len != 0))
-	{
-		return(TTLS_ERR_PK_INVALID_ALG);
-	}
+	    ((params->tag != TTLS_ASN1_NULL && params->tag != 0)
+	     || params->len != 0))
+		return TTLS_ERR_PK_INVALID_ALG;
 
 	return 0;
 }
@@ -223,7 +220,7 @@ static int pk_get_pk_alg(unsigned char **p,
  * }
  */
 int
-ttls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
+ttls_pk_parse_subpubkey(const unsigned char **p, const unsigned char *end,
 			TlsPkCtx *pk)
 {
 	int ret;
@@ -232,28 +229,27 @@ ttls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
 	ttls_pk_type_t pk_alg = TTLS_PK_NONE;
 	const TlsPkInfo *pk_info;
 
-	if ((ret = ttls_asn1_get_tag(p, end, &len,
-		TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE)) != 0)
-	{
-		return(TTLS_ERR_PK_KEY_INVALID_FORMAT + ret);
-	}
+	ret = ttls_asn1_get_tag(p, end, &len,
+				TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE);
+	if (ret)
+		return TTLS_ERR_PK_KEY_INVALID_FORMAT + ret;
 
 	end = *p + len;
 
-	if ((ret = pk_get_pk_alg(p, end, &pk_alg, &alg_params)) != 0)
+	if ((ret = pk_get_pk_alg(p, end, &pk_alg, &alg_params)))
 		return ret;
 
-	if ((ret = ttls_asn1_get_bitstring_null(p, end, &len)) != 0)
-		return(TTLS_ERR_PK_INVALID_PUBKEY + ret);
+	if ((ret = ttls_asn1_get_bitstring_null(p, end, &len)))
+		return TTLS_ERR_PK_INVALID_PUBKEY + ret;
 
 	if (*p + len != end)
-		return(TTLS_ERR_PK_INVALID_PUBKEY +
-				TTLS_ERR_ASN1_LENGTH_MISMATCH);
+		return TTLS_ERR_PK_INVALID_PUBKEY
+		       + TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
-	if ((pk_info = ttls_pk_info_from_type(pk_alg)) == NULL)
-		return(TTLS_ERR_PK_UNKNOWN_PK_ALG);
+	if (!(pk_info = ttls_pk_info_from_type(pk_alg)))
+		return TTLS_ERR_PK_UNKNOWN_PK_ALG;
 
-	if ((ret = ttls_pk_setup(pk, pk_info)) != 0)
+	if ((ret = ttls_pk_setup(pk, pk_info)))
 		return ret;
 
 	/*
@@ -274,8 +270,7 @@ ttls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
 	}
 
 	if (ret == 0 && *p != end)
-		ret = TTLS_ERR_PK_INVALID_PUBKEY
-			  TTLS_ERR_ASN1_LENGTH_MISMATCH;
+		ret = TTLS_ERR_PK_INVALID_PUBKEY + TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	return ret;
 }
@@ -288,10 +283,10 @@ __parse_key_pkcs1_der(TlsRSACtx *rsa, const unsigned char *key, size_t keylen)
 {
 	int r, version;
 	size_t len;
-	unsigned char *p, *end;
+	const unsigned char *p, *end;
 	TlsMpi *T;
 
-	p = (unsigned char *)key;
+	p = key;
 	end = p + keylen;
 
 	/*
@@ -422,9 +417,8 @@ pk_parse_key_sec1_der(TlsEcpKeypair *eck, const unsigned char *key,
 	int r, version, pubkey_done;
 	size_t len;
 	ttls_asn1_buf params;
-	unsigned char *p = (unsigned char *) key;
-	unsigned char *end = p + keylen;
-	unsigned char *end2;
+	const unsigned char *p = key;
+	const unsigned char *end = p + keylen, *end2;
 
 	/*
 	 * RFC 5915, or SEC1 Appendix C.4
@@ -515,14 +509,14 @@ pk_parse_key_sec1_der(TlsEcpKeypair *eck, const unsigned char *key,
  * The function is responsible for freeing the provided PK context on failure.
  */
 static int
-pk_parse_key_pkcs8_unencrypted_der(TlsPkCtx *pk,
-				   const unsigned char *key, size_t keylen)
+pk_parse_key_pkcs8_unencrypted_der(TlsPkCtx *pk, const unsigned char *key,
+				   size_t keylen)
 {
 	int ret, version;
 	size_t len;
 	ttls_asn1_buf params;
-	unsigned char *p = (unsigned char *)key;
-	unsigned char *end = p + keylen;
+	const unsigned char *p = key;
+	const unsigned char *end = p + keylen;
 	ttls_pk_type_t pk_alg = TTLS_PK_NONE;
 	const TlsPkInfo *pk_info;
 

--- a/tls/pkparse.c
+++ b/tls/pkparse.c
@@ -269,7 +269,7 @@ ttls_pk_parse_subpubkey(const unsigned char **p, const unsigned char *end,
 		ret = TTLS_ERR_PK_UNKNOWN_PK_ALG;
 	}
 
-	return 0;
+	return ret;
 }
 
 /**

--- a/tls/pkparse.c
+++ b/tls/pkparse.c
@@ -262,17 +262,14 @@ ttls_pk_parse_subpubkey(const unsigned char **p, const unsigned char *end,
 	}
 	else if (pk_alg == TTLS_PK_ECKEY_DH || pk_alg == TTLS_PK_ECKEY) {
 		ret = pk_use_ecparams(&alg_params, &ttls_pk_ec(*pk)->grp);
-		if (ret == 0)
+		if (!ret)
 			ret = pk_get_ecpubkey(p, end, ttls_pk_ec(*pk));
 	}
 	else {
 		ret = TTLS_ERR_PK_UNKNOWN_PK_ALG;
 	}
 
-	if (ret == 0 && *p != end)
-		ret = TTLS_ERR_PK_INVALID_PUBKEY + TTLS_ERR_ASN1_LENGTH_MISMATCH;
-
-	return ret;
+	return 0;
 }
 
 /**

--- a/tls/t/ttls_mocks.h
+++ b/tls/t/ttls_mocks.h
@@ -1,7 +1,7 @@
 /**
  *		Tempesta TLS mocks for the unit tests
  *
- * Copyright (C) 2018-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2018-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -22,6 +22,8 @@
 
 #define NR_CPUS 1
 #include "ktest.h"
+
+#define TLS_MAX_PAYLOAD_SIZE	((size_t)1 << 14)
 
 #include "ttls.h"
 

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -450,7 +450,8 @@ ttls_ticket_sess_true_size(TlsState *state)
 static inline size_t
 ttls_ticket_sess_exp_size(const TlsSess *sess)
 {
-	return sizeof(TlsState) + (sess->peer_cert ? sess->peer_cert->raw.len : 0);
+	return sizeof(TlsState)
+	       + (sess->peer_cert ? sess->peer_cert->raw.tot_len : 0);
 }
 
 /**
@@ -463,10 +464,10 @@ ttls_ticket_sess_save(const TlsSess *sess, TlsState *state, size_t buf_len)
 		return TTLS_ERR_BUFFER_TOO_SMALL;
 
 	memcpy_fast(&state->sess, sess, sizeof(TlsSess));
-	state->cert_len = sess->peer_cert ? sess->peer_cert->raw.len : 0;
+	state->cert_len = sess->peer_cert ? sess->peer_cert->raw.tot_len : 0;
 
 	if (sess->peer_cert)
-		memcpy_fast(state->cert_data, sess->peer_cert->raw.p,
+		memcpy_fast(state->cert_data, sess->peer_cert->raw.pages,
 			    state->cert_len);
 
 	return 0;
@@ -524,7 +525,7 @@ ttls_ticket_sess_load(TlsState *state, size_t len, unsigned long lifetime)
 	}
 	else {
 		TlsSess *sess = &state->sess;
-		struct page *pg;
+		unsigned long pg;
 		int r;
 
 		BUG(); /* TODO #830: client-side TLS tickets aren't tested. */
@@ -533,31 +534,22 @@ ttls_ticket_sess_load(TlsState *state, size_t len, unsigned long lifetime)
 		if (!sess->peer_cert)
 			return TTLS_ERR_ALLOC_FAILED;
 		/*
-		 * Same as in See ttls_parse_certificate(), we have to copy full
+		 * Same as in ttls_x509_crt_parse(), we have to copy full
 		 * certificate here, since some structures in TlsX509Crt may
 		 * address it.
 		 */
-		pg = alloc_pages(GFP_ATOMIC, get_order(state->cert_len));
+		sess->peer_cert->raw.order = get_order(state->cert_len + TTLS_CERT_LEN_LEN);
+		pg = __get_free_pages(GFP_KERNEL | __GFP_COMP, sess->peer_cert->raw.order);
 		if (!pg) {
 			ttls_x509_crt_destroy(&sess->peer_cert);
 			return TTLS_ERR_ALLOC_FAILED;
 		}
-		memcpy_fast(page_address(pg), state->cert_data, state->cert_len);
+		sess->peer_cert->raw.pages = (unsigned char *)pg;
+		sess->peer_cert->raw.tot_len = 0;
 
-		sess->peer_cert->raw.p = page_address(pg);
-		sess->peer_cert->raw.len = state->cert_len;
-
-		r = ttls_x509_crt_parse_der(sess->peer_cert, page_address(pg),
+		r = ttls_x509_crt_parse_der(sess->peer_cert, state->cert_data,
 					    state->cert_len);
 		if (r < 0) {
-			/*
-			 * TlsX509Crt grabs the memory under parsed certificate
-			 * and stores it in 'raw' member. ttls_x509_crt_destroy
-			 * can free it, but the parsing function may fail before
-			 * the pointer is grabbed.
-			 */
-			if (!sess->peer_cert->raw.p)
-				__free_pages(pg, get_order(state->cert_len));
 			ttls_x509_crt_destroy(&sess->peer_cert);
 			return r;
 		}

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -539,7 +539,7 @@ ttls_ticket_sess_load(TlsState *state, size_t len, unsigned long lifetime)
 		 * address it.
 		 */
 		sess->peer_cert->raw.order = get_order(state->cert_len + TTLS_CERT_LEN_LEN);
-		pg = __get_free_pages(GFP_KERNEL | __GFP_COMP, sess->peer_cert->raw.order);
+		pg = __get_free_pages(GFP_ATOMIC | __GFP_COMP, sess->peer_cert->raw.order);
 		if (!pg) {
 			ttls_x509_crt_destroy(&sess->peer_cert);
 			return TTLS_ERR_ALLOC_FAILED;

--- a/tls/x509.c
+++ b/tls/x509.c
@@ -15,7 +15,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,24 +46,25 @@
 /*
  *  CertificateSerialNumber  ::=  INTEGER
  */
-int ttls_x509_get_serial(unsigned char **p, const unsigned char *end,
-		 ttls_x509_buf *serial)
+int
+ttls_x509_get_serial(const unsigned char **p, const unsigned char *end,
+		     ttls_x509_buf *serial)
 {
 	int ret;
 
-	if ((end - *p) < 1)
-		return(TTLS_ERR_X509_INVALID_SERIAL +
-				TTLS_ERR_ASN1_OUT_OF_DATA);
+	if (end - *p < 1)
+		return TTLS_ERR_X509_INVALID_SERIAL
+			+ TTLS_ERR_ASN1_OUT_OF_DATA;
 
-	if (**p != (TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_PRIMITIVE | 2) &&
-		**p !=   TTLS_ASN1_INTEGER)
-		return(TTLS_ERR_X509_INVALID_SERIAL +
-				TTLS_ERR_ASN1_UNEXPECTED_TAG);
+	if (**p != (TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_PRIMITIVE | 2)
+	    && **p != TTLS_ASN1_INTEGER)
+		return TTLS_ERR_X509_INVALID_SERIAL
+			+ TTLS_ERR_ASN1_UNEXPECTED_TAG;
 
 	serial->tag = *(*p)++;
 
-	if ((ret = ttls_asn1_get_len(p, end, &serial->len)) != 0)
-		return(TTLS_ERR_X509_INVALID_SERIAL + ret);
+	if ((ret = ttls_asn1_get_len(p, end, &serial->len)))
+		return TTLS_ERR_X509_INVALID_SERIAL + ret;
 
 	serial->p = *p;
 	*p += serial->len;
@@ -77,13 +78,14 @@ int ttls_x509_get_serial(unsigned char **p, const unsigned char *end,
  *	   algorithm			   OBJECT IDENTIFIER,
  *	   parameters			  ANY DEFINED BY algorithm OPTIONAL  }
  */
-int ttls_x509_get_alg_null(unsigned char **p, const unsigned char *end,
-		   ttls_x509_buf *alg)
+static int
+ttls_x509_get_alg_null(const unsigned char **p, const unsigned char *end,
+		       ttls_x509_buf *alg)
 {
 	int ret;
 
-	if ((ret = ttls_asn1_get_alg_null(p, end, alg)) != 0)
-		return(TTLS_ERR_X509_INVALID_ALG + ret);
+	if ((ret = ttls_asn1_get_alg_null(p, end, alg)))
+		return TTLS_ERR_X509_INVALID_ALG + ret;
 
 	return 0;
 }
@@ -91,13 +93,14 @@ int ttls_x509_get_alg_null(unsigned char **p, const unsigned char *end,
 /*
  * Parse an algorithm identifier with (optional) parameters
  */
-int ttls_x509_get_alg(unsigned char **p, const unsigned char *end,
-				  ttls_x509_buf *alg, ttls_x509_buf *params)
+int
+ttls_x509_get_alg(const unsigned char **p, const unsigned char *end,
+		  ttls_x509_buf *alg, ttls_x509_buf *params)
 {
 	int ret;
 
-	if ((ret = ttls_asn1_get_alg(p, end, alg, params)) != 0)
-		return(TTLS_ERR_X509_INVALID_ALG + ret);
+	if ((ret = ttls_asn1_get_alg(p, end, alg, params)))
+		return TTLS_ERR_X509_INVALID_ALG + ret;
 
 	return 0;
 }
@@ -111,37 +114,37 @@ int ttls_x509_get_alg(unsigned char **p, const unsigned char *end,
  *
  * For HashAlgorithm, parameters MUST be NULL or absent.
  */
-static int x509_get_hash_alg(const ttls_x509_buf *alg, ttls_md_type_t *md_alg)
+static int
+x509_get_hash_alg(const ttls_x509_buf *alg, ttls_md_type_t *md_alg)
 {
 	int ret;
-	unsigned char *p;
-	const unsigned char *end;
+	const unsigned char *p, *end;
 	ttls_x509_buf md_oid;
 	size_t len;
 
 	/* Make sure we got a SEQUENCE and setup bounds */
 	if (alg->tag != (TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE))
-		return(TTLS_ERR_X509_INVALID_ALG +
-				TTLS_ERR_ASN1_UNEXPECTED_TAG);
+		return TTLS_ERR_X509_INVALID_ALG
+			+ TTLS_ERR_ASN1_UNEXPECTED_TAG;
 
 	p = (unsigned char *) alg->p;
 	end = p + alg->len;
 
 	if (p >= end)
-		return(TTLS_ERR_X509_INVALID_ALG +
-				TTLS_ERR_ASN1_OUT_OF_DATA);
+		return TTLS_ERR_X509_INVALID_ALG
+			+ TTLS_ERR_ASN1_OUT_OF_DATA;
 
 	/* Parse md_oid */
 	md_oid.tag = *p;
 
-	if ((ret = ttls_asn1_get_tag(&p, end, &md_oid.len, TTLS_ASN1_OID)) != 0)
-		return(TTLS_ERR_X509_INVALID_ALG + ret);
+	if ((ret = ttls_asn1_get_tag(&p, end, &md_oid.len, TTLS_ASN1_OID)))
+		return TTLS_ERR_X509_INVALID_ALG + ret;
 
 	md_oid.p = p;
 	p += md_oid.len;
 
 	/* Get md_alg from md_oid */
-	if ((ret = ttls_oid_get_md_alg(&md_oid, md_alg)) != 0) {
+	if ((ret = ttls_oid_get_md_alg(&md_oid, md_alg))) {
 		TTLS_WITH_OID_FMT(&md_oid, md_str,
 			T_WARN("X509 - Hash algorithm with OID %s is unsupported",
 			       md_str));
@@ -152,12 +155,12 @@ static int x509_get_hash_alg(const ttls_x509_buf *alg, ttls_md_type_t *md_alg)
 	if (p == end)
 		return 0;
 
-	if ((ret = ttls_asn1_get_tag(&p, end, &len, TTLS_ASN1_NULL)) != 0 || len != 0)
-		return(TTLS_ERR_X509_INVALID_ALG + ret);
+	if ((ret = ttls_asn1_get_tag(&p, end, &len, TTLS_ASN1_NULL)) || len)
+		return TTLS_ERR_X509_INVALID_ALG + ret;
 
 	if (p != end)
-		return(TTLS_ERR_X509_INVALID_ALG +
-				TTLS_ERR_ASN1_LENGTH_MISMATCH);
+		return TTLS_ERR_X509_INVALID_ALG
+			+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	return 0;
 }
@@ -174,13 +177,13 @@ static int x509_get_hash_alg(const ttls_x509_buf *alg, ttls_md_type_t *md_alg)
  * of trailerField MUST be 1, and PKCS#1 v2.2 doesn't even define any other
  * option. Enfore this at parsing time.
  */
-int ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
-		ttls_md_type_t *md_alg, ttls_md_type_t *mgf_md,
-		int *salt_len)
+static int
+ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
+				ttls_md_type_t *md_alg, ttls_md_type_t *mgf_md,
+				int *salt_len)
 {
 	int ret;
-	unsigned char *p;
-	const unsigned char *end, *end2;
+	const unsigned char *p, *end, *end2;
 	size_t len;
 	ttls_x509_buf alg_id, alg_params;
 
@@ -191,10 +194,10 @@ int ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
 
 	/* Make sure params is a SEQUENCE and setup bounds */
 	if (params->tag != (TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE))
-		return(TTLS_ERR_X509_INVALID_ALG +
-				TTLS_ERR_ASN1_UNEXPECTED_TAG);
+		return TTLS_ERR_X509_INVALID_ALG
+			+ TTLS_ERR_ASN1_UNEXPECTED_TAG;
 
-	p = (unsigned char *) params->p;
+	p = params->p;
 	end = p + params->len;
 
 	if (p == end)
@@ -203,24 +206,24 @@ int ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
 	/*
 	 * HashAlgorithm
 	 */
-	if ((ret = ttls_asn1_get_tag(&p, end, &len,
-		TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED | 0)) == 0)
-	{
+	ret = ttls_asn1_get_tag(&p, end, &len,
+				TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED);
+	if (!ret) {
 		end2 = p + len;
 
 		/* HashAlgorithm ::= AlgorithmIdentifier (without parameters) */
-		if ((ret = ttls_x509_get_alg_null(&p, end2, &alg_id)) != 0)
+		if ((ret = ttls_x509_get_alg_null(&p, end2, &alg_id)))
 			return ret;
 
-		if ((ret = ttls_oid_get_md_alg(&alg_id, md_alg)) != 0)
+		if ((ret = ttls_oid_get_md_alg(&alg_id, md_alg)))
 			return TTLS_ERR_X509_INVALID_ALG;
 
 		if (p != end2)
-			return(TTLS_ERR_X509_INVALID_ALG +
-		TTLS_ERR_ASN1_LENGTH_MISMATCH);
+			return TTLS_ERR_X509_INVALID_ALG
+				+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 	}
 	else if (ret != TTLS_ERR_ASN1_UNEXPECTED_TAG)
-		return(TTLS_ERR_X509_INVALID_ALG + ret);
+		return TTLS_ERR_X509_INVALID_ALG + ret;
 
 	if (p == end)
 		return 0;
@@ -228,50 +231,50 @@ int ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
 	/*
 	 * MaskGenAlgorithm
 	 */
-	if ((ret = ttls_asn1_get_tag(&p, end, &len,
-		TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED | 1)) == 0)
-	{
+	ret = ttls_asn1_get_tag(&p, end, &len,
+				TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED
+				| 1);
+	if (!ret) {
 		end2 = p + len;
 
 		/* MaskGenAlgorithm ::= AlgorithmIdentifier (params = HashAlgorithm) */
-		if ((ret = ttls_x509_get_alg(&p, end2, &alg_id, &alg_params)) != 0)
+		if ((ret = ttls_x509_get_alg(&p, end2, &alg_id, &alg_params)))
 			return ret;
 
 		/* Only MFG1 is recognised for now */
-		if (TTLS_OID_CMP(TTLS_OID_MGF1, &alg_id) != 0)
+		if (TTLS_OID_CMP(TTLS_OID_MGF1, &alg_id))
 			return TTLS_ERR_X509_FEATURE_UNAVAILABLE;
 
 		/* Parse HashAlgorithm */
-		if ((ret = x509_get_hash_alg(&alg_params, mgf_md)) != 0)
+		if ((ret = x509_get_hash_alg(&alg_params, mgf_md)))
 			return ret;
 
 		if (p != end2)
-			return(TTLS_ERR_X509_INVALID_ALG +
-		TTLS_ERR_ASN1_LENGTH_MISMATCH);
+			return TTLS_ERR_X509_INVALID_ALG
+				+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 	}
 	else if (ret != TTLS_ERR_ASN1_UNEXPECTED_TAG)
-		return(TTLS_ERR_X509_INVALID_ALG + ret);
+		return TTLS_ERR_X509_INVALID_ALG + ret;
 
 	if (p == end)
 		return 0;
 
-	/*
-	 * salt_len
-	 */
-	if ((ret = ttls_asn1_get_tag(&p, end, &len,
-		TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED | 2)) == 0)
-	{
+	/* salt_len */
+	ret = ttls_asn1_get_tag(&p, end, &len,
+				TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED
+				| 2);
+	if (!ret) {
 		end2 = p + len;
 
-		if ((ret = ttls_asn1_get_int(&p, end2, salt_len)) != 0)
-			return(TTLS_ERR_X509_INVALID_ALG + ret);
+		if ((ret = ttls_asn1_get_int(&p, end2, salt_len)))
+			return TTLS_ERR_X509_INVALID_ALG + ret;
 
 		if (p != end2)
-			return(TTLS_ERR_X509_INVALID_ALG +
-		TTLS_ERR_ASN1_LENGTH_MISMATCH);
+			return TTLS_ERR_X509_INVALID_ALG
+				+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 	}
 	else if (ret != TTLS_ERR_ASN1_UNEXPECTED_TAG)
-		return(TTLS_ERR_X509_INVALID_ALG + ret);
+		return TTLS_ERR_X509_INVALID_ALG + ret;
 
 	if (p == end)
 		return 0;
@@ -279,29 +282,31 @@ int ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
 	/*
 	 * trailer_field (if present, must be 1)
 	 */
-	if ((ret = ttls_asn1_get_tag(&p, end, &len,
-		TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED | 3)) == 0)
-	{
+	ret = ttls_asn1_get_tag(&p, end, &len,
+				TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED
+				| 3);
+	if (!ret) {
 		int trailer_field;
 
 		end2 = p + len;
 
-		if ((ret = ttls_asn1_get_int(&p, end2, &trailer_field)) != 0)
-			return(TTLS_ERR_X509_INVALID_ALG + ret);
+		if ((ret = ttls_asn1_get_int(&p, end2, &trailer_field)))
+			return TTLS_ERR_X509_INVALID_ALG + ret;
 
 		if (p != end2)
-			return(TTLS_ERR_X509_INVALID_ALG +
-		TTLS_ERR_ASN1_LENGTH_MISMATCH);
+			return TTLS_ERR_X509_INVALID_ALG
+				+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 		if (trailer_field != 1)
-			return(TTLS_ERR_X509_INVALID_ALG);
+			return TTLS_ERR_X509_INVALID_ALG;
 	}
-	else if (ret != TTLS_ERR_ASN1_UNEXPECTED_TAG)
-		return(TTLS_ERR_X509_INVALID_ALG + ret);
+	else if (ret != TTLS_ERR_ASN1_UNEXPECTED_TAG) {
+		return TTLS_ERR_X509_INVALID_ALG + ret;
+	}
 
 	if (p != end)
-		return(TTLS_ERR_X509_INVALID_ALG +
-				TTLS_ERR_ASN1_LENGTH_MISMATCH);
+		return TTLS_ERR_X509_INVALID_ALG
+			+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	return 0;
 }
@@ -315,8 +320,8 @@ int ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
  *
  *  AttributeValue ::= ANY DEFINED BY AttributeType
  */
-static int x509_get_attr_type_value(unsigned char **p,
-			 const unsigned char *end,
+static int
+x509_get_attr_type_value(const unsigned char **p, const unsigned char *end,
 			 ttls_x509_name *cur)
 {
 	int ret;
@@ -324,39 +329,40 @@ static int x509_get_attr_type_value(unsigned char **p,
 	ttls_x509_buf *oid;
 	ttls_x509_buf *val;
 
-	if ((ret = ttls_asn1_get_tag(p, end, &len,
-			TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE)) != 0)
-		return(TTLS_ERR_X509_INVALID_NAME + ret);
+	ret = ttls_asn1_get_tag(p, end, &len,
+				TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE);
+	if (ret)
+		return TTLS_ERR_X509_INVALID_NAME + ret;
 
-	if ((end - *p) < 1)
-		return(TTLS_ERR_X509_INVALID_NAME +
-				TTLS_ERR_ASN1_OUT_OF_DATA);
+	if (end - *p < 1)
+		return TTLS_ERR_X509_INVALID_NAME
+			+ TTLS_ERR_ASN1_OUT_OF_DATA;
 
 	oid = &cur->oid;
 	oid->tag = **p;
 
-	if ((ret = ttls_asn1_get_tag(p, end, &oid->len, TTLS_ASN1_OID)) != 0)
-		return(TTLS_ERR_X509_INVALID_NAME + ret);
+	if ((ret = ttls_asn1_get_tag(p, end, &oid->len, TTLS_ASN1_OID)))
+		return TTLS_ERR_X509_INVALID_NAME + ret;
 
 	oid->p = *p;
 	*p += oid->len;
 
-	if ((end - *p) < 1)
-		return(TTLS_ERR_X509_INVALID_NAME +
-				TTLS_ERR_ASN1_OUT_OF_DATA);
+	if (end - *p < 1)
+		return TTLS_ERR_X509_INVALID_NAME
+			+ TTLS_ERR_ASN1_OUT_OF_DATA;
 
-	if (**p != TTLS_ASN1_BMP_STRING && **p != TTLS_ASN1_UTF8_STRING	  &&
-		**p != TTLS_ASN1_T61_STRING && **p != TTLS_ASN1_PRINTABLE_STRING &&
-		**p != TTLS_ASN1_IA5_STRING && **p != TTLS_ASN1_UNIVERSAL_STRING &&
-		**p != TTLS_ASN1_BIT_STRING)
-		return(TTLS_ERR_X509_INVALID_NAME +
-				TTLS_ERR_ASN1_UNEXPECTED_TAG);
+	if (**p != TTLS_ASN1_BMP_STRING && **p != TTLS_ASN1_UTF8_STRING
+	    && **p != TTLS_ASN1_T61_STRING && **p != TTLS_ASN1_PRINTABLE_STRING
+	    && **p != TTLS_ASN1_IA5_STRING && **p != TTLS_ASN1_UNIVERSAL_STRING
+	    && **p != TTLS_ASN1_BIT_STRING)
+		return TTLS_ERR_X509_INVALID_NAME
+			+ TTLS_ERR_ASN1_UNEXPECTED_TAG;
 
 	val = &cur->val;
 	val->tag = *(*p)++;
 
-	if ((ret = ttls_asn1_get_len(p, end, &val->len)) != 0)
-		return(TTLS_ERR_X509_INVALID_NAME + ret);
+	if ((ret = ttls_asn1_get_len(p, end, &val->len)))
+		return TTLS_ERR_X509_INVALID_NAME + ret;
 
 	val->p = *p;
 	*p += val->len;
@@ -389,28 +395,28 @@ static int x509_get_attr_type_value(unsigned char **p,
  * same set so that they are "merged" together in the functions that consume
  * this list.
  */
-int ttls_x509_get_name(unsigned char **p, const unsigned char *end,
-				   ttls_x509_name *cur)
+int
+ttls_x509_get_name(const unsigned char **p, const unsigned char *end,
+		   ttls_x509_name *cur)
 {
 	int ret;
 	size_t set_len;
 	const unsigned char *end_set;
 
 	/* don't use recursion, we'd risk stack overflow if not optimized */
-	while (1)
-	{
+	while (1) {
 		/*
 		 * parse SET
 		 */
-		if ((ret = ttls_asn1_get_tag(p, end, &set_len,
-				TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SET)) != 0)
-			return(TTLS_ERR_X509_INVALID_NAME + ret);
+		ret = ttls_asn1_get_tag(p, end, &set_len,
+					TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SET);
+		if (ret)
+			return TTLS_ERR_X509_INVALID_NAME + ret;
 
 		end_set  = *p + set_len;
 
-		while (1)
-		{
-			if ((ret = x509_get_attr_type_value(p, end_set, cur)) != 0)
+		while (1) {
+			if ((ret = x509_get_attr_type_value(p, end_set, cur)))
 				return ret;
 
 			if (*p == end_set)
@@ -420,9 +426,8 @@ int ttls_x509_get_name(unsigned char **p, const unsigned char *end,
 			cur->next_merged = 1;
 
 			cur->next = kzalloc(sizeof(ttls_x509_name), GFP_KERNEL);
-
-			if (cur->next == NULL)
-				return(TTLS_ERR_X509_ALLOC_FAILED);
+			if (!cur->next)
+				return TTLS_ERR_X509_ALLOC_FAILED;
 
 			cur = cur->next;
 		}
@@ -434,25 +439,24 @@ int ttls_x509_get_name(unsigned char **p, const unsigned char *end,
 			return 0;
 
 		cur->next = kzalloc(sizeof(ttls_x509_name), GFP_KERNEL);
-
-		if (cur->next == NULL)
-			return(TTLS_ERR_X509_ALLOC_FAILED);
+		if (!cur->next)
+			return TTLS_ERR_X509_ALLOC_FAILED;
 
 		cur = cur->next;
 	}
 }
 
-static int x509_parse_int(unsigned char **p, size_t n, int *res)
+static int
+x509_parse_int(const unsigned char **p, size_t n, int *res)
 {
 	*res = 0;
 
-	for (; n > 0; --n)
-	{
-		if ((**p < '0') || (**p > '9'))
-			return (TTLS_ERR_X509_INVALID_DATE);
+	for ( ; n > 0; --n) {
+		if (**p < '0' || **p > '9')
+			return TTLS_ERR_X509_INVALID_DATE;
 
 		*res *= 10;
-		*res += (*(*p)++ - '0');
+		*res += *(*p)++ - '0';
 	}
 
 	return 0;
@@ -495,8 +499,9 @@ static int x509_date_is_valid(const ttls_x509_time *t)
  * Parse an ASN1_UTC_TIME (yearlen=2) or ASN1_GENERALIZED_TIME (yearlen=4)
  * field.
  */
-static int x509_parse_time(unsigned char **p, size_t len, size_t yearlen,
-				ttls_x509_time *tm)
+static int
+x509_parse_time(const unsigned char **p, size_t len, size_t yearlen,
+		ttls_x509_time *tm)
 {
 	int ret;
 
@@ -560,16 +565,17 @@ static int x509_parse_time(unsigned char **p, size_t len, size_t yearlen,
  *	   utcTime		UTCTime,
  *	   generalTime	GeneralizedTime }
  */
-int ttls_x509_get_time(unsigned char **p, const unsigned char *end,
-			   ttls_x509_time *tm)
+int
+ttls_x509_get_time(const unsigned char **p, const unsigned char *end,
+		   ttls_x509_time *tm)
 {
 	int ret;
 	size_t len, year_len;
 	unsigned char tag;
 
-	if ((end - *p) < 1)
-		return(TTLS_ERR_X509_INVALID_DATE +
-				TTLS_ERR_ASN1_OUT_OF_DATA);
+	if (end - *p < 1)
+		return TTLS_ERR_X509_INVALID_DATE
+			+ TTLS_ERR_ASN1_OUT_OF_DATA;
 
 	tag = **p;
 
@@ -578,32 +584,33 @@ int ttls_x509_get_time(unsigned char **p, const unsigned char *end,
 	else if (tag == TTLS_ASN1_GENERALIZED_TIME)
 		year_len = 4;
 	else
-		return(TTLS_ERR_X509_INVALID_DATE +
-				TTLS_ERR_ASN1_UNEXPECTED_TAG);
+		return TTLS_ERR_X509_INVALID_DATE
+			+ TTLS_ERR_ASN1_UNEXPECTED_TAG;
 
 	(*p)++;
 	ret = ttls_asn1_get_len(p, end, &len);
-
-	if (ret != 0)
-		return(TTLS_ERR_X509_INVALID_DATE + ret);
+	if (ret)
+		return TTLS_ERR_X509_INVALID_DATE + ret;
 
 	return x509_parse_time(p, len, year_len, tm);
 }
 
-int ttls_x509_get_sig(unsigned char **p, const unsigned char *end, ttls_x509_buf *sig)
+int
+ttls_x509_get_sig(const unsigned char **p, const unsigned char *end,
+		  ttls_x509_buf *sig)
 {
 	int ret;
 	size_t len;
 	int tag_type;
 
-	if ((end - *p) < 1)
-		return(TTLS_ERR_X509_INVALID_SIGNATURE +
-				TTLS_ERR_ASN1_OUT_OF_DATA);
+	if (end - *p < 1)
+		return TTLS_ERR_X509_INVALID_SIGNATURE
+			+ TTLS_ERR_ASN1_OUT_OF_DATA;
 
 	tag_type = **p;
 
-	if ((ret = ttls_asn1_get_bitstring_null(p, end, &len)) != 0)
-		return(TTLS_ERR_X509_INVALID_SIGNATURE + ret);
+	if ((ret = ttls_asn1_get_bitstring_null(p, end, &len)))
+		return TTLS_ERR_X509_INVALID_SIGNATURE + ret;
 
 	sig->tag = tag_type;
 	sig->len = len;
@@ -664,12 +671,13 @@ int ttls_x509_get_sig_alg(const ttls_x509_buf *sig_oid, const ttls_x509_buf *sig
 	return 0;
 }
 
-/*
+/**
  * X.509 Extensions (No parsing of extensions, pointer should
  * be either manually updated or extensions should be parsed!)
  */
-int ttls_x509_get_ext(unsigned char **p, const unsigned char *end,
-				  ttls_x509_buf *ext, int tag)
+int
+ttls_x509_get_ext(const unsigned char **p, const unsigned char *end,
+		  ttls_x509_buf *ext, int tag)
 {
 	int ret;
 	size_t len;
@@ -679,8 +687,9 @@ int ttls_x509_get_ext(unsigned char **p, const unsigned char *end,
 
 	ext->tag = **p;
 
-	if ((ret = ttls_asn1_get_tag(p, end, &ext->len,
-			TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED | tag)) != 0)
+	ret = ttls_asn1_get_tag(p, end, &ext->len,
+				TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED | tag);
+	if (ret)
 		return ret;
 
 	ext->p = *p;
@@ -694,13 +703,14 @@ int ttls_x509_get_ext(unsigned char **p, const unsigned char *end,
 	 *	  critical	BOOLEAN DEFAULT FALSE,
 	 *	  extnValue   OCTET STRING  }
 	 */
-	if ((ret = ttls_asn1_get_tag(p, end, &len,
-			TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE)) != 0)
-		return(TTLS_ERR_X509_INVALID_EXTENSIONS + ret);
+	ret = ttls_asn1_get_tag(p, end, &len,
+				TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE);
+	if (ret)
+		return TTLS_ERR_X509_INVALID_EXTENSIONS + ret;
 
 	if (end != *p + len)
-		return(TTLS_ERR_X509_INVALID_EXTENSIONS +
-				TTLS_ERR_ASN1_LENGTH_MISMATCH);
+		return TTLS_ERR_X509_INVALID_EXTENSIONS
+			+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	return 0;
 }

--- a/tls/x509.h
+++ b/tls/x509.h
@@ -4,7 +4,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -225,24 +225,21 @@ int ttls_x509_time_is_future(const ttls_x509_time *from);
  * Internal module functions. You probably do not want to use these unless you
  * know you do.
  */
-int ttls_x509_get_name(unsigned char **p, const unsigned char *end,
+int ttls_x509_get_name(const unsigned char **p, const unsigned char *end,
 		       ttls_x509_name *cur);
-int ttls_x509_get_alg_null(unsigned char **p, const unsigned char *end,
-			   ttls_x509_buf *alg);
-int ttls_x509_get_alg(unsigned char **p, const unsigned char *end,
+int ttls_x509_get_alg(const unsigned char **p, const unsigned char *end,
 		      ttls_x509_buf *alg, ttls_x509_buf *params);
-int ttls_x509_get_rsassa_pss_params(const ttls_x509_buf *params,
-				    ttls_md_type_t *md_alg, ttls_md_type_t *mgf_md,
-				    int *salt_len);
-int ttls_x509_get_sig(unsigned char **p, const unsigned char *end, ttls_x509_buf *sig);
-int ttls_x509_get_sig_alg(const ttls_x509_buf *sig_oid, const ttls_x509_buf *sig_params,
+int ttls_x509_get_sig(const unsigned char **p, const unsigned char *end,
+		      ttls_x509_buf *sig);
+int ttls_x509_get_sig_alg(const ttls_x509_buf *sig_oid,
+			  const ttls_x509_buf *sig_params,
 			  ttls_md_type_t *md_alg, ttls_pk_type_t *pk_alg,
 			  void **sig_opts);
-int ttls_x509_get_time(unsigned char **p, const unsigned char *end,
+int ttls_x509_get_time(const unsigned char **p, const unsigned char *end,
 		       ttls_x509_time *t);
-int ttls_x509_get_serial(unsigned char **p, const unsigned char *end,
+int ttls_x509_get_serial(const unsigned char **p, const unsigned char *end,
 			 ttls_x509_buf *serial);
-int ttls_x509_get_ext(unsigned char **p, const unsigned char *end,
+int ttls_x509_get_ext(const unsigned char **p, const unsigned char *end,
 		      ttls_x509_buf *ext, int tag);
 int ttls_x509_write_sig(unsigned char **p, unsigned char *start,
 			const char *oid, size_t oid_len,

--- a/tls/x509_crt.c
+++ b/tls/x509_crt.c
@@ -15,7 +15,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -96,8 +96,7 @@ ttls_x509_crt_profile;
  * Default security profile. Should provide a good balance between security
  * and compatibility with current deployments.
  */
-const ttls_x509_crt_profile ttls_x509_crt_profile_default =
-{
+const ttls_x509_crt_profile ttls_x509_crt_profile_default = {
 	/* Only SHA-2 hashes */
 	TTLS_X509_ID_FLAG(TTLS_MD_SHA256) |
 	TTLS_X509_ID_FLAG(TTLS_MD_SHA384) |
@@ -210,13 +209,14 @@ x509_profile_check_key(const ttls_x509_crt_profile *profile,
  *  Version  ::=  INTEGER  {  v1(0), v2(1), v3(2)  }
  */
 static int
-x509_get_version(unsigned char **p, const unsigned char *end, int *ver)
+x509_get_version(const unsigned char **p, const unsigned char *end, int *ver)
 {
 	int ret;
 	size_t len;
 
 	ret = ttls_asn1_get_tag(p, end, &len,
-				TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED);
+				TTLS_ASN1_CONTEXT_SPECIFIC
+				| TTLS_ASN1_CONSTRUCTED);
 	if (unlikely(ret)) {
 		if (ret == TTLS_ERR_ASN1_UNEXPECTED_TAG) {
 			*ver = 0;
@@ -231,8 +231,8 @@ x509_get_version(unsigned char **p, const unsigned char *end, int *ver)
 		return TTLS_ERR_X509_INVALID_VERSION + ret;
 
 	if (*p != end)
-		return TTLS_ERR_X509_INVALID_VERSION +
-			TTLS_ERR_ASN1_LENGTH_MISMATCH;
+		return TTLS_ERR_X509_INVALID_VERSION
+			+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	return 0;
 }
@@ -243,7 +243,7 @@ x509_get_version(unsigned char **p, const unsigned char *end, int *ver)
  *	   notAfter	   Time }
  */
 static int
-x509_get_dates(unsigned char **p, const unsigned char *end,
+x509_get_dates(const unsigned char **p, const unsigned char *end,
 	       ttls_x509_time *from, ttls_x509_time *to)
 {
 	int ret;
@@ -261,8 +261,8 @@ x509_get_dates(unsigned char **p, const unsigned char *end,
 	if ((ret = ttls_x509_get_time(p, end, to)))
 		return ret;
 	if (*p != end)
-		return TTLS_ERR_X509_INVALID_DATE +
-			TTLS_ERR_ASN1_LENGTH_MISMATCH;
+		return TTLS_ERR_X509_INVALID_DATE
+			+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	return 0;
 }
@@ -271,8 +271,8 @@ x509_get_dates(unsigned char **p, const unsigned char *end,
  * X.509 v2/v3 unique identifier (not parsed)
  */
 static int
-x509_get_uid(unsigned char **p, const unsigned char *end, ttls_x509_buf *uid,
-	     int n)
+x509_get_uid(const unsigned char **p, const unsigned char *end,
+	     ttls_x509_buf *uid, int n)
 {
 	int ret;
 
@@ -282,7 +282,8 @@ x509_get_uid(unsigned char **p, const unsigned char *end, ttls_x509_buf *uid,
 	uid->tag = **p;
 
 	ret = ttls_asn1_get_tag(p, end, &uid->len,
-				TTLS_ASN1_CONTEXT_SPECIFIC | TTLS_ASN1_CONSTRUCTED | n);
+				TTLS_ASN1_CONTEXT_SPECIFIC
+				| TTLS_ASN1_CONSTRUCTED | n);
 	if (unlikely(ret)) {
 		if (ret == TTLS_ERR_ASN1_UNEXPECTED_TAG)
 			return 0;
@@ -296,7 +297,7 @@ x509_get_uid(unsigned char **p, const unsigned char *end, ttls_x509_buf *uid,
 }
 
 static int
-x509_get_basic_constraints(unsigned char **p, const unsigned char *end,
+x509_get_basic_constraints(const unsigned char **p, const unsigned char *end,
 			   int *ca_istrue, int *max_pathlen)
 {
 	int ret;
@@ -345,11 +346,11 @@ x509_get_basic_constraints(unsigned char **p, const unsigned char *end,
 }
 
 static int
-x509_get_ns_cert_type(unsigned char **p, const unsigned char *end,
+x509_get_ns_cert_type(const unsigned char **p, const unsigned char *end,
 		      unsigned char *ns_cert_type)
 {
 	int ret;
-	ttls_x509_bitstring bs = { 0, 0, NULL };
+	ttls_x509_bitstring bs = {};
 
 	if ((ret = ttls_asn1_get_bitstring(p, end, &bs)))
 		return TTLS_ERR_X509_INVALID_EXTENSIONS + ret;
@@ -364,12 +365,12 @@ x509_get_ns_cert_type(unsigned char **p, const unsigned char *end,
 }
 
 static int
-x509_get_key_usage(unsigned char **p, const unsigned char *end,
+x509_get_key_usage(const unsigned char **p, const unsigned char *end,
 		   unsigned int *key_usage)
 {
 	int ret;
 	size_t i;
-	ttls_x509_bitstring bs = { 0, 0, NULL };
+	ttls_x509_bitstring bs = {};
 
 	if ((ret = ttls_asn1_get_bitstring(p, end, &bs)))
 		return TTLS_ERR_X509_INVALID_EXTENSIONS + ret;
@@ -380,9 +381,8 @@ x509_get_key_usage(unsigned char **p, const unsigned char *end,
 
 	/* Get actual bitstring */
 	*key_usage = 0;
-	for (i = 0; i < bs.len && i < sizeof(unsigned int); i++) {
+	for (i = 0; i < bs.len && i < sizeof(unsigned int); i++)
 		*key_usage |= (unsigned int) bs.p[i] << (8*i);
-	}
 
 	return 0;
 }
@@ -393,7 +393,7 @@ x509_get_key_usage(unsigned char **p, const unsigned char *end,
  * KeyPurposeId ::= OBJECT IDENTIFIER
  */
 static int
-x509_get_ext_key_usage(unsigned char **p, const unsigned char *end,
+x509_get_ext_key_usage(const unsigned char **p, const unsigned char *end,
 		       ttls_x509_sequence *ext_key_usage)
 {
 	int ret = ttls_asn1_get_sequence_of(p, end, ext_key_usage, TTLS_ASN1_OID);
@@ -401,9 +401,9 @@ x509_get_ext_key_usage(unsigned char **p, const unsigned char *end,
 		return TTLS_ERR_X509_INVALID_EXTENSIONS + ret;
 
 	/* Sequence length must be >= 1 */
-	if (unlikely(ext_key_usage->buf.p == NULL))
-		return TTLS_ERR_X509_INVALID_EXTENSIONS +
-		       TTLS_ERR_ASN1_INVALID_LENGTH;
+	if (unlikely(!ext_key_usage->buf.p))
+		return TTLS_ERR_X509_INVALID_EXTENSIONS
+			+ TTLS_ERR_ASN1_INVALID_LENGTH;
 
 	return 0;
 }
@@ -435,7 +435,7 @@ x509_get_ext_key_usage(unsigned char **p, const unsigned char *end,
  * NOTE: we only parse and use dNSName at this point.
  */
 static int
-x509_get_subject_alt_name(unsigned char **p, const unsigned char *end,
+x509_get_subject_alt_name(const unsigned char **p, const unsigned char *end,
 			  ttls_x509_sequence *subject_alt_name)
 {
 	int ret;
@@ -454,22 +454,21 @@ x509_get_subject_alt_name(unsigned char **p, const unsigned char *end,
 			TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	while (*p < end) {
-		unsigned char tag;
+		const unsigned char tag = **p;
 
 		if ((end - *p) < 1)
-			return TTLS_ERR_X509_INVALID_EXTENSIONS +
-			       TTLS_ERR_ASN1_OUT_OF_DATA;
+			return TTLS_ERR_X509_INVALID_EXTENSIONS
+				+ TTLS_ERR_ASN1_OUT_OF_DATA;
 
-		tag = **p;
 		(*p)++;
 		if ((ret = ttls_asn1_get_len(p, end, &tag_len)))
 			return TTLS_ERR_X509_INVALID_EXTENSIONS + ret;
 
-		if ((tag & TTLS_ASN1_TAG_CLASS_MASK) !=
-		    TTLS_ASN1_CONTEXT_SPECIFIC)
+		if ((tag & TTLS_ASN1_TAG_CLASS_MASK)
+		    != TTLS_ASN1_CONTEXT_SPECIFIC)
 		{
 			return TTLS_ERR_X509_INVALID_EXTENSIONS
-					+ TTLS_ERR_ASN1_UNEXPECTED_TAG;
+				+ TTLS_ERR_ASN1_UNEXPECTED_TAG;
 		}
 
 		/* Skip everything but DNS name */
@@ -502,8 +501,8 @@ x509_get_subject_alt_name(unsigned char **p, const unsigned char *end,
 	cur->next = NULL;
 
 	if (*p != end)
-		return TTLS_ERR_X509_INVALID_EXTENSIONS +
-			TTLS_ERR_ASN1_LENGTH_MISMATCH;
+		return TTLS_ERR_X509_INVALID_EXTENSIONS
+			+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 	return 0;
 }
@@ -513,7 +512,7 @@ x509_get_subject_alt_name(unsigned char **p, const unsigned char *end,
  *
  */
 static int
-x509_get_crt_ext(unsigned char **p, const unsigned char *end, TlsX509Crt *crt)
+x509_get_crt_ext(const unsigned char **p, const unsigned char *end, TlsX509Crt *crt)
 {
 	int ret;
 	size_t len;
@@ -525,8 +524,7 @@ x509_get_crt_ext(unsigned char **p, const unsigned char *end, TlsX509Crt *crt)
 		return ret;
 	}
 
-	while (*p < end)
-	{
+	while (*p < end) {
 		unsigned char *end_ext_data, *end_ext_octet;
 		/*
 		 * Extension  ::=  SEQUENCE  {
@@ -543,7 +541,12 @@ x509_get_crt_ext(unsigned char **p, const unsigned char *end, TlsX509Crt *crt)
 		if (unlikely(ret))
 			return TTLS_ERR_X509_INVALID_EXTENSIONS + ret;
 
-		end_ext_data = *p + len;
+		/*
+		 * TODO #1808: declare the variable here to avoid type conversion
+		 * (-std=gnu11 is allowed with the new kernel).
+		 * The same for end_ext_octet at the below.
+		 */
+		end_ext_data = (unsigned char *)*p + len;
 
 		/* Get extension ID */
 		extn_oid.tag = **p;
@@ -572,18 +575,17 @@ x509_get_crt_ext(unsigned char **p, const unsigned char *end, TlsX509Crt *crt)
 		if (unlikely(ret))
 			return TTLS_ERR_X509_INVALID_EXTENSIONS + ret;
 
-		end_ext_octet = *p + len;
+		end_ext_octet = (unsigned char *)*p + len;
 
 		if (end_ext_octet != end_ext_data)
-			return TTLS_ERR_X509_INVALID_EXTENSIONS +
-					TTLS_ERR_ASN1_LENGTH_MISMATCH;
+			return TTLS_ERR_X509_INVALID_EXTENSIONS
+				+ TTLS_ERR_ASN1_LENGTH_MISMATCH;
 
 		/*
 		 * Detect supported extensions
 		 */
 		ret = ttls_oid_get_x509_ext_type(&extn_oid, &ext_type);
-		if (unlikely(ret))
-		{
+		if (unlikely(ret)) {
 			/* No parser found, skip extension */
 			*p = end_ext_octet;
 			if (is_critical)
@@ -671,7 +673,7 @@ static int
 x509_crt_parse_der_core(TlsX509Crt *crt, const unsigned char *buf, size_t len)
 {
 	int r;
-	unsigned char *p, *end, *crt_end;
+	const unsigned char *p, *end, *crt_end;
 	ttls_x509_buf sig_params1, sig_params2, sig_oid2;
 
 	BUG_ON(!crt || !buf);
@@ -680,7 +682,7 @@ x509_crt_parse_der_core(TlsX509Crt *crt, const unsigned char *buf, size_t len)
 	memset(&sig_params2, 0, sizeof(ttls_x509_buf));
 	memset(&sig_oid2, 0, sizeof(ttls_x509_buf));
 
-	p = (unsigned char*)buf;
+	p = buf;
 	end = p + len;
 
 	/*
@@ -716,8 +718,9 @@ x509_crt_parse_der_core(TlsX509Crt *crt, const unsigned char *buf, size_t len)
 	if (!(crt->raw.p = (unsigned char *)__get_free_pages(GFP_KERNEL, 0)))
 		goto err;
 	crt->raw.len = crt_end - buf;
-	memcpy(ttls_x509_crt_raw(crt), buf, crt->raw.len);
-	x509_write_cert_len(crt->raw.p, crt->raw.len);
+	/* Copy original constant raw data to the just initialized cert. */
+	memcpy((void *)ttls_x509_crt_raw(crt), buf, crt->raw.len);
+	x509_write_cert_len((unsigned char *)crt->raw.p, crt->raw.len);
 
 	/* Direct pointers to the new buffer. */
 	p = ttls_x509_crt_raw(crt) + crt->raw.len - len;

--- a/tls/x509_crt.c
+++ b/tls/x509_crt.c
@@ -746,7 +746,7 @@ x509_crt_parse_der_core(TlsX509Crt *crt, const unsigned char *buf, size_t len)
 	 *
 	 * signature AlgorithmIdentifier
 	 */
-	if ((r = x509_get_version( &p, end, &crt->version ))
+	if ((r = x509_get_version(&p, end, &crt->version))
 	    || (r = ttls_x509_get_serial(&p, end, &crt->serial))
 	    || (r = ttls_x509_get_alg(&p, end, &crt->sig_oid, &sig_params1)))
 	{
@@ -765,7 +765,6 @@ x509_crt_parse_der_core(TlsX509Crt *crt, const unsigned char *buf, size_t len)
 
 	/* issuer Name */
 	crt->issuer_raw.p = p;
-
 	r = ttls_asn1_get_tag(&p, end, &len,
 			      TTLS_ASN1_CONSTRUCTED | TTLS_ASN1_SEQUENCE);
 	if (r) {

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -151,7 +151,7 @@ void ttls_x509_crt_init(TlsX509Crt *crt);
 void ttls_x509_crt_free(TlsX509Crt *crt);
 void ttls_x509_crt_destroy(TlsX509Crt **crt);
 
-static inline void *
+static inline const void *
 ttls_x509_crt_raw(TlsX509Crt *crt)
 {
 	return crt->raw.p + TTLS_CERT_LEN_LEN;

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -28,12 +28,17 @@
 #include "x509.h"
 #include "x509_crl.h"
 
+#define TTLS_CERT_MAX_CHAIN_LEN			8
 #define TTLS_CERT_LEN_LEN			3
 
 /**
  * Container for an X.509 certificate. The certificate may be chained.
  *
- * @raw			- The raw certificate data (DER) prepended with length.
+ * @raw			- The raw certificates _chain_ data in DER format
+ *			  prepended with length, i.e. ready to be transmitted
+ *			  in a TLS handshake.
+ *			  TODO #769 #830: do we need separate raw certificates
+ *			  for any of the modes?
  * @tbs			- The raw certificate body (DER). The part that is
  *			  To Be Signed.
  * @version		- The X.509 version. (1=v1, 2=v2, 3=v3)
@@ -68,9 +73,10 @@
  *			  signature algorithm, e.g. TTLS_MD_SHA256
  * @sig_pk		- Internal representation of the Public Key algorithm
  *			  of the signature algorithm, e.g. TTLS_PK_RSA
- * @*sig_opts		- Signature options to be passed to ttls_pk_verify_ext(),
+ * @sig_opts		- Signature options to be passed to ttls_pk_verify_ext(),
  *			  e.g. for RSASSA-PSS
- * @TlsX509Crt *next	- Next certificate in the CA-chain.
+ * @next		- Next certificate in the CA-chain. Isn't used in server
+ *			  mode.
  */
 typedef struct TlsX509Crt {
 	ttls_x509_buf raw;
@@ -116,7 +122,7 @@ typedef struct TlsX509Crt {
 
 int ttls_x509_crt_parse_der(TlsX509Crt *chain, const unsigned char *buf,
 			    size_t buflen);
-int ttls_x509_crt_parse(TlsX509Crt *chain, unsigned char *buf, size_t buflen);
+int ttls_x509_crt_parse(TlsX509Crt *crt, unsigned char *buf, size_t buflen);
 
 enum {
 	TLS_X509_CERT_PROFILE_DEFAULT,

--- a/tls/x509_crt.h
+++ b/tls/x509_crt.h
@@ -25,11 +25,14 @@
 #ifndef TTLS_X509_CRT_H
 #define TTLS_X509_CRT_H
 
+#include <net/tls.h>
+
 #include "x509.h"
 #include "x509_crl.h"
 
 #define TTLS_CERT_MAX_CHAIN_LEN			8
 #define TTLS_CERT_LEN_LEN			3
+#define TTLS_CERT_RAW_P_N			(TLS_MAX_PAYLOAD_SIZE / PAGE_SIZE)
 
 /**
  * Container for an X.509 certificate. The certificate may be chained.
@@ -76,51 +79,57 @@
  * @sig_opts		- Signature options to be passed to ttls_pk_verify_ext(),
  *			  e.g. for RSASSA-PSS
  * @next		- Next certificate in the CA-chain. Isn't used in server
- *			  mode.
+ *			  mode. TODO #769 #830: do we need it for client mode?
  */
 typedef struct TlsX509Crt {
-	ttls_x509_buf raw;
-	ttls_x509_buf tbs;
+	struct {
+		unsigned int		tot_len;
+		unsigned int		order;
+		const unsigned char	*pages;
+	}			raw;
+	ttls_x509_buf		tbs;
 
-	int version;
-	ttls_x509_buf serial;
-	ttls_x509_buf sig_oid;
+	int			version;
+	ttls_x509_buf		serial;
+	ttls_x509_buf		sig_oid;
 
-	ttls_x509_buf issuer_raw;
-	ttls_x509_buf subject_raw;
+	ttls_x509_buf		issuer_raw;
+	ttls_x509_buf		subject_raw;
 
-	ttls_x509_name issuer;
-	ttls_x509_name subject;
+	ttls_x509_name		issuer;
+	ttls_x509_name		subject;
 
-	ttls_x509_time valid_from;
-	ttls_x509_time valid_to;
+	ttls_x509_time		valid_from;
+	ttls_x509_time		valid_to;
 
-	TlsPkCtx pk;
+	TlsPkCtx		pk;
 
-	ttls_x509_buf issuer_id;
-	ttls_x509_buf subject_id;
-	ttls_x509_buf v3_ext;
-	ttls_x509_sequence subject_alt_names;
+	ttls_x509_buf		issuer_id;
+	ttls_x509_buf		subject_id;
+	ttls_x509_buf		v3_ext;
+	ttls_x509_sequence	subject_alt_names;
 
-	int ext_types;
-	int ca_istrue;
-	int max_pathlen;
+	int			ext_types;
+	int			ca_istrue;
+	int			max_pathlen;
+	unsigned int		key_usage;
 
-	unsigned int key_usage;
+	ttls_x509_sequence	ext_key_usage;
 
-	ttls_x509_sequence ext_key_usage;
+	unsigned char		ns_cert_type;
 
-	unsigned char ns_cert_type;
+	ttls_x509_buf		sig;
+	ttls_md_type_t		sig_md;
+	ttls_pk_type_t		sig_pk;
+	void			*sig_opts;
 
-	ttls_x509_buf sig;
-	ttls_md_type_t sig_md;
-	ttls_pk_type_t sig_pk;
-	void *sig_opts;
-
-	struct TlsX509Crt *next;
+	struct TlsX509Crt	*next;
 } TlsX509Crt;
 
-int ttls_x509_crt_parse_der(TlsX509Crt *chain, const unsigned char *buf,
+int ttls_x509_crt_raw_alloc_cpy(TlsX509Crt *crt, const unsigned char *buf,
+				size_t len, gfp_t gfp_mask);
+
+int ttls_x509_crt_parse_der(TlsX509Crt *crt, const unsigned char *buf,
 			    size_t buflen);
 int ttls_x509_crt_parse(TlsX509Crt *crt, unsigned char *buf, size_t buflen);
 
@@ -157,10 +166,10 @@ void ttls_x509_crt_init(TlsX509Crt *crt);
 void ttls_x509_crt_free(TlsX509Crt *crt);
 void ttls_x509_crt_destroy(TlsX509Crt **crt);
 
-static inline const void *
+static inline unsigned char *
 ttls_x509_crt_raw(TlsX509Crt *crt)
 {
-	return crt->raw.p + TTLS_CERT_LEN_LEN;
+	return (unsigned char *)crt->raw.pages + TTLS_CERT_LEN_LEN;
 }
 
 int ttls_x509_init(void);


### PR DESCRIPTION
Fix #2156.

The PR is pretty big, but the most of it is improving the TLS code hygiene: use `const` pointers for x509 parsing functions and adjusting coding style. Please review individual patches.