### PR TITLE
Fix releasing not dead sock

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -218,21 +218,27 @@ typedef struct {
 	TfwRBQueue		wq;
 } TfwWorkTasklet;
 
+/* Cache modes. */
+typedef enum {
+        TFW_CACHE_UNDEFINED = -1,
+        TFW_CACHE_NONE = 0,
+        TFW_CACHE_SHARD,
+        TFW_CACHE_REPLICA,
+} TfwCacheMode;
+
 static struct {
 	int cache;
 	unsigned int methods;
 	unsigned long db_size;
 	const char *db_path;
-} cache_cfg __read_mostly;
+} cache_cfg __read_mostly = {
+	.cache = TFW_CACHE_UNDEFINED,
+	.methods = 0,
+	.db_size = 0,
+	.db_path = NULL
+};
 
 unsigned int cache_default_ttl;
-
-/* Cache modes. */
-enum {
-	TFW_CACHE_NONE = 0,
-	TFW_CACHE_SHARD,
-	TFW_CACHE_REPLICA,
-};
 
 typedef struct {
 	int 		*cpu;
@@ -3222,11 +3228,13 @@ static int
 tfw_cache_start(void)
 {
 	int i, r = 1;
-	TfwGlobal *g_vhost = tfw_vhost_get_global();
+
+	if (WARN_ON_ONCE(cache_cfg.cache == TFW_CACHE_UNDEFINED))
+		return -EINVAL;
 
 	if (tfw_runstate_is_reconfig())
 		return 0;
-	if (!(cache_cfg.cache || g_vhost->cache_purge))
+	if (!cache_cfg.cache)
 		return 0;
 
 	if ((r = tfw_init_node_cpus()))
@@ -3292,12 +3300,13 @@ node_cpus_alloc_err:
 static void
 tfw_cache_stop(void)
 {
-	TfwGlobal *g_vhost = tfw_vhost_get_global();
 	int i;
+
+	BUG_ON(cache_cfg.cache == TFW_CACHE_UNDEFINED);
 
 	if (tfw_runstate_is_reconfig())
 		return;
-	if (!(cache_cfg.cache || g_vhost->cache_purge))
+	if (!cache_cfg.cache)
 		return;
 
 	for_each_online_cpu(i)
@@ -3338,6 +3347,29 @@ static const TfwCfgEnum cache_http_methods_enum[] = {
 };
 
 static int
+tfw_cfgop_cache_val(TfwCfgSpec *cs, TfwCfgEntry *ce)
+{
+	TfwGlobal *g_vhost = tfw_vhost_get_global();
+	int cache;
+	int r;
+
+	cs->dest = &cache;
+	r = tfw_cfg_set_int(cs, ce);
+	cs->dest = NULL;
+	if (r)
+		return r;
+
+	if (g_vhost->cache_purge && !cache) {
+		T_ERR_NL("Directives mismatching: 'cache_purge' directive "
+			  "requires 'cache' be not zero\n");
+		return -EINVAL;
+	}
+
+	cache_cfg.cache = cache;
+	return r;
+}
+
+static int
 tfw_cfgop_cache_methods(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {
 	unsigned int i, method;
@@ -3376,14 +3408,19 @@ tfw_cfgop_cleanup_cache_methods(TfwCfgSpec *cs)
 	cache_cfg.methods = 0;
 }
 
+bool
+tfw_cache_is_enabled_or_not_configured(void)
+{
+	return cache_cfg.cache != TFW_CACHE_NONE;
+}
+
 static TfwCfgSpec tfw_cache_specs[] = {
 	{
 		.name = "cache",
 		.deflt = "2",
-		.handler = tfw_cfg_set_int,
-		.dest = &cache_cfg.cache,
+		.handler = tfw_cfgop_cache_val,
 		.spec_ext = &(TfwCfgSpecInt) {
-			.range = { 0, 2 },
+			.range = { TFW_CACHE_NONE, TFW_CACHE_REPLICA },
 		},
 	},
 	{

--- a/fw/cache.c
+++ b/fw/cache.c
@@ -3292,11 +3292,12 @@ node_cpus_alloc_err:
 static void
 tfw_cache_stop(void)
 {
+	TfwGlobal *g_vhost = tfw_vhost_get_global();
 	int i;
 
 	if (tfw_runstate_is_reconfig())
 		return;
-	if (!cache_cfg.cache)
+	if (!(cache_cfg.cache || g_vhost->cache_purge))
 		return;
 
 	for_each_online_cpu(i)

--- a/fw/cache.h
+++ b/fw/cache.h
@@ -24,6 +24,7 @@
 #include "http.h"
 
 int tfw_cache_process(TfwHttpMsg *msg, tfw_http_cache_cb_t action);
+bool tfw_cache_is_enabled_or_not_configured(void);
 
 extern unsigned int cache_default_ttl;
 

--- a/fw/http_sess_conf.c
+++ b/fw/http_sess_conf.c
@@ -865,11 +865,10 @@ tfw_http_sess_cfgstart()
  * Need to free them after configuration processing and before shutdown,
  * since cfgend() hook is not called for failed configurations.
  */
-int
+void
 tfw_http_sess_cfgend()
 {
 	tfw_http_sess_cfg_defaults_reset();
-	return 0;
 }
 
 TfwCfgSpec tfw_http_sess_specs[] = {

--- a/fw/http_sess_conf.h
+++ b/fw/http_sess_conf.h
@@ -29,7 +29,7 @@
 extern TfwCfgSpec tfw_http_sess_specs[];
 
 void tfw_http_sess_cfgstart(void);
-int tfw_http_sess_cfgend(void);
+void tfw_http_sess_cfgend(void);
 
 int tfw_http_sess_cfgop_begin(TfwVhost *vhost, TfwCfgSpec *cs, TfwCfgEntry *ce);
 int tfw_http_sess_cfgop_finish(TfwVhost *vhost, TfwCfgSpec *cs);

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -601,7 +601,7 @@ EXPORT_SYMBOL(ss_send);
  *
  * Called with locked socket.
  */
-static void
+void
 ss_do_close(struct sock *sk, int flags)
 {
 	struct sk_buff *skb;

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -601,7 +601,7 @@ EXPORT_SYMBOL(ss_send);
  *
  * Called with locked socket.
  */
-void
+static void
 ss_do_close(struct sock *sk, int flags)
 {
 	struct sk_buff *skb;
@@ -713,6 +713,16 @@ adjudge_to_death:
 			tcp_write_queue_purge(sk);
 		inet_csk_destroy_sock(sk);
 	}
+}
+
+void
+ss_close_not_connected_socket(struct sock *sk)
+{
+	bh_lock_sock(sk);
+	ss_do_close(sk, 0);
+	bh_unlock_sock(sk);
+	sock_put(sk);
+	SS_CALL(connection_drop, sk);
 }
 
 /**

--- a/fw/sock_srv.c
+++ b/fw/sock_srv.c
@@ -277,6 +277,9 @@ tfw_sock_srv_connect_try(TfwSrvConn *srv_conn)
 		if (r != -ESHUTDOWN)
 			T_ERR("Unable to initiate a connect to server: %d\n",
 				r);
+		bh_lock_sock(sk);
+		ss_do_close(sk, 0);
+		bh_unlock_sock(sk);
 		sock_put(sk);
 		SS_CALL(connection_drop, sk);
 		/* Another try is handled in tfw_srv_conn_release() */

--- a/fw/sock_srv.c
+++ b/fw/sock_srv.c
@@ -277,11 +277,7 @@ tfw_sock_srv_connect_try(TfwSrvConn *srv_conn)
 		if (r != -ESHUTDOWN)
 			T_ERR("Unable to initiate a connect to server: %d\n",
 				r);
-		bh_lock_sock(sk);
-		ss_do_close(sk, 0);
-		bh_unlock_sock(sk);
-		sock_put(sk);
-		SS_CALL(connection_drop, sk);
+		ss_close_not_connected_socket(sk);
 		/* Another try is handled in tfw_srv_conn_release() */
 	}
 }

--- a/fw/sync_socket.h
+++ b/fw/sync_socket.h
@@ -168,6 +168,7 @@ void ss_set_listen(struct sock *sk);
 int ss_send(struct sock *sk, struct sk_buff **skb_head, int flags);
 int ss_close(struct sock *sk, int flags);
 int ss_shutdown(struct sock *sk, int flags);
+void ss_do_close(struct sock *sk, int flags);
 int ss_sock_create(int family, int type, int protocol, struct sock **res);
 void ss_release(struct sock *sk);
 int ss_connect(struct sock *sk, const TfwAddr *addr, int flags);

--- a/fw/sync_socket.h
+++ b/fw/sync_socket.h
@@ -168,7 +168,6 @@ void ss_set_listen(struct sock *sk);
 int ss_send(struct sock *sk, struct sk_buff **skb_head, int flags);
 int ss_close(struct sock *sk, int flags);
 int ss_shutdown(struct sock *sk, int flags);
-void ss_do_close(struct sock *sk, int flags);
 int ss_sock_create(int family, int type, int protocol, struct sock **res);
 void ss_release(struct sock *sk);
 int ss_connect(struct sock *sk, const TfwAddr *addr, int flags);
@@ -191,5 +190,16 @@ void ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb_head);
 	: 0)
 
 #define SS_CONN_TYPE(sk)	(((SsProto *)(sk)->sk_user_data)->type)
+
+/*
+ * This function is used to close sockets in TCP_CLOSE state.
+ * Whe socket is created using `ss_inet_create` it is created
+ * in TCP_CLOSE state. We can't close such socket using `ss_close`
+ * because we check socket state in `ss_tx_action` before
+ * calling `ss_do_close` to prevent multiple socket closing. But
+ * we should close such sockets to prevent memory leak, because
+ * socket destructor is not called for not DEAD sockets.
+ */
+void ss_close_not_connected_socket(struct sock *sk);
 
 #endif /* __SS_SOCK_H__ */


### PR DESCRIPTION
When `ss_connect` fails we put socket refcounter
and release sock (when it becames equal to zero),
but socket was not closed. That leads to error
message in dmesg and some socket resources could
be not freed. This patch fix this behaviour, now
we close socket before free it.