### PR TITLE
Fix duplicate error reporting (#2227)

### DIFF
--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -242,7 +242,7 @@ start_tempesta_and_check_state()
 {
 	local _err
 
-	_err=$(sysctl -w net.tempesta.state=start 2>&1 1>/dev/null)
+	_err=$((echo start > /proc/sys/net/tempesta/state) 2>&1)
 	TFW_STATE=$(sysctl net.tempesta.state 2> /dev/null)
 	TFW_STATE=${TFW_STATE##net.tempesta.state = }
 


### PR DESCRIPTION
If sysctl handler returns EINVAL error, fprintf() in 'sysctl' command calls write() one more time. It leads to duplication of errors in dmesg when 'sysctl -w net.tempesta.state=start' is executed.

Use 'echo' to write directly to /proc/sys/net/tempesta/state instead of 'sysctl' execution. This change ensures that errors are reported only once, providing clearer feedback.