### PR TITLE
Don't cache set-cookie header

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -2125,9 +2125,9 @@ tfw_cache_copy_resp(TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 		 * possible duplicates), since we will substitute it with our
 		 * version of this header.
 		 */
-		if ((field->flags & (TFW_STR_HBH_HDR | TFW_STR_NOCCPY_HDR))
-		    || hid == TFW_HTTP_HDR_SERVER
-		    || TFW_STR_EMPTY(field))
+		if (TFW_STR_EMPTY(field)
+		    || (field->flags & (TFW_STR_HBH_HDR | TFW_STR_NOCCPY_HDR))
+		    || hid == TFW_HTTP_HDR_SERVER)
 		{
 			--ce->hdr_num;
 			continue;
@@ -2363,9 +2363,9 @@ __cache_entry_size(TfwHttpResp *resp)
 		 * possible duplicates), since we will substitute it with our
 		 * version of this header.
 		 */
-		if ((hdr->flags & TFW_STR_HBH_HDR)
-		    || hid == TFW_HTTP_HDR_SERVER
-		    || TFW_STR_EMPTY(hdr))
+		if (TFW_STR_EMPTY(hdr)
+		    || (hdr->flags & (TFW_STR_HBH_HDR | TFW_STR_NOCCPY_HDR))
+		    || hid == TFW_HTTP_HDR_SERVER)
 			continue;
 
 		if (hid == TFW_HTTP_HDR_TRANSFER_ENCODING)

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -11528,6 +11528,8 @@ __resp_parse_set_cookie(TfwHttpResp *resp, unsigned char *data, size_t len)
 	 */
 	__FSM_START(parser->_i_st);
 
+	msg->stream->parser.hdr.flags |= TFW_STR_NOCCPY_HDR;
+
 	__FSM_STATE(Resp_I_CookieStart) {
 		__FSM_I_MATCH_MOVE_fixup(token, Resp_I_CookieName, TFW_STR_NAME);
 		/*

--- a/fw/str.h
+++ b/fw/str.h
@@ -234,7 +234,10 @@ basic_stricmp_fast(const BasicStr *s1, const BasicStr *s2)
 #define TFW_STR_VALUE		0x08
 /* The string represents hop-by-hop header, not end-to-end one */
 #define TFW_STR_HBH_HDR		0x10
-/* Not cachable due to configuration settings or no-cache/private directive */
+/*
+ * Not cachable due to configuration settings or no-cache/private directive.
+ * Used to not cache set-cookie as well.
+ */
 #define TFW_STR_NOCCPY_HDR	0x20
 /*
  * The string/chunk is a header fully indexed in HPACK static


### PR DESCRIPTION
Caching of set-cookie can lead to sharing sensitive client information and increases security risks.

Little enhancement:
During copy response to the cache we iterate over header table that contains empty headers, to not do bitwise operation on empty headers `TFW_STR_EMPTY` moved to first place in the condition.