### PR TITLE
Fix double free of `stream->msg`

### DIFF
--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -273,6 +273,7 @@ tfw_h2_stream_unlink_nolock(TfwH2Ctx *ctx, TfwStream *stream)
 
 	if (hmreq) {
 		hmreq->stream = NULL;
+		stream->msg = NULL;
 		/*
 		 * If the request is linked with a stream, but not complete yet,
 		 * it must be deleted right here to avoid leakage, because in
@@ -282,10 +283,8 @@ tfw_h2_stream_unlink_nolock(TfwH2Ctx *ctx, TfwStream *stream)
 		 * cases controlled by server connection side (after adding to
 		 * @fwd_queue): successful response sending, eviction etc.
 		 */
-		if (!test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags)) {
+		if (!test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags))
 			tfw_http_conn_msg_free(hmreq);
-			stream->msg = NULL;
-		}
 	}
 }
 


### PR DESCRIPTION
We should zero `stream->msg` pointer in `tfw_h2_stream_unlink_nolock` function regardless of whether we delete the message directly in this function or not. If request is fully parsed it will be deleted later in `tfw_http_resp_cache_cb->tfw_h2_resp_adjust_fwd` and if we don't zero `stream->msg` in `tfw_h2_stream_unlink_nolock` we access already freed request in `test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags)`.

Closes #2285