### PR TITLE
Remove `BUG_ON(v_min == USHRT_MAX)` in apm.c

### DIFF
--- a/fw/apm.c
+++ b/fw/apm.c
@@ -615,6 +615,7 @@ typedef struct {
 } TfwApmUBuf;
 
 #define TFW_APM_DATA_F_REARM	(0x0001)	/* Re-arm the timer. */
+#define TFW_APM_DATA_F_RECALC	(0x0002)	/* Need to recalculate. */
 
 #define TFW_APM_TIMER_INTVL	(HZ / 20)
 #define TFW_APM_UBUF_SZ		TFW_APM_TIMER_INTVL	/* a slot per ms. */
@@ -755,8 +756,18 @@ tfw_apm_state_next(TfwPcntRanges *rng, TfwApmRBEState *st)
 
 /*
  * Calculate the latest percentiles from the current stats data.
+ *
+ * There's a small chance for a race condition, because @tot_cnt and the
+ * buckets' @cnt[][] are updated without a lock, asynchronously and at
+ * slightly different times (__tfw_apm_update -> tfw_apm_rbent_checkreset).
+ * Due to a tiny discrepancy between @tot_cnt and the sum of hit counters
+ * in @cnt[][], the calculation may not be able to reach the target value.
+ * In that case the calculation exits prematurely, and a recalculation is
+ * scheduled at the next run of the timer.
+ *
+ * Returns the number of percentile values that have been filled.
  */
-static void
+static int
 tfw_apm_prnctl_calc(TfwApmRBuf *rbuf, TfwApmRBCtl *rbctl, TfwPrcntlStats *pstats)
 {
 #define IDX_MIN		TFW_PSTATS_IDX_MIN
@@ -793,7 +804,20 @@ tfw_apm_prnctl_calc(TfwApmRBuf *rbuf, TfwApmRBCtl *rbctl, TfwPrcntlStats *pstats
 			if (st[i].v < v_min)
 				v_min = st[i].v;
 		}
-		BUG_ON(v_min == USHRT_MAX);
+		/*
+		 * If the race condition has occured, then the results
+		 * are incomplete and can be used only partially.
+		 */
+		if (unlikely(v_min == USHRT_MAX)) {
+			T_DBG3("%s: Calculation stopped prematurely: "
+				 "cnt [%lu] total_cnt [%lu]\n",
+				 __func__, cnt, rbctl->total_cnt);
+			T_DBG3("%s: [%lu] [%lu] [%lu] [%lu] [%lu] [%lu]\n",
+				 __func__, pval[IDX_ITH], pval[IDX_ITH + 1],
+				 pval[IDX_ITH + 2], pval[IDX_ITH + 3],
+				 pval[IDX_ITH + 4], pval[IDX_ITH + 5]);
+			break;
+		}
 		for (i = 0; i < rbuf->rbufsz; i++) {
 			if (st[i].v != v_min)
 				continue;
@@ -825,6 +849,8 @@ tfw_apm_prnctl_calc(TfwApmRBuf *rbuf, TfwApmRBCtl *rbctl, TfwPrcntlStats *pstats
 
 	if (likely(cnt))
 		pstats->val[IDX_AVG] = val / cnt;
+
+	return p;
 
 #undef IDX_ITH
 #undef IDX_AVG
@@ -874,7 +900,7 @@ tfw_apm_rbent_checkreset(TfwApmRBEnt *crbent, unsigned long jtmistamp)
  * Return false if the percentile values don't need the recalculation.
  */
 static bool
-tfw_apm_rbctl_update(TfwApmData *data)
+tfw_apm_rbctl_update(TfwApmData *data, bool recalc)
 {
 	int i, centry;
 	unsigned long jtmnow = jiffies;
@@ -919,8 +945,15 @@ tfw_apm_rbctl_update(TfwApmData *data)
 
 	/* Nothing to do if there were no stats updates. */
 	entry_cnt = rbent[centry].pcntrng.tot_cnt;
-	if (unlikely(rbctl->entry_cnt == entry_cnt))
+	if (unlikely(rbctl->entry_cnt == entry_cnt)) {
+		if (unlikely(recalc)) {
+			T_DBG3("%s: Old time window: recalculate: "
+				 "centry [%d] total_cnt [%lu]\n",
+				 __func__, centry, rbctl->total_cnt);
+			return true;
+		}
 		return false;
+	}
 	BUG_ON(rbctl->entry_cnt > entry_cnt);
 
 	/* Update the counts incrementally. */
@@ -935,10 +968,14 @@ tfw_apm_rbctl_update(TfwApmData *data)
 
 /*
  * Calculate the latest percentiles if necessary.
+ *
+ * Return 0 if the calculation is successful.
+ * Return > 0 and < @prcntlsz if the calculation is incomplete.
  */
-static void
+static int
 tfw_apm_calc(TfwApmData *data)
 {
+	int nfilled, recalc;
 	unsigned int rdidx;
 	unsigned int val[T_PSZ] = { 0 };
 	TfwPrcntlStats pstats = {
@@ -950,18 +987,24 @@ tfw_apm_calc(TfwApmData *data)
 	rdidx = atomic_read(&data->stats.rdidx);
 	asent = &data->stats.asent[(rdidx + 1) % 2];
 
-	if (!tfw_apm_rbctl_update(data))
-		return;
-	tfw_apm_prnctl_calc(&data->rbuf, &data->rbctl, &pstats);
+	recalc = test_and_clear_bit(TFW_APM_DATA_F_RECALC, &data->flags);
+	if (!tfw_apm_rbctl_update(data, recalc))
+		return 0;
 
-	T_DBG3("%s: Percentile values may have changed.\n", __func__);
-	write_seqlock(&asent->seqlock);
-	memcpy_fast(asent->pstats.val, pstats.val,
-		    T_PSZ * sizeof(asent->pstats.val[0]));
-	atomic_inc(&data->stats.rdidx);
-	write_sequnlock(&asent->seqlock);
+	nfilled = tfw_apm_prnctl_calc(&data->rbuf, &data->rbctl, &pstats);
+	if (nfilled < T_PSZ) {
+		T_DBG3("%s: Percentile calculation incomplete.\n", __func__);
+		set_bit(TFW_APM_DATA_F_RECALC, &data->flags);
+	} else {
+		T_DBG3("%s: Percentile values may have changed.\n", __func__);
+		write_seqlock(&asent->seqlock);
+		memcpy_fast(asent->pstats.val, pstats.val,
+			    T_PSZ * sizeof(asent->pstats.val[0]));
+		atomic_inc(&data->stats.rdidx);
+		write_sequnlock(&asent->seqlock);
+	}
 
-	return;
+	return nfilled % T_PSZ;
 }
 
 /*
@@ -1040,7 +1083,9 @@ tfw_apm_prcntl_tmfn(struct timer_list *t)
 					 rtt_data.rtt);
 		}
 	}
-	tfw_apm_calc(data);
+
+	if (unlikely(tfw_apm_calc(data)))
+		T_DBG3("%s: Incomplete calculation\n", __func__);
 
 	smp_mb();
 	if (test_bit(TFW_APM_DATA_F_REARM, &data->flags))


### PR DESCRIPTION
There was a commit (903cddae857658239cdc9b898970b03988cd2d13) where this BUG_ON was added. But there is a still small chance of race between calling `tfw_apm_prnctl_calc` and `__tfw_apm_update -> tfw_apm_rbent_checkreset`. If this race occurs `tot_cnt` and the buckets `cnt[][]` will be zeroed during there usage for calculation in `tfw_apm_prnctl_calc`, that leads to BUG_ON.
We can use lock to prevent race condition, but more effective way is revert (903cddae) and break the loop if race occurs and recalculate statistics on the next call.