### PR TITLE
Rework allocation for stream schedulers.

### DIFF
--- a/fw/connection.h
+++ b/fw/connection.h
@@ -268,7 +268,7 @@ enum {
 /**
  * TLS hardened connection.
  */
-typedef struct {
+typedef struct tfw_tls_conn_t {
 	TfwCliConn	cli_conn;
 	TlsCtx		tls;
 } TfwTlsConn;
@@ -278,9 +278,9 @@ typedef struct {
 /**
  * HTTP/2 connection.
  */
-typedef struct {
+typedef struct tfw_h2_conn_t {
 	TfwTlsConn	tls_conn;
-	TfwH2Ctx	h2;
+	TfwH2Ctx	*h2;
 } TfwH2Conn;
 
 /*
@@ -290,9 +290,7 @@ typedef struct {
  * accessing http2 context, when we are sure and not sure that tls handskare
  * was finished.
  */
-#define tfw_h2_context_unsafe(conn)	((TfwH2Ctx *)(&((TfwH2Conn *)conn)->h2))
-#define tfw_h2_context_safe(conn)	\
-	ttls_hs_done(tfw_tls_context(conn)) ? tfw_h2_context_unsafe(conn) : NULL
+#define tfw_h2_context(conn)	((TfwH2Conn *)conn)->h2
 
 
 /* Callbacks used by l5-l7 protocols to operate on connection level. */

--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -3553,7 +3553,7 @@ __tfw_hpack_encode(TfwHttpResp *__restrict resp, TfwStr *__restrict hdr,
 	bool st_full_index;
 	unsigned short st_index, index = 0;
 	TfwConn *conn = resp->req->conn;
-	TfwH2Ctx *ctx = tfw_h2_context_unsafe(conn);
+	TfwH2Ctx *ctx = tfw_h2_context(conn);
 	TfwHPackETbl *tbl = &ctx->hpack.enc_tbl;
 	int r = HPACK_IDX_ST_NOT_FOUND;
 	bool name_indexed = true;

--- a/fw/http.c
+++ b/fw/http.c
@@ -2831,7 +2831,7 @@ tfw_http_conn_drop(TfwConn *conn)
 
 	if (TFW_CONN_TYPE(conn) & Conn_Clnt) {
 		if (h2_mode) {
-			TfwH2Ctx *ctx = tfw_h2_context_safe(conn);
+			TfwH2Ctx *ctx = tfw_h2_context(conn);
 
 			if (ctx)
 				tfw_h2_conn_streams_cleanup(ctx);
@@ -4858,7 +4858,7 @@ tfw_h2_append_predefined_body(TfwHttpResp *resp, const TfwStr *body)
 int
 tfw_http_on_send_resp(void *conn, struct sk_buff **skb_head)
 {
-	TfwH2Ctx *ctx = tfw_h2_context_unsafe((TfwConn *)conn);
+	TfwH2Ctx *ctx = tfw_h2_context((TfwConn *)conn);
 	struct tfw_skb_cb *tfw_cb = TFW_SKB_CB(*skb_head);
 	TfwStream *stream;
 
@@ -4992,7 +4992,7 @@ tfw_h2_error_resp(TfwHttpReq *req, int status, bool reply, ErrorType type,
 		  bool on_req_recv_event, TfwH2Err err_code)
 {
 	TfwStream *stream;
-	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
 	bool close_after_send = (type == TFW_ERROR_TYPE_ATTACK ||
 		type == TFW_ERROR_TYPE_BAD);
 
@@ -5883,7 +5883,7 @@ next_msg:
 					HTTP2_ECODE_PROTO);
 		}
 		if (TFW_MSG_H2(req)) {
-			TfwH2Ctx *ctx = tfw_h2_context_unsafe(conn);
+			TfwH2Ctx *ctx = tfw_h2_context(conn);
 
 			/* Do not check the request validity until
 			 * it has been fully parsed.

--- a/fw/http2.h
+++ b/fw/http2.h
@@ -47,6 +47,8 @@ typedef struct {
 	unsigned int max_lhdr_sz;
 } TfwSettings;
 
+typedef struct tfw_conn_t TfwConn;
+
 /**
  * Context for HTTP/2 frames processing.
  *
@@ -85,6 +87,7 @@ typedef struct {
  * @extra_sched_entries_count - count of extries in @extra_sched_entries array;
  * @extra_sched_entries_size  - maximum count of extries in @extra_sched_entries
  *				array;
+ * @conn		- pointer to h2 connection of this context;
  * @__off               - offset to reinitialize processing context;
  * @skb_head            - collected list of processed skbs containing HTTP/2
  *                        frames;
@@ -132,6 +135,7 @@ typedef struct tfw_h2_ctx_t {
 	struct page	**extra_sched_entries;
 	unsigned int	extra_sched_entries_count;
 	unsigned int	extra_sched_entries_size;
+	TfwH2Conn	*conn;
 	char            __off[0];
 	struct sk_buff  *skb_head;
 	TfwStream       *cur_stream;
@@ -148,7 +152,9 @@ typedef struct tfw_h2_ctx_t {
 
 int tfw_h2_init(void);
 void tfw_h2_cleanup(void);
-int tfw_h2_context_init(TfwH2Ctx *ctx);
+TfwH2Ctx *tfw_h2_context_alloc(void);
+void tfw_h2_context_free(TfwH2Ctx *ctx);
+int tfw_h2_context_init(TfwH2Ctx *ctx, TfwH2Conn *conn);
 void tfw_h2_context_clear(TfwH2Ctx *ctx);
 int tfw_h2_check_settings_entry(TfwH2Ctx *ctx, unsigned short id,
 				unsigned int val);

--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -2179,11 +2179,11 @@ tfw_h2_make_frames(struct sock *sk, TfwH2Ctx *ctx, unsigned long snd_wnd,
 	{
 		if (ctx->cur_send_headers) {
 			stream = ctx->cur_send_headers;
-			parent = stream->sched.parent;
+			parent = stream->sched->parent;
 			tfw_h2_stream_sched_remove(sched, stream);
 		} else if (ctx->error) {
 			stream = ctx->error;
-			parent = stream->sched.parent;
+			parent = stream->sched->parent;
 			tfw_h2_stream_sched_remove(sched, stream);
 			error_was_sent = true;
 		} else {

--- a/fw/http_frame.h
+++ b/fw/http_frame.h
@@ -153,7 +153,7 @@ typedef enum {
 #define MAX_WND_SIZE			((1U << 31) - 1)
 #define DEF_WND_SIZE			((1U << 16) - 1)
 
-typedef struct tfw_conn_t TfwConn;
+typedef struct tfw_h2_conn_t TfwH2Conn;
 
 int tfw_h2_frame_process(TfwConn *c, struct sk_buff *skb,
 			 struct sk_buff **next);

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -10639,7 +10639,7 @@ tfw_h2_parse_body(char *data, unsigned int len, TfwHttpReq *req,
 		  unsigned int *parsed)
 {
 	unsigned int m_len;
-	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
 	TfwHttpMsg *msg = (TfwHttpMsg *)req;
 	TfwHttpParser *parser = &msg->stream->parser;
 	int ret = T_POSTPONE;
@@ -10698,7 +10698,7 @@ tfw_h2_parse_req(void *req_data, unsigned char *data, unsigned int len,
 {
 	int r;
 	TfwHttpReq *req = (TfwHttpReq *)req_data;
-	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context(req->conn);
 
 	WARN_ON_ONCE(!len);
 	*parsed = 0;

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -170,7 +170,7 @@ tfw_h2_stream_purge_all_and_free_response(TfwStream *stream)
 void
 tfw_h2_stream_add_idle(TfwH2Ctx *ctx, TfwStream *idle)
 {
-	TfwH2Conn *conn = container_of(ctx, TfwH2Conn, h2);
+	TfwH2Conn *conn = ctx->conn;
 	struct list_head *pos, *prev = &ctx->idle_streams.list;
 	bool found = false;
 
@@ -206,7 +206,7 @@ tfw_h2_stream_add_idle(TfwH2Ctx *ctx, TfwStream *idle)
 void
 tfw_h2_stream_remove_idle(TfwH2Ctx *ctx, TfwStream *stream)
 {
-	TfwH2Conn *conn = container_of(ctx, TfwH2Conn, h2);
+	TfwH2Conn *conn = ctx->conn;
 
 	/*
 	 * We add and remove streams from idle queue under the
@@ -850,7 +850,7 @@ int
 tfw_h2_stream_init_for_xmit(TfwHttpResp *resp, TfwStreamXmitState state,
 			    unsigned long h_len, unsigned long b_len)
 {
-	TfwH2Ctx *ctx = tfw_h2_context_unsafe(resp->req->conn);
+	TfwH2Ctx *ctx = tfw_h2_context(resp->req->conn);
 	struct sk_buff *skb_head = resp->msg.skb_head;
 	TfwStream *stream;
 

--- a/fw/http_stream.h
+++ b/fw/http_stream.h
@@ -182,7 +182,7 @@ struct tfw_http_stream_t {
 	struct rb_node		node;
 	struct eb64_node	sched_node;
 	TfwStreamSchedState	sched_state;
-	TfwStreamSchedEntry	sched;
+	TfwStreamSchedEntry	*sched;
 	struct list_head	hcl_node;
 	unsigned int		id;
 	int			state;

--- a/fw/http_stream_sched.c
+++ b/fw/http_stream_sched.c
@@ -75,7 +75,7 @@ static inline void
 tfw_h2_stream_sched_spin_lock_assert(TfwStreamSched *sched)
 {
 	TfwH2Ctx *ctx = container_of(sched, TfwH2Ctx, sched);
-	TfwH2Conn *conn = container_of(ctx, TfwH2Conn, h2);
+	TfwH2Conn *conn = ctx->conn;
 
 	/*
 	 * All scheduler functions schould be called under the

--- a/fw/http_stream_sched.h
+++ b/fw/http_stream_sched.h
@@ -27,18 +27,22 @@
 #include "http_types.h"
 
 /**
- * @total_weight - total weight of the streams for this scheduler;
- * @active_cnt	 - count of active child streams for this scheduler;
- * @parent	 - parent scheduler;
- * @active	 - root of the active streams scheduler ebtree;
- * @blocked	 - root of the blocked streams scheduler ebtree;
+ * @total_weight  - total weight of the streams for this scheduler;
+ * @active_cnt	  - count of active child streams for this scheduler;
+ * @owner	  - stream that owns this scheduler
+ * @parent	  - parent scheduler;
+ * @active	  - root of the active streams scheduler ebtree;
+ * @blocked	  - root of the blocked streams scheduler ebtree;
+ * @in_empty_list - entry in list of empty schedulers;
  */ 
 typedef struct tfw_stream_sched_entry_t {
 	u64				total_weight;
 	long int			active_cnt;
-	struct tfw_stream_sched_entry_t	*parent;
+	TfwStream 			*owner;
+	struct tfw_stream_sched_entry_t *parent;
 	struct eb_root			active;
 	struct eb_root			blocked;
+	struct list_head		in_empty_list;
 } TfwStreamSchedEntry;
 
 /**
@@ -48,13 +52,17 @@ typedef struct tfw_stream_sched_entry_t {
  * @streams		- root red-black tree entry for per-connection streams storage;
  * @root		- root scheduler of per-connection priority tree;
  * @blocked_streams	- count of blocked streams;
+ * @empty_scheds	- list of unused schedulers;
  */
 typedef struct tfw_stream_sched_t {
 	struct rb_root		streams;
 	TfwStreamSchedEntry	root;
 	long int		blocked_streams;
+	struct list_head	empty_scheds;
 } TfwStreamSched;
 
+void tfw_h2_stream_sched_init_entry_storage(TfwStreamSched *sched, void *base,
+					    unsigned int count);
 TfwStreamSchedEntry *tfw_h2_find_stream_dep(TfwStreamSched *sched,
 					    unsigned int id);
 void tfw_h2_add_stream_dep(TfwStreamSched *sched, TfwStream *stream,
@@ -70,6 +78,8 @@ void tfw_h2_sched_stream_enqueue(TfwStreamSched *sched, TfwStream *stream,
 TfwStream *tfw_h2_sched_stream_dequeue(TfwStreamSched *sched,
 				       TfwStreamSchedEntry **parent);
 void tfw_h2_sched_activate_stream(TfwStreamSched *sched, TfwStream *stream);
+void tfw_h2_init_stream_sched_entry(TfwStreamSchedEntry *entry,
+				    TfwStream *owner);
 
 static inline bool
 tfw_h2_stream_sched_is_active(TfwStreamSchedEntry *sched)
@@ -78,18 +88,12 @@ tfw_h2_stream_sched_is_active(TfwStreamSchedEntry *sched)
 }
 
 static inline void
-tfw_h2_init_stream_sched_entry(TfwStreamSchedEntry *entry)
-{
-	entry->total_weight = entry->active_cnt = 0;
-	entry->parent = NULL;
-	entry->blocked = entry->active = EB_ROOT;
-}
-
-static inline void
-tfw_h2_init_stream_sched(TfwStreamSched *sched)
+tfw_h2_stream_sched_init(TfwStreamSched *sched)
 {
 	sched->streams = RB_ROOT;
-	tfw_h2_init_stream_sched_entry(&sched->root);
+	tfw_h2_init_stream_sched_entry(&sched->root, NULL);
+	INIT_LIST_HEAD(&sched->empty_scheds);
 }
+
 
 #endif /* __HTTP_STREAM_SCHED__ */

--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -199,7 +199,7 @@ tfw_sk_fill_write_queue(struct sock *sk, unsigned int mss_now, int ss_action)
 	 * shutdowned before TLS hadshake was finished.
 	 */
 	h2 = TFW_CONN_PROTO(conn) == TFW_FSM_H2 ?
-		tfw_h2_context_safe(conn) : NULL;
+		tfw_h2_context(conn) : NULL;
 	if (!h2) {
 		if (ss_action == SS_SHUTDOWN)
 			tcp_shutdown(sk, SEND_SHUTDOWN);
@@ -969,7 +969,7 @@ tfw_sock_clnt_init(void)
 	}
 
 	tfw_h2_conn_cache = kmem_cache_create("tfw_h2_conn_cache",
-					      2 * PAGE_SIZE, 0, 0, NULL);
+					      sizeof(TfwH2Conn), 0, 0, NULL);
 	if (!tfw_h2_conn_cache) {
 		kmem_cache_destroy(tfw_https_conn_cache);
 		kmem_cache_destroy(tfw_h1_conn_cache);

--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -35,6 +35,7 @@
 #include "sync_socket.h"
 #include "tls.h"
 #include "tcp.h"
+#include "http2.h"
 
 /*
  * ------------------------------------------------------------------------
@@ -968,7 +969,7 @@ tfw_sock_clnt_init(void)
 	}
 
 	tfw_h2_conn_cache = kmem_cache_create("tfw_h2_conn_cache",
-					      sizeof(TfwH2Conn), 0, 0, NULL);
+					      2 * PAGE_SIZE, 0, 0, NULL);
 	if (!tfw_h2_conn_cache) {
 		kmem_cache_destroy(tfw_https_conn_cache);
 		kmem_cache_destroy(tfw_h1_conn_cache);

--- a/fw/t/unit/test.c
+++ b/fw/t/unit/test.c
@@ -22,6 +22,7 @@
 #include <linux/module.h>
 #include "test.h"
 #include "test_http_parser_defs.h"
+#include "test_http_parser_common.h"
 
 int test_fail_counter;
 test_fixture_fn_t test_setup_fn;
@@ -133,8 +134,12 @@ test_run_all(void)
 	TEST_SUITE_MPART_RUN(http1_parser);
 	__fpu_schedule();
 
+	test_case_alloc_h2();
+
 	TEST_SUITE_MPART_RUN(http2_parser);
 	__fpu_schedule();
+
+	test_case_cleanup_h2();
 
 	TEST_SUITE_RUN(http2_parser_hpack);
 	__fpu_schedule();

--- a/fw/t/unit/test_http2_parser_hpack.c
+++ b/fw/t/unit/test_http2_parser_hpack.c
@@ -1698,6 +1698,8 @@ TEST(http2_parser_hpack, erased_indexes_not_come_back)
 
 TEST_SUITE(http2_parser_hpack)
 {
+	test_case_alloc_h2();
+	
 	TEST_SETUP(test_case_parse_prepare_h2);
 
 	TEST_RUN(http2_parser_hpack, literal_header_field_with_incremental_indexing);
@@ -1712,4 +1714,6 @@ TEST_SUITE(http2_parser_hpack)
 	TEST_RUN(http2_parser_hpack, dup_with_equal_values_in_indexes);
 	TEST_RUN(http2_parser_hpack, dup_with_diff_values_in_indexes);
 	TEST_RUN(http2_parser_hpack, erased_indexes_not_come_back);
+
+	test_case_cleanup_h2();
 }

--- a/fw/t/unit/test_http_parser_common.c
+++ b/fw/t/unit/test_http_parser_common.c
@@ -31,7 +31,7 @@ unsigned int chunk_size_index = 0;
 
 TfwHttpReq *req, *sample_req;
 TfwHttpResp *resp;
-TfwH2Conn *conn;
+TfwH2Conn conn;
 TfwStream stream;
 
 /**
@@ -419,44 +419,28 @@ test_case_parse_prepare_http(char *str)
 	tfw_h1_frames_assign(str, strlen(str));
 }
 
-static TfwH2Conn *
-test_alloc_conn(void)
-{
-	struct page *page;
-
-	/*
-	 * Each TfwH2Conn structure has 2 * PAGE_SZIE bytes.
-	 * Extra memory used for streams schedulers.
-	 */
-	page = alloc_pages(GFP_ATOMIC, 1);
-	if (!page)
-		return NULL;
-
-	return (TfwH2Conn *)page_address(page);
-}
-
 void
 test_case_alloc_h2(void)
 {
-	BUG_ON(conn);
-	conn = test_alloc_conn();
-	BUG_ON(!conn);
+	conn.h2 = tfw_h2_context_alloc();
+	BUG_ON(!conn.h2);
 }
 
 void
 test_case_cleanup_h2(void)
 {
-	BUG_ON(!conn);
-	free_pages((unsigned long)conn, 1);
-	conn = NULL;
+	BUG_ON(!conn.h2);
+
+	tfw_h2_context_free(conn.h2);
+	conn.h2 = NULL;
 }
 
 void
 test_case_parse_prepare_h2(void)
 {
-	BUG_ON(!conn);
-	tfw_h2_context_init(&conn->h2);
-	conn->h2.hdr.type = HTTP2_HEADERS;
+	BUG_ON(!conn.h2);
+	tfw_h2_context_init(conn.h2, &conn);
+	conn.h2->hdr.type = HTTP2_HEADERS;
 	tfw_h2_set_stream_state(&stream, HTTP2_STREAM_REM_HALF_CLOSED);
 }
 
@@ -520,18 +504,18 @@ do_split_and_parse(int type, int chunk_mode)
 		 */
 		static TfwH2Ctx	h2_origin;
 		if (chunk_size_index == 0)
-			h2_origin = conn->h2;
+			h2_origin = *conn.h2;
 		else
-			conn->h2 = h2_origin;
+			*(conn.h2) = h2_origin;
 
-		conn->h2.hpack.state = 0;
-		conn->h2.hpack.length = 0;
-		conn->h2.hpack.dec_tbl.wnd_update = true;
+		conn.h2->hpack.state = 0;
+		conn.h2->hpack.length = 0;
+		conn.h2->hpack.dec_tbl.wnd_update = true;
 
 		if (req)
 			test_req_free(req);
 		req = test_req_alloc(frames_total_sz);
-		req->conn = (TfwConn*)conn;
+		req->conn = (TfwConn*)&conn;
 		req->pit.parsed_hdr = &stream.parser.hdr;
 		req->stream = &stream;
 		tfw_http_init_parser_req(req);
@@ -567,7 +551,7 @@ do_split_and_parse(int type, int chunk_mode)
 		}
 
 		if (type == FUZZ_REQ_H2) {
-			TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
+			TfwH2Ctx *ctx = tfw_h2_context(req->conn);
 			ctx->hdr.type = frame->subtype;
 			ctx->plen = frame->len;
 		}

--- a/fw/t/unit/test_http_parser_common.h
+++ b/fw/t/unit/test_http_parser_common.h
@@ -550,12 +550,14 @@ int split_and_parse_n(unsigned char *str, uint32_t type, uint32_t len,
 extern unsigned int chunk_size_index;
 extern TfwHttpReq *req, *sample_req;
 extern TfwHttpResp *resp;
-extern TfwH2Conn conn;
+extern TfwH2Conn *conn;
 extern TfwStream stream;
 
 int set_sample_req(unsigned char *str);
 
 void test_case_parse_prepare_http(char *str);
+void test_case_alloc_h2(void);
+void test_case_cleanup_h2(void);
 void test_case_parse_prepare_h2(void);
 int do_split_and_parse(int type, int chunk_mode);
 

--- a/fw/t/unit/test_http_parser_common.h
+++ b/fw/t/unit/test_http_parser_common.h
@@ -550,7 +550,7 @@ int split_and_parse_n(unsigned char *str, uint32_t type, uint32_t len,
 extern unsigned int chunk_size_index;
 extern TfwHttpReq *req, *sample_req;
 extern TfwHttpResp *resp;
-extern TfwH2Conn *conn;
+extern TfwH2Conn conn;
 extern TfwStream stream;
 
 int set_sample_req(unsigned char *str);


### PR DESCRIPTION
According to our discussion the best way is to allocate two pages for each connection and save streams schedulers after the end of `struct TfwH2Conn`. When we create new stream, we get scheduler for such stream from the list of preallocated schedulers. If limit of such schedulers is exceeded we allocate new page and use it to initialize new schedulers.