### PR TITLE
Move streams closed by RST to closed queue

### DIFF
--- a/fw/http2.h
+++ b/fw/http2.h
@@ -151,6 +151,7 @@ void tfw_h2_conn_terminate_close(TfwH2Ctx *ctx, TfwH2Err err_code, bool close,
                                  bool attack);
 void tfw_h2_conn_streams_cleanup(TfwH2Ctx *ctx);
 void tfw_h2_current_stream_remove(TfwH2Ctx *ctx);
+int tfw_h2_current_stream_send_rst(TfwH2Ctx *ctx, int err_code);
 void tfw_h2_remove_idle_streams(TfwH2Ctx *ctx, unsigned int id);
 void tfw_h2_closed_streams_shrink(TfwH2Ctx *ctx);
 void tfw_h2_check_current_stream_is_closed(TfwH2Ctx *ctx);

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -282,8 +282,10 @@ tfw_h2_stream_unlink_nolock(TfwH2Ctx *ctx, TfwStream *stream)
 		 * cases controlled by server connection side (after adding to
 		 * @fwd_queue): successful response sending, eviction etc.
 		 */
-		if (!test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags))
+		if (!test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags)) {
 			tfw_http_conn_msg_free(hmreq);
+			stream->msg = NULL;
+		}
 	}
 }
 


### PR DESCRIPTION
According RFC 9113 :
An endpoint that sends a RST_STREAM frame on a stream that is in the "open" or "half-closed (local)" state could receive any type of frame. The peer might have sent or enqueued for sending these frames before
processing the RST_STREAM frame.
For this purpose Tempesta FW implements special not described in RFC state - HTTP2_STREAM_LOC_CLOSED
state. When Tempesta FW sends RST stream stream moved to HTTP2_STREAM_LOC_CLOSED state and silently ignores new received frames. But such stream is not moved to closed queue, so it will be never deleted until
connection will be closed. If count of such streams exceeded max concurrent streams client can't open
new streams. This patch fixes this problem.