### PR TITLE
Fix bug if stale response build fails

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -1556,7 +1556,7 @@ __tfw_http_resp_fwd_stale(TfwHttpMsg *hmresp)
 	TfwHttpReq *req = hmresp->req;
 	TfwHttpResp *stale_resp;
 
-	req->resp = NULL;
+	tfw_http_msg_unpair(hmresp);
 
 	stale_resp = tfw_cache_build_resp_stale(req);
 	/* For HTTP2 response will not be built if stream already closed. */
@@ -1567,7 +1567,6 @@ __tfw_http_resp_fwd_stale(TfwHttpMsg *hmresp)
 	/* Unlink response. */
 	tfw_stream_unlink_msg(hmresp->stream);
 
-	hmresp->pair = NULL;
 	req->resp->conn = hmresp->conn;
 	hmresp->conn->stream.msg = (TfwMsg *)stale_resp;
 

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -1335,7 +1335,7 @@ tfw_http_msg_pair(TfwHttpResp *resp, TfwHttpReq *req)
 	req->resp = resp;
 }
 
-static void
+void
 tfw_http_msg_unpair(TfwHttpMsg *msg)
 {
 	if (!msg->pair)

--- a/fw/http_msg.h
+++ b/fw/http_msg.h
@@ -75,6 +75,7 @@ tfw_http_msg_srvhdr_val(TfwStr *hdr, unsigned id, TfwStr *val)
 }
 
 void tfw_http_msg_pair(TfwHttpResp *resp, TfwHttpReq *req);
+void tfw_http_msg_unpair(TfwHttpMsg *msg);
 TfwHttpMsg *__tfw_http_msg_alloc(int type, bool full);
 
 static inline TfwHttpReq *


### PR DESCRIPTION
We should zeroed `hmresp->pair` before trying to
build stale response, otherwise we access `hmresp->pair` later during response freeing. Look we build new response in `tfw_h1_send_resp` so `req->pair` will point to the new response, later both this request and response will be freed in `tfw_http_resp_fwd`. Old request (hmresp) will be freed from `tfw_sock_srv_connect_drop` but `hmresp->pair` point to the already freed response! To prevent it we should zeroed `hmresp->pair` as was described below.