### PR TITLE
Add CRLF filter.

### DIFF
--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -74,8 +74,9 @@ templater()
 	# Replace !include dircetive with file contents
 	> $tfw_cfg_temp
 	mkdir $TFW_ROOT/etc 2>/dev/null
-	while IFS= read -r line
+	while IFS= read -r raw_line
 	do
+		line=$(echo "$raw_line" | sed -e '/request /s/\\r\\n/\x0d\x0a/g')
 		if [[ ${line:0:1} = \# ]]; then
 			:
 		elif [[ $line =~ '!include' ]]; then
@@ -84,8 +85,10 @@ templater()
 
 			files=$(find ${path[1]} -type f -regextype posix-extended -regex '.*\.conf$')
 			while IFS= read -r file; do
-				value=`cat $file`
-				echo "$value" >> $tfw_cfg_temp
+				inc_file=$(cat $file \
+					| sed -e '/request /s/\\r\\n/\x0d\x0a/g')
+				echo $inc_file >> $tfw_cfg_temp
+
 			done <<< "$files"
 		else
 			value="$line"


### PR DESCRIPTION
Strings in configuration file containing '\r' and '\n' passed to code as is which led to malforming of HTTP requests.
To fix this added two sed filters which substitute escaped symbols with hex codes. One for main file and second for includes. WARNING: This requires no additional escape symbols in the config file.

I took this task by myself, because #2147 was very dependent on it and task itself take no more then one hour.