### PR TITLE
Content-Lenth and Content-Type in bodyless message

### DIFF
--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -1189,6 +1189,18 @@
 #   http_max_header_list_size 4096;
 #
 
+# TAG: http_allow_empty_body_content_type
+#
+# This directive controls whether HTTP requests are allowed to include
+# a Content-Type header even when the message body is empty.
+#
+# Syntax:
+#   http_allow_empty_body_content_type true|false
+#
+# Example:
+#   http_allow_empty_body_content_type true;
+#
+
 #
 # Health monitoring configuration.
 #

--- a/fw/http.c
+++ b/fw/http.c
@@ -149,6 +149,7 @@ static struct {
  * here, because it refers to HTTP layer.
  */
 unsigned int max_header_list_size = 0;
+bool allow_empty_body_content_type;
 
 #define S_CRLFCRLF		"\r\n\r\n"
 #define S_HTTP			"http://"
@@ -7908,6 +7909,12 @@ tfw_cfgop_cleanup_max_header_list_size(TfwCfgSpec *cs)
 	max_header_list_size = 0;
 }
 
+static void
+tfw_cfgop_cleanup_allow_empty_body_content_type(TfwCfgSpec *cs)
+{
+	allow_empty_body_content_type = false;
+}
+
 static TfwCfgSpec tfw_http_specs[] = {
 	{
 		.name = "block_action",
@@ -7994,6 +8001,15 @@ static TfwCfgSpec tfw_http_specs[] = {
 		.handler = tfw_cfgop_max_header_list_size,
 		.allow_none = true,
 		.cleanup = tfw_cfgop_cleanup_max_header_list_size,
+	},
+	{
+		.name = "http_allow_empty_body_content_type",
+		.deflt = "false",
+		.handler = tfw_cfg_set_bool,
+		.dest = &allow_empty_body_content_type,
+		.allow_none = true,
+		.allow_repeat = false,
+		.cleanup = tfw_cfgop_cleanup_allow_empty_body_content_type,
 	},
 	{
 		.name = "ja5h",

--- a/fw/http.h
+++ b/fw/http.h
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -736,6 +736,7 @@ typedef void (*tfw_http_cache_cb_t)(TfwHttpMsg *);
 	(TFW_MSG_H2(hmmsg) ? HTTP2_EXTRA_HDR_OVERHEAD : 0)
 
 extern unsigned int max_header_list_size;
+extern bool allow_empty_body_content_type;
 
 /* External HTTP functions. */
 int tfw_http_msg_process(TfwConn *conn, struct sk_buff *skb,

--- a/fw/t/fuzzer.c
+++ b/fw/t/fuzzer.c
@@ -3,7 +3,7 @@
  *
  * Tempesta HTTP fuzzer.
  *
- * Copyright (C) 2015-2022 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -92,8 +92,9 @@ static FuzzMsg host_val[] = {
 static FuzzMsg content_type[] = {
 	{"text/html;charset=utf-8"}, {"image/jpeg"}, {"text/plain"}
 };
+#define FUZZ_FLD_F_ZERO_CL		(0x0001 << FUZZ_MSG_F_SHIFT)
 static FuzzMsg content_len[] = {
-	{"10000"}, {"0"}, {"-42", FUZZ_MSG_F_INVAL},
+	{"10000"}, {"0", FUZZ_FLD_F_ZERO_CL}, {"-42", FUZZ_MSG_F_INVAL},
 	{"146"}, {"0100"}, {"100500"}
 };
 #define FUZZ_FLD_F_CHUNKED		(0x0001 << FUZZ_MSG_F_SHIFT)
@@ -762,7 +763,8 @@ fuzz_hdrs_compatible(TfwFuzzContext *ctx, int type, unsigned int v)
 		if ((ctx->fld_flags[RESP_CODE]
 		     & (FUZZ_FLD_F_STATUS_100
 			| FUZZ_FLD_F_STATUS_204))
-		    && (ctx->hdr_flags & (1 << CONTENT_LENGTH)))
+		    && (ctx->hdr_flags & (1 << CONTENT_LENGTH))
+		    && !(ctx->fld_flags[CONTENT_LENGTH] & FUZZ_FLD_F_ZERO_CL))
 		{
 			return false;
 		}

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -1275,7 +1275,7 @@ TEST(http_parser, upgrade)
 
 #define EXPECT_BLOCK_BODYLESS_REQ(METHOD)					\
 	EXPECT_BLOCK_REQ(#METHOD " / HTTP/1.1\r\n"				\
-			 "Content-Length: 0\r\n"				\
+			 "Content-Length: 1\r\n"				\
 			 "\r\n")						\
 	{									\
 		EXPECT_EQ(req->method, TFW_HTTP_METH_##METHOD);			\
@@ -1289,7 +1289,7 @@ TEST(http_parser, upgrade)
 
 #define EXPECT_BLOCK_BODYLESS_REQ_OVERRIDE(METHOD)				\
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
-			 "Content-Length: 0\r\n"				\
+			 "Content-Length: 1\r\n"				\
 			 "X-Method-Override: " #METHOD "\r\n"			\
 			 "\r\n")						\
 	{									\
@@ -1297,7 +1297,7 @@ TEST(http_parser, upgrade)
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
 	}									\
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
-			 "Content-Length: 0\r\n"				\
+			 "Content-Length: 1\r\n"				\
 			 "X-HTTP-Method-Override: " #METHOD "\r\n"		\
 			 "\r\n")						\
 	{									\
@@ -1305,7 +1305,7 @@ TEST(http_parser, upgrade)
 		EXPECT_EQ(req->method_override, TFW_HTTP_METH_##METHOD);	\
 	}									\
 	EXPECT_BLOCK_REQ("PUT / HTTP/1.1\r\n"					\
-			 "Content-Length: 0\r\n"				\
+			 "Content-Length: 1\r\n"				\
 			 "X-HTTP-Method: " #METHOD "\r\n"			\
 			 "\r\n")						\
 	{									\
@@ -1390,8 +1390,16 @@ TEST(http1_parser, content_length)
 	/* Content-Length is mandatory for responses. */
 	EXPECT_BLOCK_RESP("HTTP/1.1 200 OK\r\n\r\n");
 
-	/* Content-Length must not be present in GET requests */
-	EXPECT_BLOCK_REQ_SIMPLE("Content-Length: 0");
+	/* Content-Length greater than zero must not be present in GET requests */
+	EXPECT_BLOCK_REQ_SIMPLE("Content-Length: 1");
+
+	/* Content-Length: 0 treats as the absence of a Content-Length. */
+	FOR_REQ("GET / HTTP/1.1\r\n"
+		"Content-Length: 0\r\n"
+		"\r\n")
+	{
+		EXPECT_TRUE(req->content_length == 0);
+	}
 
 	FOR_REQ("POST / HTTP/1.1\r\n"
 		"Content-Length: 0\r\n"
@@ -1492,7 +1500,7 @@ TEST(http1_parser, content_length)
 			  "\r\n"
 			  "dummy");
 	EXPECT_BLOCK_RESP("HTTP/1.1 101 Switching Protocols\r\n"
-			  "Content-Length: 0\r\n"
+			  "Content-Length: 1\r\n"
 			  "\r\n");
 
 	EXPECT_BLOCK_RESP("HTTP/1.1 199 Dummy\r\n"
@@ -1500,7 +1508,7 @@ TEST(http1_parser, content_length)
 			  "\r\n"
 			  "dummy");
 	EXPECT_BLOCK_RESP("HTTP/1.1 199 Dummy\r\n"
-			  "Content-Length: 0\r\n"
+			  "Content-Length: 1\r\n"
 			  "\r\n");
 
 	EXPECT_BLOCK_RESP("HTTP/1.0 204 No Content\r\n"
@@ -1508,7 +1516,7 @@ TEST(http1_parser, content_length)
 			  "\r\n"
 			  "dummy");
 	EXPECT_BLOCK_RESP("HTTP/1.0 204 No Content\r\n"
-			  "Content-Length: 0\r\n"
+			  "Content-Length: 1\r\n"
 			  "\r\n");
 
 	FOR_RESP("HTTP/1.0 205 Reset Content\r\n"

--- a/fw/t/unit/test_http2_parser.c
+++ b/fw/t/unit/test_http2_parser.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2022-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2022-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -848,7 +848,7 @@ TEST(http2_parser, suspicious_x_forwarded_for)
 		HEADER(WO_IND(NAME(":method"), VALUE(#METHOD)));		\
 		HEADER(WO_IND(NAME(":scheme"), VALUE("https")));		\
 		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));		\
-		HEADER(WO_IND(NAME("content-length"), VALUE("0")));		\
+		HEADER(WO_IND(NAME("content-length"), VALUE("1")));		\
 	    HEADERS_FRAME_END();						\
 	)									\
 	{									\
@@ -872,7 +872,7 @@ TEST(http2_parser, suspicious_x_forwarded_for)
 		HEADER(WO_IND(NAME(":method"), VALUE("PUT")));			\
 		HEADER(WO_IND(NAME(":scheme"), VALUE("https")));		\
 		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));		\
-		HEADER(WO_IND(NAME("content-length"), VALUE("0")));		\
+		HEADER(WO_IND(NAME("content-length"), VALUE("1")));		\
 		HEADER(WO_IND(NAME("x-method-override"), VALUE(#METHOD)));	\
 	    HEADERS_FRAME_END();						\
 	)									\
@@ -898,7 +898,7 @@ TEST(http2_parser, suspicious_x_forwarded_for)
 		HEADER(WO_IND(NAME(":method"), VALUE("PUT")));			\
 		HEADER(WO_IND(NAME(":scheme"), VALUE("https")));		\
 		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));		\
-		HEADER(WO_IND(NAME("content-length"), VALUE("0")));		\
+		HEADER(WO_IND(NAME("content-length"), VALUE("1")));		\
 		HEADER(WO_IND(NAME("x-http-method-override"), VALUE(#METHOD)));	\
 	    HEADERS_FRAME_END();						\
 	)									\
@@ -924,7 +924,7 @@ TEST(http2_parser, suspicious_x_forwarded_for)
 		HEADER(WO_IND(NAME(":method"), VALUE("PUT")));			\
 		HEADER(WO_IND(NAME(":scheme"), VALUE("https")));		\
 		HEADER(WO_IND(NAME(":path"), VALUE("/filename")));		\
-		HEADER(WO_IND(NAME("content-length"), VALUE("0")));		\
+		HEADER(WO_IND(NAME("content-length"), VALUE("1")));		\
 		HEADER(WO_IND(NAME("x-http-method"), VALUE(#METHOD)));		\
 	    HEADERS_FRAME_END();						\
 	)									\


### PR DESCRIPTION
RFC 9110 8.6:
A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).

Now for responses 1xx and 204 Tempesta FW treats `Content-Length: 0` as the absence of a Content-Length header. Some implementations send `Content-Length: 0` within 204 (No Content) response, to be able to process such messages the rule from RFC 9110 8.6 has been relaxed.

For requests with bodyless methods such as HEAD, GET, etc. Tempesta also treats `Content-Length: 0` as empty body and considers such requests as valid.

Added directive `http_allow_empty_body_content_type` that allows Tempesta FW to process requests with bodyless methods. By default Tempesta FW drops such requests.