### PR TITLE
fix: call frang for non-tempesta socket [port 0.8]

### DIFF
--- a/fw/http_limits.c
+++ b/fw/http_limits.c
@@ -347,6 +347,9 @@ tfw_classify_conn_close(struct sock *sk)
 {
 	FrangAcc *ra = frang_acc_from_sk(sk);
 
+	if (unlikely(!sock_flag(sk, SOCK_TEMPESTA)))
+		return;
+
 	if(ra == NULL)
 		return;
 
@@ -1744,7 +1747,8 @@ tfw_classifier_cleanup_inport(void)
 static int
 tfw_classify_conn_estab(struct sock *sk, struct sk_buff *skb)
 {
-	if (test_bit(tfw_addr_get_sk_sport(sk), tfw_inports))
+	if (test_bit(tfw_addr_get_sk_sport(sk), tfw_inports)
+	    && sock_flag(sk, SOCK_TEMPESTA))
 		return frang_conn_new(sk, skb);
 
 	return T_OK;
@@ -1757,6 +1761,9 @@ tfw_classify_conn_estab(struct sock *sk, struct sk_buff *skb)
 static int
 tfw_classify_tcp(struct sock *sk, struct sk_buff *skb)
 {
+	/* Just a hint. Be careful calling not only for Tempesta's socket. */
+	if (!sock_flag(sk, SOCK_TEMPESTA))
+		return T_OK;
 	return T_OK;
 }
 


### PR DESCRIPTION
In `tfw_classify_conn_estab()` force Tempesta to call `frang_conn_new()` only for Tempesta's socket.