### PR TITLE
Fix crash in `tls_on_send_alert`.

### DIFF
--- a/fw/cfg.h
+++ b/fw/cfg.h
@@ -183,13 +183,16 @@ typedef struct {
  */
 #define TFW_CFG_ENTRY_FOR_EACH_ATTR(e, idx, k, v)	\
 	for ((idx) = 0, (k) = (e)->attrs[0].key, (v) = (e)->attrs[0].val; \
-	     (idx++) < (e)->attr_n; \
-	     (k) = (e)->attrs[(idx)].key, (v) = (e)->attrs[(idx)].val)
+	     (idx) < (e)->attr_n; \
+	     (idx)++,  \
+	     (k) = (idx < (e)->attr_n ? (e)->attrs[(idx)].key : NULL), \
+	     (v) = (idx < (e)->attr_n ? (e)->attrs[(idx)].val : NULL))
 
 #define TFW_CFG_ENTRY_FOR_EACH_VAL(e, idx, v)	\
 	for ((idx) = 0, (v) = (e)->vals[0];	\
 	     (idx) < (e)->val_n;		\
-	     (v) = (e)->vals[++(idx)])
+	     (idx)++,				\
+	     (v) = (idx < (e)->val_n ? (e)->vals[(idx)] : NULL))
 
 #define TFW_CFG_CHECK_NO_ATTRS(spec, entry)				\
 	if ((entry)->attr_n) {						\

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -525,6 +525,7 @@ tfw_tls_on_send_alert(void *conn, struct sk_buff **skb_head)
 {
 	TfwH2Ctx *ctx;
 
+	BUG_ON(TFW_CONN_PROTO((TfwConn *)conn) != TFW_FSM_H2);
 	ctx = tfw_h2_context_safe((TfwConn *)conn);
 	if (!ctx)
 		return 0;
@@ -620,7 +621,10 @@ tfw_tls_send(TlsCtx *tls, struct sg_table *sgt)
 	     io->alert[0] == TTLS_ALERT_LEVEL_FATAL)) {
 		TFW_CONN_TYPE(((TfwConn *)conn)) |= Conn_Stop;
 		flags |= tfw_tls_close_msg_flags(io);
-		TFW_SKB_CB(io->skb_list)->on_send = tfw_tls_on_send_alert;
+		if (TFW_CONN_PROTO((TfwConn *)conn) == TFW_FSM_H2) {
+			TFW_SKB_CB(io->skb_list)->on_send =
+				tfw_tls_on_send_alert;
+		}
 	}
 
 	r = ss_send(conn->cli_conn.sk, &io->skb_list, flags);


### PR DESCRIPTION
We should not set `tls_on_send_alert` callback for HTTP1.