### PR TITLE
fix: FPU state corruption[port 0.8]

### DIFF
--- a/tls/pkparse.c
+++ b/tls/pkparse.c
@@ -6,7 +6,7 @@
  * Based on mbed TLS, https://tls.mbed.org.
  *
  * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -400,13 +400,13 @@ pk_parse_key_pkcs1_der(TlsRSACtx *rsa, const unsigned char *key, size_t keylen)
 {
 	int r;
 
-	kernel_fpu_begin();
 	local_bh_disable();
+	kernel_fpu_begin();
 
 	r = __parse_key_pkcs1_der(rsa, key, keylen);
 
-	local_bh_enable();
 	kernel_fpu_end();
+	local_bh_enable();
 
 	return r;
 }


### PR DESCRIPTION
Store fpu context only when BH has been disabled and restore before enabling BH. Otherwise we may have
dobule call of `kernel_fpu_begin()`, it may happens in following case:
```
1) kernel_fpu_begin();
2) local_bh_disable();
3) do_something();
4) local_bh_enable();
5) kernel_fpu_end();
```
In line (4) `local_bh_enable()` may call softIRQ
handler that will call `kernel_fpu_begin()` before calling paired `kernel_fpu_end()` in line (5).