### PR TITLE
Fix memory leak during reconfiguration

### DIFF
--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -793,6 +793,7 @@ tfw_sock_clnt_start(void)
 		if (ls_found) {
 			touched[ls_found - &listen_socks_array[0]] = true;
 			list_del(&ls->list);
+			kfree(ls);
 			continue;
 		}
 	}


### PR DESCRIPTION
When we reload Tempesta FW and one of the old
listening address is equal to the listening
address from the new config, we forget to allocate `TfwListenSock` structure to this address but
forget to delete it. This patch fix it.