### PR TITLE
Fix bug with accessing already released connection

### DIFF
--- a/fw/connection.c
+++ b/fw/connection.c
@@ -219,3 +219,22 @@ tfw_connection_hooks_unregister(int type)
 {
 	conn_hooks[TFW_CONN_TYPE2IDX(type)] = NULL;
 }
+
+/*
+ * Do an opposite to what tfw_connection_link_to_sk() does. Tempesta
+ * is unlinked from Sync Sockets layer, so that no data can be sent
+ * anymore on a connection. The previously held socket is released.
+ * Note that clearing of conn->sk is necessary. In case of failover
+ * on a server connection an indicator is needed to remove a hold
+ * on the socket. A zeroed conn->sk is that indicator.
+ */
+void
+tfw_connection_unlink_to_sk(TfwConn *conn)
+{
+	struct sock *sk = conn->sk;
+
+	if (sk->sk_security)
+		tfw_classify_conn_close(sk);
+	conn->sk = NULL;
+	ss_sock_put(sk);
+}

--- a/fw/connection.h
+++ b/fw/connection.h
@@ -555,23 +555,6 @@ tfw_connection_unlink_from_sk(struct sock *sk)
 	sk->sk_user_data = NULL;
 }
 
-/*
- * Do an opposite to what tfw_connection_link_to_sk() does. Tempesta
- * is unlinked from Sync Sockets layer, so that no data can be sent
- * anymore on a connection. The previously held socket is released.
- * Note that clearing of conn->sk is necessary. In case of failover
- * on a server connection an indicator is needed to remove a hold
- * on the socket. A zeroed conn->sk is that indicator.
- */
-static inline void
-tfw_connection_unlink_to_sk(TfwConn *conn)
-{
-	struct sock *sk = conn->sk;
-
-	conn->sk = NULL;
-	ss_sock_put(sk);
-}
-
 static inline void
 tfw_connection_unlink_from_peer(TfwConn *conn)
 {
@@ -630,6 +613,7 @@ tfw_peer_for_each_conn(TfwPeer *p, int (*cb)(TfwConn *))
 
 extern unsigned int tfw_cli_max_concurrent_streams;
 
+void tfw_connection_unlink_to_sk(TfwConn *conn);
 void tfw_connection_hooks_register(TfwConnHooks *hooks, int type);
 void tfw_connection_hooks_unregister(int type);
 int tfw_connection_send(TfwConn *conn, TfwMsg *msg);

--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -352,8 +352,6 @@ tfw_classify_conn_close(struct sock *sk)
 	if(ra == NULL)
 		return;
 
-	assert_spin_locked(&sk->sk_lock.slock);
-
 	spin_lock(&ra->lock);
 
 	BUG_ON(ra->conn_curr == 0);
@@ -1397,6 +1395,8 @@ frang_resp_fwd_process(TfwHttpResp *resp)
 		return T_OK;
 
 	ra = frang_acc_from_sk(req->conn->sk);
+	BUG_ON(!ra);
+
 	if (req->peer)
 		ra = FRANG_CLI2ACC(req->peer);
 

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -191,8 +191,6 @@ ss_conn_drop_guard_exit(struct sock *sk)
 {
 	SS_CONN_TYPE(sk) &= ~Conn_Closing;
 	SS_CALL(connection_drop, sk);
-	if (sk->sk_security)
-		tfw_classify_conn_close(sk);
 	ss_active_guard_exit(SS_V_ACT_LIVECONN);
 }
 


### PR DESCRIPTION
There was a problem with accessing already released connection when we send error response to client,
after error in processing http response. Reponse
processing can occurs on different cpus (moreover
we can process several responses in parallel on
several cpus). Problem we fail to process two or
more responses in parallel.
We call tfw_h2_error_resp->tfw_h2_send_err_resp
and free request inside `tfw_h2_send_err_resp`
and also decrement connection reference counter
because of it. Also we call `tfw_h2_conn_terminate_close` and send FIN to the client. If FIN from the client comes immediatly `ss_conn_drop_guard_exit` will
be called on another cpu in parallel. For one
response everything is ok, we drop connection
in `ss_conn_drop_guard_exit` and release it, but
if we also call `tfw_h2_error_resp` for second response we release connection inside `tfw_h2_send_err_resp` after sending response and access already deleted connection in `tfw_h2_conn_terminate_close`!
- To fix this problem we should increment connection reference counter before `tfw_h2_error_resp` and
release it after `ss_conn_drop_guard_exit`.
- Also we have a problem with `sk->security` - we release this pointer in `ss_conn_drop_guard_exit` but this function can be called when connection stil has active processed responses and we can pass this responses to frang. So we should release `sk->security` when we totally release connection.