### PR TITLE
Fix: irqbalance warning

### DIFF
--- a/scripts/tfw_lib.sh
+++ b/scripts/tfw_lib.sh
@@ -292,13 +292,12 @@ tfw_set_net_queues()
 
 tfw_irqbalance_revert()
 {
-	systemctl status irqbalance.service >/dev/null
-	if [ $? -eq 0 -a -f $IRQB_CONF_PATH ]; then
+	if systemctl -q is-active irqbalance.service 2>/dev/null && [ -f $IRQB_CONF_PATH ]; then
 		echo "...revert irqbalance config"
 		perl -i.orig -ple '
 			s/^('"$BAN_CONF_VAR"'=).*$/$1/;
 		' $IRQB_CONF_PATH
-		systemctl restart irqbalance.service >/dev/null
+		systemctl restart irqbalance.service >/dev/null 2>&1 || true
 	fi
 }
 


### PR DESCRIPTION
**What**
Added systemd service availability check before attempting to modify and restart the irqbalance service during Tempesta FW shutdown.

Current behavior:

- If irqbalance is installed and running, the function works as before
- If irqbalance isn't installed or running, the function silently does nothing
- The script continues execution without errors either way

**Why**
Ubuntu 24.04 doesn't include irqbalance by default, causing error messages during Tempesta FW shutdown:
`Unit irqbalance.service could not be found.`

**Links**
[2258](https://github.com/tempesta-tech/tempesta/issues/2258)