### PR TITLE
Fix: check config file existence

### DIFF
--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -344,6 +344,13 @@ stop_tfw_logger()
 	fi
 }
 
+check_configuration_file_presense()
+{
+	if [ ! -f "$tfw_cfg_path" ]; then
+		error "Configuration file $tfw_cfg_path does not exist. Please create a configuration file before starting Tempesta FW."
+	fi
+}
+
 start()
 {
 	echo "Starting Tempesta..."
@@ -351,6 +358,8 @@ start()
 	TFW_STATE=$(sysctl net.tempesta.state 2> /dev/null)
 	TFW_STATE=${TFW_STATE##* }
 	TFW_LOGGER_EXEC=$(expr "$TFW_STATE" != "start")
+	
+	check_configuration_file_presense
 
 	if [[ -z ${TFW_STATE} ]]; then
 		setup
@@ -397,6 +406,7 @@ stop()
 
 reload()
 {
+	check_configuration_file_presense
 	update_js_challenge_templates
 	echo "Running live reconfiguration of Tempesta..."
 


### PR DESCRIPTION
**What**
Add a check for the existence of the configuration file before starting Tempesta FW.

**Why**
Currently when Tempesta FW is started without a configuration file, it produces confusing error messages instead of clearly indicating the root cause of the issue.

**Links**
[2278](https://github.com/tempesta-tech/tempesta/issues/2278)