### PR TITLE
Fix memory under ping flood

### DIFF
--- a/fw/connection.h
+++ b/fw/connection.h
@@ -455,6 +455,13 @@ __tfw_connection_get_if_live(TfwConn *conn)
 	__tfw_connection_get_if_live((TfwConn *)(c))
 
 static inline bool
+tfw_connection_was_stopped(TfwConn *conn)
+{
+	return (TFW_CONN_TYPE(conn) & Conn_Stop)
+		|| (TFW_CONN_TYPE(conn) & Conn_Shutdown);
+}
+
+static inline bool
 tfw_connection_stop_rcv(TfwConn *conn)
 {
 	/*
@@ -462,8 +469,8 @@ tfw_connection_stop_rcv(TfwConn *conn)
 	 * for HTTP2 client connections, to ensure delivery of
 	 * response with a body larger than HTTP window size.
 	 */
-	return (TFW_CONN_TYPE(conn) & Conn_Stop) &&
-		(!((TFW_CONN_TYPE(conn) & Conn_H2Clnt) == Conn_H2Clnt));
+	return (tfw_connection_was_stopped(conn)
+		&& (!((TFW_CONN_TYPE(conn) & Conn_H2Clnt) == Conn_H2Clnt)));
 }
 
 static inline void
@@ -611,6 +618,35 @@ tfw_peer_for_each_conn(TfwPeer *p, int (*cb)(TfwConn *))
 
 	return r;
 }
+
+#define TFW_CONN_PROCESS_RESULT(r, was_stopped, extra_cond_to_out, nskb) \
+do {									\
+	/*								\
+	 * If error occurs second time (save_error_code is not zero or	\
+	 * was_stopped is true) close connection immediately with RST.	\
+	 */								\
+	r = (r != T_OK && (save_err_code != T_OK || was_stopped)) ?	\
+		SS_BLOCK_WITH_RST : r;					\
+	if (r == T_BLOCK_WITH_FIN || r == T_BLOCK_WITH_RST) {		\
+		kfree_skb(nskb);					\
+		goto out;						\
+	} else if (r && r != T_DROP) {					\
+		if (extra_cond_to_out) {				\
+			kfree_skb(nskb);				\
+			goto out;					\
+		}		 					\
+	/*								\
+	 * In case of T_BAD or system errors we close connection	\
+	 * with tcp_shutdown() and gracefully send all pending		\
+	 * responses to client. We should continue to process		\
+	 * WINDOW_UPDATE frames so, we should decrypt all skbs,		\
+	 * not drop them.						\
+	 */								\
+		save_err_code = T_BAD;					\
+	} else if (save_err_code != T_OK) {				\
+		r = save_err_code;					\
+	}								\
+} while(0)
 
 extern unsigned int tfw_cli_max_concurrent_streams;
 

--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -383,6 +383,7 @@ tfw_h2_send_ping(TfwH2Ctx *ctx)
 	return tfw_h2_send_frame(ctx, &hdr, &data);
 
 }
+ALLOW_ERROR_INJECTION(tfw_h2_send_ping, ERRNO);
 
 static inline int
 tfw_h2_send_wnd_update(TfwH2Ctx *ctx, unsigned int id, unsigned int wnd_incr)
@@ -722,6 +723,7 @@ fail:
 	return tfw_h2_send_rst_stream(ctx, hdr->stream_id,
 				      err_code);
 }
+ALLOW_ERROR_INJECTION(tfw_h2_wnd_update_process, ERRNO);
 
 static inline int
 tfw_h2_priority_process(TfwH2Ctx *ctx)
@@ -1041,7 +1043,8 @@ do {									\
 	T_DBG3("%s: hdr->type %u(%s), ctx->state %u\n", __func__, hdr_type,
 	       __h2_frm_type_n(hdr_type), ctx->state);
 
-	if ((TFW_CONN_TYPE((TfwConn *)conn) & Conn_Stop)
+	if (((TFW_CONN_TYPE((TfwConn *)conn) & Conn_Stop) ||
+	    (TFW_CONN_TYPE((TfwConn *)conn) & Conn_Shutdown))
 	    && hdr_type != HTTP2_WINDOW_UPDATE) {
 		T_DBG3("Drop %s frame, because connection is closing",
 		       __h2_frm_type_n(hdr_type));
@@ -1697,11 +1700,12 @@ tfw_h2_allowed_empty_frame(TfwH2Ctx *ctx)
 int
 tfw_h2_frame_process(TfwConn *c, struct sk_buff *skb, struct sk_buff **next)
 {
-	int r;
+	int r, save_err_code = T_OK;
 	bool postponed;
 	unsigned int parsed, unused;
 	TfwH2Ctx *h2 = tfw_h2_context_unsafe(c);
 	struct sk_buff *nskb = NULL;
+	bool was_stopped = tfw_connection_was_stopped(c);
 
 next_msg:
 	postponed = false;
@@ -1721,6 +1725,8 @@ next_msg:
 	case T_DROP:
 	case T_BAD:
 	case T_BLOCK_WITH_FIN:
+		r = (save_err_code != T_OK || was_stopped)
+			? SS_BLOCK_WITH_RST : r;
 	case T_BLOCK_WITH_RST:
 		T_DBG3("Drop invalid HTTP/2 frame and close connection\n");
 		goto out;
@@ -1740,7 +1746,7 @@ next_msg:
 			break;
 		}
 
-		return T_OK;
+		return save_err_code;
 	case T_OK:
 		T_DBG3("%s: parsed=%d skb->len=%u\n", __func__,
 		       parsed, skb->len);
@@ -1802,7 +1808,7 @@ next_msg:
 			 */
 			if (!h2->skb_head) {
 				WARN_ON_ONCE(h2->data_off);
-				return T_OK;
+				return save_err_code;
 			}
 		}
 
@@ -1820,12 +1826,13 @@ next_msg:
 		h2->data_off = 0;
 		h2->skb_head = pskb->next = pskb->prev = NULL;
 		r = tfw_http_msg_process_generic(c, h2->cur_stream, pskb, next);
-		/* TODO #1490: Check this place, when working on the task. */
-		if (r && r != T_DROP) {
-			WARN_ON_ONCE(r == T_POSTPONE);
-			kfree_skb(nskb);
-			goto out;
-		}
+		/*
+		 * If Conn_Stop bit is not set we don't send error response
+		 * to client, so we don't need to process WINDOW_UPDATE frames
+		 * and can immediately close connection.
+		 */
+		TFW_CONN_PROCESS_RESULT(r, was_stopped,
+					!(TFW_CONN_TYPE(c) & Conn_Stop), nskb);
 	}
 	else if (unlikely(tfw_h2_allowed_empty_frame(h2))) {
 		/*
@@ -1848,18 +1855,19 @@ next_msg:
 		h2->data_off = 0;
 		/* The skb will not be parsed, just flags will be checked. */
 		r = tfw_http_msg_process_generic(c, h2->cur_stream, pskb, next);
-
-		/* TODO #1490: Check this place, when working on the task. */
-		if (r && r != T_DROP) {
-			WARN_ON_ONCE(r == T_POSTPONE);
-			kfree_skb(nskb);
-			goto out;
-		}
+		/*
+		 * If Conn_Stop bit is not set we don't send error response
+		 * to client, so we don't need to process WINDOW_UPDATE frames
+		 * and can immediately close connection.
+		 */ 
+		TFW_CONN_PROCESS_RESULT(r, was_stopped,
+					!(TFW_CONN_TYPE(c) & Conn_Stop), nskb);
 	}
 	else {
 purge:
 		h2->data_off = 0;
 		ss_skb_queue_purge(&h2->skb_head);
+		r = save_err_code;
 	}
 
 	tfw_h2_context_reinit(h2, postponed);
@@ -1872,8 +1880,16 @@ purge:
 
 out:
 	ss_skb_queue_purge(&h2->skb_head);
-	if (r && r != T_POSTPONE && r != T_DROP)
+	/*
+	 * If save error code is not null and r == T_BAD
+	 * we should continue to process WINDOW_UPDATE frames
+	 * so skip data from previous frame if necessary.
+	 */
+	if (h2->to_read && r == T_BAD && save_err_code) {
+		h2->state = HTTP2_IGNORE_FRAME_DATA;
+	} else if (r && r != T_POSTPONE && r != T_DROP) {
 		tfw_h2_context_reinit(h2, false);
+	}
 	return r;
 }
 

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -176,7 +176,7 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	SPRNE("Client connections active\t\t",
 	      stat.clnt.conn_established - stat.clnt.conn_disconnects);
 	SPRN("Client RX bytes\t\t\t\t", clnt.rx_bytes);
-	SPRN("Client max streams number exceeded\t\t", clnt.streams_num_exceeded);
+	SPRN("Client max streams number exceeded\t", clnt.streams_num_exceeded);
 
 	/* Server related statistics. */
 	serv_conn_active = stat.serv.conn_established

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -998,7 +998,7 @@ ss_tcp_data_ready(struct sock *sk)
 	int flags;
 	int (*action)(struct sock *sk, int flags);
 	bool was_stopped = (SS_CONN_TYPE(sk) & Conn_Stop)
-		|| (SS_CONN_TYPE(sk) & Conn_Shutdown);
+                           || (SS_CONN_TYPE(sk) & Conn_Shutdown);
 
 	T_DBG3("[%d]: %s: sk=%p state=%s\n",
 	       smp_processor_id(), __func__, sk, ss_statename[sk->sk_state]);

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -997,7 +997,8 @@ ss_tcp_data_ready(struct sock *sk)
 {
 	int flags;
 	int (*action)(struct sock *sk, int flags);
-	bool was_stopped = (SS_CONN_TYPE(sk) & Conn_Stop);
+	bool was_stopped = (SS_CONN_TYPE(sk) & Conn_Stop)
+		|| (SS_CONN_TYPE(sk) & Conn_Shutdown);
 
 	T_DBG3("[%d]: %s: sk=%p state=%s\n",
 	       smp_processor_id(), __func__, sk, ss_statename[sk->sk_state]);
@@ -1036,8 +1037,7 @@ ss_tcp_data_ready(struct sock *sk)
 		action = ss_close;
 		break;
 	case SS_BLOCK_WITH_RST:
-		flags = SS_F_ABORT_FORCE;
-		action = ss_close;
+		was_stopped = true;
 		break;
 	case SS_BAD:
 		flags = SS_F_SYNC;

--- a/fw/tls.c
+++ b/fw/tls.c
@@ -77,6 +77,7 @@ tfw_tls_connection_recv(TfwConn *conn, struct sk_buff *skb)
 	struct sk_buff *nskb = NULL;
 	TlsCtx *tls = tfw_tls_context(conn);
 	TfwFsmData data_up = {};
+	bool was_stopped = tfw_connection_was_stopped(conn);
 
 	if (unlikely(tfw_connection_stop_rcv(conn))) {
 		__kfree_skb(skb);
@@ -113,6 +114,8 @@ next_msg:
 		r = T_BAD;
 		fallthrough;
 	case T_BLOCK_WITH_FIN:
+		r = (save_err_code != T_OK || was_stopped)
+			? SS_BLOCK_WITH_RST : T_BAD;
 		fallthrough;
 	case T_BLOCK_WITH_RST:
 		if (tls->conf->endpoint == TTLS_IS_SERVER)
@@ -163,7 +166,14 @@ next_msg:
 		}
 	}
 
-	if (tls->io_in.msgtype == TTLS_MSG_APPLICATION_DATA) {
+	/*
+	 * If Conn_Stop bit is not set we don't send error response
+	 * to client, so we decrypt skbs to avoid tls errors, but
+	 * don't process it.
+	 */
+	if (tls->io_in.msgtype == TTLS_MSG_APPLICATION_DATA
+	    && (save_err_code == T_OK || TFW_CONN_TYPE(conn) & Conn_Stop))
+	{
 		/*
 		 * Current record contains an "application data" message.
 		 * ttls_recv() has already decrypted the payload, but TLS
@@ -189,24 +199,8 @@ next_msg:
 		spin_unlock(&tls->lock);
 
 		/* Do upcall to http or websocket */
-		if (save_err_code == T_OK)
-			r = tfw_connection_recv(conn, data_up.skb);
-		else
-			r = save_err_code;
-
-		if (r == T_BLOCK_WITH_FIN || r == T_BLOCK_WITH_RST) {
-			kfree_skb(nskb);
-			return r;
-		} else if (r == T_BAD) {
-			/*
-			 * In case of T_BAD error we close connection
-			 * with tcp_shutdown() and gracefully send all
-			 * pending responses to client. We should continue
-			 * to process WINDOW_UPDATE frames so, we should
-			 * decrypt all skbs, not drop them.
-			 */
-			save_err_code = r;
-		}
+		r = tfw_connection_recv(conn, data_up.skb);
+		TFW_CONN_PROCESS_RESULT(r, was_stopped, false, nskb);
 	} else {
 		/*
 		 * The decrypted payload is not required for upper levels.
@@ -214,6 +208,7 @@ next_msg:
 		 */
 		tfw_tls_purge_io_ctx(&tls->io_in);
 		spin_unlock(&tls->lock);
+		r = save_err_code;
 	}
 
 	if (nskb) {
@@ -222,6 +217,7 @@ next_msg:
 		goto next_msg;
 	}
 
+out:
 	return r;
 }
 


### PR DESCRIPTION
There was a memory leak if `tfw_connection_recv`
fails with T_BAD in `tfw_tls_connection_recv -
because we continue to process skbs in this case
but don't call `tfw_connection_recv` and do not
free skbs. But if error occurs we should decrypt
skbs and pass it to `tfw_connection_recv` to process WINDOW_UPDATE frames (it is necessary to send
custom error responses with long body).
Also fix some replated problems:
- we should check Conn_Shutdown bit in all places where we check Conn_Stop bit to prevent processing any other frames.
- we should continue to process frames if `tfw_http_msg_process_generic` fails same as we do it in tls.c.
- add ALLOW_ERROR_INJECTION marso to check fixes.

Closes #2149 #2117