### PR TITLE
Remove unnecessary call of `tfw_hpack_exp_hdr`.

### DIFF
--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -330,7 +330,6 @@ do {								\
 do {								\
 	(it)->hdr.data = (it)->pos;				\
 	(it)->hdr.len = 0;					\
-	(it)->next = 0;						\
 } while (0)
 
 #define	BUFFER_NAME_OPEN(length)				\
@@ -374,14 +373,9 @@ do {								\
 		r = tfw_hpack_buffer_get(it, len, false);	\
 		if (unlikely(r))				\
 			goto out;				\
-		if (!TFW_STR_EMPTY(&it->hdr)) {			\
-			r = tfw_hpack_exp_hdr(req->pool, 0, it); \
-			if (unlikely(r))			\
-				return r;			\
-			it->next = it->hdr.nchunks - 1;		\
-		} else	{					\
-			BUFFER_HDR_INIT(it);			\
-		}						\
+								\
+		TFW_STR_INIT(&it->hdr);				\
+		BUFFER_HDR_INIT(it);				\
 	}							\
 } while (0)
 
@@ -393,7 +387,6 @@ __hpack_process_hdr_name(TfwHttpReq *req)
 	const TfwStr *hdr = &it->hdr;
 	int ret = -EINVAL;
 
-	WARN_ON_ONCE(it->next != 0);
 	TFW_STR_FOR_EACH_CHUNK(c, hdr, end) {
 		bool last = c + 1 == end;
 
@@ -411,23 +404,15 @@ __hpack_process_hdr_value(TfwHttpReq *req)
 	const TfwStr *chunk, *end;
 	TfwMsgParseIter *it = &req->pit;
 	const TfwStr *hdr = &it->hdr;
-	const TfwStr *next = TFW_STR_CHUNK(hdr, it->next);
 	int ret = -EINVAL;
 
 	BUG_ON(TFW_STR_DUP(hdr));
 	if (TFW_STR_PLAIN(hdr)) {
-		WARN_ON_ONCE(hdr != next);
 		chunk = hdr;
 		end = hdr + 1;
 	} else {
-		/*
-		 * In case of compound @hdr the @next can point either to the
-		 * @hdr itself (if only header's value has been Huffman-decoded,
-		 * i.e. in case of indexed or raw header's name), or to some
-		 * chunk inside the @hdr (if both, the name and the value, has
-		 * been Huffman-decoded).
-		 */
-		chunk = (hdr != next) ? next : next->chunks;
+
+		chunk = hdr->chunks;
 		end = hdr->chunks + hdr->nchunks;
 	}
 

--- a/fw/msg.h
+++ b/fw/msg.h
@@ -94,7 +94,6 @@ typedef struct {
 	unsigned int	to_alloc;
 	unsigned int	nm_num;
 	unsigned int	tag;
-	unsigned int	next;
 	TfwStr		hdr;
 } TfwMsgParseIter;
 


### PR DESCRIPTION
There is no sence to call `tfw_hpack_exp_hdr` in `BUFFER_VAL_OPEN` macros, we should just reinit `it->hdr`. Old descriptors in `it->hdr` for header's name can be just forgotten as they are not needed any more, since the name is parsed by now, and all necessary information is already in `it->parsed_hdr`. Removing the extra tfw_hpack_exp_hdr` call has two advantages:
- We can reduce size of `TfwMsgParseIter` structure.
- Intersection between of usage `req->pool` in `tfw_hpack_exp_hdr` and during `it->parsed_hdr` allocation can lead to memory reallocation in `tfw_pool_alloc_np`.