### PR TITLE
Optimize tfw_current_timestamp() with per-CPU caching

### DIFF
--- a/fw/access_log.c
+++ b/fw/access_log.c
@@ -298,9 +298,8 @@ do_access_log_req_mmap(TfwHttpReq *req, u16 resp_status,
 		room_size -= sizeof(val);		\
 	} while (0)
 
-	ktime_get_real_ts64(&ts);
-
-	event->timestamp = ts.tv_sec * 1000 + ts.tv_nsec/1000000;
+	tfw_current_timestamp_ts64(&ts);
+	event->timestamp = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 	event->type = TFW_MMAP_LOG_TYPE_ACCESS;
 	event->fields = TFW_MMAP_LOG_ALL_FIELDS_MASK; /* Enable all the fields */
 

--- a/lib/common.h
+++ b/lib/common.h
@@ -20,13 +20,37 @@
 #ifndef __LIB_COMMON_H__
 #define __LIB_COMMON_H__
 
-/* Get current timestamp in secs. */
+#include <linux/percpu.h>
+#include <linux/time.h>
+
+static DEFINE_PER_CPU(struct timespec64, tfw_cached_ts);
+static DEFINE_PER_CPU(unsigned long, tfw_ts_last_update);
+
+#define TFW_TS_REFRESH_INTERVAL (HZ)
+
+/**
+ * Get current timestamp in seconds.
+ * Uses cached value if available and not stale when in softirq context.
+ */
 static inline long
 tfw_current_timestamp(void)
 {
-	struct timespec64 ts;
-	ktime_get_real_ts64(&ts);
-	return ts.tv_sec;
+	if (likely(in_serving_softirq())) {
+		struct timespec64 *cached_ts = this_cpu_ptr(&tfw_cached_ts);
+		unsigned long *last_update = this_cpu_ptr(&tfw_ts_last_update);
+		unsigned long now = jiffies;
+		
+		if (unlikely(time_after(now, *last_update + TFW_TS_REFRESH_INTERVAL))) {
+			ktime_get_real_ts64(cached_ts);
+			*last_update = now;
+		}
+		
+		return cached_ts->tv_sec;
+	} else {
+		struct timespec64 ts;
+		ktime_get_real_ts64(&ts);
+		return ts.tv_sec;
+	}
 }
 
 #endif /* __LIB_COMMON_H__ */

--- a/tls/tls_cli.c
+++ b/tls/tls_cli.c
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2018 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,6 +25,7 @@
 #if 0 /* TODO #769 Full TLS proxying */
 
 #include "debug.h"
+#include "lib/common.h"
 #include "ttls.h"
 #include "tls_internal.h"
 
@@ -418,7 +419,7 @@ static int ssl_generate_random(TlsCtx *ssl)
 	unsigned char *p = ssl->handshake->randbytes;
 	long t;
 
-	t = ttls_time();
+	t = tfw_current_timestamp();
 	*p++ = (unsigned char)(t >> 24);
 	*p++ = (unsigned char)(t >> 16);
 	*p++ = (unsigned char)(t >>  8);
@@ -965,7 +966,7 @@ static int ssl_parse_server_hello(TlsCtx *ssl)
 	{
 		ssl->state++;
 		ssl->handshake->resume = 0;
-		ssl->session_negotiate->start = ttls_time();
+		ssl->session_negotiate->start = tfw_current_timestamp();
 		ssl->session_negotiate->ciphersuite = i;
 		ssl->session_negotiate->compression = comp;
 		ssl->session_negotiate->id_len = n;

--- a/tls/tls_internal.h
+++ b/tls/tls_internal.h
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -397,12 +397,8 @@ ttls_rnd(void *buf, size_t len)
 	memset(buf, 0x55, len);
 }
 
-unsigned long ttls_time_debug(void);
-
-#define ttls_time()		ttls_time_debug()
 
 #else
-#define ttls_time()		get_seconds()
 /*
  * CPUs since Intel Ice Lake are safe against SRBDS attack, so we're good
  * with the hardware random generator.

--- a/tls/tls_srv.c
+++ b/tls/tls_srv.c
@@ -24,6 +24,7 @@
  */
 #include "debug.h"
 #include "lib/str.h"
+#include "lib/common.h"
 #include "ecp.h"
 #include "mpool.h"
 #include "tls_internal.h"
@@ -1311,7 +1312,7 @@ ttls_write_server_hello(TlsCtx *tls, struct sg_table *sgt,
 	T_DBG("server hello, chosen version %d:%d, buf=%pK\n",
 	      buf[4], buf[5], buf);
 
-	*(unsigned int *)p = htonl(ttls_time());
+	*(unsigned int *)p = htonl(tfw_current_timestamp());
 	p += 4;
 	ttls_rnd(p, 28);
 	p += 28;
@@ -1325,7 +1326,7 @@ ttls_write_server_hello(TlsCtx *tls, struct sg_table *sgt,
 		 */
 		tls->state = TTLS_SERVER_CERTIFICATE;
 
-		tls->sess.start = ttls_time();
+		tls->sess.start = tfw_current_timestamp();
 
 		if (tls->hs->new_session_ticket) {
 			tls->sess.id_len = n = 0;

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -357,7 +357,7 @@ ttls_tickets_configure(TlsPeerCfg *cfg, unsigned long lifetime,
 	}
 
 	timer_setup(&tcfg->timer, ttls_ticket_rotate_keys, 0);
-	tfw_current_timestamp_ts64(&ts);
+	tfw_current_timestamp_real(&ts);
 	secs = tcfg->lifetime - (ts.tv_sec % tcfg->lifetime);
 	mod_timer(&tcfg->timer, jiffies + msecs_to_jiffies(secs * 1000));
 

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -74,7 +74,16 @@ ttls_ticket_get_time(unsigned long lifetime)
 	struct timespec64 ts;
 	unsigned long ts_sec;
 
-	tfw_current_timestamp_real(&ts);
+	/*
+	 * This function is called from both process context
+	 * (ttls_tickets_configure) and softirq context
+	 * (ttls_ticket_rotate_keys timer callback).
+	 */
+	if (in_softirq()) {
+		tfw_current_timestamp_ts64(&ts);
+	} else {
+		tfw_current_timestamp_real(&ts);
+	}
 	ts_sec = ts.tv_sec;
 	ts_sec -= ts_sec % lifetime;
 

--- a/tls/tls_ticket.c
+++ b/tls/tls_ticket.c
@@ -71,7 +71,7 @@ const char *ticket_key_name_iv =
 static inline unsigned long
 ttls_ticket_get_time(unsigned long lifetime)
 {
-	unsigned long ts = tfw_current_timestamp();
+	unsigned long ts = tfw_current_timestamp_real().tv_sec;
 
 	ts -= ts % lifetime;
 
@@ -192,7 +192,7 @@ ttls_ticket_rotate_keys(struct timer_list *t)
 	 * and callback will fire at different time on different Tempesta
 	 * nodes. To avoid it need to recalculate timer every time.
 	 */
-	secs = tcfg->lifetime - (tfw_current_timestamp() % tcfg->lifetime);
+	secs = tcfg->lifetime - (tfw_current_timestamp_real().tv_sec % tcfg->lifetime);
 	mod_timer(&tcfg->timer, jiffies + msecs_to_jiffies(secs * 1000));
 }
 
@@ -351,7 +351,7 @@ ttls_tickets_configure(TlsPeerCfg *cfg, unsigned long lifetime,
 	}
 
 	timer_setup(&tcfg->timer, ttls_ticket_rotate_keys, 0);
-	secs = tcfg->lifetime - (tfw_current_timestamp() % tcfg->lifetime);
+	secs = tcfg->lifetime - (tfw_current_timestamp_real().tv_sec % tcfg->lifetime);
 	mod_timer(&tcfg->timer, jiffies + msecs_to_jiffies(secs * 1000));
 
 err:

--- a/tls/ttls.c
+++ b/tls/ttls.c
@@ -8,7 +8,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2849,15 +2849,6 @@ ttls_alpn_ext_eq(const ttls_alpn_proto *proto, const unsigned char *buf,
 	return !memcmp_fast(proto->name, buf, len);
 }
 
-#if DBG_TLS >= 3
-unsigned long
-ttls_time_debug(void)
-{
-	static atomic64_t curr_time = ATOMIC_INIT(0);
-
-	return atomic64_inc_return(&curr_time);
-}
-#endif
 
 static void
 ttls_exit(void)

--- a/tls/x509.c
+++ b/tls/x509.c
@@ -15,7 +15,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "debug.h"
+#include "lib/common.h"
 #include "ttls.h"
 #include "asn1.h"
 #include "oid.h"
@@ -709,7 +710,7 @@ x509_get_current_time(ttls_x509_time *now)
 {
 	struct tm t;
 
-	time64_to_tm(ttls_time(), 0, &t);
+	time64_to_tm(tfw_current_timestamp(), 0, &t);
 
 	now->year = t.tm_year + 1900;
 	now->mon  = t.tm_mon  + 1;

--- a/tls/x509.c
+++ b/tls/x509.c
@@ -709,8 +709,10 @@ static void
 x509_get_current_time(ttls_x509_time *now)
 {
 	struct tm t;
+	struct timespec64 ts;
 
-	time64_to_tm(tfw_current_timestamp(), 0, &t);
+	tfw_current_timestamp_real(&ts);
+	time64_to_tm(ts.tv_sec, 0, &t);
 
 	now->year = t.tm_year + 1900;
 	now->mon  = t.tm_mon  + 1;


### PR DESCRIPTION
  Replace heavyweight ktime_get_real_ts64() calls with per-CPU cached
  timestamps during softirq processing. Cache is refreshed every second
  and uses atomic jiffies snapshot for consistency.