### PR TITLE
Fix spin_lock bug.

### DIFF
--- a/fw/sock.c
+++ b/fw/sock.c
@@ -1312,6 +1312,7 @@ ss_inet_create(struct net *net, int family,
 	inet_clear_bit(NODEFRAG, sk);
 	inet = inet_sk(sk);
 	atomic_set(&inet->inet_id, 0);
+	inet_init_csk_locks(sk);
 
 	if (net->ipv4.sysctl_ip_no_pmtu_disc)
 		inet->pmtudisc = IP_PMTUDISC_DONT;


### PR DESCRIPTION
Previosly in linux kernel 5.10.35 `icsk_accept_queue` lock was initialized in `reqsk_queue_alloc` inside `inet_csk_listen_start` call. In current kernel version locks initialization was moved to the `inet_create` inside `inet_init_csk_locks` function call. Since Tempesta FW uses it's own version of `inet_create` (ss_inet_create) we should also move socket locks initialization to this function.