### PR TITLE
Fix kernel bugs in case of call `tcp_done`.

### DIFF
--- a/fw/http_frame.c
+++ b/fw/http_frame.c
@@ -698,13 +698,13 @@ tfw_h2_wnd_update_process(TfwH2Ctx *ctx)
 		if (*window > 0) {
 			if (ctx->sched.root.active_cnt) {
 				sock_set_flag(sk, SOCK_TEMPESTA_HAS_DATA);
-				sock_set_flag(sk, SOCK_TEMPESTA_IN_USE);
-				tcp_push_pending_frames(sk);
-				sock_reset_flag(sk, SOCK_TEMPESTA_IN_USE);
+				SS_IN_USE_PROTECT({
+					tcp_push_pending_frames(sk);
+				});
 			}
 		}
 
-		return likely(sk->sk_state != TCP_CLOSE) ? T_OK : sk->sk_err;
+		return likely(!ss_sock_is_closed(sk)) ? T_OK : sk->sk_err;
 	}
 
 fail:

--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -950,7 +950,7 @@ index 89163ef8c..49ad1ddc9 100644
  	union {
  		struct ip_options_rcu __rcu	*ireq_opt;
 diff --git a/include/net/sock.h b/include/net/sock.h
-index 261195598..f03d8b999 100644
+index 261195598..c7e9ffbcf 100644
 --- a/include/net/sock.h
 +++ b/include/net/sock.h
 @@ -506,6 +506,30 @@ struct sock {
@@ -993,10 +993,10 @@ index 261195598..f03d8b999 100644
 +	SOCK_TEMPESTA_HAS_DATA, /* The socket has data in Tempesta FW
 +				 * write queue.
 +				 */
-+	SOCK_TEMPESTA_IS_CLOSING, /* The socket is closing by Tempesta FW
-+				   * from `ss_do_close`. `tcp_done` should
-+				   * not be called from the kernel code.
-+				   */
++	SOCK_TEMPESTA_IN_USE, /* Currently socket is used by Tempesta FW.
++			       * `tcp_done` should not be called from the
++			       * kernel code.
++			       */
 +#endif
  };
  
@@ -1029,7 +1029,7 @@ index 261195598..f03d8b999 100644
  
  static inline struct dst_entry *
 diff --git a/include/net/tcp.h b/include/net/tcp.h
-index 7d66c61d2..f85ea9a2b 100644
+index 7d66c61d2..c14996e05 100644
 --- a/include/net/tcp.h
 +++ b/include/net/tcp.h
 @@ -307,6 +307,7 @@ bool tcp_check_oom(struct sock *sk, int shift);
@@ -1082,14 +1082,14 @@ index 7d66c61d2..f85ea9a2b 100644
 +	sk->sk_error_report(sk);
 +	tcp_write_queue_purge(sk);
 +	/*
-+	 * SOCK_TEMPESTA_IS_CLOSING is set from `ss_do_close`
-+	 * or `ss_do_shutdown` function from Tempesta FW code.
-+	 * We should not call `tcp_done` if error occurs during
-+	 * one of this function, just set socket state to TCP_CLOSE,
++	 * SOCK_TEMPESTA_IN_USE is set when function is called
++	 * from Tempesta FW code.
++	 * We should not call `tcp_done` if error occurs when
++	 * Tempesta FW uses socket, just set socket state to TCP_CLOSE,
 +	 * clear timers and socket write queue. Socket will be
-+	 * closed in one of this function.
++	 * closed later from Tempesta FW code.
 +	 */
-+	if (unlikely(sock_flag(sk, SOCK_TEMPESTA_IS_CLOSING))) {
++	if (unlikely(sock_flag(sk, SOCK_TEMPESTA_IN_USE))) {
 +		tcp_set_state(sk, TCP_CLOSE);
 +		tcp_clear_xmit_timers(sk);
 +	} else {


### PR DESCRIPTION
We call `tcp_push_pending_frames` from Tempesta FW directly in `ss_do_send/ss_do_close/ss_do_shutdown` functions and during WINDOW_UPDATE frame processing if HTTP2 window became greater then zero. In all this cases `tcp_done` should not be called in case of error in `tcp_push_pending_frames`. To prevent it we set special flag `SOCK_TEMPESTA_IN_USE`, when this flag is set `tw_handle_error` hust set socket state to TCP_CLOSE and clear xmit timers not call `tcp_done`. Later Tempesta FW checks socket state and if it is `TCP_CLOSE` close socket and drop connection.

Closes #2443