### PR TITLE
Fix long work test on big server

### DIFF
--- a/fw/t/unit/test_wq.c
+++ b/fw/t/unit/test_wq.c
@@ -297,7 +297,15 @@ TEST(wq, one_prod_one_con)
 
 TEST(wq, many_prod_one_con)
 {
-	tfw_test_wq_test(JOB_N * num_online_cpus(), 1);
+	/*
+	 * If num_online_cpus is a big value test works for a long
+	 * time (about 30 minutes if num_online_cpus == 112 for
+	 * example).
+	 */
+	size_t n = num_online_cpus() < 32
+		? JOB_N * num_online_cpus()
+		: num_online_cpus();
+	tfw_test_wq_test(n, 1);
 }
 
 TEST_SUITE(wq)


### PR DESCRIPTION
There is no crash in unittests described in #2222
- everything is ok, but test works too long (about 30 minutes), because of a lot of cpu in system. Fix test
- now if count of cpu is greater then 32 count of workers == count of cpu not count of cpu * 10.

Closes #2222