### PR TITLE
Fix use after free.

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -7137,6 +7137,7 @@ tfw_http_msg_process_generic(TfwConn *conn, TfwStream *stream,
 {
 	int r = T_BAD;
 	TfwHttpMsg *req;
+	bool websocket;
 
 	if (WARN_ON_ONCE(!stream))
 		goto err;
@@ -7161,10 +7162,9 @@ tfw_http_msg_process_generic(TfwConn *conn, TfwStream *stream,
 	/* That is paired request, it may be freed after resp processing,
 	 * so we cannot move it iside `if` clause. */
 	req = ((TfwHttpMsg *)stream->msg)->pair;
+	websocket = test_bit(TFW_HTTP_B_UPGRADE_WEBSOCKET, req->flags);
 	if ((r = tfw_http_resp_process(conn, stream, skb, next))) {
 		TfwSrvConn *srv_conn = (TfwSrvConn *)conn;
-		bool websocket = test_bit(TFW_HTTP_B_UPGRADE_WEBSOCKET,
-					  req->flags);
 		/*
 		 * We must clear TFW_CONN_B_UNSCHED to make server connection
 		 * available for request scheduling further if websocket upgrade


### PR DESCRIPTION
We can't use 'req' after `tfw_http_resp_process`
fails, because there are some case when 'req' was
already freed. For example:
tfw_http_resp_process->tfw_http_resp_cache->
tfw_cache_process, `tfw_cache_process` fails and
tfw_http_send_err_resp->tfw_http_send_err_resp_nolog-> tfw_h2_send_err_resp->tfw_h2_send_resp->tfw_h2_prep_resp, ->tfw_h2_prep_resp, `tfw_h2_prep_resp` fails and we clear request in `tfw_http_resp_build_error`.