### PR TITLE
Fix BUG if Tempesta FW received skb with small headroom

### DIFF
--- a/fw/sock.c
+++ b/fw/sock.c
@@ -884,6 +884,7 @@ do {									\
 		if (unlikely(offset > 0 &&
 			     ss_skb_chop_head_tail(NULL, skb, offset, 0) != 0))
 		{
+			__kfree_skb(skb);
 			r = SS_BAD;
 			goto out;
 		}
@@ -902,6 +903,22 @@ do {									\
 		if (SS_CONN_TYPE(sk) & Conn_Stop) {
 			__kfree_skb(skb);
 			continue;
+		}
+
+		if (unlikely(skb_headroom(skb) < MAX_TCP_HEADER)) {
+			struct sk_buff *twin_skb =
+				__pskb_copy_fclone(skb, MAX_TCP_HEADER,
+						   GFP_ATOMIC, true);
+			if (!twin_skb) {
+				T_WARN("Unable to copy SKB with small "
+				       "headroom.\n");
+				__kfree_skb(skb);
+				r = SS_BAD;
+				goto out;
+			}
+
+			__kfree_skb(skb);
+			skb = twin_skb;
 		}
 
 		r = SS_CALL(connection_recv, conn, skb);


### PR DESCRIPTION
- Tempesta FW reuses received skbs to prevent extra copying. If such skbs have small headroom and later will be pushed to the socket write queue BUG_ON will be occured during pushing TCP and IP headers to such skbs. For all skbs allocated by Tempesta FW we allocate headroom which is equal to MAX_TCP_HEADER. Now for all received skbs we check headroom and if it is less then MAX_TCP_HEADER reallocate skb with MAX_TCP_HEADER headroom.
- Also fix potencial memleak if `ss_skb_chop_head_tail` failed.

Author: @EvgeniiMekhanik
Review: @const-t 