### PR TITLE
Fix freeing of websocket negotiable connetions

### DIFF
--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -65,7 +65,8 @@ tfw_cli_cache(int type)
 		return type & Conn_Negotiable ? tfw_h2_conn_cache
 					      : tfw_https_conn_cache;
 	case TFW_FSM_WSS:
-		return tfw_https_conn_cache;
+		return type & Conn_Negotiable ? tfw_h2_conn_cache
+					      : tfw_https_conn_cache;
 	case TFW_FSM_HTTP:
 	case TFW_FSM_WS:
 		return tfw_h1_conn_cache;


### PR DESCRIPTION
When we specify proto as `https,h2` or `h2,https`
we always allocate memory for connection from
http2 connection cache. Later when we free connection we check if connection is negotiable and put it to http2 cache. We should do same If we have https connection which was upgraded to websocket connnection.

Closes #2300