### PR TITLE
Fix double adding 'age' header.

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -4,7 +4,7 @@
  * HTTP cache (RFC 7234).
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -2147,7 +2147,8 @@ tfw_cache_copy_resp(TDB *db, TfwCacheEntry *ce, TfwHttpResp *resp, TfwStr *rph,
 		 */
 		if (TFW_STR_EMPTY(field)
 		    || (field->flags & (TFW_STR_HBH_HDR | TFW_STR_NOCCPY_HDR))
-		    || hid == TFW_HTTP_HDR_SERVER)
+		    || hid == TFW_HTTP_HDR_SERVER
+		    || hid == TFW_HTTP_HDR_AGE)
 		{
 			--ce->hdr_num;
 			continue;
@@ -2387,7 +2388,8 @@ __cache_entry_size(TfwHttpResp *resp)
 		 */
 		if (TFW_STR_EMPTY(hdr)
 		    || (hdr->flags & (TFW_STR_HBH_HDR | TFW_STR_NOCCPY_HDR))
-		    || hid == TFW_HTTP_HDR_SERVER)
+		    || hid == TFW_HTTP_HDR_SERVER
+		    || hid == TFW_HTTP_HDR_AGE)
 			continue;
 
 		if (hid == TFW_HTTP_HDR_TRANSFER_ENCODING)

--- a/fw/http.h
+++ b/fw/http.h
@@ -217,6 +217,7 @@ typedef enum {
 	TFW_HTTP_HDR_IF_NONE_MATCH,
 	TFW_HTTP_HDR_ETAG = TFW_HTTP_HDR_IF_NONE_MATCH,
 	TFW_HTTP_HDR_X_TEMPESTA_CACHE,
+	TFW_HTTP_HDR_AGE,
 
 	/* End of list of singular header. */
 	TFW_HTTP_HDR_NONSINGULAR,
@@ -621,7 +622,7 @@ tfw_h2_pseudo_index(unsigned short status)
 static inline size_t
 tfw_http_req_header_table_size(void)
 {
-	return TFW_HTTP_HDR_RAW - TFW_HTTP_HDR_REGULAR - 2;
+	return TFW_HTTP_HDR_RAW - TFW_HTTP_HDR_REGULAR - 3;
 }
 
 static inline size_t

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -152,6 +152,7 @@ unsigned int
 tfw_http_msg_resp_spec_hid(const TfwStr *hdr)
 {
 	static const TfwHdrDef resp_hdrs[] = {
+		TfwStrDefV("age:",		TFW_HTTP_HDR_AGE),
 		TfwStrDefV("connection:",	TFW_HTTP_HDR_CONNECTION),
 		TfwStrDefV("content-encoding:", TFW_HTTP_HDR_CONTENT_ENCODING),
 		TfwStrDefV("content-length:",	TFW_HTTP_HDR_CONTENT_LENGTH),
@@ -225,6 +226,7 @@ __http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val, bool client)
 			[TFW_HTTP_HDR_CONTENT_LENGTH]	= SLEN("Content-Length:"),
 			[TFW_HTTP_HDR_CONTENT_LOCATION] = SLEN("Content-Location:"),
 			[TFW_HTTP_HDR_CONTENT_TYPE]	= SLEN("Content-Type:"),
+			[TFW_HTTP_HDR_AGE]		= SLEN("Age:"),
 			[TFW_HTTP_HDR_CONNECTION]	= SLEN("Connection:"),
 			[TFW_HTTP_HDR_EXPECT]		= SLEN("Expect:"),
 			[TFW_HTTP_HDR_X_FORWARDED_FOR]	= SLEN("X-Forwarded-For:"),

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -965,6 +965,7 @@ process_trailer_hdr(TfwHttpMsg *hm, TfwStr *hdr, unsigned int id)
 	case TFW_HTTP_HDR_CONTENT_ENCODING:
 	case TFW_HTTP_HDR_SET_COOKIE:
 	case TFW_HTTP_HDR_FORWARDED:
+	case TFW_HTTP_HDR_AGE:
 		return CSTR_NEQ;
 	}
 
@@ -12353,7 +12354,8 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, unsigned int len,
 	}
 
 	/* 'Age:*OWS' is read, process field-value. */
-	__TFW_HTTP_PARSE_RAWHDR_VAL(Resp_HdrAgeV, resp, __resp_parse_age, 0);
+	__TFW_HTTP_PARSE_SPECHDR_VAL(Resp_HdrAgeV, resp, __resp_parse_age,
+				   TFW_HTTP_HDR_AGE, 0);
 
 	/* 'Cache-Control:*OWS' is read, process field-value. */
 	__TFW_HTTP_PARSE_RAWHDR_VAL(Resp_HdrCache_CtrlV, resp,

--- a/fw/t/unit/test_http1_parser.c
+++ b/fw/t/unit/test_http1_parser.c
@@ -647,9 +647,9 @@ TEST(http1_parser, fills_hdr_tbl_for_req)
 TEST(http1_parser, fills_hdr_tbl_for_resp)
 {
 	TfwHttpHdrTbl *ht;
-	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_age, *h_date, *h_exp;
+	TfwStr *h_dummy4, *h_dummy9, *h_cc, *h_date, *h_exp;
 	TfwStr *h_lastmodified, *h_pragma;
-	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka, h_etag;
+	TfwStr h_connection, h_conttype, h_srv, h_te, h_ka, h_etag, h_age;
 	TfwStr h_setcookie;
 
 	/* Expected values for special headers. */
@@ -668,7 +668,7 @@ TEST(http1_parser, fills_hdr_tbl_for_resp)
 	const char *s_exp = "Expires: Tue, 31 Jan 2012 15:02:53 GMT";
 	const char *s_ka = "timeout=600, max=65526";
 	/* Trailing spaces are stored within header strings. */
-	const char *s_age = "Age: 12  ";
+	const char *s_age = "12  ";
 	const char *s_date = "Date: Sun, 09 Sep 2001 01:46:40 GMT\t";
 	const char *s_lastmodified =
 		"Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT ";
@@ -730,21 +730,23 @@ TEST(http1_parser, fills_hdr_tbl_for_resp)
 		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_SET_COOKIE],
 					TFW_HTTP_HDR_SET_COOKIE,
 					&h_setcookie);
+		tfw_http_msg_srvhdr_val(&ht->tbl[TFW_HTTP_HDR_AGE],
+					TFW_HTTP_HDR_AGE,
+					&h_age);
 
 		/*
 		 * Common (raw) headers: 10 dummies, Cache-Control,
 		 * Expires, Age, Date.
 		 */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 16);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 15);
 
 		h_dummy4 = &ht->tbl[TFW_HTTP_HDR_RAW + 4];
 		h_cc = &ht->tbl[TFW_HTTP_HDR_RAW + 9];
 		h_dummy9 = &ht->tbl[TFW_HTTP_HDR_RAW + 10];
 		h_exp = &ht->tbl[TFW_HTTP_HDR_RAW + 11];
-		h_age = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
-		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
-		h_lastmodified = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
-		h_pragma = &ht->tbl[TFW_HTTP_HDR_RAW + 15];
+		h_date = &ht->tbl[TFW_HTTP_HDR_RAW + 12];
+		h_lastmodified = &ht->tbl[TFW_HTTP_HDR_RAW + 13];
+		h_pragma = &ht->tbl[TFW_HTTP_HDR_RAW + 14];
 
 		EXPECT_TFWSTR_EQ(&h_connection, s_connection);
 		EXPECT_TFWSTR_EQ(&h_conttype, s_ct);
@@ -753,12 +755,12 @@ TEST(http1_parser, fills_hdr_tbl_for_resp)
 		EXPECT_TFWSTR_EQ(&h_ka, s_ka);
 		EXPECT_TFWSTR_EQ(&h_etag, s_etag);
 		EXPECT_TFWSTR_EQ(&h_setcookie, s_setcookie);
+		EXPECT_TFWSTR_EQ(&h_age, s_age);
 
 		EXPECT_TFWSTR_EQ(h_dummy4, s_dummy4);
 		EXPECT_TFWSTR_EQ(h_cc, s_cc);
 		EXPECT_TFWSTR_EQ(h_dummy9, s_dummy9);
 		EXPECT_TFWSTR_EQ(h_exp, s_exp);
-		EXPECT_TFWSTR_EQ(h_age, s_age);
 		EXPECT_TFWSTR_EQ(h_date, s_date);
 		EXPECT_TFWSTR_EQ(h_lastmodified, s_lastmodified);
 		EXPECT_TFWSTR_EQ(h_pragma, s_pragma);
@@ -1920,6 +1922,16 @@ TEST(http1_parser, chunked_cut_len)
 		EXPECT_EQ(tfw_str_eolen(&resp->body), 2);
 	}
 
+	/* Header 'Age' is forbidden in trailers. */
+	EXPECT_BLOCK_RESP_SIMPLE("HTTP/1.1 200 OK\r\n"
+		 "Transfer-Encoding: chunked\r\n"
+		 "\r\n"
+		 "8\r\n"
+		 "abcdefgh\r\n"
+		 "0\r\n"
+		 "Age: 1\r\n"
+		 "\r\n");
+
 	/* Chunked response with trailer */
 	FOR_RESP("HTTP/1.1 200 OK\r\n"
 		 "Transfer-Encoding: chunked\r\n"
@@ -1927,7 +1939,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "8\r\n"
 		 "abcdefgh\r\n"
 		 "0\r\n"
-		 "Age: 1\r\n"
+		 "X-Token: value\r\n"
 		 "\r\n")
 	{
 		EXPECT_EQ(resp->cut.len, 8);
@@ -1954,7 +1966,7 @@ TEST(http1_parser, chunked_cut_len)
 		 "8\n"
 		 "abcdefgh\n"
 		 "0\r\n"
-		 "Age: 1\n"
+		 "X-Token: value\n"
 		 "\r\n")
 	{
 		EXPECT_EQ(resp->cut.len, 6);
@@ -2138,21 +2150,17 @@ TEST(http1_parser, transfer_encoding)
 		 "0\n"
 		 "Connection: keep-alive\r\n"
 		 "Pragma: no-cache\r\n"
-		 "Age: 2147483647\r\n"
 		 "\r\n")
 	{
 		EXPECT_TFWSTR_EQ(&resp->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION],
 				 "Connection: keep-alive");
 		EXPECT_TRUE(test_bit(TFW_HTTP_B_CONN_KA, resp->flags));
 		EXPECT_TRUE(resp->cache_ctl.flags & TFW_HTTP_CC_PRAGMA_NO_CACHE);
-		EXPECT_TRUE(resp->cache_ctl.age == 2147483647);
 
 		EXPECT_TRUE(test_bit(TFW_HTTP_B_CHUNKED_TRAILER, resp->flags));
 		EXPECT_TRUE(resp->h_tbl->tbl[TFW_HTTP_HDR_CONNECTION].flags
 			    & TFW_STR_TRAILER);
 		EXPECT_TRUE(resp->h_tbl->tbl[TFW_HTTP_HDR_RAW].flags
-			    & TFW_STR_TRAILER);
-		EXPECT_TRUE(resp->h_tbl->tbl[TFW_HTTP_HDR_RAW + 1].flags
 			    & TFW_STR_TRAILER);
 	}
 
@@ -3195,7 +3203,7 @@ TEST(http1_parser, resp_hop_by_hop)
 	{
 		ht = resp->h_tbl;
 		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -3218,7 +3226,7 @@ TEST(http1_parser, resp_hop_by_hop)
 	{
 		ht = resp->h_tbl;
 		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];
@@ -3242,7 +3250,7 @@ TEST(http1_parser, resp_hop_by_hop)
 	{
 		ht = resp->h_tbl;
 		/* Common (raw) headers: 16 total with 10 dummies. */
-		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 18);
+		EXPECT_EQ(ht->off, TFW_HTTP_HDR_RAW + 17);
 
 		for(id = 0; id < ht->off; ++id) {
 			field = &ht->tbl[id];


### PR DESCRIPTION
Previously Tempesta FW save 'age' header in cache
(if it is present in response). Then when Tempesta FW satisfy request from cache, Tempesta FW adds it's
onw 'age' header, so the result response contains
two 'age' header (that is mistake). This patch fixes this behaviour - now Tempesta FW doesn't save 'age' header in cache, but takes it into account during
building response from cache (during 'age' caclulation).