### PR TITLE
db: File mapping fix

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -3395,12 +3395,12 @@ static TfwCfgSpec tfw_cache_specs[] = {
 	},
 	{
 		.name = "cache_size",
-		.deflt = "268435456",
-		.handler = tfw_cfg_set_long,
+		.deflt = "256M",
+		.handler = tfw_cfg_set_mem,
 		.dest = &cache_cfg.db_size,
-		.spec_ext = &(TfwCfgSpecInt) {
-			.multiple_of = 2 * 1024 * 1024,
-			.range = { 16 * 1024 * 1024, (1UL << 37) },
+		.spec_ext = &(TfwCfgSpecMem) {
+			.multiple_of = "2M",
+			.range = { "16M", "128G" },
 		}
 	},
 	{

--- a/fw/cfg.c
+++ b/fw/cfg.c
@@ -1234,7 +1234,7 @@ tfw_cfg_get_attr(const TfwCfgEntry *e, const char *attr_key,
  * Check that memory parameter is in specified range.
  * Print an error and return non-zero if it is out of range.
  */
-int
+static int
 tfw_cfg_mem_check_range(const char *mem, const char *mem_min,
 			const char *mem_max)
 {
@@ -1242,7 +1242,7 @@ tfw_cfg_mem_check_range(const char *mem, const char *mem_min,
 	unsigned long min = memparse(mem_min, NULL);
 	unsigned long max = memparse(mem_max, NULL);
 
-	if (min != max && (value < min || value > max)) {
+	if (value < min || value > max) {
 		T_ERR_NL("the value %s is out of range: [%s, %s]\n",
 			 mem, mem_min, mem_max);
 		return -EINVAL;
@@ -1254,7 +1254,7 @@ tfw_cfg_mem_check_range(const char *mem, const char *mem_min,
  * Check that memory parameter @value is a multiple of @divisor (print an error
  * otherwise);
  */
-int
+static int
 tfw_cfg_mem_check_multiple_of(const char *mem, const char *mem_divisor)
 {
 	unsigned long value = memparse(mem, NULL);
@@ -1824,13 +1824,9 @@ tfw_cfg_set_mem(TfwCfgSpec *cs, TfwCfgEntry *e)
 	/* Check value restrictions if we have any in the spec extension. */
 	cse = cs->spec_ext;
 	if (cse) {
-		int r;
-
-		r = tfw_cfg_mem_check_multiple_of(e->vals[0],
-						  cse->multiple_of);
-		r |= tfw_cfg_mem_check_range(e->vals[0], cse->range.min,
-					     cse->range.max);
-		if (r)
+		if (tfw_cfg_mem_check_multiple_of(e->vals[0], cse->multiple_of)
+		    || tfw_cfg_mem_check_range(e->vals[0], cse->range.min,
+					       cse->range.max))
 			return -EINVAL;
 	}
 

--- a/fw/cfg.c
+++ b/fw/cfg.c
@@ -1231,6 +1231,44 @@ tfw_cfg_get_attr(const TfwCfgEntry *e, const char *attr_key,
 }
 
 /**
+ * Check that memory parameter is in specified range.
+ * Print an error and return non-zero if it is out of range.
+ */
+int
+tfw_cfg_mem_check_range(const char *mem, const char *mem_min,
+			const char *mem_max)
+{
+	unsigned long value = memparse(mem, NULL);
+	unsigned long min = memparse(mem_min, NULL);
+	unsigned long max = memparse(mem_max, NULL);
+
+	if (min != max && (value < min || value > max)) {
+		T_ERR_NL("the value %s is out of range: [%s, %s]\n",
+			 mem, mem_min, mem_max);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+/**
+ * Check that memory parameter @value is a multiple of @divisor (print an error
+ * otherwise);
+ */
+int
+tfw_cfg_mem_check_multiple_of(const char *mem, const char *mem_divisor)
+{
+	unsigned long value = memparse(mem, NULL);
+	unsigned long divisor = memparse(mem_divisor, NULL);
+
+	if (divisor && (value % divisor)) {
+		T_ERR_NL("the value of %s is not a multiple of %s\n",
+			 mem, mem_divisor);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+/**
  * Check that integer is in specified range.
  * Print an error and return non-zero if it is out of range.
  */
@@ -1767,6 +1805,39 @@ tfw_cfg_set_str(TfwCfgSpec *cs, TfwCfgEntry *e)
 	*dest_strp = e->vals[0];
 	e->vals[0] = NULL;
 	cs->cleanup = tfw_cfg_cleanup_str;
+
+	return 0;
+}
+
+int
+tfw_cfg_set_mem(TfwCfgSpec *cs, TfwCfgEntry *e)
+{
+	long *dest_long;
+	unsigned long val;
+	TfwCfgSpecMem *cse;
+
+	BUG_ON(!cs->dest);
+
+	if (tfw_cfg_check_single_val(e))
+		return -EINVAL;
+
+	/* Check value restrictions if we have any in the spec extension. */
+	cse = cs->spec_ext;
+	if (cse) {
+		int r;
+
+		r = tfw_cfg_mem_check_multiple_of(e->vals[0],
+						  cse->multiple_of);
+		r |= tfw_cfg_mem_check_range(e->vals[0], cse->range.min,
+					     cse->range.max);
+		if (r)
+			return -EINVAL;
+	}
+
+	val = memparse(e->vals[0], NULL);
+
+	dest_long = cs->dest;
+	*dest_long = val;
 
 	return 0;
 }

--- a/fw/cfg.h
+++ b/fw/cfg.h
@@ -395,6 +395,15 @@ typedef struct {
 	int (*finish_hook)(TfwCfgSpec *self);
 } TfwCfgSpecChild;
 
+/* TfwCfgSpec->spec_ext for tfw_cfg_set_mem(). */
+typedef struct {
+	const char *multiple_of;
+	struct {
+		const char *min;
+		const char *max;
+	} range;
+} TfwCfgSpecMem;
+
 static inline bool
 tfw_cfg_is_dflt_value(TfwCfgEntry *cfg_entry)
 {
@@ -431,10 +440,14 @@ int tfw_cfg_set_bool(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_int(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_long(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_set_str(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
+int tfw_cfg_set_mem(TfwCfgSpec *spec, TfwCfgEntry *parsed_entry);
 int tfw_cfg_handle_children(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 void tfw_cfg_cleanup_children(TfwCfgSpec *cs);
 
 /* Various helpers for building custom handler functions. */
+int tfw_cfg_mem_check_range(const char *mem, const char *mem_min,
+			    const char *mem_max);
+int tfw_cfg_mem_check_multiple_of(const char *mem, const char *mem_divisor);
 int tfw_cfg_check_range(long value, long min, long max);
 int tfw_cfg_check_multiple_of(long value, int divisor);
 int tfw_cfg_check_val_n(const TfwCfgEntry *e, int val_n);

--- a/fw/cfg.h
+++ b/fw/cfg.h
@@ -445,9 +445,6 @@ int tfw_cfg_handle_children(TfwCfgSpec *self, TfwCfgEntry *parsed_entry);
 void tfw_cfg_cleanup_children(TfwCfgSpec *cs);
 
 /* Various helpers for building custom handler functions. */
-int tfw_cfg_mem_check_range(const char *mem, const char *mem_min,
-			    const char *mem_max);
-int tfw_cfg_mem_check_multiple_of(const char *mem, const char *mem_divisor);
 int tfw_cfg_check_range(long value, long min, long max);
 int tfw_cfg_check_multiple_of(long value, int divisor);
 int tfw_cfg_check_val_n(const TfwCfgEntry *e, int val_n);

--- a/fw/client.c
+++ b/fw/client.c
@@ -307,12 +307,12 @@ tfw_client_stop(void)
 static TfwCfgSpec tfw_client_specs[] = {
 	{
 		.name = "client_tbl_size",
-		.deflt = "16777216",
-		.handler = tfw_cfg_set_int,
+		.deflt = "16M",
+		.handler = tfw_cfg_set_mem,
 		.dest = &client_cfg.db_size,
-		.spec_ext = &(TfwCfgSpecInt) {
-			.multiple_of = PAGE_SIZE,
-			.range = { PAGE_SIZE, (1 << 30) },
+		.spec_ext = &(TfwCfgSpecMem) {
+			.multiple_of = "4K",
+			.range = { "4K", "1G" },
 		}
 	},
 	{

--- a/fw/filter.c
+++ b/fw/filter.c
@@ -306,12 +306,12 @@ tfw_filter_stop(void)
 static TfwCfgSpec tfw_filter_specs[] = {
 	{
 		.name = "filter_tbl_size",
-		.deflt = "16777216",
-		.handler = tfw_cfg_set_int,
+		.deflt = "16M",
+		.handler = tfw_cfg_set_mem,
 		.dest = &filter_cfg.db_size,
-		.spec_ext = &(TfwCfgSpecInt) {
-			.multiple_of = PAGE_SIZE,
-			.range = { PAGE_SIZE, (1 << 30) },
+		.spec_ext = &(TfwCfgSpecMem) {
+			.multiple_of = "4K",
+			.range = { "4K", "1G" },
 		}
 	},
 	{

--- a/fw/http_sess.c
+++ b/fw/http_sess.c
@@ -1262,12 +1262,12 @@ tfw_http_sess_stop(void)
 static TfwCfgSpec tfw_http_sess_specs_table[] = {
 	{
 		.name = "sessions_tbl_size",
-		.deflt = "16777216",
-		.handler = tfw_cfg_set_int,
+		.deflt = "16M",
+		.handler = tfw_cfg_set_mem,
 		.dest = &sess_db_cfg.db_size,
-		.spec_ext = &(TfwCfgSpecInt) {
-			.multiple_of = PAGE_SIZE,
-			.range = { PAGE_SIZE, (1 << 30) },
+		.spec_ext = &(TfwCfgSpecMem) {
+			.multiple_of = "4K",
+			.range = { "4K", "1G" },
 		}
 	},
 	{

--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -1,5 +1,5 @@
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 26bfe7ae7..35390651e 100644
+index 26bfe7ae7..82283cfda 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -5259,6 +5259,12 @@
@@ -7,14 +7,100 @@ index 26bfe7ae7..35390651e 100644
  	tdfx=		[HW,DRM]
  
 +	tempesta_dbmem=	[KNL]
-+			Order of 2MB memory blocks reserved on each NUMA node
-+			for Tempesta database. Huge pages are used if
-+			possible. Minimum value to start Tempesta is 4 (32MB).
-+			Default is 8, i.e. 512MB is reserved.
++			Amount of memory reserved on all NUMA nodes for Tempesta
++			database. The amount is divided between NUMA nodes.
++			Huge pages are used if possible. Minimum value to start
++			Tempesta is 32MB per node. Default is 512MB.
 +
  	test_suspend=	[SUSPEND][,N]
  			Specify "mem" (for Suspend-to-RAM) or "standby" (for
  			standby suspend) or "freeze" (for suspend type freeze)
+diff --git a/arch/x86/boot/compressed/kaslr.c b/arch/x86/boot/compressed/kaslr.c
+index b92fffbe7..353f31e1e 100644
+--- a/arch/x86/boot/compressed/kaslr.c
++++ b/arch/x86/boot/compressed/kaslr.c
+@@ -88,6 +88,10 @@ static bool memmap_too_large;
+  */
+ static u64 mem_limit;
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++static u64 tempesta_dbmem_sz;
++#endif
++
+ /* Number of immovable memory regions */
+ static int num_immovable_mem;
+ 
+@@ -302,6 +306,17 @@ static void handle_mem_options(void)
+ 		} else if (!strcmp(param, "efi_fake_mem")) {
+ 			mem_avoid_memmap(PARSE_EFI, val);
+ 		}
++#ifdef CONFIG_SECURITY_TEMPESTA
++		else if (!strcmp(param, "tempesta_dbmem")) {
++			char *p = val;
++
++			tempesta_dbmem_sz = round_up(memparse(p, &p),
++						     HPAGE_SIZE);
++			/* Don't clamp memory region when reserved less 32M */
++			if (tempesta_dbmem_sz < SZ_32M)
++				tempesta_dbmem_sz = 0;
++		}
++#endif
+ 	}
+ 
+ 	free(tmp_cmdline);
+@@ -557,6 +572,29 @@ process_gb_huge_pages(struct mem_vector *region, unsigned long image_size)
+ 	}
+ }
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++static void
++tempesta_clamp_region(struct mem_vector *region)
++{
++	if (!tempesta_dbmem_sz)
++		return;
++
++	if (region->size > tempesta_dbmem_sz) {
++		region->size -= tempesta_dbmem_sz;
++		/* Clamp only one region, it must enough. */
++		tempesta_dbmem_sz = 0;
++	}
++}
++
++static void
++post_process_region(struct mem_vector region, unsigned long image_size)
++{
++	/* Reserve space for Tempesta. */
++	tempesta_clamp_region(&region);
++	process_gb_huge_pages(&region, image_size);
++}
++#endif
++
+ static u64 slots_fetch_random(void)
+ {
+ 	unsigned long slot;
+@@ -610,14 +648,22 @@ static void __process_mem_region(struct mem_vector *entry,
+ 
+ 		/* If nothing overlaps, store the region and return. */
+ 		if (!mem_avoid_overlap(&region, &overlap)) {
++#ifdef CONFIG_SECURITY_TEMPESTA
++			post_process_region(region, image_size);
++#else
+ 			process_gb_huge_pages(&region, image_size);
++#endif
+ 			return;
+ 		}
+ 
+ 		/* Store beginning of region if holds at least image_size. */
+ 		if (overlap.start >= region.start + image_size) {
+ 			region.size = overlap.start - region.start;
++#ifdef CONFIG_SECURITY_TEMPESTA
++			post_process_region(region, image_size);
++#else
+ 			process_gb_huge_pages(&region, image_size);
++#endif
+ 		}
+ 
+ 		/* Clip off the overlapping region and start over. */
 diff --git a/arch/x86/include/asm/fpu/api.h b/arch/x86/include/asm/fpu/api.h
 index 38f493604..4c244d605 100644
 --- a/arch/x86/include/asm/fpu/api.h
@@ -696,7 +782,7 @@ index 000000000..90eedcba5
 + * Linux interface for Tempesta FW.
 + *
 + * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-+ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by
@@ -944,7 +1030,7 @@ index 2bdd80221..356850dda 100644
   *
   * IV[16] = b0[1] || implicit nonce[4] || explicit nonce[8] || length[3]
 diff --git a/init/main.c b/init/main.c
-index d9d914111..9a56ca35d 100644
+index d9d914111..412aff866 100644
 --- a/init/main.c
 +++ b/init/main.c
 @@ -110,6 +110,8 @@
@@ -956,23 +1042,29 @@ index d9d914111..9a56ca35d 100644
  static int kernel_init(void *);
  
  extern void init_IRQ(void);
-@@ -828,6 +830,15 @@ static void __init mm_init(void)
+@@ -820,6 +822,13 @@ static void __init report_meminit(void)
+  */
+ static void __init mm_init(void)
+ {
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/*
++	 * Tempesta: reserve memory at boot stage to get continous address
++	 * space. Do it while memblock is available.
++	 */
++	tempesta_reserve_pages();
++#endif
+ 	/*
+ 	 * page_ext requires contiguous pages,
+ 	 * bigger than MAX_ORDER unless SPARSEMEM.
+@@ -828,6 +837,7 @@ static void __init mm_init(void)
  	init_debug_pagealloc();
  	report_meminit();
  	mem_init();
 +
-+#ifdef CONFIG_SECURITY_TEMPESTA
-+	/*
-+	 * Tempesta: reserve pages just when zones are initialized
-+	 * to get continous address space of huge pages.
-+	 */
-+	tempesta_reserve_pages();
-+#endif
-+
  	kmem_cache_init();
  	kmemleak_init();
  	pgtable_init();
-@@ -838,6 +849,11 @@ static void __init mm_init(void)
+@@ -838,6 +848,11 @@ static void __init mm_init(void)
  	init_espfix_bsp();
  	/* Should be run after espfix64 is set up. */
  	pti_init();
@@ -1058,14 +1150,14 @@ index d73aed0fc..d19a4ecc1 100644
 +obj-$(CONFIG_SECURITY_TEMPESTA) += tempesta_mm.o
 diff --git a/mm/tempesta_mm.c b/mm/tempesta_mm.c
 new file mode 100644
-index 000000000..7ee3ead54
+index 000000000..2c9bd2aaa
 --- /dev/null
 +++ b/mm/tempesta_mm.c
-@@ -0,0 +1,274 @@
+@@ -0,0 +1,157 @@
 +/**
 + *		Tempesta Memory Reservation
 + *
-+ * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by
@@ -1086,41 +1178,45 @@ index 000000000..7ee3ead54
 +#include <linux/tempesta.h>
 +#include <linux/topology.h>
 +#include <linux/vmalloc.h>
++#include <linux/memblock.h>
 +
 +#include "internal.h"
 +
-+#define MAX_PGORDER		16	/* 128GB per one table */
-+#define MIN_PGORDER		4	/* 32MB */
-+#define DEFAULT_PGORDER		8	/* 512MB */
-+/* Modern processors support up to 1.5TB of RAM, be ready for 2TB. */
-+#define GREEDY_ARNUM		(1024 * 1024 + 1)
-+#define PGNUM			(1 << pgorder)
-+#define PGNUM4K			(PGNUM * (1 << HUGETLB_PAGE_ORDER))
++#define MAX_MEMSZ		65536 * HPAGE_SIZE /* 128GB per node */
++#define MIN_MEMSZ		16 * HPAGE_SIZE	/* 32MB per node */
++#define DEFAULT_MEMSZ		256 * HPAGE_SIZE /* 512MB */
 +
-+static int pgorder = DEFAULT_PGORDER;
-+static gfp_t gfp_f = GFP_HIGHUSER | __GFP_COMP | __GFP_THISNODE | __GFP_ZERO
-+		     | __GFP_RETRY_MAYFAIL;
++static unsigned long dbmem = DEFAULT_MEMSZ;
 +static TempestaMapping map[MAX_NUMNODES];
-+/*
-+ * Modern x86-64 has not more than 512GB RAM per physical node.
-+ * This is very large amount of memory, but it will be freed when
-+ * initialization phase ends.
-+ */
-+static struct page *greedy[GREEDY_ARNUM] __initdata = { 0 };
++
++static unsigned long
++__dbsize_mb(unsigned long size)
++{
++	if (size >= SZ_1M)
++		return size / SZ_1M;
++
++	return 0;
++}
 +
 +static int __init
 +tempesta_setup_pages(char *str)
 +{
-+	get_option(&str, &pgorder);
-+	if (pgorder < MIN_PGORDER) {
-+		pr_err("Tempesta: bad dbmem value %d, must be [%d:%d]\n",
-+		       pgorder, MIN_PGORDER, MAX_PGORDER);
-+		pgorder = MIN_PGORDER;
++	unsigned long min = __dbsize_mb(MIN_MEMSZ) * nr_online_nodes;
++	unsigned long max = __dbsize_mb(MAX_MEMSZ) * nr_online_nodes;
++	unsigned long raw_dbmem = memparse(str, NULL);
++
++	/* Count memory per node */
++	dbmem = round_up(raw_dbmem / nr_online_nodes, HPAGE_SIZE);
++
++	if (dbmem < MIN_MEMSZ) {
++		pr_err("Tempesta: bad dbmem value %lu(%luM), must be [%luM:%luM]"
++		       "\n", raw_dbmem, __dbsize_mb(raw_dbmem), min, max);
++		dbmem = MIN_MEMSZ;
 +	}
-+	if (pgorder > MAX_PGORDER) {
-+		pr_err("Tempesta: bad dbmem value %d, must be [%d:%d]\n",
-+		       pgorder, MIN_PGORDER, MAX_PGORDER);
-+		pgorder = MAX_PGORDER;
++	if (dbmem > MAX_MEMSZ) {
++		pr_err("Tempesta: bad dbmem value %lu(%luM), must be [%luM:%luM]"
++		       "\n", raw_dbmem, __dbsize_mb(raw_dbmem), min, max);
++		dbmem = MAX_MEMSZ;
 +	}
 +
 +	return 1;
@@ -1128,162 +1224,42 @@ index 000000000..7ee3ead54
 +__setup("tempesta_dbmem=", tempesta_setup_pages);
 +
 +/**
-+ * The code is somewhat stollen from mm/hugetlb.c.
-+ */
-+static struct page *
-+tempesta_alloc_hpage(int nid)
-+{
-+	struct page *p;
-+
-+	p = alloc_pages_node(nid, gfp_f, HUGETLB_PAGE_ORDER);
-+	if (!p)
-+		return NULL;
-+
-+	count_vm_event(HTLB_BUDDY_PGALLOC);
-+
-+	__ClearPageReserved(p);
-+
-+	return p;
-+}
-+
-+static void
-+tempesta_free_hpage(struct page *p)
-+{
-+	__free_pages(p, HUGETLB_PAGE_ORDER);
-+}
-+
-+/**
-+ * Greedely alloc huge pages and try to find continous region organized
-+ * by sorted set of allocated pages. When the region is found, all pages
-+ * out of it are returned to system.
-+ */
-+static struct page *
-+tempesta_alloc_contmem(int nid)
-+{
-+	long min = -1, start = -1, curr = 0, end = -1, max = -1;
-+	struct page *p;
-+
-+	while (1) {
-+		p = tempesta_alloc_hpage(nid);
-+		if (!p)
-+			goto err;
-+		curr = ((long)page_address(p) - PAGE_OFFSET) >> HPAGE_SHIFT;
-+		/*
-+		 * The first kernel mapped page is always reserved.
-+		 * Keep untouched (zero) bounds for faster lookups.
-+		 */
-+		BUG_ON(curr < 1 || curr >= GREEDY_ARNUM);
-+		greedy[curr] = p;
-+
-+		/* First time initialization. */
-+		if (min < 0) {
-+			min = start = end = max = curr;
-+		} else {
-+			/* Update bounds for faster pages return. */
-+			if (min > curr)
-+				min = curr;
-+			if (max < curr)
-+				max = curr;
-+			/* Update continous memory segment bounds. */
-+			if (curr == end + 1) {
-+				while (end <= max && greedy[end + 1])
-+					++end;
-+			}
-+			else if (curr + 1 == start) {
-+				while (start >= min && greedy[start - 1])
-+					--start;
-+			}
-+			else {
-+				/* Try to find new continous segment. */
-+				long i, d_max = 0, good_start = start = min;
-+				for (i = min; i <= max; ++i) {
-+					if (greedy[i]) {
-+						if (start == -1)
-+							start = i;
-+						end = i;
-+						if (i - start + 1 == PGNUM)
-+							break;
-+						continue;
-+					}
-+
-+					if (start > 0 && end - start > d_max) {
-+						good_start = start;
-+						d_max = end - start;
-+					}
-+					start = -1;
-+				}
-+				if (end - start < d_max) {
-+					start = good_start;
-+					end = start + d_max;
-+				}
-+			}
-+		}
-+
-+		if (end - start + 1 == PGNUM)
-+			break; /* continous space is built! */
-+	}
-+
-+	/* Return unnecessary pages. */
-+	BUG_ON(min < 0 || start < 0 || end < 0 || max < 0);
-+	for ( ; min < start; ++min)
-+		if (greedy[min]) {
-+			tempesta_free_hpage(greedy[min]);
-+			greedy[min] = NULL;
-+		}
-+	for ( ; max > end; --max)
-+		if (greedy[max]) {
-+			tempesta_free_hpage(greedy[max]);
-+			greedy[max] = NULL;
-+		}
-+	return greedy[start];
-+
-+err:
-+	pr_err("Tempesta: cannot allocate %u continous huge pages at node"
-+	       " %d\n", PGNUM, nid);
-+	for ( ; min >= 0 && min <= max; ++min)
-+		if (greedy[min]) {
-+			tempesta_free_hpage(greedy[min]);
-+			greedy[min] = NULL;
-+		}
-+	return NULL;
-+}
-+
-+/**
-+ * Allocate continous virtual space of huge pages for Tempesta.
-+ * We do not use giantic 1GB pages since not all modern x86-64 CPUs
-+ * allows them in virtualized mode.
-+ *
-+ * TODO try firstly to allocate giantic pages, next huge pages and finally
-+ * fallback to common 4KB pages allocation if previous tries failed.
++ * Reserve physically continous block of memory for Tempesta.
 + */
 +void __init
 +tempesta_reserve_pages(void)
 +{
 +	int nid;
-+	struct page *p;
++	void *addr;
 +
 +	for_each_online_node(nid) {
-+		p = tempesta_alloc_contmem(nid);
-+		if (!p)
++		addr = memblock_alloc_try_nid_raw(dbmem, HPAGE_SIZE,
++						  MEMBLOCK_LOW_LIMIT,
++						  MEMBLOCK_ALLOC_ANYWHERE,
++						  nid);
++		if (!addr) {
++			pr_err("Tempesta: can't reserve %lu memory at node %d"
++			       "\n", __dbsize_mb(dbmem), nid);
 +			goto err;
++		}
 +
-+		map[nid].addr = (unsigned long)page_address(p);
-+		map[nid].pages = PGNUM4K;
-+
-+		pr_info("Tempesta: allocated huge pages space %pK %luMB at node"
-+			" %d\n", page_address(p),
-+			PGNUM4K * PAGE_SIZE / (1024 * 1024), nid);
++		map[nid].addr = (unsigned long)addr;
++		map[nid].pages = dbmem / PAGE_SIZE;
++		pr_info("Tempesta: reserved space %luMB addr %p at node %d\n",
++			__dbsize_mb(dbmem), addr, nid);
 +	}
 +
 +	return;
++
 +err:
 +	for_each_online_node(nid) {
-+		struct page *pend;
++		phys_addr_t phys_addr;
++
 +		if (!map[nid].addr)
 +			continue;
-+		for (p = virt_to_page(map[nid].addr), pend = p + PGNUM4K;
-+		     p < pend; p += 1 << HUGETLB_PAGE_ORDER)
-+			tempesta_free_hpage(p);
++
++		phys_addr = virt_to_phys((void *)map[nid].addr);
++		memblock_free(phys_addr, map[nid].pages * PAGE_SIZE);
 +	}
 +	memset(map, 0, sizeof(map));
 +}
@@ -1295,7 +1271,6 @@ index 000000000..7ee3ead54
 +tempesta_reserve_vmpages(void)
 +{
 +	int nid, maps = 0;
-+	size_t vmsize = PGNUM * (1 << HPAGE_SHIFT);
 +
 +	for_each_online_node(nid)
 +		maps += !!map[nid].addr;
@@ -1305,19 +1280,19 @@ index 000000000..7ee3ead54
 +		return;
 +
 +	for_each_online_node(nid) {
-+		pr_warn("Tempesta: allocate %u vmalloc pages at node %d\n",
-+			PGNUM4K, nid);
++		pr_warn("Tempesta: allocate %lu vmalloc pages at node %d\n",
++			__dbsize_mb(dbmem), nid);
 +
-+		map[nid].addr = (unsigned long)vzalloc_node(vmsize, nid);
++		map[nid].addr = (unsigned long)vzalloc_node(dbmem, nid);
 +		if (!map[nid].addr)
 +			goto err;
-+		map[nid].pages = PGNUM4K;
++		map[nid].pages = dbmem / PAGE_SIZE;
 +	}
 +
 +	return;
 +err:
 +	pr_err("Tempesta: cannot vmalloc area of %lu bytes at node %d\n",
-+	       vmsize, nid);
++	       dbmem, nid);
 +	for_each_online_node(nid)
 +		if (map[nid].addr)
 +			vfree((void *)map[nid].addr);
@@ -2986,7 +2961,3100 @@ index 000000000..313101304
 + *		Tempesta FW
 + *
 + * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
-+ * Copyright (C) 2015-2023 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License,
++ * or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
++ * FOR A PARTICULAR PURPOSE.
++ * See the GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along with
++ * this program; if not, write to the Free Software Foundation, Inc., 59
++ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ */
++#include <linux/ipv6.h>
++#include <linux/lsm_hooks.h>
++#include <linux/spinlock.h>
++#include <linux/tempesta.h>
++
++static TempestaOps __rcu *tempesta_ops = NULL;
++static DEFINE_SPINLOCK(tops_lock);
++
++void
++tempesta_register_ops(TempestaOps *tops)
++{
++	spin_lock(&tops_lock);
++
++	BUG_ON(tempesta_ops);
++
++	rcu_assign_pointer(tempesta_ops, tops);
++
++	spin_unlock(&tops_lock);
++}
++EXPORT_SYMBOL(tempesta_register_ops);
++
++void
++tempesta_unregister_ops(TempestaOps *tops)
++{
++	spin_lock(&tops_lock);
++
++	BUG_ON(tempesta_ops != tops);
++
++	rcu_assign_pointer(tempesta_ops, NULL);
++
++	spin_unlock(&tops_lock);
++
++	/*
++	 * tempesta_ops is called in softirq only, so if there are some users
++	 * of the structures then they are active on their CPUs.
++	 * After the below we can be sure that nobody refers @tops and we can
++	 * go forward and destroy it.
++	 */
++	synchronize_rcu();
++}
++EXPORT_SYMBOL(tempesta_unregister_ops);
++
++int
++tempesta_new_clntsk(struct sock *newsk, struct sk_buff *skb)
++{
++	int r = 0;
++
++	TempestaOps *tops;
++
++	WARN_ON(newsk->sk_security);
++
++	rcu_read_lock();
++
++	tops = rcu_dereference(tempesta_ops);
++	if (likely(tops))
++		r = tops->sk_alloc(newsk, skb);
++
++	rcu_read_unlock();
++
++	return r;
++}
++EXPORT_SYMBOL(tempesta_new_clntsk);
++
++void
++tempesta_close_clntsk(struct sock *sk)
++{
++	TempestaOps *tops;
++
++	rcu_read_lock();
++
++	tops = rcu_dereference(tempesta_ops);
++	if (likely(tops))
++		tops->sk_free(sk);
++
++	rcu_read_unlock();
++}
++EXPORT_SYMBOL(tempesta_close_clntsk);
++
++static int
++tempesta_sock_tcp_rcv(struct sock *sk, struct sk_buff *skb)
++{
++	int r = 0;
++	TempestaOps *tops;
++
++	rcu_read_lock();
++
++	tops = rcu_dereference(tempesta_ops);
++	if (likely(tops)) {
++		if (skb->protocol == htons(ETH_P_IP))
++			r = tops->sock_tcp_rcv(sk, skb);
++	}
++
++	rcu_read_unlock();
++
++	return r;
++}
++
++static struct security_hook_list tempesta_hooks[] __read_mostly = {
++	LSM_HOOK_INIT(socket_sock_rcv_skb, tempesta_sock_tcp_rcv),
++};
++
++static __init int
++tempesta_init(void)
++{
++	security_add_hooks(tempesta_hooks, ARRAY_SIZE(tempesta_hooks),
++			   "tempesta");
++
++	return 0;
++}
++
++DEFINE_LSM(smack) = {
++	.name = "tempesta",
++	.flags = LSM_FLAG_LEGACY_MAJOR | LSM_FLAG_EXCLUSIVE,
++	.init = tempesta_init,
++};
+diff --git a/tools/lib/subcmd/subcmd-util.h b/tools/lib/subcmd/subcmd-util.h
+index 794a375da..7bf9be99b 100644
+--- a/tools/lib/subcmd/subcmd-util.h
++++ b/tools/lib/subcmd/subcmd-util.h
+@@ -47,6 +47,7 @@ static NORETURN inline void die(const char *err, ...)
+ 		} \
+ 	} while(0)
+ 
++#pragma GCC diagnostic ignored "-Wuse-after-free"
+ static inline void *xrealloc(void *ptr, size_t size)
+ {
+ 	void *ret = realloc(ptr, size);
+diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
+index 26bfe7ae7..82283cfda 100644
+--- a/Documentation/admin-guide/kernel-parameters.txt
++++ b/Documentation/admin-guide/kernel-parameters.txt
+@@ -5259,6 +5259,12 @@
+ 
+ 	tdfx=		[HW,DRM]
+ 
++	tempesta_dbmem=	[KNL]
++			Amount of memory reserved on all NUMA nodes for Tempesta
++			database. The amount is divided between NUMA nodes.
++			Huge pages are used if possible. Minimum value to start
++			Tempesta is 32MB per node. Default is 512MB.
++
+ 	test_suspend=	[SUSPEND][,N]
+ 			Specify "mem" (for Suspend-to-RAM) or "standby" (for
+ 			standby suspend) or "freeze" (for suspend type freeze)
+diff --git a/arch/x86/boot/compressed/kaslr.c b/arch/x86/boot/compressed/kaslr.c
+index b92fffbe7..353f31e1e 100644
+--- a/arch/x86/boot/compressed/kaslr.c
++++ b/arch/x86/boot/compressed/kaslr.c
+@@ -88,6 +88,10 @@ static bool memmap_too_large;
+  */
+ static u64 mem_limit;
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++static u64 tempesta_dbmem_sz;
++#endif
++
+ /* Number of immovable memory regions */
+ static int num_immovable_mem;
+ 
+@@ -302,6 +306,17 @@ static void handle_mem_options(void)
+ 		} else if (!strcmp(param, "efi_fake_mem")) {
+ 			mem_avoid_memmap(PARSE_EFI, val);
+ 		}
++#ifdef CONFIG_SECURITY_TEMPESTA
++		else if (!strcmp(param, "tempesta_dbmem")) {
++			char *p = val;
++
++			tempesta_dbmem_sz = round_up(memparse(p, &p),
++						     HPAGE_SIZE);
++			/* Don't clamp memory region when reserved less 32M */
++			if (tempesta_dbmem_sz < SZ_32M)
++				tempesta_dbmem_sz = 0;
++		}
++#endif
+ 	}
+ 
+ 	free(tmp_cmdline);
+@@ -557,6 +572,29 @@ process_gb_huge_pages(struct mem_vector *region, unsigned long image_size)
+ 	}
+ }
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++static void
++tempesta_clamp_region(struct mem_vector *region)
++{
++	if (!tempesta_dbmem_sz)
++		return;
++
++	if (region->size > tempesta_dbmem_sz) {
++		region->size -= tempesta_dbmem_sz;
++		/* Clamp only one region, it must enough. */
++		tempesta_dbmem_sz = 0;
++	}
++}
++
++static void
++post_process_region(struct mem_vector region, unsigned long image_size)
++{
++	/* Reserve space for Tempesta. */
++	tempesta_clamp_region(&region);
++	process_gb_huge_pages(&region, image_size);
++}
++#endif
++
+ static u64 slots_fetch_random(void)
+ {
+ 	unsigned long slot;
+@@ -610,14 +648,22 @@ static void __process_mem_region(struct mem_vector *entry,
+ 
+ 		/* If nothing overlaps, store the region and return. */
+ 		if (!mem_avoid_overlap(&region, &overlap)) {
++#ifdef CONFIG_SECURITY_TEMPESTA
++			post_process_region(region, image_size);
++#else
+ 			process_gb_huge_pages(&region, image_size);
++#endif
+ 			return;
+ 		}
+ 
+ 		/* Store beginning of region if holds at least image_size. */
+ 		if (overlap.start >= region.start + image_size) {
+ 			region.size = overlap.start - region.start;
++#ifdef CONFIG_SECURITY_TEMPESTA
++			post_process_region(region, image_size);
++#else
+ 			process_gb_huge_pages(&region, image_size);
++#endif
+ 		}
+ 
+ 		/* Clip off the overlapping region and start over. */
+diff --git a/arch/x86/include/asm/fpu/api.h b/arch/x86/include/asm/fpu/api.h
+index 38f493604..4c244d605 100644
+--- a/arch/x86/include/asm/fpu/api.h
++++ b/arch/x86/include/asm/fpu/api.h
+@@ -24,6 +24,10 @@
+ #define KFPU_387	_BITUL(0)	/* 387 state will be initialized */
+ #define KFPU_MXCSR	_BITUL(1)	/* MXCSR will be initialized */
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++extern void __kernel_fpu_begin_mask(unsigned int kfpu_mask);
++extern void __kernel_fpu_end_bh(void);
++#endif
+ extern void kernel_fpu_begin_mask(unsigned int kfpu_mask);
+ extern void kernel_fpu_end(void);
+ extern bool irq_fpu_usable(void);
+diff --git a/arch/x86/kernel/fpu/core.c b/arch/x86/kernel/fpu/core.c
+index 571220ac8..a7ce7c357 100644
+--- a/arch/x86/kernel/fpu/core.c
++++ b/arch/x86/kernel/fpu/core.c
+@@ -76,6 +76,10 @@ static bool interrupted_user_mode(void)
+  */
+ bool irq_fpu_usable(void)
+ {
++#ifdef CONFIG_SECURITY_TEMPESTA
++	if (likely(in_serving_softirq()))
++		return true;
++#endif
+ 	return !in_interrupt() ||
+ 		interrupted_user_mode() ||
+ 		interrupted_kernel_fpu_idle();
+@@ -121,10 +125,8 @@ int copy_fpregs_to_fpstate(struct fpu *fpu)
+ }
+ EXPORT_SYMBOL(copy_fpregs_to_fpstate);
+ 
+-void kernel_fpu_begin_mask(unsigned int kfpu_mask)
++void __kernel_fpu_begin_mask(unsigned int kfpu_mask)
+ {
+-	preempt_disable();
+-
+ 	WARN_ON_FPU(!irq_fpu_usable());
+ 	WARN_ON_FPU(this_cpu_read(in_kernel_fpu));
+ 
+@@ -148,14 +150,46 @@ void kernel_fpu_begin_mask(unsigned int kfpu_mask)
+ 	if (unlikely(kfpu_mask & KFPU_387) && boot_cpu_has(X86_FEATURE_FPU))
+ 		asm volatile ("fninit");
+ }
++
++void kernel_fpu_begin_mask(unsigned int kfpu_mask)
++{
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/* SoftIRQ in the Tempesta kernel always enables FPU. */
++	if (likely(in_serving_softirq()))
++		return;
++
++	/*
++	 * We don't know in which context the function is called, but we know
++	 * preciseely that softirq uses FPU, so we have to disable softirq as
++	 * well as task preemption.
++	 */
++	local_bh_disable();
++#endif
++	preempt_disable();
++
++	__kernel_fpu_begin_mask(kfpu_mask);
++}
+ EXPORT_SYMBOL_GPL(kernel_fpu_begin_mask);
+ 
+-void kernel_fpu_end(void)
++void __kernel_fpu_end_bh(void)
+ {
+ 	WARN_ON_FPU(!this_cpu_read(in_kernel_fpu));
+ 
+ 	this_cpu_write(in_kernel_fpu, false);
++}
++
++void kernel_fpu_end(void)
++{
++#ifdef CONFIG_SECURITY_TEMPESTA
++	if (likely(in_serving_softirq()))
++		return;
++#endif
++	__kernel_fpu_end_bh();
++
+ 	preempt_enable();
++#ifdef CONFIG_SECURITY_TEMPESTA
++	local_bh_enable();
++#endif
+ }
+ EXPORT_SYMBOL_GPL(kernel_fpu_end);
+ 
+diff --git a/crypto/aead.c b/crypto/aead.c
+index 169910952..a3f0aeca1 100644
+--- a/crypto/aead.c
++++ b/crypto/aead.c
+@@ -217,6 +217,24 @@ struct crypto_aead *crypto_alloc_aead(const char *alg_name, u32 type, u32 mask)
+ }
+ EXPORT_SYMBOL_GPL(crypto_alloc_aead);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++struct crypto_alg *
++crypto_find_aead(const char *alg_name, u32 type, u32 mask)
++{
++	return crypto_find_alg(alg_name, &crypto_aead_type, type, mask);
++}
++EXPORT_SYMBOL_GPL(crypto_find_aead);
++
++struct crypto_aead *
++crypto_alloc_aead_atomic(struct crypto_alg *alg)
++{
++	alg = crypto_mod_get(alg);
++	BUG_ON(!alg);
++	return crypto_create_tfm(alg, &crypto_aead_type);
++}
++EXPORT_SYMBOL_GPL(crypto_alloc_aead_atomic);
++#endif
++
+ static int aead_prepare_alg(struct aead_alg *alg)
+ {
+ 	struct crypto_alg *base = &alg->base;
+diff --git a/crypto/ahash.c b/crypto/ahash.c
+index c2ca631a1..c49313c1a 100644
+--- a/crypto/ahash.c
++++ b/crypto/ahash.c
+@@ -559,6 +559,25 @@ struct crypto_ahash *crypto_alloc_ahash(const char *alg_name, u32 type,
+ }
+ EXPORT_SYMBOL_GPL(crypto_alloc_ahash);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++/* Asynch hash is required by GHASH used in GCM. */
++struct crypto_alg *
++crypto_find_ahash(const char *alg_name, u32 type, u32 mask)
++{
++	return crypto_find_alg(alg_name, &crypto_ahash_type, type, mask);
++}
++EXPORT_SYMBOL_GPL(crypto_find_ahash);
++
++struct crypto_ahash *
++crypto_alloc_ahash_atomic(struct crypto_alg *alg)
++{
++	alg = crypto_mod_get(alg);
++	BUG_ON(!alg);
++	return crypto_create_tfm(alg, &crypto_ahash_type);
++}
++EXPORT_SYMBOL_GPL(crypto_alloc_ahash_atomic);
++#endif
++
+ int crypto_has_ahash(const char *alg_name, u32 type, u32 mask)
+ {
+ 	return crypto_type_has_alg(alg_name, &crypto_ahash_type, type, mask);
+diff --git a/crypto/api.c b/crypto/api.c
+index ed08cbd5b..17b5789d4 100644
+--- a/crypto/api.c
++++ b/crypto/api.c
+@@ -446,7 +446,11 @@ void *crypto_create_tfm_node(struct crypto_alg *alg,
+ 	tfmsize = frontend->tfmsize;
+ 	total = tfmsize + sizeof(*tfm) + frontend->extsize(alg);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	mem = kzalloc_node(total, GFP_ATOMIC, node);
++#else
+ 	mem = kzalloc_node(total, GFP_KERNEL, node);
++#endif
+ 	if (mem == NULL)
+ 		goto out_err;
+ 
+@@ -480,6 +484,9 @@ struct crypto_alg *crypto_find_alg(const char *alg_name,
+ 				   const struct crypto_type *frontend,
+ 				   u32 type, u32 mask)
+ {
++	/* The function is slow and preemptable to be called in softirq. */
++	WARN_ON_ONCE(in_serving_softirq());
++
+ 	if (frontend) {
+ 		type &= frontend->maskclear;
+ 		mask &= frontend->maskclear;
+diff --git a/crypto/cryptd.c b/crypto/cryptd.c
+index a1bea0f4b..29515a891 100644
+--- a/crypto/cryptd.c
++++ b/crypto/cryptd.c
+@@ -27,6 +27,8 @@
+ #include <linux/slab.h>
+ #include <linux/workqueue.h>
+ 
++#include "internal.h"
++
+ static unsigned int cryptd_max_cpu_qlen = 1000;
+ module_param(cryptd_max_cpu_qlen, uint, 0);
+ MODULE_PARM_DESC(cryptd_max_cpu_qlen, "Set cryptd Max queue depth");
+@@ -901,6 +903,75 @@ static struct crypto_template cryptd_tmpl = {
+ 	.module = THIS_MODULE,
+ };
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++
++#define MAX_CACHED_ALG_COUNT	8
++struct alg_cache {
++	int n;
++	spinlock_t lock;
++	struct {
++		u32 type;
++		u32 mask;
++		struct crypto_alg *alg;
++		char alg_name[CRYPTO_MAX_ALG_NAME];
++	} a[MAX_CACHED_ALG_COUNT];
++};
++
++static struct alg_cache skcipher_alg_cache;
++static struct alg_cache ahash_alg_cache;
++static struct alg_cache aead_alg_cache;
++
++/*
++ * Finds a previously allocated algorithm or allocates a new one. In any case,
++ * returned alg holds at least one reference to its module.
++ */
++static struct crypto_alg *
++cryptd_find_alg_cached(const char *cryptd_alg_name, u32 type, u32 mask,
++		       struct crypto_alg *(*find_alg)(const char *, u32, u32),
++		       struct alg_cache *__restrict ac)
++{
++	struct crypto_alg *alg;
++	int k;
++
++	spin_lock(&ac->lock);
++	for (k = 0; k < ac->n; k++) {
++		if (strcmp(ac->a[k].alg_name, cryptd_alg_name) == 0
++		    && ac->a[k].type == type && ac->a[k].mask == mask)
++		{
++			spin_unlock(&ac->lock);
++			return ac->a[k].alg;
++		}
++	}
++	spin_unlock(&ac->lock);
++
++	/* Searching for the algorithm may sleep, so warn about it. */
++	WARN_ON_ONCE(in_serving_softirq());
++
++	alg = find_alg(cryptd_alg_name, type, mask);
++	if (IS_ERR(alg))
++		return alg;
++
++	spin_lock(&ac->lock);
++	if (ac->n >= MAX_CACHED_ALG_COUNT) {
++		spin_unlock(&ac->lock);
++		BUG();
++		return ERR_PTR(-ENOMEM);
++	}
++
++	snprintf(ac->a[ac->n].alg_name, sizeof(ac->a[ac->n].alg_name), "%s",
++		 cryptd_alg_name);
++
++	ac->a[ac->n].type = type;
++	ac->a[ac->n].mask = mask;
++	ac->a[ac->n].alg = alg;
++
++	ac->n += 1;
++	spin_unlock(&ac->lock);
++
++	return alg;
++}
++#endif /* CONFIG_SECURITY_TEMPESTA */
++
+ struct cryptd_skcipher *cryptd_alloc_skcipher(const char *alg_name,
+ 					      u32 type, u32 mask)
+ {
+@@ -912,7 +983,20 @@ struct cryptd_skcipher *cryptd_alloc_skcipher(const char *alg_name,
+ 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
+ 		return ERR_PTR(-EINVAL);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	{
++		struct crypto_alg *alg =
++			cryptd_find_alg_cached(cryptd_alg_name, type, mask,
++					       crypto_find_skcipher,
++					       &skcipher_alg_cache);
++		if (IS_ERR(alg))
++			return (struct cryptd_skcipher *)alg;
++
++		tfm = crypto_alloc_skcipher_atomic(alg);
++	}
++#else
+ 	tfm = crypto_alloc_skcipher(cryptd_alg_name, type, mask);
++#endif
+ 	if (IS_ERR(tfm))
+ 		return ERR_CAST(tfm);
+ 
+@@ -963,7 +1047,21 @@ struct cryptd_ahash *cryptd_alloc_ahash(const char *alg_name,
+ 	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
+ 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
+ 		return ERR_PTR(-EINVAL);
++
++#ifdef CONFIG_SECURITY_TEMPESTA
++	{
++		struct crypto_alg *alg =
++			cryptd_find_alg_cached(cryptd_alg_name, type, mask,
++					       crypto_find_ahash,
++					       &ahash_alg_cache);
++		if (IS_ERR(alg))
++			return (struct cryptd_ahash *)alg;
++
++		tfm = crypto_alloc_ahash_atomic(alg);
++	}
++#else
+ 	tfm = crypto_alloc_ahash(cryptd_alg_name, type, mask);
++#endif
+ 	if (IS_ERR(tfm))
+ 		return ERR_CAST(tfm);
+ 	if (tfm->base.__crt_alg->cra_module != THIS_MODULE) {
+@@ -1020,7 +1118,21 @@ struct cryptd_aead *cryptd_alloc_aead(const char *alg_name,
+ 	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
+ 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
+ 		return ERR_PTR(-EINVAL);
++
++#ifdef CONFIG_SECURITY_TEMPESTA
++	{
++		struct crypto_alg *alg =
++			cryptd_find_alg_cached(cryptd_alg_name, type, mask,
++					       crypto_find_aead,
++					       &aead_alg_cache);
++		if (IS_ERR(alg))
++			return (struct cryptd_aead *)alg;
++
++		tfm = crypto_alloc_aead_atomic(alg);
++	}
++#else
+ 	tfm = crypto_alloc_aead(cryptd_alg_name, type, mask);
++#endif
+ 	if (IS_ERR(tfm))
+ 		return ERR_CAST(tfm);
+ 	if (tfm->base.__crt_alg->cra_module != THIS_MODULE) {
+diff --git a/crypto/shash.c b/crypto/shash.c
+index 2e3433ad9..bc9c26dfe 100644
+--- a/crypto/shash.c
++++ b/crypto/shash.c
+@@ -509,6 +509,24 @@ struct crypto_shash *crypto_alloc_shash(const char *alg_name, u32 type,
+ }
+ EXPORT_SYMBOL_GPL(crypto_alloc_shash);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++struct crypto_alg *
++crypto_find_shash(const char *alg_name, u32 type, u32 mask)
++{
++	return crypto_find_alg(alg_name, &crypto_shash_type, type, mask);
++}
++EXPORT_SYMBOL_GPL(crypto_find_shash);
++
++struct crypto_shash *
++crypto_alloc_shash_atomic(struct crypto_alg *alg)
++{
++	alg = crypto_mod_get(alg);
++	BUG_ON(!alg);
++	return crypto_create_tfm(alg, &crypto_shash_type);
++}
++EXPORT_SYMBOL_GPL(crypto_alloc_shash_atomic);
++#endif
++
+ static int shash_prepare_alg(struct shash_alg *alg)
+ {
+ 	struct crypto_alg *base = &alg->base;
+diff --git a/crypto/skcipher.c b/crypto/skcipher.c
+index b4dae640d..1b6d4a669 100644
+--- a/crypto/skcipher.c
++++ b/crypto/skcipher.c
+@@ -762,6 +762,24 @@ struct crypto_skcipher *crypto_alloc_skcipher(const char *alg_name,
+ }
+ EXPORT_SYMBOL_GPL(crypto_alloc_skcipher);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++struct crypto_alg *
++crypto_find_skcipher(const char *alg_name, u32 type, u32 mask)
++{
++	return crypto_find_alg(alg_name, &crypto_skcipher_type, type, mask);
++}
++EXPORT_SYMBOL_GPL(crypto_find_skcipher);
++
++struct crypto_skcipher *
++crypto_alloc_skcipher_atomic(struct crypto_alg *alg)
++{
++	alg = crypto_mod_get(alg);
++	BUG_ON(!alg);
++	return crypto_create_tfm(alg, &crypto_skcipher_type);
++}
++EXPORT_SYMBOL_GPL(crypto_alloc_skcipher_atomic);
++#endif
++
+ struct crypto_sync_skcipher *crypto_alloc_sync_skcipher(
+ 				const char *alg_name, u32 type, u32 mask)
+ {
+diff --git a/include/crypto/aead.h b/include/crypto/aead.h
+index c32a6f566..5fe1addcc 100644
+--- a/include/crypto/aead.h
++++ b/include/crypto/aead.h
+@@ -177,6 +177,11 @@ static inline struct crypto_aead *__crypto_aead_cast(struct crypto_tfm *tfm)
+  */
+ struct crypto_aead *crypto_alloc_aead(const char *alg_name, u32 type, u32 mask);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++struct crypto_alg *crypto_find_aead(const char *alg_name, u32 type, u32 mask);
++struct crypto_aead *crypto_alloc_aead_atomic(struct crypto_alg *alg);
++#endif
++
+ static inline struct crypto_tfm *crypto_aead_tfm(struct crypto_aead *tfm)
+ {
+ 	return &tfm->base;
+diff --git a/include/crypto/hash.h b/include/crypto/hash.h
+index 13f8a6a54..bba113f6d 100644
+--- a/include/crypto/hash.h
++++ b/include/crypto/hash.h
+@@ -273,6 +273,11 @@ static inline struct crypto_ahash *__crypto_ahash_cast(struct crypto_tfm *tfm)
+ struct crypto_ahash *crypto_alloc_ahash(const char *alg_name, u32 type,
+ 					u32 mask);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++struct crypto_alg *crypto_find_ahash(const char *alg_name, u32 type, u32 mask);
++struct crypto_ahash *crypto_alloc_ahash_atomic(struct crypto_alg *alg);
++#endif
++
+ static inline struct crypto_tfm *crypto_ahash_tfm(struct crypto_ahash *tfm)
+ {
+ 	return &tfm->base;
+@@ -716,6 +721,11 @@ static inline void ahash_request_set_crypt(struct ahash_request *req,
+ struct crypto_shash *crypto_alloc_shash(const char *alg_name, u32 type,
+ 					u32 mask);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++struct crypto_alg *crypto_find_shash(const char *alg_name, u32 type, u32 mask);
++struct crypto_shash *crypto_alloc_shash_atomic(struct crypto_alg *alg);
++#endif
++
+ static inline struct crypto_tfm *crypto_shash_tfm(struct crypto_shash *tfm)
+ {
+ 	return &tfm->base;
+diff --git a/include/crypto/skcipher.h b/include/crypto/skcipher.h
+index 6a733b171..d7e354ab2 100644
+--- a/include/crypto/skcipher.h
++++ b/include/crypto/skcipher.h
+@@ -187,6 +187,12 @@ struct crypto_skcipher *crypto_alloc_skcipher(const char *alg_name,
+ struct crypto_sync_skcipher *crypto_alloc_sync_skcipher(const char *alg_name,
+ 					      u32 type, u32 mask);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++struct crypto_alg *crypto_find_skcipher(const char *alg_name, u32 type,
++					u32 mask);
++struct crypto_skcipher *crypto_alloc_skcipher_atomic(struct crypto_alg *alg);
++#endif
++
+ static inline struct crypto_tfm *crypto_skcipher_tfm(
+ 	struct crypto_skcipher *tfm)
+ {
+diff --git a/include/linux/interrupt.h b/include/linux/interrupt.h
+index ee8299eb1..da02a1d9d 100644
+--- a/include/linux/interrupt.h
++++ b/include/linux/interrupt.h
+@@ -524,13 +524,13 @@ extern bool force_irqthreads;
+    tasklets are more than enough. F.e. all serial device BHs et
+    al. should be converted to tasklets, not to softirqs.
+  */
+-
++/* Tempesta: process RX before TX to proxy traffic in one softirq shot. */
+ enum
+ {
+ 	HI_SOFTIRQ=0,
+ 	TIMER_SOFTIRQ,
+-	NET_TX_SOFTIRQ,
+ 	NET_RX_SOFTIRQ,
++	NET_TX_SOFTIRQ,
+ 	BLOCK_SOFTIRQ,
+ 	IRQ_POLL_SOFTIRQ,
+ 	TASKLET_SOFTIRQ,
+@@ -574,7 +574,7 @@ extern void softirq_init(void);
+ extern void __raise_softirq_irqoff(unsigned int nr);
+ 
+ extern void raise_softirq_irqoff(unsigned int nr);
+-extern void raise_softirq(unsigned int nr);
++void raise_softirq(unsigned int nr);
+ 
+ DECLARE_PER_CPU(struct task_struct *, ksoftirqd);
+ 
+diff --git a/include/linux/net.h b/include/linux/net.h
+index 0dcd51fee..9a09576a8 100644
+--- a/include/linux/net.h
++++ b/include/linux/net.h
+@@ -215,6 +215,8 @@ struct net_proto_family {
+ 	struct module	*owner;
+ };
+ 
++extern const struct net_proto_family *get_proto_family(int family);
++
+ struct iovec;
+ struct kvec;
+ 
+diff --git a/include/linux/netdevice.h b/include/linux/netdevice.h
+index e37480b5f..8236d5929 100644
+--- a/include/linux/netdevice.h
++++ b/include/linux/netdevice.h
+@@ -154,11 +154,22 @@ static inline bool dev_xmit_complete(int rc)
+ # define LL_MAX_HEADER 32
+ #endif
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++/*
++ * For Tempesta case the most traffic is TLS encrypted, so we need the extra
++ * room for TLS record header and explicit IV on skb allocation to avoid data
++ * movement on tcp_write_xmit(). Not all skbs have TLS headers - not a big deal
++ * to allocate 16 more bytes (5 - TLS header, 8 - IV, 3 - alignment).
++ */
++#define TLS_MAX_HDR		16
++#else
++#define TLS_MAX_HDR		0
++#endif
+ #if !IS_ENABLED(CONFIG_NET_IPIP) && !IS_ENABLED(CONFIG_NET_IPGRE) && \
+     !IS_ENABLED(CONFIG_IPV6_SIT) && !IS_ENABLED(CONFIG_IPV6_TUNNEL)
+-#define MAX_HEADER LL_MAX_HEADER
++#define MAX_HEADER (LL_MAX_HEADER + TLS_MAX_HDR)
+ #else
+-#define MAX_HEADER (LL_MAX_HEADER + 48)
++#define MAX_HEADER (LL_MAX_HEADER + 48 + TLS_MAX_HDR)
+ #endif
+ 
+ /*
+diff --git a/include/linux/skbuff.h b/include/linux/skbuff.h
+index a828cf99c..5d416997a 100644
+--- a/include/linux/skbuff.h
++++ b/include/linux/skbuff.h
+@@ -232,6 +232,12 @@
+ 	SKB_WITH_OVERHEAD((PAGE_SIZE << (ORDER)) - (X))
+ #define SKB_MAX_HEAD(X)		(SKB_MAX_ORDER((X), 0))
+ #define SKB_MAX_ALLOC		(SKB_MAX_ORDER(0, 2))
++#ifdef CONFIG_SECURITY_TEMPESTA
++#define SKB_MAX_HEADER	(PAGE_SIZE - MAX_TCP_HEADER			\
++			 - SKB_DATA_ALIGN(sizeof(struct sk_buff))	\
++			 - SKB_DATA_ALIGN(sizeof(struct skb_shared_info)) \
++			 - SKB_DATA_ALIGN(1))
++#endif
+ 
+ /* return minimum truesize of one skb containing X bytes of data */
+ #define SKB_TRUESIZE(X) ((X) +						\
+@@ -724,6 +730,12 @@ struct sk_buff {
+ 				 * UDP receive path is one user.
+ 				 */
+ 				unsigned long		dev_scratch;
++#ifdef CONFIG_SECURITY_TEMPESTA
++				struct {
++					__u8		present : 1;
++					__u8		tls_type : 7;
++				} tfw_cb;
++#endif
+ 			};
+ 		};
+ 		struct rb_node		rbnode; /* used in netem, ip4 defrag, and tcp stack */
+@@ -784,9 +796,15 @@ struct sk_buff {
+ 				fclone:2,
+ 				peeked:1,
+ 				head_frag:1,
++#ifdef CONFIG_SECURITY_TEMPESTA
++				skb_page:1,
++#endif
+ 				pfmemalloc:1;
+ #ifdef CONFIG_SKB_EXTENSIONS
+ 	__u8			active_extensions;
++#endif
++#ifdef CONFIG_SECURITY_TEMPESTA
++	__u8			tail_lock:1;
+ #endif
+ 	/* fields enclosed in headers_start/headers_end are copied
+ 	 * using a single memcpy() in __copy_skb_header()
+@@ -839,7 +857,6 @@ struct sk_buff {
+ #ifdef CONFIG_IPV6_NDISC_NODETYPE
+ 	__u8			ndisc_nodetype:2;
+ #endif
+-
+ 	__u8			ipvs_property:1;
+ 	__u8			inner_protocol_type:1;
+ 	__u8			remcsum_offload:1;
+@@ -931,6 +948,43 @@ struct sk_buff {
+ #define SKB_ALLOC_RX		0x02
+ #define SKB_ALLOC_NAPI		0x04
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++
++static inline unsigned long
++skb_tfw_is_present(struct sk_buff *skb)
++{
++	return skb->tfw_cb.present;
++}
++
++static inline void
++skb_set_tfw_tls_type(struct sk_buff *skb, unsigned char tls_type)
++{
++	BUG_ON(tls_type > 0x7F);
++	skb->tfw_cb.present = 1;
++	skb->tfw_cb.tls_type = tls_type;
++}
++
++static inline unsigned char
++skb_tfw_tls_type(struct sk_buff *skb)
++{
++	return skb->tfw_cb.present ? skb->tfw_cb.tls_type : 0;
++}
++
++static inline void
++skb_copy_tfw_cb(struct sk_buff *dst, struct sk_buff *src)
++{
++	dst->dev = src->dev;
++}
++
++static inline void
++skb_clear_tfw_cb(struct sk_buff *skb)
++{
++	WARN_ON_ONCE(!skb->tfw_cb.present);
++	skb->dev = NULL;
++}
++
++#endif
++
+ /**
+  * skb_pfmemalloc - Test if the skb was allocated from PFMEMALLOC reserves
+  * @skb: buffer
+@@ -1074,6 +1128,7 @@ void kfree_skb_partial(struct sk_buff *skb, bool head_stolen);
+ bool skb_try_coalesce(struct sk_buff *to, struct sk_buff *from,
+ 		      bool *fragstolen, int *delta_truesize);
+ 
++void *pg_skb_alloc(unsigned int size, gfp_t gfp_mask, int node);
+ struct sk_buff *__alloc_skb(unsigned int size, gfp_t priority, int flags,
+ 			    int node);
+ struct sk_buff *__build_skb(void *data, unsigned int frag_size);
+@@ -2104,7 +2159,11 @@ struct sk_buff *skb_dequeue_tail(struct sk_buff_head *list);
+ 
+ static inline bool skb_is_nonlinear(const struct sk_buff *skb)
+ {
++#ifdef CONFIG_SECURITY_TEMPESTA
++	return skb->tail_lock || skb->data_len;
++#else
+ 	return skb->data_len;
++#endif
+ }
+ 
+ static inline unsigned int skb_headlen(const struct sk_buff *skb)
+@@ -2341,6 +2400,20 @@ static inline unsigned int skb_headroom(const struct sk_buff *skb)
+ 	return skb->data - skb->head;
+ }
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++/**
++ *	skb_tailroom_locked - bytes at buffer end
++ *	@skb: buffer to check
++ *
++ *	Return the number of bytes of free space at the tail of an sk_buff with
++ *	respect to tail locking only.
++ */
++static inline int skb_tailroom_locked(const struct sk_buff *skb)
++{
++	return skb->tail_lock ? 0 : skb->end - skb->tail;
++}
++#endif
++
+ /**
+  *	skb_tailroom - bytes at buffer end
+  *	@skb: buffer to check
+diff --git a/include/linux/tempesta.h b/include/linux/tempesta.h
+new file mode 100644
+index 000000000..90eedcba5
+--- /dev/null
++++ b/include/linux/tempesta.h
+@@ -0,0 +1,55 @@
++/**
++ * Linux interface for Tempesta FW.
++ *
++ * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
++ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License,
++ * or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.
++ * See the GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along with
++ * this program; if not, write to the Free Software Foundation, Inc., 59
++ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ */
++#ifndef __TEMPESTA_H__
++#define __TEMPESTA_H__
++
++#include <net/sock.h>
++
++typedef void (*TempestaTxAction)(void);
++
++typedef struct {
++	int (*sk_alloc)(struct sock *sk, struct sk_buff *skb);
++	void (*sk_free)(struct sock *sk);
++	int (*sock_tcp_rcv)(struct sock *sk, struct sk_buff *skb);
++} TempestaOps;
++
++typedef struct {
++	unsigned long	addr;
++	unsigned long	pages; /* number of 4KB pages */
++} TempestaMapping;
++
++/* Security hooks. */
++int tempesta_new_clntsk(struct sock *newsk, struct sk_buff *skb);
++void tempesta_close_clntsk(struct sock *sk);
++void tempesta_register_ops(TempestaOps *tops);
++void tempesta_unregister_ops(TempestaOps *tops);
++
++/* Network hooks. */
++void tempesta_set_tx_action(TempestaTxAction action);
++void tempesta_del_tx_action(void);
++
++/* Memory management. */
++void tempesta_reserve_pages(void);
++void tempesta_reserve_vmpages(void);
++int tempesta_get_mapping(int node, TempestaMapping **tm);
++
++#endif /* __TEMPESTA_H__ */
++
+diff --git a/include/net/inet_sock.h b/include/net/inet_sock.h
+index 89163ef8c..49ad1ddc9 100644
+--- a/include/net/inet_sock.h
++++ b/include/net/inet_sock.h
+@@ -87,7 +87,12 @@ struct inet_request_sock {
+ 				ecn_ok	   : 1,
+ 				acked	   : 1,
+ 				no_srccheck: 1,
++#ifdef CONFIG_SECURITY_TEMPESTA
++				smc_ok	   : 1,
++				aborted	   : 1;
++#else
+ 				smc_ok	   : 1;
++#endif
+ 	u32                     ir_mark;
+ 	union {
+ 		struct ip_options_rcu __rcu	*ireq_opt;
+diff --git a/include/net/sock.h b/include/net/sock.h
+index 261195598..6b7910c55 100644
+--- a/include/net/sock.h
++++ b/include/net/sock.h
+@@ -506,6 +506,31 @@ struct sock {
+ 	void			(*sk_state_change)(struct sock *sk);
+ 	void			(*sk_data_ready)(struct sock *sk);
+ 	void			(*sk_write_space)(struct sock *sk);
++#ifdef CONFIG_SECURITY_TEMPESTA
++				/*
++				 * Tempesta FW callback to ecrypt one
++				 * or more skb in socket write queue
++				 * before sending.
++				 */
++	int			(*sk_write_xmit)(struct sock *sk,
++						 struct sk_buff *skb,
++						 unsigned int mss_now,
++						 unsigned int limit);
++				/*
++				 * Tempesta FW callback to prepare and push
++				 * skbs from Tempesta FW private scheduler
++				 * to socket write queue according sender
++				 * and receiver window.
++				 */
++	int			(*sk_fill_write_queue)(struct sock *sk,
++						       unsigned int mss_now,
++						       int ss_action);
++				/*
++				 * Tempesta FW callback to free all private
++				 * resources associated with socket.
++				 */
++	void			(*sk_destroy_cb)(struct sock *sk);
++#endif
+ 	void			(*sk_error_report)(struct sock *sk);
+ 	int			(*sk_backlog_rcv)(struct sock *sk,
+ 						  struct sk_buff *skb);
+@@ -861,6 +886,10 @@ enum sock_flags {
+ 	SOCK_TXTIME,
+ 	SOCK_XDP, /* XDP is attached */
+ 	SOCK_TSTAMP_NEW, /* Indicates 64 bit timestamps always */
++#ifdef CONFIG_SECURITY_TEMPESTA
++	SOCK_TEMPESTA, /* The socket is managed by Tempesta FW */
++	SOCK_TEMPESTA_HAS_DATA /* The socket has data in Tempesta FW write queue */
++#endif
+ };
+ 
+ #define SK_FLAGS_TIMESTAMP ((1UL << SOCK_TIMESTAMP) | (1UL << SOCK_TIMESTAMPING_RX_SOFTWARE))
+@@ -1081,6 +1110,16 @@ static inline void sock_rps_reset_rxhash(struct sock *sk)
+ 		__rc;							\
+ 	})
+ 
++/**
++ * sk_stream_closing - Return 1 if we still have things to send in our buffers.
++ * @sk: socket to verify
++ */
++static inline int sk_stream_closing(struct sock *sk)
++{
++	return (1 << sk->sk_state) &
++	       (TCPF_FIN_WAIT1 | TCPF_CLOSING | TCPF_LAST_ACK);
++}
++
+ int sk_stream_wait_connect(struct sock *sk, long *timeo_p);
+ int sk_stream_wait_memory(struct sock *sk, long *timeo_p);
+ void sk_stream_wait_close(struct sock *sk, long timeo_p);
+@@ -1915,8 +1954,7 @@ static inline bool sk_rethink_txhash(struct sock *sk)
+ static inline struct dst_entry *
+ __sk_dst_get(struct sock *sk)
+ {
+-	return rcu_dereference_check(sk->sk_dst_cache,
+-				     lockdep_sock_is_held(sk));
++	return rcu_dereference_raw(sk->sk_dst_cache);
+ }
+ 
+ static inline struct dst_entry *
+diff --git a/include/net/tcp.h b/include/net/tcp.h
+index 7d66c61d2..7785fc8a6 100644
+--- a/include/net/tcp.h
++++ b/include/net/tcp.h
+@@ -307,6 +307,7 @@ bool tcp_check_oom(struct sock *sk, int shift);
+ 
+ 
+ extern struct proto tcp_prot;
++extern struct proto tcpv6_prot;
+ 
+ #define TCP_INC_STATS(net, field)	SNMP_INC_STATS((net)->mib.tcp_statistics, field)
+ #define __TCP_INC_STATS(net, field)	__SNMP_INC_STATS((net)->mib.tcp_statistics, field)
+@@ -653,6 +654,22 @@ static inline int tcp_bound_to_half_wnd(struct tcp_sock *tp, int pktsize)
+ /* tcp.c */
+ void tcp_get_info(struct sock *, struct tcp_info *);
+ 
++/* Routines required by Tempesta FW. */
++void tcp_cleanup_rbuf(struct sock *sk, int copied);
++extern void tcp_push(struct sock *sk, int flags, int mss_now, int nonagle,
++		     int size_goal);
++extern int tcp_send_mss(struct sock *sk, int *size_goal, int flags);
++extern void tcp_mark_push(struct tcp_sock *tp, struct sk_buff *skb);
++extern void tcp_init_nondata_skb(struct sk_buff *skb, u32 seq, u8 flags);
++extern void tcp_queue_skb(struct sock *sk, struct sk_buff *skb);
++extern void tcp_set_skb_tso_segs(struct sk_buff *skb, unsigned int mss_now);
++extern void tcp_adjust_pcount(struct sock *sk, const struct sk_buff *skb,
++			      int decr);
++extern void tcp_fragment_tstamp(struct sk_buff *skb, struct sk_buff *skb2);
++extern void tcp_skb_fragment_eor(struct sk_buff *skb, struct sk_buff *skb2);
++extern int tcp_close_state(struct sock *sk);
++extern void skb_entail(struct sock *sk, struct sk_buff *skb);
++
+ /* Read 'sendfile()'-style from a TCP socket */
+ int tcp_read_sock(struct sock *sk, read_descriptor_t *desc,
+ 		  sk_read_actor_t recv_actor);
+@@ -1858,11 +1875,51 @@ static inline void tcp_rtx_queue_unlink_and_free(struct sk_buff *skb, struct soc
+ 	sk_wmem_free_skb(sk, skb);
+ }
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++/**
++ * This function is similar to `tcp_write_err` except that we send
++ * TCP RST to remote peer.  We call this function when an error occurs
++ * while sending data from which we cannot recover, so we close the
++ * connection with TCP RST.
++ */
++static inline void
++tcp_tfw_handle_error(struct sock *sk, int error)
++{
++	tcp_send_active_reset(sk, GFP_ATOMIC);
++	sk->sk_err = error;
++	sk->sk_error_report(sk);
++	tcp_write_queue_purge(sk);
++	tcp_done(sk);
++}
++#endif
++
+ static inline void tcp_push_pending_frames(struct sock *sk)
+ {
++#ifdef CONFIG_SECURITY_TEMPESTA
++	unsigned int mss_now = 0;
++
++	if (sock_flag(sk, SOCK_TEMPESTA_HAS_DATA)
++	    && sk->sk_fill_write_queue)
++	{
++		int result;
++
++		mss_now = tcp_current_mss(sk);
++		result = sk->sk_fill_write_queue(sk, mss_now, 0);
++		if (unlikely(result < 0 && result != -ENOMEM)) {
++			tcp_tfw_handle_error(sk, result);
++			return;
++		}
++	}
++#endif
+ 	if (tcp_send_head(sk)) {
+ 		struct tcp_sock *tp = tcp_sk(sk);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++		if (mss_now != 0) {
++			int nonagle = TCP_NAGLE_OFF | TCP_NAGLE_PUSH;
++			__tcp_push_pending_frames(sk, mss_now, nonagle);
++		} else
++#endif
+ 		__tcp_push_pending_frames(sk, tcp_current_mss(sk), tp->nonagle);
+ 	}
+ }
+diff --git a/include/net/tls.h b/include/net/tls.h
+index 2bdd80221..356850dda 100644
+--- a/include/net/tls.h
++++ b/include/net/tls.h
+@@ -66,6 +66,13 @@
+ #define MAX_IV_SIZE			16
+ #define TLS_MAX_REC_SEQ_SIZE		8
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++#define TLS_MAX_TAG_SZ			16
++/* Maximum size for required skb overhead: header, IV, tag. */
++#define TLS_MAX_OVERHEAD		(TLS_HEADER_SIZE + TLS_AAD_SPACE_SIZE \
++					 + TLS_MAX_TAG_SZ)
++#endif
++
+ /* For AES-CCM, the full 16-bytes of IV is made of '4' fields of given sizes.
+  *
+  * IV[16] = b0[1] || implicit nonce[4] || explicit nonce[8] || length[3]
+diff --git a/init/main.c b/init/main.c
+index d9d914111..412aff866 100644
+--- a/init/main.c
++++ b/init/main.c
+@@ -110,6 +110,8 @@
+ 
+ #include <kunit/test.h>
+ 
++#include <linux/tempesta.h>
++
+ static int kernel_init(void *);
+ 
+ extern void init_IRQ(void);
+@@ -820,6 +822,13 @@ static void __init report_meminit(void)
+  */
+ static void __init mm_init(void)
+ {
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/*
++	 * Tempesta: reserve memory at boot stage to get continous address
++	 * space. Do it while memblock is available.
++	 */
++	tempesta_reserve_pages();
++#endif
+ 	/*
+ 	 * page_ext requires contiguous pages,
+ 	 * bigger than MAX_ORDER unless SPARSEMEM.
+@@ -828,6 +837,7 @@ static void __init mm_init(void)
+ 	init_debug_pagealloc();
+ 	report_meminit();
+ 	mem_init();
++
+ 	kmem_cache_init();
+ 	kmemleak_init();
+ 	pgtable_init();
+@@ -838,6 +848,11 @@ static void __init mm_init(void)
+ 	init_espfix_bsp();
+ 	/* Should be run after espfix64 is set up. */
+ 	pti_init();
++
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/* Try vmalloc() if the previous one failed. */
++	tempesta_reserve_vmpages();
++#endif
+ }
+ 
+ void __init __weak arch_call_rest_init(void)
+diff --git a/kernel/irq_work.c b/kernel/irq_work.c
+index eca83965b..e0ed16db6 100644
+--- a/kernel/irq_work.c
++++ b/kernel/irq_work.c
+@@ -111,7 +111,7 @@ bool irq_work_queue_on(struct irq_work *work, int cpu)
+ 	return true;
+ #endif /* CONFIG_SMP */
+ }
+-
++EXPORT_SYMBOL_GPL(irq_work_queue_on);
+ 
+ bool irq_work_needs_cpu(void)
+ {
+diff --git a/kernel/softirq.c b/kernel/softirq.c
+index 09229ad82..4d1de66af 100644
+--- a/kernel/softirq.c
++++ b/kernel/softirq.c
+@@ -25,6 +25,7 @@
+ #include <linux/smpboot.h>
+ #include <linux/tick.h>
+ #include <linux/irq.h>
++#include <asm/fpu/api.h>
+ 
+ #define CREATE_TRACE_POINTS
+ #include <trace/events/irq.h>
+@@ -57,7 +58,7 @@ static struct softirq_action softirq_vec[NR_SOFTIRQS] __cacheline_aligned_in_smp
+ DEFINE_PER_CPU(struct task_struct *, ksoftirqd);
+ 
+ const char * const softirq_to_name[NR_SOFTIRQS] = {
+-	"HI", "TIMER", "NET_TX", "NET_RX", "BLOCK", "IRQ_POLL",
++	"HI", "TIMER", "NET_RX", "NET_TX", "BLOCK", "IRQ_POLL",
+ 	"TASKLET", "SCHED", "HRTIMER", "RCU"
+ };
+ 
+@@ -275,6 +276,10 @@ asmlinkage __visible void __softirq_entry __do_softirq(void)
+ 	__local_bh_disable_ip(_RET_IP_, SOFTIRQ_OFFSET);
+ 	in_hardirq = lockdep_softirq_start();
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	__kernel_fpu_begin_mask(KFPU_MXCSR);
++#endif
++
+ restart:
+ 	/* Reset the pending bitmask before enabling irqs */
+ 	set_softirq_pending(0);
+@@ -320,6 +325,9 @@ asmlinkage __visible void __softirq_entry __do_softirq(void)
+ 		wakeup_softirqd();
+ 	}
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	__kernel_fpu_end_bh();
++#endif
+ 	lockdep_softirq_end(in_hardirq);
+ 	account_irq_exit_time(current);
+ 	__local_bh_enable(SOFTIRQ_OFFSET);
+@@ -478,6 +486,7 @@ void raise_softirq(unsigned int nr)
+ 	raise_softirq_irqoff(nr);
+ 	local_irq_restore(flags);
+ }
++EXPORT_SYMBOL(raise_softirq);
+ 
+ void __raise_softirq_irqoff(unsigned int nr)
+ {
+diff --git a/mm/Makefile b/mm/Makefile
+index d73aed0fc..d19a4ecc1 100644
+--- a/mm/Makefile
++++ b/mm/Makefile
+@@ -120,3 +120,4 @@ obj-$(CONFIG_MEMFD_CREATE) += memfd.o
+ obj-$(CONFIG_MAPPING_DIRTY_HELPERS) += mapping_dirty_helpers.o
+ obj-$(CONFIG_PTDUMP_CORE) += ptdump.o
+ obj-$(CONFIG_PAGE_REPORTING) += page_reporting.o
++obj-$(CONFIG_SECURITY_TEMPESTA) += tempesta_mm.o
+diff --git a/mm/tempesta_mm.c b/mm/tempesta_mm.c
+new file mode 100644
+index 000000000..56ab5e02d
+--- /dev/null
++++ b/mm/tempesta_mm.c
+@@ -0,0 +1,157 @@
++/**
++ *		Tempesta Memory Reservation
++ *
++ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License,
++ * or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
++ * FOR A PARTICULAR PURPOSE.
++ * See the GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along with
++ * this program; if not, write to the Free Software Foundation, Inc., 59
++ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ */
++#include <linux/gfp.h>
++#include <linux/hugetlb.h>
++#include <linux/tempesta.h>
++#include <linux/topology.h>
++#include <linux/vmalloc.h>
++#include <linux/memblock.h>
++
++#include "internal.h"
++
++#define MAX_MEMSZ		65536 * HPAGE_SIZE /* 128GB per node */
++#define MIN_MEMSZ		16 * HPAGE_SIZE	/* 32MB per node */
++#define DEFAULT_MEMSZ		256 * HPAGE_SIZE /* 512MB */
++
++static unsigned long dbmem = DEFAULT_MEMSZ;
++static TempestaMapping map[MAX_NUMNODES];
++
++static unsigned long
++__dbsize_mb(unsigned long size)
++{
++	if (size >= SZ_1M)
++		return size / SZ_1M;
++
++	return 0;
++}
++
++static int __init
++tempesta_setup_pages(char *str)
++{
++	unsigned long min = __dbsize_mb(MIN_MEMSZ) * nr_online_nodes;
++	unsigned long max = __dbsize_mb(MAX_MEMSZ) * nr_online_nodes;
++	unsigned long raw_dbmem = memparse(str, NULL);
++
++	/* Count memory per node */
++	dbmem = round_up(raw_dbmem / nr_online_nodes, HPAGE_SIZE);
++
++	if (dbmem < MIN_MEMSZ) {
++		pr_err("Tempesta: bad dbmem value %lu(%luM), must be [%luM:%luM]"
++		       "\n", raw_dbmem, __dbsize_mb(raw_dbmem), min, max);
++		dbmem = MIN_MEMSZ;
++	}
++	if (dbmem > MAX_MEMSZ) {
++		pr_err("Tempesta: bad dbmem value %lu(%luM), must be [%luM:%luM]"
++		       "\n", raw_dbmem, __dbsize_mb(raw_dbmem), min, max);
++		dbmem = MAX_MEMSZ;
++	}
++
++	return 1;
++}
++__setup("tempesta_dbmem=", tempesta_setup_pages);
++
++/**
++ * Reserve physically contiguous per-node blocks of memory for Tempesta DB.
++ */
++void __init
++tempesta_reserve_pages(void)
++{
++	int nid;
++	void *addr;
++
++	for_each_online_node(nid) {
++		addr = memblock_alloc_try_nid_raw(dbmem, HPAGE_SIZE,
++						  MEMBLOCK_LOW_LIMIT,
++						  MEMBLOCK_ALLOC_ANYWHERE,
++						  nid);
++		if (!addr) {
++			pr_err("Tempesta: can't reserve %lu memory at node %d"
++			       "\n", __dbsize_mb(dbmem), nid);
++			goto err;
++		}
++
++		map[nid].addr = (unsigned long)addr;
++		map[nid].pages = dbmem / PAGE_SIZE;
++		pr_info("Tempesta: reserved space %luMB addr %p at node %d\n",
++			__dbsize_mb(dbmem), addr, nid);
++	}
++
++	return;
++
++err:
++	for_each_online_node(nid) {
++		phys_addr_t phys_addr;
++
++		if (!map[nid].addr)
++			continue;
++
++		phys_addr = virt_to_phys((void *)map[nid].addr);
++		memblock_free(phys_addr, map[nid].pages * PAGE_SIZE);
++	}
++	memset(map, 0, sizeof(map));
++}
++
++/**
++ * Allocates necessary space if tempesta_reserve_pages() failed.
++ */
++void __init
++tempesta_reserve_vmpages(void)
++{
++	int nid, maps = 0;
++
++	for_each_online_node(nid)
++		maps += !!map[nid].addr;
++
++	BUG_ON(maps && maps < nr_online_nodes);
++	if (maps == nr_online_nodes)
++		return;
++
++	for_each_online_node(nid) {
++		pr_warn("Tempesta: allocate %lu vmalloc pages at node %d\n",
++			__dbsize_mb(dbmem), nid);
++
++		map[nid].addr = (unsigned long)vzalloc_node(dbmem, nid);
++		if (!map[nid].addr)
++			goto err;
++		map[nid].pages = dbmem / PAGE_SIZE;
++	}
++
++	return;
++err:
++	pr_err("Tempesta: cannot vmalloc area of %lu bytes at node %d\n",
++	       dbmem, nid);
++	for_each_online_node(nid)
++		if (map[nid].addr)
++			vfree((void *)map[nid].addr);
++	memset(map, 0, sizeof(map));
++}
++
++int
++tempesta_get_mapping(int nid, TempestaMapping **tm)
++{
++	if (unlikely(!map[nid].addr))
++		return -ENOMEM;
++
++	*tm = &map[nid];
++
++	return 0;
++}
++EXPORT_SYMBOL(tempesta_get_mapping);
++
+diff --git a/net/core/dev.c b/net/core/dev.c
+index 64f4c7ec7..e9c30a2b0 100644
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -4246,7 +4246,9 @@ int weight_p __read_mostly = 64;           /* old backlog weight */
+ int dev_weight_rx_bias __read_mostly = 1;  /* bias for backlog weight */
+ int dev_weight_tx_bias __read_mostly = 1;  /* bias for output_queue quota */
+ int dev_rx_weight __read_mostly = 64;
++EXPORT_SYMBOL(dev_rx_weight);
+ int dev_tx_weight __read_mostly = 64;
++EXPORT_SYMBOL(dev_tx_weight);
+ /* Maximum number of GRO_NORMAL skbs to batch up for list-RX */
+ int gro_normal_batch __read_mostly = 8;
+ 
+@@ -4869,6 +4871,28 @@ int netif_rx_any_context(struct sk_buff *skb)
+ }
+ EXPORT_SYMBOL(netif_rx_any_context);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++#include <linux/tempesta.h>
++
++static TempestaTxAction __rcu tempesta_tx_action = NULL;
++
++void
++tempesta_set_tx_action(TempestaTxAction action)
++{
++	rcu_assign_pointer(tempesta_tx_action, action);
++}
++EXPORT_SYMBOL(tempesta_set_tx_action);
++
++void
++tempesta_del_tx_action(void)
++{
++	rcu_assign_pointer(tempesta_tx_action, NULL);
++	synchronize_rcu();
++}
++EXPORT_SYMBOL(tempesta_del_tx_action);
++#endif
++
++
+ static __latent_entropy void net_tx_action(struct softirq_action *h)
+ {
+ 	struct softnet_data *sd = this_cpu_ptr(&softnet_data);
+@@ -4901,6 +4925,20 @@ static __latent_entropy void net_tx_action(struct softirq_action *h)
+ 		__kfree_skb_flush();
+ 	}
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	{
++		TempestaTxAction action;
++
++		rcu_read_lock();
++
++		action = rcu_dereference(tempesta_tx_action);
++		if (likely(action))
++			action();
++
++		rcu_read_unlock();
++	}
++#endif
++
+ 	if (sd->output_queue) {
+ 		struct Qdisc *head;
+ 
+@@ -6062,6 +6100,11 @@ static void napi_skb_free_stolen_head(struct sk_buff *skb)
+ {
+ 	skb_dst_drop(skb);
+ 	skb_ext_put(skb);
++#ifdef CONFIG_SECURITY_TEMPESTA
++	if (skb->skb_page)
++		put_page(virt_to_page(skb));
++	else
++#endif
+ 	kmem_cache_free(skbuff_head_cache, skb);
+ }
+ 
+diff --git a/net/core/request_sock.c b/net/core/request_sock.c
+index f35c2e998..6ec40ac3c 100644
+--- a/net/core/request_sock.c
++++ b/net/core/request_sock.c
+@@ -130,3 +130,4 @@ void reqsk_fastopen_remove(struct sock *sk, struct request_sock *req,
+ out:
+ 	spin_unlock_bh(&fastopenq->lock);
+ }
++EXPORT_SYMBOL(reqsk_fastopen_remove);
+diff --git a/net/core/skbuff.c b/net/core/skbuff.c
+index 1301ea694..42fc8a110 100644
+--- a/net/core/skbuff.c
++++ b/net/core/skbuff.c
+@@ -80,7 +80,9 @@
+ #include "datagram.h"
+ 
+ struct kmem_cache *skbuff_head_cache __ro_after_init;
++#ifndef CONFIG_SECURITY_TEMPESTA
+ static struct kmem_cache *skbuff_fclone_cache __ro_after_init;
++#endif
+ #ifdef CONFIG_SKB_EXTENSIONS
+ static struct kmem_cache *skbuff_ext_cache __ro_after_init;
+ #endif
+@@ -119,6 +121,7 @@ static void skb_under_panic(struct sk_buff *skb, unsigned int sz, void *addr)
+ 	skb_panic(skb, sz, addr, __func__);
+ }
+ 
++#ifndef CONFIG_SECURITY_TEMPESTA
+ /*
+  * kmalloc_reserve is a wrapper around kmalloc_node_track_caller that tells
+  * the caller if emergency pfmemalloc reserves are being used. If it is and
+@@ -155,6 +158,224 @@ static void *__kmalloc_reserve(size_t size, gfp_t flags, int node,
+ 
+ 	return obj;
+ }
++#else
++/*
++ * Chunks of size 128B, 256B, 512B, 1KB and 2KB.
++ * Typical sk_buff requires ~272B or ~552B (for fclone),
++ * skb_shared_info is ~320B.
++ */
++#define PG_LISTS_N		5
++#define PG_CHUNK_BITS		(PAGE_SHIFT - 5)
++#define PG_CHUNK_SZ		(1 << PG_CHUNK_BITS)
++#define PG_CHUNK_MASK		(~(PG_CHUNK_SZ - 1))
++#define PG_ALLOC_SZ(s)		(((s) + (PG_CHUNK_SZ - 1)) & PG_CHUNK_MASK)
++#define PG_CHUNK_NUM(s)		(PG_ALLOC_SZ(s) >> PG_CHUNK_BITS)
++#define PG_POOL_HLIM_BASE	256
++
++/**
++ * @lh		- list head of chunk pool;
++ * @count	- current number of chunks in @lh;
++ * @h_limit	- hard limit for size of @lh;
++ * @max		- current maximum allowed size of the list, can be 0.
++ */
++typedef struct {
++	struct list_head	lh;
++	unsigned int		count;
++	unsigned int		h_limit;
++	unsigned int		max;
++} TfwSkbMemPool;
++
++static DEFINE_PER_CPU(TfwSkbMemPool [PG_LISTS_N], pg_mpool);
++
++static bool
++__pg_pool_grow(TfwSkbMemPool *pool)
++{
++	if (!pool->count) {
++		/* Too few chunks were provisioned. */
++		unsigned int n = max(pool->max, 1U) << 1; /* start from 2 */
++		pool->max = (n > pool->h_limit) ? pool->h_limit : n;
++		return false;
++	}
++	if (pool->max < pool->h_limit)
++		++pool->max;
++	return true;
++}
++
++static bool
++__pg_pool_shrink(TfwSkbMemPool *pool)
++{
++	if (unlikely(pool->count >= pool->max)) {
++		/* Producers are much faster consumers right now. */
++		pool->max >>= 1;
++		while (pool->count > pool->max) {
++			struct list_head *pc = pool->lh.next;
++			list_del(pc);
++			put_page(virt_to_page(pc));
++			--pool->count;
++		}
++		return false;
++	}
++	/*
++	 * Producers and consumers look balanced.
++	 * Slowly reduce provisioning.
++	 */
++	if (pool->max)
++		--pool->max;
++	return true;
++}
++
++void *
++pg_skb_alloc(unsigned int size, gfp_t gfp_mask, int node)
++{
++	/*
++	 * Don't disable softirq if hardirqs are already disabled to avoid
++	 * warning in __local_bh_enable_ip(). Disable user space process
++	 * preemption as well as preemption by softirq (see SOFTIRQ_LOCK_OFFSET
++	 * usage in spin locks for the same motivation).
++	 */
++	bool dolock = !(in_irq() || irqs_disabled());
++#define PREEMPT_CTX_DISABLE()						\
++do {									\
++	if (dolock)							\
++		local_bh_disable();					\
++	preempt_disable();						\
++} while (0)
++
++#define PREEMPT_CTX_ENABLE()						\
++do {									\
++	preempt_enable();						\
++	if (dolock)							\
++		local_bh_enable();					\
++} while (0)
++
++	char *ptr;
++	struct page *pg;
++	TfwSkbMemPool *pools;
++	unsigned int c, cn, o, l, po;
++
++	cn = PG_CHUNK_NUM(size);
++	po = get_order(PG_ALLOC_SZ(size));
++
++	PREEMPT_CTX_DISABLE();
++
++	pools = this_cpu_ptr(pg_mpool);
++
++	o = (cn == 1) ? 0
++	    : (cn == 2) ? 1
++	      : (cn <= 4) ? 2
++	        : (cn <= 8) ? 3
++		  : (cn <= 16) ? 4 : PG_LISTS_N;
++
++	for (; o < PG_LISTS_N; ++o)
++	{
++		struct list_head *pc;
++		if (!__pg_pool_grow(&pools[o]))
++			continue;
++
++		pc = pools[o].lh.next;
++		list_del(pc);
++		--pools[o].count;
++		ptr = (char *)pc;
++		pg = virt_to_page(ptr);
++		goto assign_tail_chunks;
++	}
++
++	PREEMPT_CTX_ENABLE();
++
++	/*
++	 * Add compound page metadata, if page order is > 0.
++	 * Don't use __GFP_NOMEMALLOC to allow caller access to reserved pools if
++	 * it requested so.
++	 */
++	gfp_mask |= __GFP_NOWARN | __GFP_NORETRY | (po ? __GFP_COMP : 0);
++	pg = alloc_pages_node(node, gfp_mask, po);
++	if (!pg)
++		return NULL;
++	ptr = (char *)page_address(pg);
++	/*
++	 * Don't try to split compound page. Also don't try to reuse pages
++	 * from reserved memory areas to put and free them quicker.
++	 *
++	 * TODO compound pages can be split as __alloc_page_frag() does it
++	 * using fragment size in page reference counter. Large messages
++	 * (e.g. large HTML pages returned by a backend server) go this way
++	 * and allocate compound pages.
++	 */
++	if (po || page_is_pfmemalloc(pg))
++		return ptr;
++	o = PAGE_SHIFT - PG_CHUNK_BITS;
++
++	PREEMPT_CTX_DISABLE();
++
++	pools = this_cpu_ptr(pg_mpool);
++
++assign_tail_chunks:
++	/* Split and store small tail chunks. */
++	for (c = cn, cn = 1 << o, l = PG_LISTS_N - 1; c < cn; c += (1 << l)) {
++		struct list_head *chunk;
++		while (c + (1 << l) > cn)
++			--l;
++		chunk = (struct list_head *)(ptr + PG_CHUNK_SZ * c);
++		if (__pg_pool_shrink(&pools[l])) {
++			get_page(pg);
++			list_add(chunk, &pools[l].lh);
++			++pools[l].count;
++		}
++	}
++
++	PREEMPT_CTX_ENABLE();
++
++	return ptr;
++#undef PREEMPT_CTX_DISABLE
++#undef PREEMPT_CTX_ENABLE
++}
++EXPORT_SYMBOL(pg_skb_alloc);
++#endif
++
++static void
++__alloc_skb_init(struct sk_buff *skb, u8 *data, unsigned int size,
++		 int flags, bool pfmemalloc)
++{
++	struct skb_shared_info *shinfo;
++
++	/*
++	 * Only clear those fields we need to clear, not those that we will
++	 * actually initialise below. Hence, don't put any more fields after
++	 * the tail pointer in struct sk_buff!
++	 */
++	memset(skb, 0, offsetof(struct sk_buff, tail));
++	/* Account for allocated memory : skb + skb->head */
++	skb->truesize = SKB_TRUESIZE(size);
++	skb->pfmemalloc = pfmemalloc;
++	refcount_set(&skb->users, 1);
++	skb->head = data;
++	skb->data = data;
++	skb_reset_tail_pointer(skb);
++	skb->end = skb->tail + size;
++	skb->mac_header = (typeof(skb->mac_header))~0U;
++	skb->transport_header = (typeof(skb->transport_header))~0U;
++
++	/* make sure we initialize shinfo sequentially */
++	shinfo = skb_shinfo(skb);
++	memset(shinfo, 0, offsetof(struct skb_shared_info, dataref));
++	atomic_set(&shinfo->dataref, 1);
++
++	if (flags & SKB_ALLOC_FCLONE) {
++		struct sk_buff_fclones *fclones;
++
++		fclones = container_of(skb, struct sk_buff_fclones, skb1);
++
++		skb->fclone = SKB_FCLONE_ORIG;
++		refcount_set(&fclones->fclone_ref, 1);
++
++		fclones->skb2.fclone = SKB_FCLONE_CLONE;
++#ifdef CONFIG_SECURITY_TEMPESTA
++		fclones->skb2.skb_page = 1;
++		fclones->skb2.head_frag = 1;
++#endif
++	}
++}
++
+ 
+ /* 	Allocate a new skbuff. We do this ourselves so we can fill in a few
+  *	'private' fields and also do memory statistics to find all the
+@@ -179,11 +400,11 @@ static void *__kmalloc_reserve(size_t size, gfp_t flags, int node,
+  *	Buffers may only be allocated from interrupts using a @gfp_mask of
+  *	%GFP_ATOMIC.
+  */
++#ifndef CONFIG_SECURITY_TEMPESTA
+ struct sk_buff *__alloc_skb(unsigned int size, gfp_t gfp_mask,
+ 			    int flags, int node)
+ {
+ 	struct kmem_cache *cache;
+-	struct skb_shared_info *shinfo;
+ 	struct sk_buff *skb;
+ 	u8 *data;
+ 	bool pfmemalloc;
+@@ -217,38 +438,7 @@ struct sk_buff *__alloc_skb(unsigned int size, gfp_t gfp_mask,
+ 	size = SKB_WITH_OVERHEAD(ksize(data));
+ 	prefetchw(data + size);
+ 
+-	/*
+-	 * Only clear those fields we need to clear, not those that we will
+-	 * actually initialise below. Hence, don't put any more fields after
+-	 * the tail pointer in struct sk_buff!
+-	 */
+-	memset(skb, 0, offsetof(struct sk_buff, tail));
+-	/* Account for allocated memory : skb + skb->head */
+-	skb->truesize = SKB_TRUESIZE(size);
+-	skb->pfmemalloc = pfmemalloc;
+-	refcount_set(&skb->users, 1);
+-	skb->head = data;
+-	skb->data = data;
+-	skb_reset_tail_pointer(skb);
+-	skb->end = skb->tail + size;
+-	skb->mac_header = (typeof(skb->mac_header))~0U;
+-	skb->transport_header = (typeof(skb->transport_header))~0U;
+-
+-	/* make sure we initialize shinfo sequentially */
+-	shinfo = skb_shinfo(skb);
+-	memset(shinfo, 0, offsetof(struct skb_shared_info, dataref));
+-	atomic_set(&shinfo->dataref, 1);
+-
+-	if (flags & SKB_ALLOC_FCLONE) {
+-		struct sk_buff_fclones *fclones;
+-
+-		fclones = container_of(skb, struct sk_buff_fclones, skb1);
+-
+-		skb->fclone = SKB_FCLONE_ORIG;
+-		refcount_set(&fclones->fclone_ref, 1);
+-
+-		fclones->skb2.fclone = SKB_FCLONE_CLONE;
+-	}
++	__alloc_skb_init(skb, data, size, flags, pfmemalloc);
+ out:
+ 	return skb;
+ nodata:
+@@ -256,6 +446,43 @@ struct sk_buff *__alloc_skb(unsigned int size, gfp_t gfp_mask,
+ 	skb = NULL;
+ 	goto out;
+ }
++#else
++
++/**
++ * Tempesta: allocate skb on the same page with data to improve space locality
++ * and make head data fragmentation easier.
++ */
++struct sk_buff *
++__alloc_skb(unsigned int size, gfp_t gfp_mask, int flags, int node)
++{
++	struct sk_buff *skb;
++	struct page *pg;
++	u8 *data;
++	size_t skb_sz = (flags & SKB_ALLOC_FCLONE)
++			? SKB_DATA_ALIGN(sizeof(struct sk_buff_fclones))
++			: SKB_DATA_ALIGN(sizeof(struct sk_buff));
++	size_t shi_sz = SKB_DATA_ALIGN(sizeof(struct skb_shared_info));
++	size_t n = skb_sz + shi_sz + SKB_DATA_ALIGN(size);
++
++	if (sk_memalloc_socks() && (flags & SKB_ALLOC_RX))
++		gfp_mask |= __GFP_MEMALLOC;
++
++	if (!(skb = pg_skb_alloc(n, gfp_mask, node)))
++		return NULL;
++
++	data = (u8 *)skb + skb_sz;
++	size = SKB_WITH_OVERHEAD(PG_ALLOC_SZ(n) - skb_sz);
++	prefetchw(data + size);
++
++	pg = virt_to_head_page(data);
++	get_page(pg);
++	__alloc_skb_init(skb, data, size, flags, page_is_pfmemalloc(pg));
++	skb->head_frag = 1;
++	skb->skb_page = 1;
++
++	return skb;
++}
++#endif
+ EXPORT_SYMBOL(__alloc_skb);
+ 
+ /* Caller must provide SKB that is memset cleared */
+@@ -628,7 +855,12 @@ static void kfree_skbmem(struct sk_buff *skb)
+ 
+ 	switch (skb->fclone) {
+ 	case SKB_FCLONE_UNAVAILABLE:
+-		kmem_cache_free(skbuff_head_cache, skb);
++#ifdef CONFIG_SECURITY_TEMPESTA
++		if (skb->skb_page)
++			put_page(virt_to_page(skb));
++		else
++#endif
++			kmem_cache_free(skbuff_head_cache, skb);
+ 		return;
+ 
+ 	case SKB_FCLONE_ORIG:
+@@ -649,7 +881,12 @@ static void kfree_skbmem(struct sk_buff *skb)
+ 	if (!refcount_dec_and_test(&fclones->fclone_ref))
+ 		return;
+ fastpath:
++#ifdef CONFIG_SECURITY_TEMPESTA
++	BUG_ON(!skb->skb_page);
++	put_page(virt_to_page(skb));
++#else
+ 	kmem_cache_free(skbuff_fclone_cache, fclones);
++#endif
+ }
+ 
+ void skb_release_head_state(struct sk_buff *skb)
+@@ -878,6 +1115,17 @@ static inline void _kfree_skb_defer(struct sk_buff *skb)
+ 	/* drop skb->head and call any destructors for packet */
+ 	skb_release_all(skb);
+ 
++	/*
++	 * Tempesta uses its own fast page allocator for socket buffers,
++	 * so no need to use napi_alloc_cache for paged skbs.
++	 */
++#ifdef CONFIG_SECURITY_TEMPESTA
++	if (skb->skb_page) {
++		put_page(virt_to_page(skb));
++		return;
++	}
++#endif
++
+ 	/* record skb to CPU local list */
+ 	nc->skb_cache[nc->skb_count++] = skb;
+ 
+@@ -989,6 +1237,9 @@ static struct sk_buff *__skb_clone(struct sk_buff *n, struct sk_buff *skb)
+ 	n->sk = NULL;
+ 	__copy_skb_header(n, skb);
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	C(tail_lock);
++#endif
+ 	C(len);
+ 	C(data_len);
+ 	C(mac_len);
+@@ -1444,6 +1695,10 @@ struct sk_buff *skb_clone(struct sk_buff *skb, gfp_t gfp_mask)
+ 	    refcount_read(&fclones->fclone_ref) == 1) {
+ 		n = &fclones->skb2;
+ 		refcount_set(&fclones->fclone_ref, 2);
++#ifdef CONFIG_SECURITY_TEMPESTA
++		BUG_ON(!skb->skb_page);
++		BUG_ON(!n->skb_page);
++#endif
+ 	} else {
+ 		if (skb_pfmemalloc(skb))
+ 			gfp_mask |= __GFP_MEMALLOC;
+@@ -1453,6 +1708,9 @@ struct sk_buff *skb_clone(struct sk_buff *skb, gfp_t gfp_mask)
+ 			return NULL;
+ 
+ 		n->fclone = SKB_FCLONE_UNAVAILABLE;
++#ifdef CONFIG_SECURITY_TEMPESTA
++		n->skb_page = 0;
++#endif
+ 	}
+ 
+ 	return __skb_clone(n, skb);
+@@ -1624,15 +1882,22 @@ int pskb_expand_head(struct sk_buff *skb, int nhead, int ntail,
+ 
+ 	BUG_ON(skb_shared(skb));
+ 
+-	size = SKB_DATA_ALIGN(size);
++	size = SKB_DATA_ALIGN(size)
++	       + SKB_DATA_ALIGN(sizeof(struct skb_shared_info));
+ 
+ 	if (skb_pfmemalloc(skb))
+ 		gfp_mask |= __GFP_MEMALLOC;
+-	data = kmalloc_reserve(size + SKB_DATA_ALIGN(sizeof(struct skb_shared_info)),
+-			       gfp_mask, NUMA_NO_NODE, NULL);
++#ifdef CONFIG_SECURITY_TEMPESTA
++	data = pg_skb_alloc(size, gfp_mask, NUMA_NO_NODE);
++	if (!data)
++		goto nodata;
++	size = SKB_WITH_OVERHEAD(PG_ALLOC_SZ(size));
++#else
++	data = kmalloc_reserve(size, gfp_mask, NUMA_NO_NODE, NULL);
+ 	if (!data)
+ 		goto nodata;
+ 	size = SKB_WITH_OVERHEAD(ksize(data));
++#endif
+ 
+ 	/* Copy only real data... and, alas, header. This should be
+ 	 * optimized for the cases when header is void.
+@@ -1666,7 +1931,12 @@ int pskb_expand_head(struct sk_buff *skb, int nhead, int ntail,
+ 	off = (data + nhead) - skb->head;
+ 
+ 	skb->head     = data;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	skb->head_frag = 1;
++	skb->tail_lock = 0;
++#else
+ 	skb->head_frag = 0;
++#endif
+ 	skb->data    += off;
+ #ifdef NET_SKBUFF_DATA_USES_OFFSET
+ 	skb->end      = size;
+@@ -1693,7 +1963,11 @@ int pskb_expand_head(struct sk_buff *skb, int nhead, int ntail,
+ 	return 0;
+ 
+ nofrags:
++#ifdef CONFIG_SECURITY_TEMPESTA
++	put_page(virt_to_page(data));
++#else
+ 	kfree(data);
++#endif
+ nodata:
+ 	return -ENOMEM;
+ }
+@@ -1803,7 +2077,11 @@ int __skb_pad(struct sk_buff *skb, int pad, bool free_on_error)
+ 		return 0;
+ 	}
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	ntail = skb->data_len + pad - skb_tailroom_locked(skb);
++#else
+ 	ntail = skb->data_len + pad - (skb->end - skb->tail);
++#endif
+ 	if (likely(skb_cloned(skb) || ntail > 0)) {
+ 		err = pskb_expand_head(skb, 0, ntail, GFP_ATOMIC);
+ 		if (unlikely(err))
+@@ -2062,7 +2340,13 @@ void *__pskb_pull_tail(struct sk_buff *skb, int delta)
+ 	 * plus 128 bytes for future expansions. If we have enough
+ 	 * room at tail, reallocate without expansion only if skb is cloned.
+ 	 */
+-	int i, k, eat = (skb->tail + delta) - skb->end;
++	int i, k, eat;
++
++#ifdef CONFIG_SECURITY_TEMPESTA
++	eat = delta - skb_tailroom_locked(skb);
++#else
++	eat = (skb->tail + delta) - skb->end;
++#endif
+ 
+ 	if (eat > 0 || skb_cloned(skb)) {
+ 		if (pskb_expand_head(skb, 0, eat > 0 ? eat + 128 : 0,
+@@ -4285,6 +4569,25 @@ static void skb_extensions_init(void) {}
+ 
+ void __init skb_init(void)
+ {
++#ifdef CONFIG_SECURITY_TEMPESTA
++	int cpu, l;
++	for_each_online_cpu(cpu)
++		for (l = 0; l < PG_LISTS_N; ++l) {
++			TfwSkbMemPool *pool = per_cpu_ptr(&pg_mpool[l], cpu);
++			INIT_LIST_HEAD(&pool->lh);
++			/*
++			 * Large chunks are also can be used to get smaller
++			 * chunks, so we cache them more aggressively.
++			 */
++			pool->h_limit = PG_POOL_HLIM_BASE << l;
++		}
++#else
++	skbuff_fclone_cache = kmem_cache_create("skbuff_fclone_cache",
++						sizeof(struct sk_buff_fclones),
++						0,
++						SLAB_HWCACHE_ALIGN|SLAB_PANIC,
++						NULL);
++#endif
+ 	skbuff_head_cache = kmem_cache_create_usercopy("skbuff_head_cache",
+ 					      sizeof(struct sk_buff),
+ 					      0,
+@@ -4292,11 +4595,6 @@ void __init skb_init(void)
+ 					      offsetof(struct sk_buff, cb),
+ 					      sizeof_field(struct sk_buff, cb),
+ 					      NULL);
+-	skbuff_fclone_cache = kmem_cache_create("skbuff_fclone_cache",
+-						sizeof(struct sk_buff_fclones),
+-						0,
+-						SLAB_HWCACHE_ALIGN|SLAB_PANIC,
+-						NULL);
+ 	skb_extensions_init();
+ }
+ 
+@@ -5151,7 +5449,15 @@ void kfree_skb_partial(struct sk_buff *skb, bool head_stolen)
+ {
+ 	if (head_stolen) {
+ 		skb_release_head_state(skb);
++#ifdef CONFIG_SECURITY_TEMPESTA
++		/*
++		 * fclones are possible here with Tempesta due to using
++		 * pskb_copy_for_clone() in ss_send().
++		 */
++		kfree_skbmem(skb);
++#else
+ 		kmem_cache_free(skbuff_head_cache, skb);
++#endif
+ 	} else {
+ 		__kfree_skb(skb);
+ 	}
+@@ -5931,13 +6237,20 @@ static int pskb_carve_inside_header(struct sk_buff *skb, const u32 off,
+ 
+ 	if (skb_pfmemalloc(skb))
+ 		gfp_mask |= __GFP_MEMALLOC;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	size += SKB_DATA_ALIGN(sizeof(struct skb_shared_info));
++	data = pg_skb_alloc(size, gfp_mask, NUMA_NO_NODE);
++	if (!data)
++		return -ENOMEM;
++	size = SKB_WITH_OVERHEAD(PG_ALLOC_SZ(size));
++#else
+ 	data = kmalloc_reserve(size +
+ 			       SKB_DATA_ALIGN(sizeof(struct skb_shared_info)),
+ 			       gfp_mask, NUMA_NO_NODE, NULL);
+ 	if (!data)
+ 		return -ENOMEM;
+-
+ 	size = SKB_WITH_OVERHEAD(ksize(data));
++#endif
+ 
+ 	/* Copy real data, and all frags */
+ 	skb_copy_from_linear_data_offset(skb, off, data, new_hlen);
+@@ -5950,7 +6263,11 @@ static int pskb_carve_inside_header(struct sk_buff *skb, const u32 off,
+ 	if (skb_cloned(skb)) {
+ 		/* drop the old head gracefully */
+ 		if (skb_orphan_frags(skb, gfp_mask)) {
++#ifdef CONFIG_SECURITY_TEMPESTA
++			skb_free_frag(data);
++#else
+ 			kfree(data);
++#endif
+ 			return -ENOMEM;
+ 		}
+ 		for (i = 0; i < skb_shinfo(skb)->nr_frags; i++)
+@@ -5967,7 +6284,11 @@ static int pskb_carve_inside_header(struct sk_buff *skb, const u32 off,
+ 
+ 	skb->head = data;
+ 	skb->data = data;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	skb->head_frag = 1;
++#else
+ 	skb->head_frag = 0;
++#endif
+ #ifdef NET_SKBUFF_DATA_USES_OFFSET
+ 	skb->end = size;
+ #else
+@@ -6055,6 +6376,13 @@ static int pskb_carve_inside_nonlinear(struct sk_buff *skb, const u32 off,
+ 
+ 	if (skb_pfmemalloc(skb))
+ 		gfp_mask |= __GFP_MEMALLOC;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	size += SKB_DATA_ALIGN(sizeof(struct skb_shared_info));
++	data = pg_skb_alloc(size, gfp_mask, NUMA_NO_NODE);
++	if (!data)
++		return -ENOMEM;
++	size = SKB_WITH_OVERHEAD(PG_ALLOC_SZ(size));
++#else
+ 	data = kmalloc_reserve(size +
+ 			       SKB_DATA_ALIGN(sizeof(struct skb_shared_info)),
+ 			       gfp_mask, NUMA_NO_NODE, NULL);
+@@ -6062,11 +6390,16 @@ static int pskb_carve_inside_nonlinear(struct sk_buff *skb, const u32 off,
+ 		return -ENOMEM;
+ 
+ 	size = SKB_WITH_OVERHEAD(ksize(data));
++#endif
+ 
+ 	memcpy((struct skb_shared_info *)(data + size),
+ 	       skb_shinfo(skb), offsetof(struct skb_shared_info, frags[0]));
+ 	if (skb_orphan_frags(skb, gfp_mask)) {
++#ifdef CONFIG_SECURITY_TEMPESTA
++		skb_free_frag(data);
++#else
+ 		kfree(data);
++#endif
+ 		return -ENOMEM;
+ 	}
+ 	shinfo = (struct skb_shared_info *)(data + size);
+@@ -6108,8 +6441,12 @@ static int pskb_carve_inside_nonlinear(struct sk_buff *skb, const u32 off,
+ 	skb_release_data(skb);
+ 
+ 	skb->head = data;
+-	skb->head_frag = 0;
+ 	skb->data = data;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	skb->head_frag = 1;
++#else
++	skb->head_frag = 0;
++#endif
+ #ifdef NET_SKBUFF_DATA_USES_OFFSET
+ 	skb->end = size;
+ #else
+diff --git a/net/core/stream.c b/net/core/stream.c
+index 4f1d4aa5f..47ce31da5 100644
+--- a/net/core/stream.c
++++ b/net/core/stream.c
+@@ -83,16 +83,6 @@ int sk_stream_wait_connect(struct sock *sk, long *timeo_p)
+ }
+ EXPORT_SYMBOL(sk_stream_wait_connect);
+ 
+-/**
+- * sk_stream_closing - Return 1 if we still have things to send in our buffers.
+- * @sk: socket to verify
+- */
+-static inline int sk_stream_closing(struct sock *sk)
+-{
+-	return (1 << sk->sk_state) &
+-	       (TCPF_FIN_WAIT1 | TCPF_CLOSING | TCPF_LAST_ACK);
+-}
+-
+ void sk_stream_wait_close(struct sock *sk, long timeout)
+ {
+ 	if (timeout) {
+diff --git a/net/ipv4/inet_connection_sock.c b/net/ipv4/inet_connection_sock.c
+index 1dfa561e8..2ba1ce470 100644
+--- a/net/ipv4/inet_connection_sock.c
++++ b/net/ipv4/inet_connection_sock.c
+@@ -974,6 +974,14 @@ struct sock *inet_csk_reqsk_queue_add(struct sock *sk,
+ {
+ 	struct request_sock_queue *queue = &inet_csk(sk)->icsk_accept_queue;
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	if (sk->sk_state == TCP_LISTEN && sock_flag(sk, SOCK_TEMPESTA)) {
++		/* Tempesta doesn't use accept queue, just put the request. */
++		reqsk_put(req);
++		return child;
++	}
++#endif
++
+ 	spin_lock(&queue->rskq_lock);
+ 	if (unlikely(sk->sk_state != TCP_LISTEN)) {
+ 		inet_child_forget(sk, req, child);
+diff --git a/net/ipv4/inet_hashtables.c b/net/ipv4/inet_hashtables.c
+index 45fb450b4..48da5be43 100644
+--- a/net/ipv4/inet_hashtables.c
++++ b/net/ipv4/inet_hashtables.c
+@@ -794,7 +794,8 @@ int __inet_hash_connect(struct inet_timewait_death_row *death_row,
+ 		goto ok;
+ next_port:
+ 		spin_unlock_bh(&head->lock);
+-		cond_resched();
++		if (!in_serving_softirq())
++			cond_resched();
+ 	}
+ 
+ 	offset++;
+diff --git a/net/ipv4/ip_output.c b/net/ipv4/ip_output.c
+index 97975bed4..3d195228e 100644
+--- a/net/ipv4/ip_output.c
++++ b/net/ipv4/ip_output.c
+@@ -82,6 +82,9 @@
+ #include <linux/netfilter_bridge.h>
+ #include <linux/netlink.h>
+ #include <linux/tcp.h>
++#ifdef CONFIG_SECURITY_TEMPESTA
++#include <net/tcp.h>
++#endif
+ 
+ static int
+ ip_fragment(struct net *net, struct sock *sk, struct sk_buff *skb,
+@@ -527,6 +530,15 @@ int __ip_queue_xmit(struct sock *sk, struct sk_buff *skb, struct flowi *fl,
+ 
+ 	/* TODO : should we use skb->sk here instead of sk ? */
+ 	skb->priority = sk->sk_priority;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/*
++	 * Tempesta can set skb->mark for some skbs. And moreover
++	 * sk_mark is never set for Tempesta sockets.
++	 */
++	if (sock_flag(sk, SOCK_TEMPESTA))
++		WARN_ON_ONCE(sk->sk_mark);
++	else
++#endif
+ 	skb->mark = sk->sk_mark;
+ 
+ 	res = ip_local_out(net, sk, skb);
+@@ -702,7 +714,31 @@ struct sk_buff *ip_frag_next(struct sk_buff *skb, struct ip_frag_state *state)
+ 	}
+ 
+ 	/* Allocate buffer */
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/*
++	 * Since Tempesta FW tries to reuse incoming SKBs containing the response
++	 * from the backend, sometimes we might encounter an SKB with quite a small
++	 * head room, which is not big enough to accommodate all the transport headers
++	 * and TLS overhead.
++	 * It usually the case when working over loopback, tun/tap, bridge or similar
++	 * interfaces with small MTU. The issue is specific to aforementioned ifaces
++	 * because the outgoing SKB would be injected back to the stack.
++	 * In order not to reallocate sk_buffs' headroom on RX path,
++	 * allocate and reserve a little bit more memory on TX path.
++	 * Even though it would introduce some memory overhead, it's still
++	 * cheaper than doing transformation.
++	 *
++	 * It seems like no such actions are required for IPv6 counterparts:
++	 * ip6_fragment() / ip6_frag_next() due to the fact that the
++	 * lowest acceptable MTU (1280) is sufficient to fit all the headers.
++	 *
++	 * When receiving SKBs from the outter world, the NIC driver should
++	 * allocate and reserve all necessary space by itself.
++	 */
++	skb2 = alloc_skb(len + state->hlen + MAX_TCP_HEADER, GFP_ATOMIC);
++#else
+ 	skb2 = alloc_skb(len + state->hlen + state->ll_rs, GFP_ATOMIC);
++#endif
+ 	if (!skb2)
+ 		return ERR_PTR(-ENOMEM);
+ 
+@@ -711,7 +747,11 @@ struct sk_buff *ip_frag_next(struct sk_buff *skb, struct ip_frag_state *state)
+ 	 */
+ 
+ 	ip_copy_metadata(skb2, skb);
++#ifdef CONFIG_SECURITY_TEMPESTA
++	skb_reserve(skb2, MAX_TCP_HEADER);
++#else
+ 	skb_reserve(skb2, state->ll_rs);
++#endif
+ 	skb_put(skb2, len + state->hlen);
+ 	skb_reset_network_header(skb2);
+ 	skb2->transport_header = skb2->network_header + state->hlen;
+diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
+index 2384ac048..9939c65e5 100644
+--- a/net/ipv4/tcp.c
++++ b/net/ipv4/tcp.c
+@@ -322,6 +322,7 @@ DEFINE_STATIC_KEY_FALSE(tcp_rx_skb_cache_key);
+ EXPORT_SYMBOL(tcp_rx_skb_cache_key);
+ 
+ DEFINE_STATIC_KEY_FALSE(tcp_tx_skb_cache_key);
++EXPORT_SYMBOL_GPL(tcp_tx_skb_cache_key);
+ 
+ void tcp_enter_memory_pressure(struct sock *sk)
+ {
+@@ -648,18 +649,19 @@ int tcp_ioctl(struct sock *sk, int cmd, unsigned long arg)
+ }
+ EXPORT_SYMBOL(tcp_ioctl);
+ 
+-static inline void tcp_mark_push(struct tcp_sock *tp, struct sk_buff *skb)
++void tcp_mark_push(struct tcp_sock *tp, struct sk_buff *skb)
+ {
+ 	TCP_SKB_CB(skb)->tcp_flags |= TCPHDR_PSH;
+ 	tp->pushed_seq = tp->write_seq;
+ }
++EXPORT_SYMBOL(tcp_mark_push);
+ 
+ static inline bool forced_push(const struct tcp_sock *tp)
+ {
+ 	return after(tp->write_seq, tp->pushed_seq + (tp->max_window >> 1));
+ }
+ 
+-static void skb_entail(struct sock *sk, struct sk_buff *skb)
++void skb_entail(struct sock *sk, struct sk_buff *skb)
+ {
+ 	struct tcp_sock *tp = tcp_sk(sk);
+ 	struct tcp_skb_cb *tcb = TCP_SKB_CB(skb);
+@@ -668,7 +670,15 @@ static void skb_entail(struct sock *sk, struct sk_buff *skb)
+ 	tcb->seq     = tcb->end_seq = tp->write_seq;
+ 	tcb->tcp_flags = TCPHDR_ACK;
+ 	tcb->sacked  = 0;
+-	__skb_header_release(skb);
++
++	/*
++	 * fclones are possible here, so accurately update
++	 * skb_shinfo(skb)->dataref.
++	 */
++	BUG_ON(skb->nohdr);
++	skb->nohdr = 1;
++	atomic_add(1 << SKB_DATAREF_SHIFT, &skb_shinfo(skb)->dataref);
++
+ 	tcp_add_write_queue_tail(sk, skb);
+ 	sk_wmem_queued_add(sk, skb->truesize);
+ 	sk_mem_charge(sk, skb->truesize);
+@@ -677,6 +687,7 @@ static void skb_entail(struct sock *sk, struct sk_buff *skb)
+ 
+ 	tcp_slow_start_after_idle_check(sk);
+ }
++EXPORT_SYMBOL(skb_entail);
+ 
+ static inline void tcp_mark_urg(struct tcp_sock *tp, int flags)
+ {
+@@ -736,6 +747,7 @@ void tcp_push(struct sock *sk, int flags, int mss_now,
+ 
+ 	__tcp_push_pending_frames(sk, mss_now, nonagle);
+ }
++EXPORT_SYMBOL(tcp_push);
+ 
+ static int tcp_splice_data_recv(read_descriptor_t *rd_desc, struct sk_buff *skb,
+ 				unsigned int offset, size_t len)
+@@ -912,6 +924,7 @@ struct sk_buff *sk_stream_alloc_skb(struct sock *sk, int size, gfp_t gfp,
+ 	}
+ 	return NULL;
+ }
++EXPORT_SYMBOL(sk_stream_alloc_skb);
+ 
+ static unsigned int tcp_xmit_size_goal(struct sock *sk, u32 mss_now,
+ 				       int large_allowed)
+@@ -947,6 +960,7 @@ int tcp_send_mss(struct sock *sk, int *size_goal, int flags)
+ 
+ 	return mss_now;
+ }
++EXPORT_SYMBOL(tcp_send_mss);
+ 
+ /* In some cases, both sendpage() and sendmsg() could have added
+  * an skb to the write queue, but failed adding payload on it.
+@@ -1583,6 +1597,7 @@ void tcp_cleanup_rbuf(struct sock *sk, int copied)
+ 	if (time_to_ack)
+ 		tcp_send_ack(sk);
+ }
++EXPORT_SYMBOL(tcp_cleanup_rbuf);
+ 
+ static struct sk_buff *tcp_recv_skb(struct sock *sk, u32 seq, u32 *off)
+ {
+@@ -2356,7 +2371,7 @@ static const unsigned char new_state[16] = {
+   [TCP_NEW_SYN_RECV]	= TCP_CLOSE,	/* should not happen ! */
+ };
+ 
+-static int tcp_close_state(struct sock *sk)
++int tcp_close_state(struct sock *sk)
+ {
+ 	int next = (int)new_state[sk->sk_state];
+ 	int ns = next & TCP_STATE_MASK;
+@@ -2365,6 +2380,7 @@ static int tcp_close_state(struct sock *sk)
+ 
+ 	return next & TCP_ACTION_FIN;
+ }
++EXPORT_SYMBOL(tcp_close_state);
+ 
+ /*
+  *	Shutdown the sending side of a connection. Much like close except
+@@ -2404,6 +2420,7 @@ bool tcp_check_oom(struct sock *sk, int shift)
+ 		net_info_ratelimited("out of memory -- consider tuning tcp_mem\n");
+ 	return too_many_orphans || out_of_socket_memory;
+ }
++EXPORT_SYMBOL(tcp_check_oom);
+ 
+ void tcp_close(struct sock *sk, long timeout)
+ {
+@@ -2627,6 +2644,7 @@ void tcp_write_queue_purge(struct sock *sk)
+ 	tcp_sk(sk)->packets_out = 0;
+ 	inet_csk(sk)->icsk_backoff = 0;
+ }
++EXPORT_SYMBOL_GPL(tcp_write_queue_purge);
+ 
+ int tcp_disconnect(struct sock *sk, int flags)
+ {
+@@ -4052,10 +4070,15 @@ void tcp_done(struct sock *sk)
+ 
+ 	sk->sk_shutdown = SHUTDOWN_MASK;
+ 
+-	if (!sock_flag(sk, SOCK_DEAD))
++	if (!sock_flag(sk, SOCK_DEAD)) {
+ 		sk->sk_state_change(sk);
+-	else
++	} else {
++#ifdef CONFIG_SECURITY_TEMPESTA
++		if (sk->sk_destroy_cb)
++			sk->sk_destroy_cb(sk);
++#endif
+ 		inet_csk_destroy_sock(sk);
++	}
+ }
+ EXPORT_SYMBOL_GPL(tcp_done);
+ 
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index fac5c1469..f9f8000bf 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -728,6 +728,7 @@ void tcp_rcv_space_adjust(struct sock *sk)
+ 	tp->rcvq_space.seq = tp->copied_seq;
+ 	tp->rcvq_space.time = tp->tcp_mstamp;
+ }
++EXPORT_SYMBOL(tcp_rcv_space_adjust);
+ 
+ /* There is something which you must keep in mind when you analyze the
+  * behavior of the tp->ato delayed ack timeout interval.  When a
+@@ -5125,9 +5126,20 @@ tcp_collapse(struct sock *sk, struct sk_buff_head *list, struct rb_root *root,
+ 		int copy = min_t(int, SKB_MAX_ORDER(0, 0), end - start);
+ 		struct sk_buff *nskb;
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++		/*
++		 * This skb can be reused by Tempesta FW. Thus allocate
++		 * space for TCP headers.
++		 */
++		nskb = alloc_skb(copy + MAX_TCP_HEADER, GFP_ATOMIC);
++#else
+ 		nskb = alloc_skb(copy, GFP_ATOMIC);
++#endif
+ 		if (!nskb)
+ 			break;
++#ifdef CONFIG_SECURITY_TEMPESTA
++		skb_reserve(nskb, MAX_TCP_HEADER);
++#endif
+ 
+ 		memcpy(nskb->cb, skb->cb, sizeof(skb->cb));
+ #ifdef CONFIG_TLS_DEVICE
+diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
+index ab8ed0fc4..7effbed4a 100644
+--- a/net/ipv4/tcp_ipv4.c
++++ b/net/ipv4/tcp_ipv4.c
+@@ -57,6 +57,7 @@
+ #include <linux/init.h>
+ #include <linux/times.h>
+ #include <linux/slab.h>
++#include <linux/tempesta.h>
+ 
+ #include <net/net_namespace.h>
+ #include <net/icmp.h>
+@@ -215,8 +216,7 @@ int tcp_v4_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
+ 		return -EAFNOSUPPORT;
+ 
+ 	nexthop = daddr = usin->sin_addr.s_addr;
+-	inet_opt = rcu_dereference_protected(inet->inet_opt,
+-					     lockdep_sock_is_held(sk));
++	inet_opt = rcu_dereference_raw(inet->inet_opt);
+ 	if (inet_opt && inet_opt->opt.srr) {
+ 		if (!daddr)
+ 			return -EINVAL;
+@@ -1078,8 +1078,7 @@ static struct tcp_md5sig_key *tcp_md5_do_lookup_exact(const struct sock *sk,
+ 	const struct tcp_md5sig_info *md5sig;
+ 
+ 	/* caller either holds rcu_read_lock() or socket lock */
+-	md5sig = rcu_dereference_check(tp->md5sig_info,
+-				       lockdep_sock_is_held(sk));
++	md5sig = rcu_dereference_raw(tp->md5sig_info);
+ 	if (!md5sig)
+ 		return NULL;
+ #if IS_ENABLED(CONFIG_IPV6)
+@@ -1582,6 +1581,18 @@ struct sock *tcp_v4_syn_recv_sock(const struct sock *sk, struct sk_buff *skb,
+ 	}
+ #endif
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/*
++	 * We need already initialized socket addresses,
++	 * so there is no appropriate security hook.
++	 */
++	if (tempesta_new_clntsk(newsk, skb)) {
++		tcp_v4_send_reset(newsk, skb);
++		tempesta_close_clntsk(newsk);
++		ireq->aborted = true;
++		goto put_and_exit;
++	}
++#endif
+ 	if (__inet_inherit_port(sk, newsk) < 0)
+ 		goto put_and_exit;
+ 	*own_req = inet_ehash_nolisten(newsk, req_to_sk(req_unhash),
+diff --git a/net/ipv4/tcp_minisocks.c b/net/ipv4/tcp_minisocks.c
+index f0f67b25c..58fbfb071 100644
+--- a/net/ipv4/tcp_minisocks.c
++++ b/net/ipv4/tcp_minisocks.c
+@@ -786,7 +786,12 @@ struct sock *tcp_check_req(struct sock *sk, struct sk_buff *skb,
+ 	return inet_csk_complete_hashdance(sk, child, req, own_req);
+ 
+ listen_overflow:
++#ifdef CONFIG_SECURITY_TEMPESTA
++	if (!sock_net(sk)->ipv4.sysctl_tcp_abort_on_overflow
++	    && !inet_rsk(req)->aborted) {
++#else
+ 	if (!sock_net(sk)->ipv4.sysctl_tcp_abort_on_overflow) {
++#endif
+ 		inet_rsk(req)->acked = 1;
+ 		return NULL;
+ 	}
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index f99494637..14d28bcca 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -39,6 +39,9 @@
+ 
+ #include <net/tcp.h>
+ #include <net/mptcp.h>
++#ifdef CONFIG_SECURITY_TEMPESTA
++#include <net/tls.h>
++#endif
+ 
+ #include <linux/compiler.h>
+ #include <linux/gfp.h>
+@@ -155,6 +158,9 @@ void tcp_cwnd_restart(struct sock *sk, s32 delta)
+ 	tp->snd_cwnd_stamp = tcp_jiffies32;
+ 	tp->snd_cwnd_used = 0;
+ }
++#ifdef CONFIG_SECURITY_TEMPESTA
++EXPORT_SYMBOL(tcp_cwnd_restart);
++#endif
+ 
+ /* Congestion state accounting after a packet has been sent. */
+ static void tcp_event_data_sent(struct tcp_sock *tp,
+@@ -389,7 +395,7 @@ static void tcp_ecn_send(struct sock *sk, struct sk_buff *skb,
+ /* Constructs common control bits of non-data skb. If SYN/FIN is present,
+  * auto increment end seqno.
+  */
+-static void tcp_init_nondata_skb(struct sk_buff *skb, u32 seq, u8 flags)
++void tcp_init_nondata_skb(struct sk_buff *skb, u32 seq, u8 flags)
+ {
+ 	skb->ip_summed = CHECKSUM_PARTIAL;
+ 
+@@ -403,6 +409,7 @@ static void tcp_init_nondata_skb(struct sk_buff *skb, u32 seq, u8 flags)
+ 		seq++;
+ 	TCP_SKB_CB(skb)->end_seq = seq;
+ }
++EXPORT_SYMBOL(tcp_init_nondata_skb);
+ 
+ static inline bool tcp_urg_mode(const struct tcp_sock *tp)
+ {
+@@ -1428,7 +1435,7 @@ static int tcp_transmit_skb(struct sock *sk, struct sk_buff *skb, int clone_it,
+  * NOTE: probe0 timer is not checked, do not forget tcp_push_pending_frames,
+  * otherwise socket can stall.
+  */
+-static void tcp_queue_skb(struct sock *sk, struct sk_buff *skb)
++void tcp_queue_skb(struct sock *sk, struct sk_buff *skb)
+ {
+ 	struct tcp_sock *tp = tcp_sk(sk);
+ 
+@@ -1439,9 +1446,10 @@ static void tcp_queue_skb(struct sock *sk, struct sk_buff *skb)
+ 	sk_wmem_queued_add(sk, skb->truesize);
+ 	sk_mem_charge(sk, skb->truesize);
+ }
++EXPORT_SYMBOL(tcp_queue_skb);
+ 
+ /* Initialize TSO segments for a packet. */
+-static void tcp_set_skb_tso_segs(struct sk_buff *skb, unsigned int mss_now)
++void tcp_set_skb_tso_segs(struct sk_buff *skb, unsigned int mss_now)
+ {
+ 	if (skb->len <= mss_now) {
+ 		/* Avoid the costly divide in the normal
+@@ -1454,11 +1462,12 @@ static void tcp_set_skb_tso_segs(struct sk_buff *skb, unsigned int mss_now)
+ 		TCP_SKB_CB(skb)->tcp_gso_size = mss_now;
+ 	}
+ }
++EXPORT_SYMBOL(tcp_set_skb_tso_segs);
+ 
+ /* Pcount in the middle of the write queue got changed, we need to do various
+  * tweaks to fix counters
+  */
+-static void tcp_adjust_pcount(struct sock *sk, const struct sk_buff *skb, int decr)
++void tcp_adjust_pcount(struct sock *sk, const struct sk_buff *skb, int decr)
+ {
+ 	struct tcp_sock *tp = tcp_sk(sk);
+ 
+@@ -1482,6 +1491,7 @@ static void tcp_adjust_pcount(struct sock *sk, const struct sk_buff *skb, int de
+ 
+ 	tcp_verify_left_out(tp);
+ }
++EXPORT_SYMBOL(tcp_adjust_pcount);
+ 
+ static bool tcp_has_tx_tstamp(const struct sk_buff *skb)
+ {
+@@ -1489,7 +1499,7 @@ static bool tcp_has_tx_tstamp(const struct sk_buff *skb)
+ 		(skb_shinfo(skb)->tx_flags & SKBTX_ANY_TSTAMP);
+ }
+ 
+-static void tcp_fragment_tstamp(struct sk_buff *skb, struct sk_buff *skb2)
++void tcp_fragment_tstamp(struct sk_buff *skb, struct sk_buff *skb2)
+ {
+ 	struct skb_shared_info *shinfo = skb_shinfo(skb);
+ 
+@@ -1505,12 +1515,14 @@ static void tcp_fragment_tstamp(struct sk_buff *skb, struct sk_buff *skb2)
+ 		TCP_SKB_CB(skb)->txstamp_ack = 0;
+ 	}
+ }
++EXPORT_SYMBOL(tcp_fragment_tstamp);
+ 
+-static void tcp_skb_fragment_eor(struct sk_buff *skb, struct sk_buff *skb2)
++void tcp_skb_fragment_eor(struct sk_buff *skb, struct sk_buff *skb2)
+ {
+ 	TCP_SKB_CB(skb2)->eor = TCP_SKB_CB(skb)->eor;
+ 	TCP_SKB_CB(skb)->eor = 0;
+ }
++EXPORT_SYMBOL(tcp_skb_fragment_eor);
+ 
+ /* Insert buff after skb on the write or rtx queue of sk.  */
+ static void tcp_insert_write_queue_after(struct sk_buff *skb,
+@@ -1518,12 +1530,39 @@ static void tcp_insert_write_queue_after(struct sk_buff *skb,
+ 					 struct sock *sk,
+ 					 enum tcp_queue tcp_queue)
+ {
++#ifdef CONFIG_SECURITY_TEMPESTA
++	skb_copy_tfw_cb(buff, skb);
++#endif
+ 	if (tcp_queue == TCP_FRAG_IN_WRITE_QUEUE)
+ 		__skb_queue_after(&sk->sk_write_queue, skb, buff);
+ 	else
+ 		tcp_rbtree_insert(&sk->tcp_rtx_queue, buff);
+ }
+ 
++/**
++ * Tempesta uses page fragments for all skb allocations, so if an skb was
++ * allocated in standard Linux way, then pskb_expand_head( , 0, 0, ) may
++ * return larger skb and we have to adjust skb->truesize and memory accounting
++ * for TCP write queue.
++ */
++static int
++tcp_skb_unclone(struct sock *sk, struct sk_buff *skb, gfp_t pri)
++{
++	int r, delta_truesize = skb->truesize;
++
++	if ((r = skb_unclone(skb, pri)))
++		return r;
++
++	delta_truesize -= skb->truesize;
++	sk->sk_wmem_queued -= delta_truesize;
++	if (delta_truesize > 0)
++		sk_mem_uncharge(sk, delta_truesize);
++	else
++		sk_mem_charge(sk, -delta_truesize);
++
++	return 0;
++}
++
+ /* Function to create two new TCP segments.  Shrinks the given segment
+  * to the specified size and appends a new segment with the rest of the
+  * packet to the list.  This won't be called frequently, I hope.
+@@ -1561,7 +1600,7 @@ int tcp_fragment(struct sock *sk, enum tcp_queue tcp_queue,
+ 		return -ENOMEM;
+ 	}
+ 
+-	if (skb_unclone(skb, gfp))
++	if (tcp_skb_unclone(sk, skb, gfp))
+ 		return -ENOMEM;
+ 
+ 	/* Get a new skb... force flag on. */
+@@ -1575,6 +1614,9 @@ int tcp_fragment(struct sock *sk, enum tcp_queue tcp_queue,
+ 	nlen = skb->len - len - nsize;
+ 	buff->truesize += nlen;
+ 	skb->truesize -= nlen;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	buff->mark = skb->mark;
++#endif
+ 
+ 	/* Correct the sequence numbers. */
+ 	TCP_SKB_CB(buff)->seq = TCP_SKB_CB(skb)->seq + len;
+@@ -1670,7 +1712,7 @@ int tcp_trim_head(struct sock *sk, struct sk_buff *skb, u32 len)
+ {
+ 	u32 delta_truesize;
+ 
+-	if (skb_unclone(skb, GFP_ATOMIC))
++	if (tcp_skb_unclone(sk, skb, GFP_ATOMIC))
+ 		return -ENOMEM;
+ 
+ 	delta_truesize = __pskb_trim_head(skb, len);
+@@ -1848,6 +1890,7 @@ unsigned int tcp_current_mss(struct sock *sk)
+ 
+ 	return mss_now;
+ }
++EXPORT_SYMBOL(tcp_current_mss);
+ 
+ /* RFC2861, slow part. Adjust cwnd, after it was not full during one rto.
+  * As additional protections, we do not touch cwnd in retransmission phases,
+@@ -2129,6 +2172,9 @@ static int tso_fragment(struct sock *sk, struct sk_buff *skb, unsigned int len,
+ 	sk_mem_charge(sk, buff->truesize);
+ 	buff->truesize += nlen;
+ 	skb->truesize -= nlen;
++#ifdef CONFIG_SECURITY_TEMPESTA
++	buff->mark = skb->mark;
++#endif
+ 
+ 	/* Correct the sequence numbers. */
+ 	TCP_SKB_CB(buff)->seq = TCP_SKB_CB(skb)->seq + len;
+@@ -2303,6 +2349,14 @@ static bool tcp_can_coalesce_send_queue_head(struct sock *sk, int len)
+ 
+ 		if (unlikely(TCP_SKB_CB(skb)->eor) || tcp_has_tx_tstamp(skb))
+ 			return false;
++#ifdef CONFIG_SECURITY_TEMPESTA
++		/* Do not coalesce tempesta skbs with tls type or set mark. */
++		if ((next != ((struct sk_buff *)&(sk)->sk_write_queue))
++		    && ((skb_tfw_tls_type(skb) != skb_tfw_tls_type(next))
++			|| (sock_flag(sk, SOCK_TEMPESTA)
++			    && (skb->mark != next->mark))))
++			return false;
++#endif
+ 
+ 		len -= skb->len;
+ 	}
+@@ -2577,6 +2631,66 @@ void tcp_chrono_stop(struct sock *sk, const enum tcp_chrono type)
+ 		tcp_chrono_set(tp, TCP_CHRONO_BUSY);
+ }
+ 
++#ifdef CONFIG_SECURITY_TEMPESTA
++
++/**
++ * The next funtion is called from places: from `tcp_write_xmit`
++ * (a usual case) and from `tcp_write_wakeup`. In other places where
++ * `tcp_transmit_skb` is called we deal with special TCP skbs or skbs
++ * not from tcp send queue.
++ */
++static int
++tcp_tfw_sk_write_xmit(struct sock *sk, struct sk_buff *skb,
++		      unsigned int mss_now)
++{
++	struct tcp_sock *tp = tcp_sk(sk);
++	unsigned int in_flight = tcp_packets_in_flight(tp);
++	unsigned int send_win, cong_win;
++	unsigned int limit;
++	int result;
++
++	if (!sk->sk_write_xmit || !skb_tfw_tls_type(skb))
++		return 0;
++
++	/* Should be checked early. */
++	BUG_ON(after(TCP_SKB_CB(skb)->seq, tcp_wnd_end(tp)));
++	cong_win = (tp->snd_cwnd - in_flight) * mss_now;
++	send_win = tcp_wnd_end(tp) - TCP_SKB_CB(skb)->seq;
++	/*
++	 * A receive side doesn’t start to process a TLS recod until
++	 * it’s fully read from a socket. Too small record size causes
++	 * too much overhead. On the other side too large record size
++	 * can lead to significant delays on receive side if current
++	 * TCP congestion and/or the receiver’s advertised window are
++	 * smaller than a TLS record size.
++	 */
++	limit = min3(cong_win, send_win, (unsigned int)TLS_MAX_PAYLOAD_SIZE);
++
++	result = sk->sk_write_xmit(sk, skb, mss_now, limit);
++	if (unlikely(result))
++		return result;
++
++	/* Fix up TSO segments after TLS overhead. */
++	tcp_set_skb_tso_segs(skb, mss_now);
++	return 0;
++}
++
++/*
++ * We should recalculate max_size, and split skb according
++ * new limit, because we add extra TLS_MAX_OVERHEAD bytes
++ * during tls encription. If we don't adjust it, we push
++ * skb with incorrect length to network.
++ */
++#define TFW_ADJUST_TLS_OVERHEAD(max_size)			\
++do {								\
++	if (max_size > TLS_MAX_PAYLOAD_SIZE + TLS_MAX_OVERHEAD)	\
++		max_size = TLS_MAX_PAYLOAD_SIZE;		\
++	else							\
++		max_size -= TLS_MAX_OVERHEAD;			\
++} while(0)
++
++#endif
++
+ /* This routine writes packets to the network.  It advances the
+  * send_head.  This happens as incoming acks open up the remote
+  * window for us.
+@@ -2666,7 +2780,17 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
+ 							  cwnd_quota,
+ 							  max_segs),
+ 						    nonagle);
+-
++#ifdef CONFIG_SECURITY_TEMPESTA
++		if (sk->sk_write_xmit && skb_tfw_tls_type(skb)) {
++			if (unlikely(limit <= TLS_MAX_OVERHEAD)) {
++			    net_warn_ratelimited("%s: too small MSS %u"
++						 " for TLS\n",
++						 __func__, mss_now);
++				break;
++			}
++			TFW_ADJUST_TLS_OVERHEAD(limit);
++		}
++#endif
+ 		if (skb->len > limit &&
+ 		    unlikely(tso_fragment(sk, skb, limit, mss_now, gfp)))
+ 			break;
+@@ -2681,7 +2805,15 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
+ 		 */
+ 		if (TCP_SKB_CB(skb)->end_seq == TCP_SKB_CB(skb)->seq)
+ 			break;
+-
++#ifdef CONFIG_SECURITY_TEMPESTA
++		result = tcp_tfw_sk_write_xmit(sk, skb, mss_now);
++		if (unlikely(result)) {
++			if (result == -ENOMEM)
++				break; /* try again next time */
++			tcp_tfw_handle_error(sk, result);
++			return false;
++		}
++#endif
+ 		if (unlikely(tcp_transmit_skb(sk, skb, 1, gfp)))
+ 			break;
+ 
+@@ -2866,6 +2998,7 @@ void __tcp_push_pending_frames(struct sock *sk, unsigned int cur_mss,
+ 			   sk_gfp_mask(sk, GFP_ATOMIC)))
+ 		tcp_check_probe_timer(sk);
+ }
++EXPORT_SYMBOL(__tcp_push_pending_frames);
+ 
+ /* Send _single_ skb sitting at the send head. This function requires
+  * true push pending frames to setup probe timer etc.
+@@ -3183,7 +3316,7 @@ int __tcp_retransmit_skb(struct sock *sk, struct sk_buff *skb, int segs)
+ 				 cur_mss, GFP_ATOMIC))
+ 			return -ENOMEM; /* We'll try again later. */
+ 	} else {
+-		if (skb_unclone(skb, GFP_ATOMIC))
++		if (tcp_skb_unclone(sk, skb, GFP_ATOMIC))
+ 			return -ENOMEM;
+ 
+ 		diff = tcp_skb_pcount(skb);
+@@ -3421,6 +3554,7 @@ void tcp_send_fin(struct sock *sk)
+ 	}
+ 	__tcp_push_pending_frames(sk, tcp_current_mss(sk), TCP_NAGLE_OFF);
+ }
++EXPORT_SYMBOL(tcp_send_fin);
+ 
+ /* We get here when a process closes a file descriptor (either due to
+  * an explicit close() or as a byproduct of exit()'ing) and there
+@@ -3454,6 +3588,7 @@ void tcp_send_active_reset(struct sock *sk, gfp_t priority)
+ 	 */
+ 	trace_tcp_send_reset(sk, NULL);
+ }
++EXPORT_SYMBOL(tcp_send_active_reset);
+ 
+ /* Send a crossed SYN-ACK during socket establishment.
+  * WARNING: This routine must only be called when we have already sent
+@@ -4044,6 +4179,17 @@ int tcp_write_wakeup(struct sock *sk, int mib)
+ 		if (seg_size < TCP_SKB_CB(skb)->end_seq - TCP_SKB_CB(skb)->seq ||
+ 		    skb->len > mss) {
+ 			seg_size = min(seg_size, mss);
++#ifdef CONFIG_SECURITY_TEMPESTA
++			if (sk->sk_write_xmit && skb_tfw_tls_type(skb)) {
++				if (unlikely(seg_size <= TLS_MAX_OVERHEAD)) {
++					net_warn_ratelimited("%s: too small"
++							     " MSS %u for TLS\n",
++							     __func__, mss);
++					return -ENOMEM;
++				}
++				TFW_ADJUST_TLS_OVERHEAD(seg_size);
++			}
++#endif
+ 			TCP_SKB_CB(skb)->tcp_flags |= TCPHDR_PSH;
+ 			if (tcp_fragment(sk, TCP_FRAG_IN_WRITE_QUEUE,
+ 					 skb, seg_size, mss, GFP_ATOMIC))
+@@ -4052,6 +4198,16 @@ int tcp_write_wakeup(struct sock *sk, int mib)
+ 			tcp_set_skb_tso_segs(skb, mss);
+ 
+ 		TCP_SKB_CB(skb)->tcp_flags |= TCPHDR_PSH;
++
++#ifdef CONFIG_SECURITY_TEMPESTA
++		err = tcp_tfw_sk_write_xmit(sk, skb, mss);
++		if (unlikely(err)) {
++			if (err != -ENOMEM)
++				tcp_tfw_handle_error(sk, err);
++			return err;
++		}
++#endif
++
+ 		err = tcp_transmit_skb(sk, skb, 1, GFP_ATOMIC);
+ 		if (!err)
+ 			tcp_event_new_data_sent(sk, skb);
+diff --git a/net/ipv6/tcp_ipv6.c b/net/ipv6/tcp_ipv6.c
+index 3f9bb6dd1..f9b137af9 100644
+--- a/net/ipv6/tcp_ipv6.c
++++ b/net/ipv6/tcp_ipv6.c
+@@ -65,6 +65,7 @@
+ 
+ #include <crypto/hash.h>
+ #include <linux/scatterlist.h>
++#include <linux/tempesta.h>
+ 
+ #include <trace/events/tcp.h>
+ 
+@@ -1376,7 +1377,20 @@ static struct sock *tcp_v6_syn_recv_sock(const struct sock *sk, struct sk_buff *
+ 			       sk_gfp_mask(sk, GFP_ATOMIC));
+ 	}
+ #endif
+-
++#ifdef CONFIG_SECURITY_TEMPESTA
++	/*
++	 * We need already initialized socket addresses,
++	 * so there is no appropriate security hook.
++	 */
++	if (tempesta_new_clntsk(newsk, skb)) {
++		tcp_v6_send_reset(newsk, skb);
++		tempesta_close_clntsk(newsk);
++		ireq->aborted = true;
++		inet_csk_prepare_forced_close(newsk);
++		tcp_done(newsk);
++		goto out;
++	}
++#endif
+ 	if (__inet_inherit_port(sk, newsk) < 0) {
+ 		inet_csk_prepare_forced_close(newsk);
+ 		tcp_done(newsk);
+diff --git a/net/socket.c b/net/socket.c
+index 6e6cccc21..161bf1b4a 100644
+--- a/net/socket.c
++++ b/net/socket.c
+@@ -172,6 +172,12 @@ static const struct file_operations socket_file_ops = {
+ static DEFINE_SPINLOCK(net_family_lock);
+ static const struct net_proto_family __rcu *net_families[NPROTO] __read_mostly;
+ 
++const struct net_proto_family *get_proto_family(int family)
++{
++	return rcu_dereference_bh(net_families[family]);
++}
++EXPORT_SYMBOL(get_proto_family);
++
+ /*
+  * Support routines.
+  * Move socket addresses back and forth across the kernel/user
+diff --git a/security/Kconfig b/security/Kconfig
+index 7561f6f99..ddc22ea44 100644
+--- a/security/Kconfig
++++ b/security/Kconfig
+@@ -238,11 +238,13 @@ source "security/loadpin/Kconfig"
+ source "security/yama/Kconfig"
+ source "security/safesetid/Kconfig"
+ source "security/lockdown/Kconfig"
++source "security/tempesta/Kconfig"
+ 
+ source "security/integrity/Kconfig"
+ 
+ choice
+ 	prompt "First legacy 'major LSM' to be initialized"
++	default DEFAULT_SECURITY_TEMPESTA if SECURITY_TEMPESTA
+ 	default DEFAULT_SECURITY_SELINUX if SECURITY_SELINUX
+ 	default DEFAULT_SECURITY_SMACK if SECURITY_SMACK
+ 	default DEFAULT_SECURITY_TOMOYO if SECURITY_TOMOYO
+@@ -258,6 +260,9 @@ choice
+ 	  Selects the legacy "major security module" that will be
+ 	  initialized first. Overridden by non-default CONFIG_LSM.
+ 
++	config DEFAULT_SECURITY_TEMPESTA
++		bool "Tempesta FW" if SECURITY_TEMPESTA=y
++
+ 	config DEFAULT_SECURITY_SELINUX
+ 		bool "SELinux" if SECURITY_SELINUX=y
+ 
+@@ -281,7 +286,7 @@ config LSM
+ 	default "lockdown,yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo,bpf" if DEFAULT_SECURITY_APPARMOR
+ 	default "lockdown,yama,loadpin,safesetid,integrity,tomoyo,bpf" if DEFAULT_SECURITY_TOMOYO
+ 	default "lockdown,yama,loadpin,safesetid,integrity,bpf" if DEFAULT_SECURITY_DAC
+-	default "lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
++	default "tempesta,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
+ 	help
+ 	  A comma-separated list of LSMs, in initialization order.
+ 	  Any LSMs left off this list will be ignored. This can be
+diff --git a/security/Makefile b/security/Makefile
+index 3baf435de..528850341 100644
+--- a/security/Makefile
++++ b/security/Makefile
+@@ -13,6 +13,7 @@ subdir-$(CONFIG_SECURITY_LOADPIN)	+= loadpin
+ subdir-$(CONFIG_SECURITY_SAFESETID)    += safesetid
+ subdir-$(CONFIG_SECURITY_LOCKDOWN_LSM)	+= lockdown
+ subdir-$(CONFIG_BPF_LSM)		+= bpf
++subdir-$(CONFIG_SECURITY_TEMPESTA)	+= tempesta
+ 
+ # always enable default capabilities
+ obj-y					+= commoncap.o
+@@ -32,6 +33,7 @@ obj-$(CONFIG_SECURITY_SAFESETID)       += safesetid/
+ obj-$(CONFIG_SECURITY_LOCKDOWN_LSM)	+= lockdown/
+ obj-$(CONFIG_CGROUPS)			+= device_cgroup.o
+ obj-$(CONFIG_BPF_LSM)			+= bpf/
++obj-$(CONFIG_SECURITY_TEMPESTA)		+= tempesta/
+ 
+ # Object integrity file lists
+ subdir-$(CONFIG_INTEGRITY)		+= integrity
+diff --git a/security/security.c b/security/security.c
+index a28045dc9..4ca11b6d7 100644
+--- a/security/security.c
++++ b/security/security.c
+@@ -29,6 +29,7 @@
+ #include <linux/string.h>
+ #include <linux/msg.h>
+ #include <net/flow.h>
++#include <net/sock.h>
+ 
+ #define MAX_LSM_EVM_XATTR	2
+ 
+@@ -2193,6 +2194,8 @@ EXPORT_SYMBOL(security_socket_getpeersec_dgram);
+ 
+ int security_sk_alloc(struct sock *sk, int family, gfp_t priority)
+ {
++	sk->sk_security = NULL;
++
+ 	return call_int_hook(sk_alloc_security, 0, sk, family, priority);
+ }
+ 
+diff --git a/security/tempesta/Kconfig b/security/tempesta/Kconfig
+new file mode 100644
+index 000000000..f6be0927a
+--- /dev/null
++++ b/security/tempesta/Kconfig
+@@ -0,0 +1,16 @@
++config SECURITY_TEMPESTA
++	bool "Tempesta FW Support"
++	depends on SECURITY && NET && INET
++	select SECURITY_NETWORK
++	select RPS
++	select CRYPTO
++	select CRYPTO_HMAC
++	select CRYPTO_SHA1
++	select CRYPTO_SHA1_SSSE3
++	select CRYPTO_GCM
++	select CRYPTO_CCM
++	default y
++	help
++	  This selects Tempesta FW security module.
++	  Further information may be found at https://github.com/natsys/tempesta
++	  If you are unsure how to answer this question, answer N.
+diff --git a/security/tempesta/Makefile b/security/tempesta/Makefile
+new file mode 100644
+index 000000000..4c439ac0c
+--- /dev/null
++++ b/security/tempesta/Makefile
+@@ -0,0 +1,3 @@
++obj-y := tempesta.o
++
++tempesta-y := tempesta_lsm.o
+diff --git a/security/tempesta/tempesta_lsm.c b/security/tempesta/tempesta_lsm.c
+new file mode 100644
+index 000000000..313101304
+--- /dev/null
++++ b/security/tempesta/tempesta_lsm.c
+@@ -0,0 +1,135 @@
++/**
++ *		Tempesta FW
++ *
++ * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
++ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by


### PR DESCRIPTION
`kernel_read()` is able to read at most MAX_RW_COUNT bytes. Break the reading of a large file into a few steps.