### PR TITLE
ALPN default protocol

### DIFF
--- a/fw/connection.h
+++ b/fw/connection.h
@@ -46,6 +46,7 @@ enum {
 	/* Each connection has Client or Server bit. */
 	Conn_Clnt	= 0x1 << __Conn_Bits,
 	Conn_Srv	= 0x2 << __Conn_Bits,
+	/* Protocol can be negotiated via ALPN. */
 	Conn_Negotiable	= 0x4 << __Conn_Bits,
 
 	/* HTTP */

--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -743,8 +743,13 @@ tfw_listen_socks_array_cmp(const void *l, const void *r)
 	if (cmp)
 		return cmp;
 
-	return TFW_CONN_TYPE2IDX(a->proto.type) -
+	cmp = TFW_CONN_TYPE2IDX(a->proto.type) -
 		TFW_CONN_TYPE2IDX(b->proto.type);
+	if (cmp)
+		return cmp;
+
+	return (a->proto.type & Conn_Negotiable) -
+		(b->proto.type & Conn_Negotiable);
 }
 
 /**

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -1037,10 +1037,10 @@ tfw_tls_alpn_match(const TlsCtx *tls, const ttls_alpn_proto *alpn)
 	int sk_proto = ((SsProto *)tls->sk->sk_user_data)->type;
 	TfwConn *conn = (TfwConn*)tls->sk->sk_user_data;
 
-	/* Downgrade from HTTP2 to HTTP1. */
-	if (sk_proto & Conn_Negotiable && alpn->id == TTLS_ALPN_ID_HTTP1) {
+	/* Upgrade to HTTP2. */
+	if (sk_proto & Conn_Negotiable && alpn->id == TTLS_ALPN_ID_HTTP2) {
 		conn->proto.type = (conn->proto.type & ~TFW_GFSM_FSM_MASK) |
-					TFW_FSM_HTTPS;
+					TFW_FSM_H2;
 		return true;
 	}
 
@@ -1167,7 +1167,7 @@ tfw_tls_cfg_alpn_protos(const char *cfg_str)
 		proto1->name = TTLS_ALPN_HTTP1;
 		proto1->len = sizeof(TTLS_ALPN_HTTP1) - 1;
 
-		return TFW_FSM_H2 | Conn_Negotiable;
+		return TFW_FSM_HTTPS | Conn_Negotiable;
 	}
 
 	return -EINVAL;


### PR DESCRIPTION
In case when ALPN not used by client, Tempesta must choose HTTP1 protocol instead of HTTP2. Likely such client doesn't support HTTP2.