### PR TITLE
Fix memory leak.

### DIFF
--- a/fw/connection.c
+++ b/fw/connection.c
@@ -179,14 +179,11 @@ tfw_connection_recv(TfwConn *conn, struct sk_buff *skb)
 				r = tfw_ws_msg_process(conn, skb);
 			else
 				r = tfw_http_msg_process(conn, skb, &splitted);
-
 			if (splitted) {
 				/*
 				 * In the case when the current skb contains
-				 * multiple requests, we split this skb along
-				 * the request boundary. If the request was
-				 * dropped we save skb with the next request
-				 * in the `splitted` pointer.
+				 * multiple requests or responses, we split this
+				 * skb along the boundary.
 				 */
 				splitted->next = next;
 				next = splitted;

--- a/fw/http.c
+++ b/fw/http.c
@@ -6446,7 +6446,7 @@ tfw_http_resp_cache(TfwHttpMsg *hmresp)
 	 */
 	if (test_bit(TFW_HTTP_B_HMONITOR, req->flags)) {
 		tfw_http_hm_drop_resp((TfwHttpResp *)hmresp);
-		return T_BAD;
+		return T_OK;
 	}
 	/*
 	 * This hook isn't in tfw_http_resp_fwd() because responses from the
@@ -6771,8 +6771,11 @@ next_msg:
 	 * @hmsib is not attached to the connection yet.
 	 */
 	r = tfw_http_resp_cache(hmresp);
-	if (unlikely(r != T_OK))
+	if (unlikely(r != T_OK)) {
+		if (hmsib)
+			tfw_http_conn_msg_free(hmsib);
 		return r;
+	}
 
 next_resp:
 	*splitted = NULL;

--- a/fw/http.c
+++ b/fw/http.c
@@ -6695,7 +6695,7 @@ next_msg:
 	 * event.
 	 */
 	r = tfw_http_resp_gfsm(hmresp, &data_up);
-	if (unlikely(r == T_BLOCK))
+	if (unlikely(r))
 		return r;
 
 	/*
@@ -6744,16 +6744,6 @@ next_msg:
 	}
 
 	/*
-	 * If a non critical error occurred in further GFSM processing,
-	 * then the response and the paired request had been handled.
-	 * Keep the server connection open for data exchange.
-	 */
-	if (unlikely(r != T_OK)) {
-		r = T_OK;
-		goto next_resp;
-	}
-
-	/*
 	 * Do upgrade if correct websocket upgrade response detected earlier.
 	 * We have to do this before going to the cache, since the cache calls
 	 * the message forwarding on a callback, which may free both the request
@@ -6778,7 +6768,6 @@ next_msg:
 		return r;
 	}
 
-next_resp:
 	*split = NULL;
 	if (skb && websocket)
 		return tfw_ws_msg_process(cli_conn->pair, skb);

--- a/fw/http.c
+++ b/fw/http.c
@@ -6983,7 +6983,9 @@ tfw_http_hm_srv_send(TfwServer *srv, char *data, unsigned long len)
 	} else {
 		BUG();
 	}
-	req->location = req->vhost->loc_dflt;
+
+	if (req->vhost)
+		req->location = req->vhost->loc_dflt;
 
 	srv_conn = srv->sg->sched->sched_srv_conn((TfwMsg *)req, srv);
 	if (!srv_conn) {


### PR DESCRIPTION
When we have pipelined responses in one skb we
split such skb and save pointer to the next skb
in local variable. If processing of first response fails we don't free splitted skb. This patch fixes this behavior.