### PR TITLE
Do not remove idle streams immediatly.

### DIFF
--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -167,50 +167,39 @@ tfw_h2_stream_purge_all_and_free_response(TfwStream *stream)
 void
 tfw_h2_stream_add_idle(TfwH2Ctx *ctx, TfwStream *idle)
 {
-	TfwH2Conn *conn = container_of(ctx, TfwH2Conn, h2);
-	struct list_head *pos, *prev = &ctx->idle_streams.list;
+	TfwStreamQueue *idle_streams = &ctx->idle_streams;
+	TfwStream *cur;
 	bool found = false;
 
-	/*
-	 * We add and remove streams from idle queue under the
-	 * socket lock.
-	 */
-	assert_spin_locked(&((TfwConn *)conn)->sk->sk_lock.slock);
-
+	spin_lock(&ctx->lock);
 	/*
 	 * Found first idle stream with id less than new idle
 	 * stream, then insert new stream before this stream.
 	 */
-	list_for_each(pos, &ctx->idle_streams.list) {
-		TfwStream *stream = list_entry(pos, TfwStream, hcl_node);
-
-		if (idle->id > stream->id) {
+	list_for_each_entry_reverse(cur, &idle_streams->list, hcl_node) {
+		if (idle->id > cur->id) {
 			found = true;
 			break;
 		}
-		prev = &stream->hcl_node;
 	}
 
 	if (found) {
-		list_add(&idle->hcl_node, prev);
-		idle->queue = &ctx->idle_streams;
+		list_add(&idle->hcl_node, &cur->hcl_node);
+		idle->queue = idle_streams;
 		++idle->queue->num;
 	} else {
-		tfw_h2_stream_add_to_queue_nolock(&ctx->idle_streams, idle);
+		tfw_h2_stream_add_to_queue_nolock(idle_streams, idle);
 	}
+
+	spin_unlock(&ctx->lock);
 }
 
 void
 tfw_h2_stream_remove_idle(TfwH2Ctx *ctx, TfwStream *stream)
 {
-	TfwH2Conn *conn = container_of(ctx, TfwH2Conn, h2);
-
-	/*
-	 * We add and remove streams from idle queue under the
-	 * socket lock.
-	 */
-	assert_spin_locked(&((TfwConn *)conn)->sk->sk_lock.slock);
+	spin_lock(&ctx->lock);
 	tfw_h2_stream_del_from_queue_nolock(stream);
+	spin_unlock(&ctx->lock);
 }
 
 /*


### PR DESCRIPTION
According to RFC 9113 section 5.1.1:
The first use of a new stream identifier implicitly closes all streams in the "idle" state that might
have been initiated by that peer with a lower-valued stream identifier.
But Firefox creates idle streams and uses them as a nodes in priority tree and such streams should not be deleted. So we don't remove and delete idle streams if there count is less then TFW_MAX_IDLE_STREAMS (6). Also make two fixes:
- add/remove idle streams under ctx lock.
- add streams to idle queue in reverse order to avoid going through all list (new stream has usually greater stream id).