### PR TITLE
Fix several BUGs in hpack.c

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -10228,7 +10228,7 @@ __FSM_STATE(st, cold) {							\
 
 	__FSM_H2_TX_AF(Req_HdrPro, 'x', Req_HdrProx);
 	__FSM_H2_TX_AF(Req_HdrProx, 'y', Req_HdrProxy);
-	__FSM_H2_TX_AF(Req_HdrProxy, '_', Req_HdrProxy_);
+	__FSM_H2_TX_AF(Req_HdrProxy, '-', Req_HdrProxy_);
 	__FSM_H2_TX_AF(Req_HdrProxy_, 'c', Req_HdrProxy_C);
 	__FSM_H2_TX_AF(Req_HdrProxy_C, 'o', Req_HdrProxy_Co);
 	__FSM_H2_TX_AF(Req_HdrProxy_Co, 'n', Req_HdrProxy_Con);

--- a/fw/msg.h
+++ b/fw/msg.h
@@ -74,11 +74,11 @@ typedef struct {
  * @pos		- pointer to the currently allocated chunk of decoded headers'
  *		  buffer;
  * @rspace	- space remained in the allocated chunk;
- * @next	- pointer to the decoded header part (name/value) to be
- *		- parsed next;
  * @nm_len	- length of the decoded header's name;
  * @nm_num	- chunks number of the decoded header's name;
  * @tag		- tag of currently processed decoded header.
+ * @next	- number of chunk which points to the decoded header part
+ *		  (name/value) to be parsed next;
  */
 typedef struct {
 	TfwPool		*pool;
@@ -89,10 +89,10 @@ typedef struct {
 	TfwStr		hdr;
 	char		*pos;
 	unsigned long	rspace;
-	TfwStr		*next;
 	unsigned long	nm_len;
 	unsigned int	nm_num;
 	unsigned int	tag;
+	unsigned int	next;
 } TfwMsgParseIter;
 
 int tfw_msg_write(TfwMsgIter *it, const TfwStr *data);


### PR DESCRIPTION
- We should check return code of `tfw_hpack_exp_hdr` in `BUFFER_VAL_OPEN` and return error if allocation fails to prevent BUG.
- Save `it->next` before call `tfw_hpack_exp_hdr` in `tfw_hpack_huffman_write` and restore `it->next` after this call. There is a small chance that during `tfw_hpack_exp_hdr->tfw_str_add_compound->__str_grow_tree` new pages will be allocated in `__tfw_pool_realloc`. In this case all chunks in it->hdr will be moved and change there addresses, but it->next still points to the old chunk address! (This lead to BUG during processing header values later, when we iterate over all chunks from `it->next`. (See `__hpack_process_hdr_value`) This patch fixes this problem - now it->next not a pointer it is a number of chunk in `it->hdr`. The number of chunk is not changed during call `tfw_hpack_exp_hdr` so even if all chunks moved, the number is correct!.