### PR TITLE
Fix incorrect assertion for the node index.

### DIFF
--- a/db/core/htrie.c
+++ b/db/core/htrie.c
@@ -971,8 +971,7 @@ tdb_htrie_node_visit(TdbHdr *dbh, TdbHtrieNode *node, int (*fn)(void *))
 		if (likely(!o))
 			continue;
 
-		BUG_ON(TDB_DI2O(o & ~TDB_HTRIE_DBIT) < TDB_HDR_SZ(dbh) + sizeof(TdbExt)
-			   || TDB_DI2O(o & ~TDB_HTRIE_DBIT) > dbh->dbsz);
+		BUG_ON(TDB_DI2O(o & ~TDB_HTRIE_DBIT) < TDB_HDR_SZ(dbh) + sizeof(TdbExt));
 
 		if (o & TDB_HTRIE_DBIT) {
 			TdbBucket *b;
@@ -980,12 +979,15 @@ tdb_htrie_node_visit(TdbHdr *dbh, TdbHtrieNode *node, int (*fn)(void *))
 			/* We're at a data pointer - resolve it. */
 			o ^= TDB_HTRIE_DBIT;
 			BUG_ON(!o);
+			BUG_ON(TDB_DI2O(o) > dbh->dbsz);
 
 			b = (TdbBucket *)TDB_PTR(dbh, TDB_DI2O(o));
 			res = tdb_htrie_bucket_walk(dbh, b, fn);
 			if (unlikely(res))
 				return res;
 		} else {
+			BUG_ON(TDB_II2O(o) > dbh->dbsz);
+
 			/*
 			 * The recursion depth being hard-limited.
 			 * The function has the deepest nesting 16.


### PR DESCRIPTION
Fix #2184

Index nodes are x2 smaller than data blocks, so on large space utilization the offset of an index node can be computed as x2 larger in the assertion in tdb_htrie_node_visit().

The crash and the fix can be reproduced with (printing changes surely aren't mandatory):
```diff
diff --git a/db/t/tdb_htrie.c b/db/t/tdb_htrie.c
index b56ea203..94b3d390 100644
--- a/db/t/tdb_htrie.c
+++ b/db/t/tdb_htrie.c
@@ -49,8 +49,8 @@
 
 #define TDB_VSF_SZ		(TDB_EXT_SZ * 1024)
 #define TDB_FSF_SZ		(TDB_EXT_SZ * 8)
-#define THR_N			4
-#define DATA_N			100
+#define THR_N			1
+#define DATA_N			1000000
 #define LOOP_N			10
 
 typedef struct {
@@ -388,17 +403,20 @@ static void
 do_fixsz(TdbHdr *dbh)
 {
 	int i;
+	int dummy_cb(void *) { return 0; }
 
 	/* Store records. */
 	for (i = 0; i < DATA_N; ++i) {
 		size_t copied = sizeof(ints[i]);
 		TdbRec *rec __attribute__((unused));
 
-		printf("insert int %u\n", ints[i]);
+		TDB_DBG("insert int %u\n", ints[i]);
 		fflush(NULL);
 
 		rec = tdb_htrie_insert(dbh, ints[i], &ints[i], &copied, true);
 		assert(rec && copied == sizeof(ints[i]));
+	
+		tdb_htrie_walk(dbh, dummy_cb);
 	}
 
 	lookup_fixsz_records(dbh);
@@ -493,13 +511,13 @@ tdb_htrie_test_fixsz(const char *fname)
 	r = gettimeofday(&tv1, NULL);
 	assert(!r);
 
-	printf("tdb htrie ints test: time=%lums\n",
+	TDB_LOG("tdb htrie ints test: time=%lums\n",
 		tv_to_ms(&tv1) - tv_to_ms(&tv0));
 
 	tdb_htrie_exit(dbh);
 	tdb_htrie_pure_close(addr, TDB_FSF_SZ, fd);
-
-	printf("\n	**** Fixed size records test reopen ****\n");
+#if 0
+	TDB_LOG("\n	**** Fixed size records test reopen ****\n");
 
 	addr = tdb_htrie_open(TDB_MAP_ADDR2, fname, TDB_FSF_SZ, &fd);
 	dbh = tdb_htrie_init(addr, TDB_FSF_SZ, sizeof(ints[0]));
@@ -510,12 +528,13 @@ tdb_htrie_test_fixsz(const char *fname)
 
 	tdb_htrie_exit(dbh);
 	tdb_htrie_pure_close(addr, TDB_FSF_SZ, fd);
+#endif
 }
 
 static void
 tdb_htrie_test(const char *vsf, const char *fsf)
 {
-	tdb_htrie_test_varsz(vsf);
+	// TODO AK_DBG tdb_htrie_test_varsz(vsf);
 	tdb_htrie_test_fixsz(fsf);
 }
 
@@ -544,7 +563,7 @@ init_test_data_for_htrie(void)
 		int r = rand();
 
 		ints[i] = r;
-
+#if 0
 		r %= 65536;
 		urls[i].data = malloc(r + 1);
 		if (!urls[i].data) {
@@ -558,11 +577,12 @@ init_test_data_for_htrie(void)
 		}
 		urls[i].data[r] = 0;
 		urls[i].len = r + 1;
+#endif
 	}
 
 	close(rfd);
 
-	printf("done\n");
+	TDB_LOG("done\n");
 }
 
 int
```