### PR TITLE
Fix bug if stale response build fails

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -1559,7 +1559,7 @@ __tfw_http_resp_fwd_stale(TfwHttpMsg *hmresp)
 	TfwHttpReq *req = hmresp->req;
 	TfwHttpResp *stale_resp;
 
-	req->resp = NULL;
+	tfw_http_msg_unpair(hmresp);
 
 	stale_resp = tfw_cache_build_resp_stale(req);
 	/* For HTTP2 response will not be built if stream already closed. */
@@ -1570,7 +1570,6 @@ __tfw_http_resp_fwd_stale(TfwHttpMsg *hmresp)
 	/* Unlink response. */
 	tfw_stream_unlink_msg(hmresp->stream);
 
-	hmresp->pair = NULL;
 	req->resp->conn = hmresp->conn;
 	hmresp->conn->stream.msg = (TfwMsg *)stale_resp;
 

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -918,7 +918,7 @@ tfw_http_msg_pair(TfwHttpResp *resp, TfwHttpReq *req)
 	req->resp = resp;
 }
 
-static void
+void
 tfw_http_msg_unpair(TfwHttpMsg *msg)
 {
 	if (!msg->pair)

--- a/fw/http_msg.h
+++ b/fw/http_msg.h
@@ -75,6 +75,7 @@ tfw_http_msg_srvhdr_val(TfwStr *hdr, unsigned id, TfwStr *val)
 }
 
 void tfw_http_msg_pair(TfwHttpResp *resp, TfwHttpReq *req);
+void tfw_http_msg_unpair(TfwHttpMsg *msg);
 TfwHttpMsg *__tfw_http_msg_alloc(int type, bool full);
 
 static inline TfwHttpReq *


### PR DESCRIPTION
We should zeroed `hmresp->pair` before trying to
build stale response, otherwise we access `hmresp->pair` later during response freeing.