### PR TITLE
Remove `__restrict` from tfw_hpack_rbuf_calc

### DIFF
--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -2927,9 +2927,9 @@ tfw_hpack_rbuf_iter(TfwHPackETbl *__restrict tbl,
 }
 
 static int
-tfw_hpack_rbuf_calc(TfwHPackETbl *__restrict tbl, unsigned short new_size,
+tfw_hpack_rbuf_calc(TfwHPackETbl *tbl, unsigned short new_size,
 		    TfwHPackNode *__restrict del_list[],
-		    TfwHPackETblIter *__restrict it)
+		    TfwHPackETblIter *it)
 {
 	int i = 0;
 	char *first = (char *)it->first;


### PR DESCRIPTION
Removed unnecessary `__restrict`, that hasn't effect on the function. Also `tbl` and `it` might points to the same tructure and this is legal and used in `tfw_hpack_set_rbuf_size()`