### PR TITLE
Remove memory corruption during trailer processing

### DIFF
--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -566,7 +566,7 @@ tfw_http_msg_hdr_close(TfwHttpMsg *hm)
 	parser->hdr.flags |= TFW_STR_COMPLETE;
 
 	/* Cumulate the trailer headers length */
-	if (parser->hdr.flags & TFW_STR_TRAILER) {
+	if (is_srv_conn && parser->hdr.flags & TFW_STR_TRAILER) {
 		TfwHttpResp* resp = (TfwHttpResp*) hm;
 
 		resp->trailers_len += parser->hdr.len +


### PR DESCRIPTION
We pass `TfwHtppMsg` which can be (request or response) in `tfw_http_msg_hdr_close`, so we should check that it is a server connection before cast it to `TfwHttpResp`, when we set response trailer length.