### PR TITLE
Fix double adding 'age' header.

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -2181,7 +2181,8 @@ tfw_cache_copy_resp(TDB *db, TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 		    || (field->flags &
 			(TFW_STR_HBH_HDR | TFW_STR_NOCCPY_HDR
 			 | TFW_STR_TRAILER_HDR))
-		    || hid == TFW_HTTP_HDR_SERVER)
+		    || hid == TFW_HTTP_HDR_SERVER
+		    || hid == TFW_HTTP_HDR_AGE)
 		{
 			--ce->hdr_num;
 			continue;
@@ -2249,7 +2250,8 @@ tfw_cache_copy_resp(TDB *db, TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 			if ((!(field->flags & TFW_STR_TRAILER) &&
 			     !(field->flags & TFW_STR_TRAILER_AND_HDR)) ||
 			    (field->flags & TFW_STR_NOCCPY_HDR)
-			    || hid == TFW_HTTP_HDR_SERVER)
+			    || hid == TFW_HTTP_HDR_SERVER
+			    || hid == TFW_HTTP_HDR_AGE)
 				continue;
 
 			n = tfw_cache_h2_copy_hdr(db, ce, resp, hid, &p, &trec,
@@ -2444,7 +2446,8 @@ __cache_entry_size(TfwHttpResp *resp)
 		if (TFW_STR_EMPTY(hdr)
 		    || (hdr->flags & (TFW_STR_HBH_HDR | TFW_STR_NOCCPY_HDR |
 			TFW_STR_TRAILER_HDR))
-		    || hid == TFW_HTTP_HDR_SERVER)
+		    || hid == TFW_HTTP_HDR_SERVER
+		    || hid == TFW_HTTP_HDR_AGE)
 			continue;
 
 		/*

--- a/fw/http.h
+++ b/fw/http.h
@@ -217,6 +217,7 @@ typedef enum {
 	TFW_HTTP_HDR_IF_NONE_MATCH,
 	TFW_HTTP_HDR_ETAG = TFW_HTTP_HDR_IF_NONE_MATCH,
 	TFW_HTTP_HDR_X_TEMPESTA_CACHE,
+	TFW_HTTP_HDR_AGE,
 
 	/* End of list of singular header. */
 	TFW_HTTP_HDR_NONSINGULAR,
@@ -623,7 +624,7 @@ tfw_h2_pseudo_index(unsigned short status)
 static inline size_t
 tfw_http_req_header_table_size(void)
 {
-	return TFW_HTTP_HDR_RAW - TFW_HTTP_HDR_REGULAR - 2;
+	return TFW_HTTP_HDR_RAW - TFW_HTTP_HDR_REGULAR - 3;
 }
 
 static inline size_t

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -152,6 +152,7 @@ unsigned int
 tfw_http_msg_resp_spec_hid(const TfwStr *hdr)
 {
 	static const TfwHdrDef resp_hdrs[] = {
+		TfwStrDefV("age:",		TFW_HTTP_HDR_AGE),
 		TfwStrDefV("connection:",	TFW_HTTP_HDR_CONNECTION),
 		TfwStrDefV("content-encoding:", TFW_HTTP_HDR_CONTENT_ENCODING),
 		TfwStrDefV("content-length:",	TFW_HTTP_HDR_CONTENT_LENGTH),
@@ -225,6 +226,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 			[TFW_HTTP_HDR_CONTENT_LENGTH]	= SLEN("Content-Length:"),
 			[TFW_HTTP_HDR_CONTENT_LOCATION] = SLEN("Content-Location:"),
 			[TFW_HTTP_HDR_CONTENT_TYPE]	= SLEN("Content-Type:"),
+			[TFW_HTTP_HDR_AGE]		= SLEN("Age:"),
 			[TFW_HTTP_HDR_CONNECTION]	= SLEN("Connection:"),
 			[TFW_HTTP_HDR_EXPECT]		= SLEN("Expect:"),
 			[TFW_HTTP_HDR_X_FORWARDED_FOR]	= SLEN("X-Forwarded-For:"),

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -969,6 +969,7 @@ process_trailer_hdr(TfwHttpMsg *hm, TfwStr *hdr, unsigned int id)
 	case TFW_HTTP_HDR_CONTENT_ENCODING:
 	case TFW_HTTP_HDR_SET_COOKIE:
 	case TFW_HTTP_HDR_FORWARDED:
+	case TFW_HTTP_HDR_AGE:
 	case TFW_HTTP_HDR_CONNECTION:
 	case TFW_HTTP_HDR_UPGRADE:
 	case TFW_HTTP_HDR_CONTENT_LOCATION:
@@ -12467,7 +12468,8 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, unsigned int len,
 	}
 
 	/* 'Age:*OWS' is read, process field-value. */
-	__TFW_HTTP_PARSE_RAWHDR_VAL(Resp_HdrAgeV, resp, __resp_parse_age, 0);
+	__TFW_HTTP_PARSE_SPECHDR_VAL(Resp_HdrAgeV, resp, __resp_parse_age,
+				   TFW_HTTP_HDR_AGE, 0);
 
 	/* 'Cache-Control:*OWS' is read, process field-value. */
 	__TFW_HTTP_PARSE_RAWHDR_VAL(Resp_HdrCache_CtrlV, resp,


### PR DESCRIPTION
Previously Tempesta FW save 'age' header in cache
(if it is present in response). Then when Tempesta FW satisfy request from cache, Tempesta FW adds it's
onw 'age' header, so the result response contains
two 'age' header (that is mistake). This patch fixes this behaviour - now Tempesta FW doesn't save 'age' header in cache, but takes it into account during
building response from cache (during 'age' caclulation).