### PR TITLE
refactor: optimize tfw current timestamp

### DIFF
--- a/lib/common.h
+++ b/lib/common.h
@@ -20,7 +20,30 @@
 #ifndef __LIB_COMMON_H__
 #define __LIB_COMMON_H__
 
-/* Get current timestamp in secs. */
+#include <linux/interrupt.h>
+
+#ifdef CONFIG_SECURITY_TEMPESTA
+/* Get current timestamp in secs.*/
+static inline long
+tfw_current_timestamp(void)
+{
+	/*
+	 * Use kernel-cached timestamp when in softirq context.
+	 * The timestamp is updated once per softirq batch in handle_softirqs().
+	 * This provides significant performance improvement by avoiding multiple
+	 * expensive ktime_get_real_ts64() calls per softirq batch.
+	 */
+	if (likely(in_serving_softirq()))
+		return softirq_current_timestamp();
+	
+	/* Fallback to direct call outside softirq context */
+	struct timespec64 ts;
+	ktime_get_real_ts64(&ts);
+	return ts.tv_sec;
+}
+
+#else
+/* Fallback implementation when Tempesta is not enabled */
 static inline long
 tfw_current_timestamp(void)
 {
@@ -28,5 +51,6 @@ tfw_current_timestamp(void)
 	ktime_get_real_ts64(&ts);
 	return ts.tv_sec;
 }
+#endif /* CONFIG_SECURITY_TEMPESTA */
 
 #endif /* __LIB_COMMON_H__ */


### PR DESCRIPTION
**What**
Optimize tfw_current_timestamp() to use kernel-level softirq timestamp caching. When in softirq context, use cached timestamp from softirq_current_timestamp() instead of calling expensive ktime_get_real_ts64() directly.

**Why**
Tempesta makes dozens of tfw_current_timestamp() calls per softirq batch, each executing expensive ktime_get_real_ts64(). This optimization leverages kernel-level caching (updated once per softirq batch) to significantly reduce CPU overhead in high-throughput scenarios while maintaining sufficient timestamp precision for Tempesta's use cases
**Links**
[Kernel patch](https://github.com/tempesta-tech/linux-6.12.12-tfw/pull/3)
[2275](https://github.com/tempesta-tech/tempesta/issues/2275)
