### PR TITLE
Integrate clang-tidy for cpp files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,83 @@
+Checks: >
+  clang-diagnostic-*,
+  clang-diagnostic-error,
+  clang-analyzer-*,
+  clang-analyzer-core.*,
+  clang-analyzer-cplusplus.*,
+  clang-analyzer-deadcode.*,
+  clang-analyzer-security.*,
+  bugprone-*,
+  cert-*,
+  cppcoreguidelines-*,
+  cppcoreguidelines-owning-memory,
+  cppcoreguidelines-no-malloc,
+  cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  cppcoreguidelines-pro-bounds-constant-array-index,
+  cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  cppcoreguidelines-pro-type-const-cast,
+  cppcoreguidelines-pro-type-cstyle-cast,
+  cppcoreguidelines-pro-type-reinterpret-cast,
+  cppcoreguidelines-pro-type-union-access,
+  cppcoreguidelines-slicing,
+  google-build-using-namespace,
+  google-explicit-constructor,
+  google-readability-casting,
+  google-runtime-int,
+  google-runtime-operator,
+  hicpp-exception-baseclass,
+  hicpp-multiway-paths-covered,
+  hicpp-no-malloc,
+  hicpp-signed-bitwise,
+  misc-*,
+  modernize-*,
+  mpi-*,
+  performance-*,
+  readability-*,
+  -modernize-use-trailing-return-type,
+  -readability-magic-numbers,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -readability-identifier-length,
+  -clang-diagnostic-error
+  -misc-unused-using-decls,
+  -misc-unused-parameters,
+  -misc-include-cleaner
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: none
+
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: true
+  - key: bugprone-dangling-handle.HandleClasses
+    value: 'std::basic_string_view;std::span'
+  - key: cert-dcl58-cpp.IgnoreMacros
+    value: true
+  - key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
+    value: true
+  - key: bugprone-suspicious-string-compare.WarnOnImplicitComparison
+    value: true
+  - key: bugprone-argument-comment.StrictMode
+    value: true
+  - key: bugprone-easily-swappable-parameters.QualifiersMix
+    value: true
+  - key: bugprone-misplaced-widening-cast.CheckImplicitCasts
+    value: true
+  - key: bugprone-sizeof-expression.WarnOnSizeOfConstant
+    value: true
+  - key: bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
+    value: true
+  - key: bugprone-suspicious-enum-usage.StrictMode
+    value: true
+  - key: bugprone-suspicious-missing-comma.RatioThreshold
+    value: 0.5
+  - key: bugprone-suspicious-string-compare.StringCompareLikeFunctions
+    value: 'strcmp;strncmp'
+  - key: cppcoreguidelines-narrowing-conversions.PedanticMode
+    value: true

--- a/Makefile
+++ b/Makefile
@@ -180,3 +180,8 @@ clean:
 	$(MAKE) -C utils clean
 	find . \( -name \*~ -o -name \*.orig -o -name \*.symvers \) \
 		-exec rm -f {} \;
+
+tidy:
+	@echo "Running clang-tidy on C++ files..."
+	@./scripts/run-clang-tidy.sh
+.PHONY: tidy

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+CLICKHOUSE_INCLUDE="-I$(pwd)/utils/clickhouse-cpp"
+
+detect_clang_tidy() {
+    if command -v "clang-tidy" &> /dev/null; then
+        echo "clang-tidy"
+        return 0
+    fi
+    
+    for cmd in $(compgen -c | grep -E "^clang-tidy-[0-9]+$" | sort -r); do
+        echo "$cmd"
+        return 0
+    done
+    
+    echo ""
+    return 1
+}
+
+main() {
+    CLANG_TIDY=$(detect_clang_tidy)
+    
+    if [ -z "$CLANG_TIDY" ]; then
+        echo "Error: clang-tidy not found. Please install clang-tidy."
+        exit 1
+    fi
+    
+    echo "Using $CLANG_TIDY"
+    
+    if [ -n "$1" ]; then
+        CPP_FILES="$1"
+    else
+        CPP_FILES=$(find utils -name "*.cc" -o -name "*.cpp" -o -name "*.hh" -o -name "*.hpp" -o -name "*.h" \
+    |   grep -v "clickhouse-cpp" \
+    |   xargs grep -L "clickhouse/")
+    fi
+    
+    for file in $CPP_FILES; do
+        echo "Checking $file..."
+        $CLANG_TIDY "$file" --config-file=./.clang-tidy -- \
+            -std=c++20  -stdlib=libc++
+    done
+}
+
+main "$@"

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -42,7 +42,7 @@ all:
 	$(MAKE) $(TARGET)
 
 $(TARGET): $(OBJS)
-	$(CXX) -o $@ $^ $(LDFLAGS)
+	$(CXX) -O3 -s -Wall -Wextra -std=c++23 -o $@ $^ $(LDFLAGS)
 
 %.o: %.cc
 	$(CXX) $(CXXFLAGS) -c $< -o $@
@@ -63,4 +63,11 @@ clickhouse_install:
 clickhouse_clean:
 	$(RM) -rf $(CLICKHOUSE_DIR)
 
-.PHONY: all clean clickhouse clickhouse_install clickhouse_clean
+sanitize: $(OBJS)
+	$(CXX) -O0 -g -Wall -Wextra -std=c++23 -fsanitize=address,undefined -fno-omit-frame-pointer -o $(TARGET) $^ $(LDFLAGS)
+
+tfw_logger_sanitize:
+	$(MAKE) clickhouse
+	$(MAKE) sanitize
+
+.PHONY: all clean clickhouse clickhouse_install clickhouse_clean sanitize tfw_logger_sanitize


### PR DESCRIPTION
## What
Added static code analysis for C++ files:
- Added new targets `tidy` and `sanitize` to Makefile
- `run-clang-tidy.sh` script to scan C++ files
- `.clang-tidy` configuration file

## Why
- Improve code quality
- Catch potential issues early
- Enforce coding standards
- Detect memory-related bugs
## Links
[2327](https://github.com/tempesta-tech/tempesta/issues/2327)