### PR TITLE
Fix using uninitialized spinlock

### DIFF
--- a/fw/apm.c
+++ b/fw/apm.c
@@ -1277,13 +1277,14 @@ tfw_apm_ref_create(void)
 
 	if (hm_size) {
 		i = 0;
-		list_for_each_entry(ent, &tfw_hm_codes_list, list)
-			hmstats[i++].hmcfg = ent;
+		list_for_each_entry(ent, &tfw_hm_codes_list, list) {
+			hmstats[i].hmcfg = ent;
+			spin_lock_init(&hmstats[i].lock);
+			i++;
+		}
 		BUG_ON(tfw_hm_codes_cnt != i);
 		ref->hmctl.hmstats = hmstats;
 	}
-
-	spin_lock_init(&ref->hmctl.hmstats->lock);
 
 	return ref;
 }


### PR DESCRIPTION
Each `TfwApmHMStats` structure contains spin_lock for `history` field protection. We should initialize this `spin_lock` for each `TfwApmHMStats` structure.