### PR TITLE
Fix use after free

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -1099,6 +1099,7 @@ tfw_h2_resp_fwd(TfwHttpResp *resp)
 {
 	bool resp_in_xmit =
 		(TFW_SKB_CB(resp->msg.skb_head)->opaque_data == resp);
+	unsigned short status = resp->status;
 	TfwHttpReq *req = resp->req;
 	TfwConn *conn = req->conn;
 
@@ -1113,7 +1114,7 @@ tfw_h2_resp_fwd(TfwHttpResp *resp)
 		resp_in_xmit = false;
 	} else {
 		TFW_INC_STAT_BH(serv.msgs_forwarded);
-		tfw_inc_global_hm_stats(resp->status);
+		tfw_inc_global_hm_stats(status);
 	}
 
 	if (!resp_in_xmit)


### PR DESCRIPTION
BUG: KASAN: use-after-free in tfw_h2_resp_fwd+0xcb/0x190 Read of size 2 at addr ffff88812ba22110 by task
ksoftirqd/4/38

KASAN report was approved by manual checking:
on free fill memory with specific pattern and then check this pattern in `tfw_h2_resp_fwd()` after `tfw_connection_send()` call.

`TfwMsg` must not be used after successfull `tfw_connection_send()`. In this case `TfwMsg` may be already freed.

Full report:
```
BUG: KASAN: use-after-free in tfw_h2_resp_fwd+0xcb/0x190 [tempesta_fw]
[ 1163.684548] Read of size 2 at addr ffff88812ba22110 by task ksoftirqd/4/38

[ 1163.689588] CPU: 4 PID: 38 Comm: ksoftirqd/4 Tainted: G           OE     5.10.35+ #207
[ 1163.692154] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS Arch Linux 1.16.3-1-1 04/01/2014
[ 1163.695044] Call Trace:
[ 1163.697995]  dump_stack+0x96/0xc4
[ 1163.700867]  ? tfw_h2_resp_fwd+0xcb/0x190 [tempesta_fw]
[ 1163.703769]  print_address_description.constprop.0+0x21/0x290
[ 1163.706713]  ? _raw_spin_lock_irqsave+0x8e/0xf0
[ 1163.709433]  ? _raw_write_trylock+0xe0/0xe0
[ 1163.712317]  ? __kasan_check_write+0x14/0x20
[ 1163.715048]  ? irq_work_claim+0x23/0x60
[ 1163.718361]  ? tfw_h2_resp_fwd+0xcb/0x190 [tempesta_fw]
[ 1163.721457]  ? tfw_h2_resp_fwd+0xcb/0x190 [tempesta_fw]
[ 1163.724180]  kasan_report.cold+0x65/0xb6
[ 1163.727108]  ? tfw_h2_resp_fwd+0xcb/0x190 [tempesta_fw]
[ 1163.729968]  __asan_load2+0x81/0xa0
[ 1163.732846]  tfw_h2_resp_fwd+0xcb/0x190 [tempesta_fw]
[ 1163.735660]  tfw_http_resp_cache_cb+0x8e/0x4f0 [tempesta_fw]
[ 1163.738551]  tfw_cache_process+0x1a4/0x640 [tempesta_fw]
[ 1163.741280]  ? tfw_http_req_cache_cb+0xd40/0xd40 [tempesta_fw]
[ 1163.744076]  ? tfw_wq_tasklet+0x1a0/0x1a0 [tempesta_fw]
[ 1163.747109]  ? __tfw_apm_update+0x10e/0x1b0 [tempesta_fw]
[ 1163.749774]  tfw_http_resp_cache+0x2b6/0x3b0 [tempesta_fw]
[ 1163.752333]  ? tfw_http_conn_repair+0xf00/0xf00 [tempesta_fw]
[ 1163.754919]  ? __kasan_check_read+0x11/0x20
[ 1163.757691]  ? tfw_http_conn_msg_alloc+0x2c4/0x3c0 [tempesta_fw]
[ 1163.760520]  tfw_http_msg_process_generic+0x835/0xa20 [tempesta_fw]
[ 1163.763161]  ? tfw_http_req_process+0x1030/0x1030 [tempesta_fw]
[ 1163.766012]  ? bzero_fast+0xe/0x10 [tempesta_lib]
[ 1163.769450]  ? tfw_h2_frame_process+0x31c/0x990 [tempesta_fw]
[ 1163.772166]  ? ttls_send_alert+0x110/0x110 [tempesta_tls]
[ 1163.775150]  ? tfw_h2_frame_recv+0x2b40/0x2b40 [tempesta_fw]
[ 1163.778044]  tfw_http_msg_process+0x80/0xc0 [tempesta_fw]
[ 1163.781228]  tfw_connection_recv+0x193/0x280 [tempesta_fw]
[ 1163.784185]  ? tfw_connection_send+0x70/0x70 [tempesta_fw]
[ 1163.786995]  ? ss_skb_unroll+0x262/0x490 [tempesta_fw]
[ 1163.789843]  ss_tcp_process_data+0x398/0x7c0 [tempesta_fw]
[ 1163.792977]  ? ss_do_close+0x7e0/0x7e0 [tempesta_fw]
[ 1163.796066]  ss_tcp_data_ready+0xa2/0x1e0 [tempesta_fw]
[ 1163.798983]  tcp_data_ready+0xac/0x260
[ 1163.801982]  ? tcp_fin+0x2c0/0x2c0
[ 1163.805387]  ? kfree_skbmem+0x100/0x170
[ 1163.808565]  tcp_data_queue+0xeab/0x1930
[ 1163.811524]  ? tcp_send_rcvq+0x2c0/0x2c0
[ 1163.814708]  ? tcp_dsack_extend+0x70/0xa0
[ 1163.817557]  ? kvm_clock_get_cycles+0x11/0x20
[ 1163.820318]  ? ktime_get+0x55/0xe0
[ 1163.823012]  tcp_rcv_established+0x353/0x910
[ 1163.825698]  ? tcp_parse_md5sig_option+0x20/0xb0
[ 1163.828351]  ? tcp_data_queue+0x1930/0x1930
[ 1163.830920]  ? __kasan_check_read+0x11/0x20
[ 1163.833447]  tcp_v4_do_rcv+0x27c/0x360
[ 1163.835953]  tcp_v4_rcv+0x14d3/0x16c0
[ 1163.838431]  ? tcp_v4_early_demux+0x300/0x300
[ 1163.840913]  ip_protocol_deliver_rcu+0x53/0x350
[ 1163.843375]  ip_local_deliver_finish+0xbb/0xe0
[ 1163.845837]  ip_local_deliver+0x10e/0x1e0
[ 1163.848278]  ? ip_local_deliver_finish+0xe0/0xe0
[ 1163.850744]  ? ip_protocol_deliver_rcu+0x350/0x350
[ 1163.853202]  ? ip_rcv_finish_core.isra.0+0x230/0x8e0
[ 1163.855713]  ? nf_nat_ipv4_pre_routing+0xaf/0xf0 [nf_nat]
[ 1163.858222]  ? ip_local_deliver+0x1e0/0x1e0
[ 1163.860719]  ip_rcv_finish+0x77/0x80
[ 1163.863190]  ip_rcv+0xb5/0x180
[ 1163.865637]  ? ip_local_deliver+0x1e0/0x1e0
[ 1163.868080]  ? __sk_mem_reduce_allocated+0x5b/0x120
[ 1163.870523]  ? ip_sublist_rcv+0x340/0x340
[ 1163.872949]  ? tcp_delack_timer_handler+0x152/0x370
[ 1163.875379]  __netif_receive_skb_one_core+0x132/0x140
[ 1163.877803]  ? __netif_receive_skb_core+0xfe0/0xfe0
[ 1163.880215]  ? __kasan_check_write+0x14/0x20
[ 1163.882596]  ? _raw_spin_lock_irq+0x82/0xd0
[ 1163.884969]  ? __kasan_check_write+0x14/0x20
[ 1163.887316]  ? _raw_spin_lock+0x7b/0xd0
[ 1163.889622]  __netif_receive_skb+0x26/0xb0
[ 1163.891906]  process_backlog+0xfd/0x270
[ 1163.894168]  net_rx_action+0x524/0x830
[ 1163.896392]  ? busy_poll_stop+0x130/0x130
[ 1163.900115]  __do_softirq+0x1c1/0x5b0
[ 1163.903778]  ? __entry_text_end+0x1fe7f2/0x1fe7f2
[ 1163.906673]  ? perf_trace_irq_handler_entry+0x280/0x280
[ 1163.909300]  ? perf_trace_irq_handler_entry+0x280/0x280
[ 1163.911637]  run_ksoftirqd+0x2b/0x40
[ 1163.913832]  smpboot_thread_fn+0x1ac/0x300
[ 1163.916349]  ? smpboot_register_percpu_thread+0xe0/0xe0
[ 1163.918587]  ? __kasan_check_read+0x11/0x20
[ 1163.921069]  ? __kthread_parkme+0x83/0xa0
[ 1163.923643]  ? smpboot_register_percpu_thread+0xe0/0xe0
[ 1163.925846]  kthread+0x197/0x1c0
[ 1163.928075]  ? __kthread_parkme+0xa0/0xa0
[ 1163.930748]  ret_from_fork+0x22/0x30

[ 1163.935786] The buggy address belongs to the page:
[ 1163.938477] page:00000000893baa66 refcount:1 mapcount:0 mapping:0000000000000000 index:0x0 pfn:0x12ba22
[ 1163.941035] flags: 0x17ffffc0000000()
[ 1163.943828] raw: 0017ffffc0000000 dead000000000100 dead000000000122 0000000000000000
[ 1163.946686] raw: 0000000000000000 0000000000000000 00000001ffffffff 0000000000000000
[ 1163.949667] page dumped because: kasan: bad access detected

[ 1163.955083] Memory state around the buggy address:
[ 1163.958001]  ffff88812ba22000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 1163.960917]  ffff88812ba22080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 1163.963745] >ffff88812ba22100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 1163.966704]                          ^
[ 1163.969618]  ffff88812ba22180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 1163.972633]  ffff88812ba22200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 1163.975638] ==================================================================
```