### PR TITLE
Set proper `tcp_gso_segs` for skb with TLS TAG.

### DIFF
--- a/fw/tls.c
+++ b/fw/tls.c
@@ -341,9 +341,6 @@ tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int mss_now,
 	 * The last skb in our list will bring TLS tag - add it to end_seqno.
 	 * Otherwise (in worst case), a new skb was inserted to fit TLS tag
 	 * - fix end_seqno's for @skb_tail and this new skb.
-	 *
-	 * @limit = mss_now - tls_overhead, so {tso,tcp}_fragment() called from
-	 * tcp_write_xmit() should set proper skb->tcp_gso_segs.
 	 */
 	if (likely(skb_tail->next == next)) {
 		TCP_SKB_CB(skb_tail)->end_seq += TTLS_TAG_LEN;
@@ -351,6 +348,8 @@ tfw_tls_encrypt(struct sock *sk, struct sk_buff *skb, unsigned int mss_now,
 		/* A new frag is added to the end of the current skb. */
 		WARN_ON_ONCE(t_sz > skb_tail->truesize);
 		t_sz = skb_tail->truesize - t_sz;
+
+		tcp_set_skb_tso_segs(skb_tail, mss_now);
 	}
 	else {
 		struct sk_buff *tail_next = skb_tail->next;


### PR DESCRIPTION
Previosly we don't set `tcp_gso_segs` for skb with new added TLS TAG, because we assume that it will be set during `tso,tcp}_fragment()` from `tcp_write_xmit`. It is not correct, because skb with new added TLS TAG can be already produced during one of previous call of `tso,tcp}_fragment()`. In this case this skb has already set `tcp_gso_segs`. Later in the loop in `tcp_write_xmit` `tcp_init_tso_segs` skips such skbs if `tcp_gso_segs` > 1, but mss is same. Limit will be also greater then mss, because if `tcp_gso_segs` > 1, limit is recalculated. In this case we never set proper `tcp_gso_segs` (with taking into account new added TLS TAG), that leads to kernel BUG during call `tcp_shifted_skb`.
This BUG was hardly reproduced, because:
- it is not a usual case when TLS TAG is added to the skb, which was produced during call `tso,tcp}_fragment()`.
- `tcp_shifted_skb` is called very rarely from `tcp_shift_skb_data`. This two conditions were reproduced only on mtu 80 under heavy load.