### PR TITLE
Fix kernel BUG for chunked response on HEAD request

### DIFF
--- a/fw/http2.c
+++ b/fw/http2.c
@@ -485,7 +485,8 @@ tfw_h2_stream_xmit_prepare_resp(TfwStream *stream)
 
 	stream->xmit.h_len = resp->mit.acc_len;
 	stream->xmit.b_len = TFW_HTTP_RESP_CUT_BODY_SZ(resp);
-	if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags))
+	if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags)
+	    && !test_bit(TFW_HTTP_B_VOID_BODY, resp->flags))
 		r = tfw_http_msg_cutoff_body_chunks(resp);
 
 finish:

--- a/fw/http2.c
+++ b/fw/http2.c
@@ -485,6 +485,10 @@ tfw_h2_stream_xmit_prepare_resp(TfwStream *stream)
 
 	stream->xmit.h_len = resp->mit.acc_len;
 	stream->xmit.b_len = TFW_HTTP_RESP_CUT_BODY_SZ(resp);
+	/*
+	 * Response is chunked encoded, but it is not a response
+	 * on HEAD request.
+	 */
 	if (test_bit(TFW_HTTP_B_CHUNKED, resp->flags)
 	    && !test_bit(TFW_HTTP_B_VOID_BODY, resp->flags))
 		r = tfw_http_msg_cutoff_body_chunks(resp);

--- a/fw/http_types.h
+++ b/fw/http_types.h
@@ -53,7 +53,12 @@ enum {
         TFW_HTTP_B_UPGRADE_WEBSOCKET,
         /* Message upgrade header contains extra fields */
         TFW_HTTP_B_UPGRADE_EXTRA,
-        /* Chunked is last transfer encoding. */
+        /*
+         * Chunked is last transfer encoding.
+         * It is important to notice that there is a valid case
+         * when we receive chunked encoded response with empty
+         * body on HEAD request.
+         */
         TFW_HTTP_B_CHUNKED,
         /* Chunked in the middle of applied transfer encodings. */
         TFW_HTTP_B_CHUNKED_APPLIED,
@@ -77,7 +82,10 @@ enum {
         TFW_HTTP_B_FULLY_PARSED,
         /* Message has HTTP/2 format. */
         TFW_HTTP_B_H2,
-        /* Message has all mandatory pseudo-headers (applicable for HTTP/2 mode only) */
+        /*
+         * Message has all mandatory pseudo-headers
+         * (applicable for HTTP/2 mode only).
+         */
         TFW_HTTP_B_H2_HDRS_FULL,
 
         /* Request flags. */
@@ -115,7 +123,10 @@ enum {
         TFW_HTTP_B_HDR_DATE,
         /* Response has header 'Last-Modified:'. */
         TFW_HTTP_B_HDR_LMODIFIED,
-        /* Response is fully processed and ready to be forwarded to the client. */
+        /*
+         * Response is fully processed and ready to be
+         * forwarded to the client.
+         */
         TFW_HTTP_B_RESP_READY,
         /*
          * Response has header 'Etag: ' and this header is


### PR DESCRIPTION
When we deal with HEAD request we set `TFW_HTTP_B_VOID_BODY` during parsing response and skip the body (because it is not expected for HEAD request!). In this case we should not call `tfw_http_msg_cutoff_body_chunks`, because there is no body for such response and `resp->body.skb` is equal to zero.

Closes #2231