### PR TITLE
Fix sock leak

### DIFF
--- a/fw/sock_srv.c
+++ b/fw/sock_srv.c
@@ -290,6 +290,7 @@ tfw_sock_srv_connect_try(TfwSrvConn *srv_conn)
 		if (r != -ESHUTDOWN)
 			T_ERR("Unable to initiate a connect to server: %d\n",
 				r);
+		sock_put(sk);
 		SS_CALL(connection_drop, sk);
 		/* Another try is handled in tfw_srv_conn_release() */
 	}


### PR DESCRIPTION
When we call `tfw_sock_srv_connect_try` we first of all set socket refcounter to 1, during socket creation and then increment it in `tfw_connection_link_to_sk`. If `ss_connect` fails we should first put socket refcounter and then call connection drop (where we put it again) to deallocate sock.