### PR TITLE
Fix accessing already closed client db.

### DIFF
--- a/fw/client.c
+++ b/fw/client.c
@@ -392,8 +392,10 @@ tfw_client_stop(void)
 {
 	if (tfw_runstate_is_reconfig())
 		return;
-	if (client_db)
+	if (client_db) {
 		tdb_close(client_db);
+		client_db = NULL;
+	}
 
 	tfw_client_free_lru();
 }

--- a/fw/sock_clnt.c
+++ b/fw/sock_clnt.c
@@ -859,6 +859,7 @@ tfw_sock_clnt_stop(void)
 	 * tfw_cfgop_cleanup_sock_clnt().
 	 */
 	list_for_each_entry(ls, &tfw_listen_socks, list) {
+		tfw_classifier_remove_inport(tfw_addr_port(&ls->addr));
 		if (!ls->sk)
 			continue;
 		ss_release(ls->sk);


### PR DESCRIPTION
During establishing new TCP connection `tempesta_new_clntsk` callback is called. If Tempesta FW is not loaded it immediately returns 0 (success), otherwise `tfw_classify_conn_estab` is called inside Tempesta FW module. In this function we check if the source port of new created socket is added to to the special bitmap and if not just return success otherwise Tempesta creates new client (We pass to this callback all new created sockets regardless of whether they are related to Еempesta or not! For example when curl connect to nginx new created socket will be passed to this callback also! But we add only Tempesta FW listen sockets prots to bitmap, so for all other cases this callback just return success). The problem occurs when Tempesta unloaded - First of all we stop all Tempesta FW modules and Tempesta FW listen sockets, then unload Tempesta. If some programm (for example nginx) start listen on the same port as Tempesta and curl connect to it new created socket will be passed to Tempesta FW callback and new client will be created (has nothing to do with Tempesta!), moreover this client will be created from already closed db, that leads to BUG. We should remove Tempesta listen socket from bitmap during it's release.