### PR TITLE
Fix BUG if Tempesta FW received skb with small headroom[0.8]

### DIFF
--- a/fw/http2.c
+++ b/fw/http2.c
@@ -556,6 +556,12 @@ tfw_h2_entail_stream_skb(struct sock *sk, TfwH2Ctx *ctx, TfwStream *stream,
 		BUG_ON(!tls_type);
 		BUG_ON(!skb->len);
 
+		r = ss_skb_realloc_headroom(skb);
+		if (unlikely(r)) {
+			ss_skb_queue_head(&stream->xmit.skb_head, skb);
+			return r;
+		}
+
 		if (skb->len > *len) {
 			if (should_split) {
 				split = ss_skb_split(skb, *len);

--- a/fw/http2.c
+++ b/fw/http2.c
@@ -304,7 +304,7 @@ tfw_h2_conn_streams_cleanup(TfwH2Ctx *ctx)
 
 	tfw_h2_remove_idle_streams(ctx, UINT_MAX);
 
-        rbtree_postorder_for_each_entry_safe(cur, next, &sched->streams, node) {
+	rbtree_postorder_for_each_entry_safe(cur, next, &sched->streams, node) {
 		tfw_h2_stream_purge_all_and_free_response(cur);
 		tfw_h2_stream_unlink_lock(ctx, cur);
 

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -826,8 +826,8 @@ tfw_h2_stream_init_for_xmit(TfwHttpResp *resp, TfwStreamXmitState state,
 		return -EPIPE;
 	}
 
-	TFW_SKB_CB(skb_head)->opaque_data = resp;
-	TFW_SKB_CB(skb_head)->destructor = tfw_http_resp_pair_free_and_put_conn;
+	ss_skb_setup_opaque_data(skb_head, resp,
+				 tfw_http_resp_pair_free_and_put_conn);
 	TFW_SKB_CB(skb_head)->on_send = tfw_http_on_send_resp;
 	TFW_SKB_CB(skb_head)->stream_id = stream->id;
 

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -380,7 +380,7 @@ ss_forced_mem_schedule(struct sock *sk, int size)
 
 void
 ss_skb_tcp_entail(struct sock *sk, struct sk_buff *skb, unsigned int mark,
-	      unsigned char tls_type)
+		  unsigned char tls_type)
 {
 	struct tcp_sock *tp = tcp_sk(sk);
 
@@ -401,12 +401,15 @@ ss_skb_tcp_entail(struct sock *sk, struct sk_buff *skb, unsigned int mark,
 	       skb_tfw_tls_type(skb));
 }
 
-void
+int
 ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb_head)
 {
-	struct sk_buff *skb;
+	struct sk_buff *skb, *tail, *next, *to_destroy;
 	unsigned char tls_type = 0;
 	unsigned int mark = 0;
+	void *opaque_data = NULL;
+	void (*destructor)(void *) = NULL;
+	int r;
 
 	while ((skb = ss_skb_dequeue(skb_head))) {
 		/*
@@ -419,6 +422,9 @@ ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb_head)
 		if (TFW_SKB_CB(skb)->is_head) {
 			tls_type = skb_tfw_tls_type(skb);
 			mark = skb->mark;
+			opaque_data = TFW_SKB_CB(skb)->opaque_data;
+			destructor = TFW_SKB_CB(skb)->destructor;
+			tail = tcp_write_queue_tail(sk);
 		}
 		/*
 		 * Zero-sized SKBs may appear when the message headers (or any
@@ -432,8 +438,28 @@ ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb_head)
 			kfree_skb(skb);
 			continue;
 		}
+
+		r = ss_skb_realloc_headroom(skb);
+		if (unlikely(r)) {
+			ss_skb_queue_head(skb_head, skb);
+			goto restore_sk_write_queue;
+		}
+
 		ss_skb_tcp_entail(sk, skb, mark, tls_type);
 	}
+
+	return 0;
+
+restore_sk_write_queue:
+	to_destroy = tail ? tail->next : tcp_send_head(sk);
+	if (to_destroy) {
+		tcp_for_write_queue_from_safe(to_destroy, next, sk) {
+			tcp_unlink_write_queue(to_destroy, sk);
+			sk_wmem_free_skb(sk, to_destroy);
+		}
+	}
+	ss_skb_setup_opaque_data(*skb_head, opaque_data, destructor);
+	return r;
 }
 
 /**
@@ -467,7 +493,10 @@ ss_do_send(struct sock *sk, struct sk_buff **skb_head, int flags)
 	 * empty and `ss_skb_tcp_entail_list` doesn't make
 	 * any job.
 	 */
-	ss_skb_tcp_entail_list(sk, skb_head);
+	if (ss_skb_tcp_entail_list(sk, skb_head)) {
+		ss_linkerror(sk, SS_F_ABORT);
+		goto cleanup;
+	}
 
 	T_DBG3("[%d]: %s: sk=%p send_head=%p sk_state=%d flags=%x\n",
 	       smp_processor_id(), __func__,
@@ -570,7 +599,8 @@ ss_send(struct sock *sk, struct sk_buff **skb_head, int flags)
 		skb = *skb_head;
 		do {
 			/* tcp_transmit_skb() will clone the skb. */
-			twin_skb = pskb_copy_for_clone(skb, GFP_ATOMIC);
+			twin_skb = __pskb_copy_fclone(skb, MAX_TCP_HEADER,
+						      GFP_ATOMIC, true);
 			if (!twin_skb) {
 				T_WARN("Unable to copy an egress SKB.\n");
 				r = -ENOMEM;
@@ -880,6 +910,7 @@ do {									\
 		if (unlikely(offset > 0 &&
 			     ss_skb_chop_head_tail(NULL, skb, offset, 0) != 0))
 		{
+			 __kfree_skb(skb);
 			r = SS_BAD;
 			goto out;
 		}

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -1483,7 +1483,7 @@ ss_bind(struct sock *sk, const TfwAddr *addr)
 	WARN_ON_ONCE(sk->sk_type != SOCK_STREAM);
 
 	return inet6_bind(&sock, tfw_addr_sa((TfwAddr *)addr),
-	                  tfw_addr_sa_len((TfwAddr *)addr));
+			  tfw_addr_sa_len((TfwAddr *)addr));
 }
 EXPORT_SYMBOL(ss_bind);
 

--- a/fw/ss_skb.c
+++ b/fw/ss_skb.c
@@ -1711,3 +1711,14 @@ ss_skb_linear_transform(struct sk_buff *skb_head, struct sk_buff *skb,
 	return 0;
 }
 
+int
+ss_skb_realloc_headroom(struct sk_buff *skb)
+{
+	int delta = MAX_TCP_HEADER - skb_headroom(skb);
+
+	if (likely(delta <= 0))
+		return 0;
+
+	return pskb_expand_head(skb, SKB_DATA_ALIGN(delta), 0, GFP_ATOMIC);
+}
+ALLOW_ERROR_INJECTION(ss_skb_realloc_headroom, ERRNO);

--- a/fw/ss_skb.h
+++ b/fw/ss_skb.h
@@ -95,6 +95,14 @@ ss_skb_setup_head_of_list(struct sk_buff *skb_head, unsigned int mark,
 }
 
 static inline void
+ss_skb_setup_opaque_data(struct sk_buff *skb_head, void *opaque_data,
+			 void (*destructor)(void *))
+{
+	TFW_SKB_CB(skb_head)->opaque_data = opaque_data;
+	TFW_SKB_CB(skb_head)->destructor = destructor;
+}
+
+static inline void
 ss_skb_destroy_opaque_data(struct sk_buff *skb_head)
 {
 	void *opaque_data = TFW_SKB_CB(skb_head)->opaque_data;
@@ -470,6 +478,7 @@ int ss_skb_add_frag(struct sk_buff *skb_head, struct sk_buff **skb, char* addr,
 int
 ss_skb_linear_transform(struct sk_buff *skb_head, struct sk_buff *skb,
 			unsigned char *split_point);
+int ss_skb_realloc_headroom(struct sk_buff *skb);
 
 #if defined(DEBUG) && (DEBUG >= 4)
 #define ss_skb_queue_for_each_do(queue, lambda)		\

--- a/fw/sync_socket.h
+++ b/fw/sync_socket.h
@@ -180,7 +180,7 @@ bool ss_active(void);
 void ss_get_stat(SsStat *stat);
 void ss_skb_tcp_entail(struct sock *sk, struct sk_buff *skb, unsigned int mark,
 		       unsigned char tls_type);
-void ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb_head);
+int ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb_head);
 
 /*
  * We should all linux kernel functions like `tcp_push` or

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -179,8 +179,9 @@ void ss_skb_tcp_entail(struct sock *sk, struct sk_buff *skb, unsigned int mark,
 {
 }
 
-void ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb)
+int ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb)
 {
+	return 0;
 }
 
 void


### PR DESCRIPTION
- Tempesta FW reuses received skbs to prevent extra copying. If such skbs have small headroom and later will be pushed to the socket write queue BUG_ON will be occured during pushing TCP and IP headers to such skbs. For all skbs allocated by Tempesta FW we allocate headroom which is equal to MAX_TCP_HEADER. Now for all received skbs we check headroom and if it is less then MAX_TCP_HEADER reallocate skb with MAX_TCP_HEADER headroom.
- Also fix potencial memleak if `ss_skb_chop_head_tail` failed.

Author: @EvgeniiMekhanik 
Review: @const-t 