### PR TITLE
Fix potencial BUG when Tempesta shutdowned

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -2895,16 +2895,7 @@ tfw_http_conn_release(TfwConn *conn)
 	 */
 	list_for_each_entry_safe(req, tmp, &zap_queue, fwd_list) {
 		list_del_init(&req->fwd_list);
-		if (TFW_MSG_H2(req)) {
-			tfw_h2_req_unlink_and_close_stream(req);
-		}
-		else if (unlikely(!list_empty_careful(&req->msg.seq_list))) {
-			spin_lock_bh(&((TfwCliConn *)req->conn)->seq_qlock);
-			if (unlikely(!list_empty(&req->msg.seq_list)))
-				list_del_init(&req->msg.seq_list);
-			spin_unlock_bh(&((TfwCliConn *)req->conn)->seq_qlock);
-		}
-		tfw_http_conn_msg_free((TfwHttpMsg *)req);
+		tfw_http_conn_req_clean(req);
 	}
 }
 

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -1143,7 +1143,6 @@ tfw_http_msg_del_trailer_hdrs(TfwHttpMsg *hm)
 		 */
 		if (was_deleted)
 			__hdr_del_from_tbl(ht, hid);
-		--ht->off;
 	} while (hid);
 }
 


### PR DESCRIPTION
There was a little optimization (we use `list_empty_careful` before `spin_lock`) in `tfw_http_conn_release`, when Tempesta shutdowned (ss_active is false). This optiomization can lead to double free:
When Tempesta FW shutdowned tfw_mods_stop->ss_stop is called, immediately after it (before clients connections will be dropped) connection with backend is closed by backend and `tfw_http_conn_release` is called. `list_empty_careful` return true and we don't remove this request from seq_list, but on other CPU request can be added! This leads to double free. In fact this optimization doesn't make sense at all, since it only works when tempesta is turned off! Let's use a secure function with a lock here!