### PR TITLE
Fix race in accessing `g_tmp_mpool`

### DIFF
--- a/tls/mpool.c
+++ b/tls/mpool.c
@@ -72,7 +72,7 @@ static DEFINE_PER_CPU(TlsMpiPool *, g_tmp_mpool);
  * 2. temporary per-cpu pool for stack allocated MPIs (softirq);
  * 3. current handshake profile cloned from (1) (softirq).
  */
-TlsMpiPool *
+static TlsMpiPool *
 ttls_mpool(void *addr)
 {
 	TlsMpiPool *mp;

--- a/tls/mpool.c
+++ b/tls/mpool.c
@@ -19,7 +19,7 @@
  * implicitly for MPI math. Dynamically allocated pages are used instead of
  * static per-cpu ones.
  *
- * Copyright (C) 2019-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tls/mpool.h
+++ b/tls/mpool.h
@@ -1,7 +1,7 @@
 /*
  *		Tempesta TLS
  *
- * Copyright (C) 2019-2020 Tempesta Technologies, Inc.
+ * Copyright (C) 2019-2024 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tls/mpool.h
+++ b/tls/mpool.h
@@ -22,7 +22,6 @@
 
 #include "tls_internal.h"
 
-TlsMpiPool *ttls_mpool(void *addr);
 void *ttls_mpool_alloc_stack(size_t n);
 void *ttls_mpool_alloc_data(TlsMpiPool *mp, size_t n);
 int ttls_mpi_pool_alloc_mpi(TlsMpi *x, size_t n);

--- a/tls/x509_crt.c
+++ b/tls/x509_crt.c
@@ -977,7 +977,9 @@ ttls_x509_crt_parse(TlsX509Crt *crt, unsigned char *buf, size_t buflen)
 
 done:
 	/* Does MPI calculations, so pool context must be freed afterwards. */
+	local_bh_disable();
 	ttls_mpi_pool_cleanup_ctx(0, false);
+	local_bh_enable();
 
 	return r;
 }


### PR DESCRIPTION
`g_tmp_mpool` is per cpu vatiable, but it can be accessed by softirq context (when we handle new tls connection) and process context (when we read/parse cetificate and key). For example we allocate memory using this pool in process context `ttls_rsa_import_raw`-> `__rsa_setup_ctx` -> `ttls_mpi_inv_mod` -> `ttls_mpool_alloc_stack` and free pool from softirq `ttls_recv` -> `ttls_mpi_pool_cleanup_ctx`. So we should disable softirq when we use pool in process context.