### PR TITLE
Fix kernel BUG in apm.c when tfw_apm_global_data is uninitialized (#2424)

### DIFF
--- a/fw/apm.c
+++ b/fw/apm.c
@@ -1047,8 +1047,12 @@ tfw_apm_stats(void *apmref, TfwPrcntlStats *pstats)
 int
 tfw_apm_stats_global(TfwPrcntlStats *pstats)
 {
-	BUG_ON(!tfw_apm_global_data);
-	return __tfw_apm_stats(tfw_apm_global_data, pstats);
+    if (!tfw_apm_global_data) {
+        pr_warn("tfw_apm: global data not initialized, skipping stats\n");
+        memset(pstats, 0, sizeof(*pstats));
+        return -ENODATA;
+    }
+    return __tfw_apm_stats(tfw_apm_global_data, pstats);
 }
 
 /*
@@ -2227,3 +2231,4 @@ tfw_apm_exit(void)
 {
 	tfw_mod_unregister(&tfw_apm_mod);
 }
+

--- a/fw/apm.c
+++ b/fw/apm.c
@@ -1,7 +1,7 @@
 /*
  *		Tempesta FW
  *
- * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1047,12 +1047,12 @@ tfw_apm_stats(void *apmref, TfwPrcntlStats *pstats)
 int
 tfw_apm_stats_global(TfwPrcntlStats *pstats)
 {
-    if (!tfw_apm_global_data) {
-        T_DBG("tfw_apm: global data not initialized, skipping stats\n");
-        memset(pstats, 0, sizeof(*pstats));
-        return -ENODATA;
-    }
-    return __tfw_apm_stats(tfw_apm_global_data, pstats);
+	if (!tfw_apm_global_data) {
+		T_DBG("tfw_apm: global data not initialized, skipping stats\n");
+		memset(pstats, 0, sizeof(*pstats));
+		return -ENODATA;
+	}
+	return __tfw_apm_stats(tfw_apm_global_data, pstats);
 }
 
 /*

--- a/fw/apm.c
+++ b/fw/apm.c
@@ -1048,7 +1048,7 @@ int
 tfw_apm_stats_global(TfwPrcntlStats *pstats)
 {
     if (!tfw_apm_global_data) {
-        pr_warn("tfw_apm: global data not initialized, skipping stats\n");
+        T_DBG("tfw_apm: global data not initialized, skipping stats\n");
         memset(pstats, 0, sizeof(*pstats));
         return -ENODATA;
     }
@@ -2231,4 +2231,3 @@ tfw_apm_exit(void)
 {
 	tfw_mod_unregister(&tfw_apm_mod);
 }
-

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1,4 +1,4 @@
-/**
+bug/**
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).

--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -1,4 +1,4 @@
-bug/**
+/**
  *		Tempesta FW
  *
  * Copyright (C) 2014 NatSys Lab. (info@natsys-lab.com).

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -150,16 +150,15 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	seq_printf(seq, "Percentiles\n");
 	for (i = TFW_PSTATS_IDX_ITH; i < ARRAY_SIZE(tfw_pstats_ith); ++i) {
 		seq_printf(seq, "%02d%%:\t%dms\n",
-				pstats.ith[i], pstats.val[i]);
+			   pstats.ith[i], pstats.val[i]);
 	}
 
-	skip_apm:
+skip_apm:
 
 	/* Ss statistics. */
 	SPRN("SS work queue full\t\t\t", ss.wq_full);
 	if (ss_stat) {
 		int cpu;
-
 		ss_get_stat(ss_stat);
 		seq_printf(seq, "SS work queues' sizes\t\t\t:");
 		for_each_online_cpu(cpu)

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2016-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2016-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -132,13 +132,13 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 
 	tfw_perfstat_collect(&stat);
 	ret = tfw_apm_stats_global(&pstats);
-	if(ret< 0){
+	if (ret < 0) {
 		seq_printf(seq, "Minimal response time\t\t: n/a\n");
 		seq_printf(seq, "Average response time\t\t: n/a\n");
 		seq_printf(seq, "Median  response time\t\t: n/a\n");
 		seq_printf(seq, "Percentiles\n");
 		for (i = TFW_PSTATS_IDX_ITH; i < ARRAY_SIZE(tfw_pstats_ith); ++i) {
-		seq_printf(seq, "%02d%%:\t n/a\n", tfw_pstats_ith[i]);
+			seq_printf(seq, "%02d%%:\t n/a\n", tfw_pstats_ith[i]);
 		}
 		goto skip_apm;
 	}
@@ -148,9 +148,10 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	SPRNED("Median  response time\t\t", pstats.val[TFW_PSTATS_IDX_P50]);
 	SPRNED("Maximum response time\t\t", pstats.val[TFW_PSTATS_IDX_MAX]);
 	seq_printf(seq, "Percentiles\n");
-	for (i = TFW_PSTATS_IDX_ITH; i < ARRAY_SIZE(tfw_pstats_ith); ++i)
+	for (i = TFW_PSTATS_IDX_ITH; i < ARRAY_SIZE(tfw_pstats_ith); ++i) {
 		seq_printf(seq, "%02d%%:\t%dms\n",
 				pstats.ith[i], pstats.val[i]);
+	}
 
 	skip_apm:
 

--- a/fw/procfs.c
+++ b/fw/procfs.c
@@ -108,37 +108,37 @@ tfw_perfstat_collect(TfwPerfStat *stat)
 static int
 tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 {
-#define SPRNE(m, e)  seq_printf(seq, m": %llu\n", e)
-#define SPRNED(m, e)  seq_printf(seq, m": %ums\n", e)
-#define SPRN(m, c)  seq_printf(seq, m": %llu\n", stat.c)
+#define SPRNE(m, e)	seq_printf(seq, m": %llu\n", e)
+#define SPRNED(m, e)	seq_printf(seq, m": %ums\n", e)
+#define SPRN(m, c)	seq_printf(seq, m": %llu\n", stat.c)
 
 	int i, ret;
 	TfwPerfStat stat = {0};
 	u64 serv_conn_active, serv_conn_sched;
 	SsStat *ss_stat = kmalloc(sizeof(SsStat) * num_online_cpus(),
-				GFP_KERNEL);
+				  GFP_KERNEL);
 	unsigned int val[T_PSZ] = { 0 };
 	TfwPrcntlStats pstats = {.val = val};
 
 	if (!ss_stat)
-    	T_WARN("Cannot allocate sync sockets statistics\n");
+		T_WARN("Cannot allocate sync sockets statistics\n");
 
 	if (health_stat_codes) {
 		stat.hm = kmalloc(tfw_hm_stats_size(health_stat_codes->ccnt),
-				GFP_KERNEL);
+				  GFP_KERNEL);
 		if (stat.hm)
 			tfw_hm_stats_clone(stat.hm, health_stat_codes);
 	}
 
 	tfw_perfstat_collect(&stat);
 	ret = tfw_apm_stats_global(&pstats);
-	if (ret < 0) {
+	if(ret< 0){
 		seq_printf(seq, "Minimal response time\t\t: n/a\n");
 		seq_printf(seq, "Average response time\t\t: n/a\n");
 		seq_printf(seq, "Median  response time\t\t: n/a\n");
 		seq_printf(seq, "Percentiles\n");
 		for (i = TFW_PSTATS_IDX_ITH; i < ARRAY_SIZE(tfw_pstats_ith); ++i) {
-			seq_printf(seq, "%02d%%:\t n/a\n", tfw_pstats_ith[i]);
+		seq_printf(seq, "%02d%%:\t n/a\n", tfw_pstats_ith[i]);
 		}
 		goto skip_apm;
 	}
@@ -149,22 +149,23 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	SPRNED("Maximum response time\t\t", pstats.val[TFW_PSTATS_IDX_MAX]);
 	seq_printf(seq, "Percentiles\n");
 	for (i = TFW_PSTATS_IDX_ITH; i < ARRAY_SIZE(tfw_pstats_ith); ++i)
-    	seq_printf(seq, "%02d%%:\t%dms\n",
-        	pstats.ith[i], pstats.val[i]);
+		seq_printf(seq, "%02d%%:\t%dms\n",
+				pstats.ith[i], pstats.val[i]);
 
 	skip_apm:
 
 	/* Ss statistics. */
 	SPRN("SS work queue full\t\t\t", ss.wq_full);
 	if (ss_stat) {
-    	int cpu;
+		int cpu;
+
 		ss_get_stat(ss_stat);
 		seq_printf(seq, "SS work queues' sizes\t\t\t:");
 		for_each_online_cpu(cpu)
-		seq_printf(seq, " %u", ss_stat[cpu].rb_wq_sz);
+			seq_printf(seq, " %u", ss_stat[cpu].rb_wq_sz);
 		seq_printf(seq, "\nSS backlog's sizes\t\t\t:");
 		for_each_online_cpu(cpu)
-		seq_printf(seq, " %u", ss_stat[cpu].backlog_sz);
+			seq_printf(seq, " %u", ss_stat[cpu].backlog_sz);
 		seq_printf(seq, "\n");
 		kfree(ss_stat);
 	} else {
@@ -189,13 +190,13 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 	SPRN("Client connection attempts\t\t", clnt.conn_attempts);
 	SPRN("Client established connections\t\t", clnt.conn_established);
 	SPRNE("Client connections active\t\t",
-			stat.clnt.conn_established - stat.clnt.conn_disconnects);
+	      stat.clnt.conn_established - stat.clnt.conn_disconnects);
 	SPRN("Client RX bytes\t\t\t\t", clnt.rx_bytes);
 	SPRN("Client max streams number exceeded\t", clnt.streams_num_exceeded);
 
 	/* Server related statistics. */
 	serv_conn_active = stat.serv.conn_established
-			- stat.serv.conn_disconnects;
+			   - stat.serv.conn_disconnects;
 	serv_conn_sched = serv_conn_active - stat.serv.conn_restricted;
 
 	SPRN("Server messages received\t\t", serv.rx_messages);
@@ -215,8 +216,8 @@ tfw_perfstat_seq_show(struct seq_file *seq, void *off)
 		seq_printf(seq, "Tempesta health statistics:\n");
 		for (i = 0; i < stat.hm->ccnt; ++i) {
 			seq_printf(seq, "\tHTTP '%d' code\t: %llu\n",
-			stat.hm->rsums[i].code,
-			stat.hm->rsums[i].total);
+				   stat.hm->rsums[i].code,
+				   stat.hm->rsums[i].total);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a kernel BUG triggered at apm.c:1050 when tfw_apm_global_data is not initialized.
Instead of crashing, the system now gracefully falls back to showing "n/a" for the APM stats in /proc output, similar to how SS statistics are handled.
Fixes: #2424
