### PR TITLE
Use src->len directly for copy length in tfw_strcpy()

### DIFF
--- a/fw/str.c
+++ b/fw/str.c
@@ -714,7 +714,7 @@ tfw_strcpy(TfwStr *dst, const TfwStr *src)
 
 	switch (mode) {
 	case 3: /* The both are plain. */
-		memcpy_fast(dst->data, src->data, min(src->len, dst->len));
+		memcpy_fast(dst->data, src->data, src->len);
 		break;
 	case 1: /* @src is compound, @dst is plain. */
 		n1 = src->nchunks;


### PR DESCRIPTION
There was used 'min(src->len, dst->len)' to determine the number of bytes to copy. However, this check is redundant because the condition 'if (unlikely(src->len > dst->len))' above already ensures that 'src->len' will not exceed 'dst->len'.

This patch simplifies the memcpy operation by using 'src->len' directly as the copy length, making the code more straightforward and slightly more efficient.