### PR TITLE
Fix possible infitite loop diring sending error response

### DIFF
--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -2173,7 +2173,7 @@ tfw_h2_make_frames(struct sock *sk, TfwH2Ctx *ctx, unsigned long snd_wnd,
 			stream = ctx->cur_send_headers;
 			parent = stream->sched.parent;
 			tfw_h2_stream_sched_remove(sched, stream);
-		} else if (ctx->error) {
+		} else if (ctx->error && tfw_h2_stream_is_active(ctx->error)) {
 			stream = ctx->error;
 			parent = stream->sched.parent;
 			tfw_h2_stream_sched_remove(sched, stream);


### PR DESCRIPTION
We should check that stream with error response
is active to prevent infinite loop during sending
error response.