### PR TITLE
Update request's `host` during heders modification

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -3550,6 +3550,18 @@ tfw_h1_set_loc_hdrs(TfwHttpMsg *hm, bool is_resp, bool from_cache)
 		T_DBG2("updated location-specific header in msg %p\n", hm);
 	}
 
+	/*
+	 * When header modifications contains `req_hdr_set` rule for `Host`
+	 * header we must update req->host also, otherwise it leads to
+	 * inconsistency between req->host and Host header in headers table.
+	 */
+	if (!is_resp && h_mods->spec_hdrs[TFW_HTTP_HDR_HOST]) {
+		TfwStr *host = &req->h_tbl->tbl[TFW_HTTP_HDR_HOST];
+
+		tfw_http_msg_clnthdr_val(req, host, TFW_HTTP_HDR_HOST,
+					 &req->host);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
We must update `TfwHttpReq::host` during headers modification to prevent inconsistency between `TfwHttpReq::host` and new host header.


One case where we got problem because of this, it's cache where we calculate size of the cache entry using `req->host.len`(total len not changed, we didn't update `req->host`), but when copy headers to cache we iterating over each chunk, however some chunks already has another length, because they are changed in `__hdr_sub()`. Chunks are changed, because `req->host` stores pointers to chunks, but not values of chunks, however `req->host.len` is value.