### PR TITLE
Rework checking Tempesta state on load

### DIFF
--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -309,7 +309,10 @@ tfw_state_seq_show(struct seq_file *seq, void *off)
 {
 	const char *st;
 	if (tfw_runstate_is_started()) {
-		st = tfw_runstate_is_reconfig() ? "reconfig\n" : "started\n";
+		st = tfw_runstate_is_reconfig()
+			? "reconfig\n"
+			: (tfw_runstate_is_started_success()
+			   ? "started\n" : "started (failed reconfig)");
 	} else {
 		st = "stopped\n";
 	}

--- a/fw/tempesta_fw.h
+++ b/fw/tempesta_fw.h
@@ -106,6 +106,7 @@ void tfw_mod_unregister(TfwMod *mod);
 TfwMod *tfw_mod_find(const char *name);
 
 bool tfw_runstate_is_reconfig(void);
+bool tfw_runstate_is_started_success(void);
 bool tfw_runstate_is_started(void);
 
 void tfw_objects_wait_release(const atomic64_t *counter, int delay,


### PR DESCRIPTION
Previoucly we check dmesg to be sure that
Tempesta FW is running, but it is not good
because when access_log is on and dmesg buffer
is small we can't check it correctly, because
dmesg buffer can be owerriten. To fix this problem:
- Implement new Tempesta FW state - started (failed reconfig) to check situation when Tempesta still
running after incorrect live reconfiguration.
- Check only Tempesta FW state during Tempesta loading. If state is "started" or "started (failed reconfig)" continue to work, otherwise unload
Tempesta modules with error.