### PR TITLE
Several `skb_fragment` and `ss_skb_data_ptr_by_offset`

### DIFF
--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -683,7 +683,7 @@ __skb_fragment(struct sk_buff *skb_head, struct sk_buff *skb, char *pspt,
 	 * advance the skb tail pointer.
 	 */
 	if (len > 0) {
-		offset = unlikely(offset == d_size) ? 0 :
+		offset = unlikely(d_size && offset == d_size) ? 0 :
 			pspt - (char *)skb_frag_address(&si->frags[0]);
 		if (unlikely(!offset)) {
 			if (!(ret = __split_try_tailroom(skb, len, it)))

--- a/fw/ss_skb.h
+++ b/fw/ss_skb.h
@@ -409,14 +409,13 @@ static inline char *
 ss_skb_data_ptr_by_offset(struct sk_buff *skb, unsigned int off)
 {
 	char *begin, *end;
-	unsigned long d;
 	unsigned char i;
 
 	if (skb_headlen(skb)) {
 		begin = skb->data;
 		end = begin + skb_headlen(skb);
 
-		if (begin + off <= end)
+		if (ss_skb_is_within_fragment(begin, begin + off, end))
 			return begin + off;
 		off -= skb_headlen(skb);
 	}
@@ -426,13 +425,11 @@ ss_skb_data_ptr_by_offset(struct sk_buff *skb, unsigned int off)
 
 		begin = skb_frag_address(f);
 		end = begin + skb_frag_size(f);
-		d = end - begin;
 
-		if (off > d) {
-			off -= d;
-			continue;
-		}
-		return begin + off;
+		if (ss_skb_is_within_fragment(begin, begin + off, end))
+			return begin + off;
+
+		off -= (end - begin);
 	}
 
 	return NULL;


### PR DESCRIPTION
- We should check that skb has linear part (d_size != 0) in `skb_fragment` because if it is not true, skb->data can points to incorrect place (for example address of skb fragment!) if this skb was previosly passed to `__split_linear_data`.
- Fix calculation of place to insert frame header in `ss_skb_data_ptr_by_offset`. If data points to the end of (linear data/fragment) we should use next (zero fragment/next fragment) not current one.