### PR TITLE
Fix memory leak in `ss_skb_to_sgvec_with_new_pages`

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -2703,17 +2703,12 @@ tfw_cache_build_resp_body(TDB *db, TdbVRec *trec, TfwMsgIter *it, char *p,
 	/*
 	 * If all skbs/frags are used up (see @tfw_http_msg_expand_data()),
 	 * create new skb with empty frags to reference the cached body;
-	 * otherwise, use next empty frag in current skb. Create a new skb, if
-	 * TX flags for headers and body differ.
+	 * otherwise, use next empty frag in current skb.
 	 */
-	if (!it->skb || (it->frag + 1 >= MAX_SKB_FRAGS)
-	    || (sh_frag == !(skb_shinfo(it->skb)->tx_flags & SKBTX_SHARED_FRAG)))
-	{
+	if (!it->skb || it->frag + 1 >= MAX_SKB_FRAGS || sh_frag) {
 		if  ((r = tfw_msg_iter_append_skb(it)))
 			return r;
-		if (!sh_frag)
-			skb_shinfo(it->skb)->tx_flags &= ~SKBTX_SHARED_FRAG;
-		else
+		if (sh_frag)
 			skb_shinfo(it->skb)->tx_flags |= SKBTX_SHARED_FRAG;
 	}
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -4838,12 +4838,9 @@ tfw_h2_append_predefined_body(TfwHttpResp *resp, const TfwStr *body)
 		return -EINVAL;
 	it->frag = skb_shinfo(it->skb)->nr_frags - 1;
 
-	if ((it->frag + 1 >= MAX_SKB_FRAGS)
-	    || (skb_shinfo(it->skb)->tx_flags & SKBTX_SHARED_FRAG))
-	{
-		if  ((r = tfw_msg_iter_append_skb(it)))
+	if (it->frag + 1 >= MAX_SKB_FRAGS) {
+		if ((r = tfw_msg_iter_append_skb(it)))
 			return r;
-		skb_shinfo(it->skb)->tx_flags &= ~SKBTX_SHARED_FRAG;
 	}
 
 	data = body->data;

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1593,6 +1593,7 @@ ss_skb_to_sgvec_with_new_pages(struct sk_buff *skb, struct scatterlist *sgl,
 				int order = get_order(size);
 				gfp_t flags = order > 0 ?
 					GFP_ATOMIC | __GFP_COMP : GFP_ATOMIC;
+
 				p = alloc_pages(flags, order);
 				if (!p)
 					return -ENOMEM;

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1591,7 +1591,9 @@ ss_skb_to_sgvec_with_new_pages(struct sk_buff *skb, struct scatterlist *sgl,
 			size = skb_frag_size(f);
 			if (remain < size) {
 				int order = get_order(size);
-				p = alloc_pages(GFP_ATOMIC, order);
+				gfp_t flags = order > 0 ?
+					GFP_ATOMIC | __GFP_COMP : GFP_ATOMIC;
+				p = alloc_pages(flags, order);
 				if (!p)
 					return -ENOMEM;
 				remain = (1 << order) * PAGE_SIZE;

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -1502,7 +1502,10 @@ ttls_parse_certificate(TlsCtx *tls, unsigned char *buf, size_t len,
 	 * TODO call ttls_update_checksum() for the message as well.
 	 */
 	T_FSM_STATE(TTLS_CC_HS_ALLOC) {
-		if (!(pg = alloc_pages(GFP_ATOMIC, get_order(io->hslen)))) {
+		int order = get_order(io->hslen);
+		gfp_t flags = order > 0 ? GFP_ATOMIC | __GFP_COMP : GFP_ATOMIC;
+
+		if (!(pg = alloc_pages(flags, order))) {
 			T_WARN("TLS: cannot allocate pages for a certificate\n");
 			return -ENOMEM;
 		}


### PR DESCRIPTION
When we allocate new pages we should use `__GFP_COMP` flag if order is greater then zero to make such pages compound, otherwise we free only one page later and destroy buddy allocator logic.

Closes #2132