### PR TITLE
Rework restoring `req->method` from hpack dynamic table.

### DIFF
--- a/fw/hpack.c
+++ b/fw/hpack.c
@@ -1363,23 +1363,14 @@ tfw_hpack_hdr_set(TfwHPack *__restrict hp, TfwHttpReq *__restrict req,
 done:
 	switch (entry->tag) {
 	case TFW_TAG_HDR_H2_METHOD:
+		parser->_hdr_tag = TFW_HTTP_HDR_H2_METHOD;
 		if (hp->index == 2) {
 			req->method = TFW_HTTP_METH_GET;
 		} else if (hp->index == 3) {
 			req->method = TFW_HTTP_METH_POST;
 		} else {
-			/*
-			 * We would end up here while processing
-			 * 'Indexed Header Field' hdr, which points
-			 * to an entry in dynamic HPACK table.
-			 * This entry must has been previously populated
-			 * by 'Literal Header Field with Incremental Indexing'
-			 * hdr parsing and dynamic table update.
-			 * RFC 7541 6.2.1
-			 * */
-			req->method = tfw_http_meth_str2id(s_hdr);
+			h2_set_method(req, &entry->cstate);
 		}
-		parser->_hdr_tag = TFW_HTTP_HDR_H2_METHOD;
 		break;
 	case TFW_TAG_HDR_H2_SCHEME:
 		parser->_hdr_tag = TFW_HTTP_HDR_H2_SCHEME;

--- a/fw/hpack.h
+++ b/fw/hpack.h
@@ -152,6 +152,7 @@ typedef enum {
  */
 typedef struct {
 	union {
+		unsigned char	method;
 		unsigned char	accept_text_html;
 		long		if_msince_date;
 		unsigned long	authority_port;

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -162,6 +162,7 @@ void tfw_idx_hdr_parse_host_port(TfwHttpReq *req, TfwStr *hdr);
 void h2_set_hdr_accept(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 int h2_set_hdr_if_mod_since(TfwHttpReq *req,
                             const TfwCachedHeaderState *cstate);
+void h2_set_method(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_authority(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_if_nmatch(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_cache_control(TfwHttpReq *req,
@@ -178,5 +179,5 @@ void h2_set_hdr_x_method_override(TfwHttpReq *req,
 void h2_set_hdr_pragma(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_referer(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_cookie(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
-unsigned char tfw_http_meth_str2id(const TfwStr *m_hdr);
+
 #endif /* __TFW_HTTP_PARSER_H__ */


### PR DESCRIPTION
Previously we use `tfw_http_meth_strid` to restore req->method from hpack dynamic table, but this function was uneffective and wrong. Moreover we should not use this function at all - when we restore some other `req` fields from hpack dynamic table we use `parser->cstate`, and we should use it for restoring `method` field also.

Closes #2362