### PR TITLE
Fix WARNING in case of error in `tfw_h2_prep_resp`.

### DIFF
--- a/fw/http2.c
+++ b/fw/http2.c
@@ -456,9 +456,8 @@ tfw_h2_req_unlink_stream(TfwHttpReq *req)
  * send RST STREAM and add stream to closed queue.
  */
 void
-tfw_h2_req_unlink_stream_with_rst(TfwHttpReq *req)
+tfw_h2_req_unlink_and_close_stream(TfwHttpReq *req)
 {
-	TfwStreamFsmRes r;
 	TfwStream *stream;
 	TfwH2Ctx *ctx = tfw_h2_context_unsafe(req->conn);
 
@@ -472,10 +471,7 @@ tfw_h2_req_unlink_stream_with_rst(TfwHttpReq *req)
 
 	req->stream = NULL;
 	stream->msg = NULL;
-
-	r = tfw_h2_stream_fsm_ignore_err(ctx, stream, HTTP2_RST_STREAM, 0);
-	WARN_ON_ONCE(r != STREAM_FSM_RES_OK && r != STREAM_FSM_RES_IGNORE);
-
+	tfw_h2_set_stream_state(stream, HTTP2_STREAM_CLOSED);
 	tfw_h2_stream_add_to_queue_nolock(&ctx->closed_streams, stream);
 
 	spin_unlock(&ctx->lock);

--- a/fw/http2.h
+++ b/fw/http2.h
@@ -160,7 +160,7 @@ TfwStream *tfw_h2_find_not_closed_stream(TfwH2Ctx *ctx, unsigned int id,
 
 unsigned int tfw_h2_req_stream_id(TfwHttpReq *req);
 void tfw_h2_req_unlink_stream(TfwHttpReq *req);
-void tfw_h2_req_unlink_stream_with_rst(TfwHttpReq *req);
+void tfw_h2_req_unlink_and_close_stream(TfwHttpReq *req);
 int tfw_h2_stream_xmit_prepare_resp(TfwStream *stream);
 int tfw_h2_entail_stream_skb(struct sock *sk, TfwH2Ctx *ctx, TfwStream *stream,
                              unsigned int *len, bool should_split);


### PR DESCRIPTION
There can be a kernel warning if `tfw_h2_frame_local_resp` fails and `ctx->cur_send_headers` is set (Tempesta FW sends response with a long headers). In this case `tfw_h2_req_unlink_stream_with_rst` -> `tfw_h2_stream_fsm_ignore_err` fails and WARNING occurs. This patch fix this behaviour:
- First of all we should not process stream state in `tfw_h2_req_unlink_stream_with_rst`, just set stream state to CLOSE state, because this function is called only when we don't send any response to client and just drop request.
- We don't need to call `tfw_h2_req_unlink_stream_with_rst` from `tfw_h2_prep_resp` if it fails because it will be called later from `tfw_h2_send_resp`.
- If `tfw_h2_prep_resp` is called from `tfw_http_prep_redir` and fails, we also don't need to call `tfw_h2_req_unlink_stream_with_rst` because we need to send error response later.