### PR TITLE
Fix deadlock in `tfw_http_conn_cli_drop`.

### DIFF
--- a/fw/connection.h
+++ b/fw/connection.h
@@ -424,6 +424,14 @@ tfw_connection_get(TfwConn *conn)
 	atomic_inc(&conn->refcnt);
 }
 
+static inline bool
+tfw_connection_last_ref(TfwConn *conn)
+{
+	int rc = atomic_read(&conn->refcnt);
+
+	return (rc - 1 == 0) || (rc - 1 == TFW_CONN_DEATHCNT);
+}
+
 /**
  * Increment reference counter and return true if @conn is not in
  * failovering process, i.e. @refcnt wasn't less or equal to zero.

--- a/fw/http.c
+++ b/fw/http.c
@@ -3036,7 +3036,7 @@ tfw_http_conn_cli_drop(TfwCliConn *cli_conn)
 			 * the same as current `cli_conn`.
 			 */
 			if (!resp->conn
-			    || !tfw_connection_last_ref(resp->conn)) {
+			    || !__tfw_connection_get_if_last_ref(resp->conn)) {
 				tfw_http_resp_pair_free(req);
 			 } else {
 				list_add_tail(&resp->msg.seq_list,
@@ -3053,6 +3053,7 @@ tfw_http_conn_cli_drop(TfwCliConn *cli_conn)
 
 	list_for_each_entry_safe(resp, tmp_resp, &resp_del_queue,
 				 msg.seq_list) {
+		tfw_connection_put(resp->conn);
 		tfw_http_conn_msg_unlink_conn((TfwHttpMsg *)resp);
 		tfw_http_msg_free((TfwHttpMsg *)resp);
 	}

--- a/fw/http.c
+++ b/fw/http.c
@@ -3036,14 +3036,17 @@ tfw_http_conn_cli_drop(TfwCliConn *cli_conn)
 			 * the same as current `cli_conn`.
 			 */
 			if (!resp->conn
-			    || !__tfw_connection_get_if_last_ref(resp->conn)) {
+			    || !__tfw_connection_get_if_last_ref(resp->conn))
+			{
 				tfw_http_resp_pair_free(req);
-			 } else {
+			} else {
+				TfwHttpMsg *hmreq = (TfwHttpMsg *)req;
+
 				list_add_tail(&resp->msg.seq_list,
 					      &resp_del_queue);
 				if (req->conn)
-					tfw_http_conn_msg_unlink_conn((TfwHttpMsg *)req);
-				tfw_http_msg_free((TfwHttpMsg *)req);
+					tfw_http_conn_msg_unlink_conn(hmreq);
+				tfw_http_msg_free(hmreq);
 			 }
 
 			TFW_INC_STAT_BH(serv.msgs_otherr);
@@ -3051,8 +3054,14 @@ tfw_http_conn_cli_drop(TfwCliConn *cli_conn)
 	}
 	spin_unlock(&cli_conn->seq_qlock);
 
+	/*
+	 * TODO #687 Should be removed during reworking current architecture of
+	 * the locking of `seq_queue` in client connections and `fwd_queue`
+	 * in server connection.
+	 */
 	list_for_each_entry_safe(resp, tmp_resp, &resp_del_queue,
-				 msg.seq_list) {
+				 msg.seq_list)
+		{
 		tfw_connection_put(resp->conn);
 		tfw_http_conn_msg_unlink_conn((TfwHttpMsg *)resp);
 		tfw_http_msg_free((TfwHttpMsg *)resp);

--- a/fw/sock_srv.c
+++ b/fw/sock_srv.c
@@ -408,21 +408,6 @@ tfw_sock_srv_abort(TfwConn *conn)
 	return 0;
 }
 
-static inline bool
-__tfw_connection_get_if_not_death(TfwConn *conn)
-{
-	int old, rc = atomic_read(&conn->refcnt);
-
-	while (likely(rc != TFW_CONN_DEATHCNT && rc != 0)) {
-		old = atomic_cmpxchg(&conn->refcnt, rc, rc + 1);
-		if (likely(old == rc))
-			return true;
-		rc = old;
-	}
-
-	return false;
-}
-
 /**
  * Close a server connection, or stop attempts to connect if a connection
  * is not established. This is called only in user context at STOP time.


### PR DESCRIPTION
In `tfw_http_conn_cli_drop` we release all requests in the `seq_queue` under the `cli_conn->seq_qlock`. In this case we can't free `req->resp` under the `cli_conn->seq_lock` if `resp->conn` is not zero and response keeps the last reference to the connection. If response will be freed here, server connection will be released here and all requests from `fwd_list` will be freed. Such requests are freed under the `cli_conn->seq_qlock`, where `cli_conn` is an appropriate client connection, which can be the same as current `cli_conn`. (If it is so deadlock occured). To fix this problem we add all such responses to another list and free it after `cli_conn->seq_lock` will be released.