### PR TITLE
2466: Add ability to specify clickhouse database name for tfw_logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ debian
 # logger
 logger/tfw_logger
 logger/clickhouse-cpp
+logger/t/tfw_logger_tests

--- a/etc/tempesta_fw.conf
+++ b/etc/tempesta_fw.conf
@@ -1429,6 +1429,7 @@
 #         "port": 9000,
 #         "user": "default",
 #         "password": "",
+#         "db_name": "default",
 #         "table_name": "access_log",
 #         "max_events": 1000,
 #         "max_wait_ms": 100
@@ -1442,6 +1443,7 @@
 #   - clickhouse.port: ClickHouse server port (default: 9000)
 #   - clickhouse.user: ClickHouse username (optional)
 #   - clickhouse.password: ClickHouse password (optional)
+#   - clickhouse.db_name: ClickHouse database name (default: "default")
 #   - clickhouse.table_name: ClickHouse table name (default: "access_log")
 #   - clickhouse.max_events: Maximum events before forced commit (default: 1000)
 #   - clickhouse.max_wait_ms: Maximum wait time in ms before commit (default: 100)

--- a/etc/tfw_logger.json
+++ b/etc/tfw_logger.json
@@ -6,6 +6,7 @@
         "port": 9000,
         "user": "default",
         "password": "",
+        "db_name": "default",
         "table_name": "access_log",
         "max_events": 1000,
         "max_wait_ms": 100

--- a/logger/clickhouse.cc
+++ b/logger/clickhouse.cc
@@ -51,6 +51,7 @@ TfwClickhouse::TfwClickhouse(const ClickHouseConfig &config,
 	auto opts = clickhouse::ClientOptions();
 
 	opts.SetHost(config.host);
+	opts.SetPort(config.port);
 	opts.SetDefaultDatabase(config.db_name);
 
 	if (const auto user = config.user.value_or(""); !user.empty())

--- a/logger/clickhouse_config.cc
+++ b/logger/clickhouse_config.cc
@@ -1,0 +1,94 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2024-2025 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include "clickhouse_config.hh"
+
+#include <regex>
+#include <stdexcept>
+
+#include <boost/property_tree/ptree.hpp>
+
+namespace {
+
+void
+validate_table_name(const std::string &table_name)
+{
+	// Check length limit (ClickHouse uses filesystem, 128 should be enough)
+	if (table_name.length() > 128) {
+		throw std::runtime_error("Table name is too long (max 128 characters): " +
+					 table_name);
+	}
+
+	// Check for allowed characters only: A-Z, a-z, 0-9, _
+	static const std::regex valid_name_regex("^[A-Za-z0-9_]+$");
+	if (!std::regex_match(table_name, valid_name_regex)) {
+		throw std::runtime_error("Table name contains invalid characters. "
+					 "Only A-Z, a-z, 0-9, and _ are allowed: " +
+					 table_name);
+	}
+}
+
+} // anonymous namespace
+
+void
+ClickHouseConfig::validate() const
+{
+	if (host.empty())
+		throw std::runtime_error("ClickHouse host cannot be empty");
+
+	if (port == 0)
+		throw std::runtime_error("Invalid ClickHouse port");
+
+	if (db_name.empty())
+		throw std::runtime_error(
+		"ClickHouse database name cannot be empty");
+
+	if (table_name.empty())
+		throw std::runtime_error(
+		"ClickHouse table name cannot be empty");
+
+	if (max_events == 0)
+		throw std::runtime_error("max_events must be greater than 0");
+
+	if (max_wait < std::chrono::milliseconds::zero())
+		throw std::runtime_error("max_wait must be non-negative");
+
+	validate_table_name(table_name);
+}
+
+void
+ClickHouseConfig::parse_from_ptree(const boost::property_tree::ptree &tree)
+{
+	host = tree.get<std::string>("host", host);
+	port = tree.get<uint16_t>("port", port);
+	db_name = tree.get<std::string>("db_name", db_name);
+	table_name = tree.get<std::string>("table_name", table_name);
+	max_events = tree.get<size_t>("max_events", max_events);
+
+	const auto max_wait_ms =
+		tree.get<int64_t>("max_wait_ms", max_wait.count());
+	max_wait = std::chrono::milliseconds(max_wait_ms);
+
+	if (const auto val = tree.get_optional<std::string>("user"))
+		user = *val;
+
+	if (const auto val = tree.get_optional<std::string>("password"))
+		password = *val;
+}

--- a/logger/clickhouse_config.hh
+++ b/logger/clickhouse_config.hh
@@ -24,6 +24,8 @@
 #include <optional>
 #include <string>
 
+#include <boost/property_tree/ptree_fwd.hpp>
+
 #include <fmt/format.h>
 
 struct ClickHouseConfig {
@@ -37,6 +39,12 @@ struct ClickHouseConfig {
 	size_t max_events{1000};
 	// Max time before commit
 	std::chrono::milliseconds max_wait{100};
+
+	void
+	parse_from_ptree(const boost::property_tree::ptree &tree);
+
+	void
+	validate() const;
 };
 
 template <> struct fmt::formatter<ClickHouseConfig> {
@@ -50,15 +58,13 @@ template <> struct fmt::formatter<ClickHouseConfig> {
 	constexpr decltype(auto)
 	format(const ClickHouseConfig &config, FormatContext &ctx)
 	{
-		static constexpr auto msg_template =
-			"{{host: '{}',"
-			" port: {},"
-			" database: '{}',"
-			" table: '{}',"
-			" user: '{}',"
-			" max_events: {},"
-			" max_wait: {}ms}}";
-
+		constexpr auto msg_template = "{{host: '{}',"
+					      " port: {},"
+					      " database: '{}',"
+					      " table: '{}',"
+					      " user: '{}',"
+					      " max_events: {},"
+					      " max_wait: {}ms}}";
 		return fmt::format_to(ctx.out(),
 				      msg_template,
 				      config.host,

--- a/logger/clickhouse_config.hh
+++ b/logger/clickhouse_config.hh
@@ -1,0 +1,72 @@
+/**
+ *		Tempesta FW
+ *
+ * Copyright (C) 2024-2025 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+#include <fmt/format.h>
+
+struct ClickHouseConfig {
+	std::string host{"localhost"};
+	uint16_t port{9000};
+	std::string db_name{"default"};
+	std::string table_name{"access_log"};
+	std::optional<std::string> user;
+	std::optional<std::string> password;
+	// Events before forcing commit
+	size_t max_events{1000};
+	// Max time before commit
+	std::chrono::milliseconds max_wait{100};
+};
+
+template <> struct fmt::formatter<ClickHouseConfig> {
+	constexpr decltype(auto)
+	parse(fmt::format_parse_context &ctx)
+	{
+		return ctx.begin();
+	}
+
+	template <typename FormatContext>
+	constexpr decltype(auto)
+	format(const ClickHouseConfig &config, FormatContext &ctx)
+	{
+		static constexpr auto msg_template =
+			"{{host: '{}',"
+			" port: {},"
+			" database: '{}',"
+			" table: '{}',"
+			" user: '{}',"
+			" max_events: {},"
+			" max_wait: {}ms}}";
+
+		return fmt::format_to(ctx.out(),
+				      msg_template,
+				      config.host,
+				      config.port,
+				      config.db_name,
+				      config.table_name,
+				      config.user.value_or("<none>"),
+				      config.max_events,
+				      config.max_wait.count());
+	}
+};

--- a/logger/t/Makefile
+++ b/logger/t/Makefile
@@ -27,7 +27,7 @@ LDFLAGS += $(shell pkgconf --libs spdlog)
 LDFLAGS += -lboost_filesystem -lboost_system
 LDFLAGS += -pthread
 
-PARENT_SRCS := ../tfw_logger_config.cc ../pidfile.cc
+PARENT_SRCS := ../tfw_logger_config.cc ../pidfile.cc ../clickhouse_config.cc
 PARENT_OBJS := $(PARENT_SRCS:.cc=.o)
 
 TEST_SRCS := test_config.cc test_pidfile.cc

--- a/logger/tfw_logger_config.cc
+++ b/logger/tfw_logger_config.cc
@@ -33,8 +33,6 @@ TfwLoggerConfig::parse_from_ptree(const pt::ptree &tree)
 	if (const auto val = tree.get_optional<std::string>("log_path"))
 		log_path = *val;
 
-	buffer_size = tree.get<size_t>("buffer_size", buffer_size);
-
 	if (const auto node = tree.get_child_optional("clickhouse"))
 		clickhouse.parse_from_ptree(*node);
 }
@@ -42,10 +40,6 @@ TfwLoggerConfig::parse_from_ptree(const pt::ptree &tree)
 void
 TfwLoggerConfig::validate() const
 {
-	if (buffer_size < MIN_BUFFER_SIZE)
-		throw std::runtime_error("Buffer size must be at least " +
-					 std::to_string(MIN_BUFFER_SIZE) +
-					 " bytes (one memory page)");
 	clickhouse.validate();
 }
 

--- a/logger/tfw_logger_config.cc
+++ b/logger/tfw_logger_config.cc
@@ -75,6 +75,8 @@ TfwLoggerConfig::parse_from_ptree(const pt::ptree &tree)
 		    ch_node->get<std::string>("host", clickhouse_.host);
 		clickhouse_.port =
 		    ch_node->get<uint16_t>("port", clickhouse_.port);
+		clickhouse_.db_name = ch_node->get<std::string>(
+		    "db_name", clickhouse_.db_name);
 		clickhouse_.table_name = ch_node->get<std::string>(
 		    "table_name", clickhouse_.table_name);
 
@@ -108,6 +110,9 @@ TfwLoggerConfig::parse_from_ptree(const pt::ptree &tree)
 
 	if (clickhouse_.port == 0)
 		throw std::runtime_error("Invalid ClickHouse port");
+
+	if (clickhouse_.db_name.empty())
+		throw std::runtime_error("ClickHouse database name cannot be empty");
 
 	if (clickhouse_.table_name.empty())
 		throw std::runtime_error("ClickHouse table name cannot be empty");

--- a/logger/tfw_logger_config.hh
+++ b/logger/tfw_logger_config.hh
@@ -25,7 +25,9 @@
 #include <optional>
 #include <string>
 
-#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
+
+#include "clickhouse_config.hh"
 
 namespace fs = std::filesystem;
 
@@ -38,23 +40,6 @@ namespace fs = std::filesystem;
 class TfwLoggerConfig
 {
 public:
-	struct ClickHouseConfig {
-		// ClickHouse server hostname
-		std::string host{"localhost"};
-		// ClickHouse native protocol port
-		uint16_t port{9000};
-		// ClickHouse table name
-		std::string table_name{"access_log"};
-		// Optional username
-		std::optional<std::string> user;
-		// Optional password
-		std::optional<std::string> password;
-		// Events before forcing commit
-		size_t max_events{1000};
-		// Max time before commit
-		std::chrono::milliseconds max_wait{100};
-	};
-
 	/**
 	 * Default constructor.
 	 */
@@ -120,6 +105,12 @@ public:
 	override_clickhouse_port(uint16_t port)
 	{
 		clickhouse_.port = port;
+	}
+
+	void
+	override_clickhouse_db_name(const std::string &db_name)
+	{
+		clickhouse_.db_name = db_name;
 	}
 
 	void

--- a/logger/tfw_logger_config.hh
+++ b/logger/tfw_logger_config.hh
@@ -32,20 +32,8 @@ namespace fs = std::filesystem;
 struct TfwLoggerConfig {
 	// Log file path - default set in tfw_logger.cc
 	fs::path log_path;
-	// mmap buffer size (4MB default)
-	size_t buffer_size{4 * 1024 * 1024};
-	// ClickHouse connection settings
 	ClickHouseConfig clickhouse;
 
-	// Minimum buffer size (one memory page)
-	static constexpr size_t MIN_BUFFER_SIZE = 4096;
-
-	/**
-	 * Load configuration from a JSON file.
-	 *
-	 * @param path JSON configuration file path
-	 * @return Configuration object if successful, empty optional on error
-	 */
 	static std::optional<TfwLoggerConfig>
 	load_from_file(const fs::path &path);
 

--- a/logger/tfw_logger_config.hh
+++ b/logger/tfw_logger_config.hh
@@ -20,10 +20,8 @@
 
 #pragma once
 
-#include <chrono>
 #include <filesystem>
 #include <optional>
-#include <string>
 
 #include <boost/property_tree/ptree_fwd.hpp>
 
@@ -31,28 +29,16 @@
 
 namespace fs = std::filesystem;
 
-/**
- * Configuration for Tempesta FW Logger.
- *
- * This class handles loading configuration from JSON files and provides
- * methods to override settings from command line arguments.
- */
-class TfwLoggerConfig
-{
-public:
-	/**
-	 * Default constructor.
-	 */
-	TfwLoggerConfig() = default;
+struct TfwLoggerConfig {
+	// Log file path - default set in tfw_logger.cc
+	fs::path log_path;
+	// mmap buffer size (4MB default)
+	size_t buffer_size{4 * 1024 * 1024};
+	// ClickHouse connection settings
+	ClickHouseConfig clickhouse;
 
-	/**
-	 * Get minimum buffer size constant.
-	 */
-	static constexpr size_t
-	get_min_buffer_size() noexcept
-	{
-		return MIN_BUFFER_SIZE;
-	}
+	// Minimum buffer size (one memory page)
+	static constexpr size_t MIN_BUFFER_SIZE = 4096;
 
 	/**
 	 * Load configuration from a JSON file.
@@ -63,103 +49,9 @@ public:
 	static std::optional<TfwLoggerConfig>
 	load_from_file(const fs::path &path);
 
-	// Getters
-	const fs::path &
-	get_log_path() const
-	{
-		return log_path_;
-	}
-
-	size_t
-	get_buffer_size() const
-	{
-		return buffer_size_;
-	}
-
-	const ClickHouseConfig &
-	get_clickhouse() const
-	{
-		return clickhouse_;
-	}
-
-	// Override methods for command line arguments
 	void
-	override_log_path(const fs::path &path)
-	{
-		log_path_ = path;
-	}
+	validate() const;
 
-	void
-	override_buffer_size(size_t size)
-	{
-		buffer_size_ = size;
-	}
-
-	void
-	override_clickhouse_host(const std::string &host)
-	{
-		clickhouse_.host = host;
-	}
-
-	void
-	override_clickhouse_port(uint16_t port)
-	{
-		clickhouse_.port = port;
-	}
-
-	void
-	override_clickhouse_db_name(const std::string &db_name)
-	{
-		clickhouse_.db_name = db_name;
-	}
-
-	void
-	override_clickhouse_table(const std::string &table)
-	{
-		clickhouse_.table_name = table;
-	}
-
-	void
-	override_clickhouse_user(const std::string &user)
-	{
-		clickhouse_.user = user;
-	}
-
-	void
-	override_clickhouse_password(const std::string &password)
-	{
-		clickhouse_.password = password;
-	}
-
-	void
-	override_clickhouse_max_events(size_t events)
-	{
-		clickhouse_.max_events = events;
-	}
-
-	void
-	override_clickhouse_max_wait(int ms)
-	{
-		clickhouse_.max_wait = std::chrono::milliseconds(ms);
-	}
-
-private:
-	// Minimum buffer size (one memory page)
-	static constexpr size_t MIN_BUFFER_SIZE = 4096;
-
-	// Log file path - default set in tfw_logger.cc
-	fs::path log_path_;
-	// mmap buffer size (4MB default)
-	size_t buffer_size_{4 * 1024 * 1024};
-	// ClickHouse connection settings
-	ClickHouseConfig clickhouse_;
-
-	/**
-	 * Parse configuration from property tree (loaded from JSON).
-	 *
-	 * @param tree Property tree containing configuration
-	 * @throws std::runtime_error on invalid configuration values
-	 */
 	void
 	parse_from_ptree(const boost::property_tree::ptree &tree);
 };


### PR DESCRIPTION
The database name can be specified in the JSON configuration using the "db_name" key, or as a command-line argument using "--database/-d <name>". The "port" parameter is now taken into account. It existed earlier, but was ignored.