### PR TITLE
Remove tainting debug

### DIFF
--- a/fw/http_sess.h
+++ b/fw/http_sess.h
@@ -91,8 +91,6 @@ typedef struct {
  *
  * @shash		- Secret server value to generate reliable client
  *			  identifiers.
- * @key			- string representation of secret key for shash,
- *			  used only for debugging.
  * @name		- name of sticky cookie;
  * @name_eq		- @name plus "=" to make some operations faster;
  * @js_challenge	- JS challenge configuration;
@@ -109,9 +107,6 @@ typedef struct {
  */
 struct tfw_http_cookie_t {
 	struct crypto_shash	*shash;
-#ifdef DEBUG
-	char			key[STICKY_KEY_HMAC_LEN];
-#endif
 	char			sticky_name[STICKY_NAME_MAXLEN + 1];
 	char			options_str[STICKY_OPT_MAXLEN];
 	TfwStr			options;

--- a/fw/http_sess_conf.c
+++ b/fw/http_sess_conf.c
@@ -575,12 +575,6 @@ tfw_cfgop_sticky_secret_set(TfwStickyCookie *sticky, const char *secret_str,
 		return r;
 	}
 
-#ifdef DEBUG
-	if (len != sizeof(sticky->key))
-		T_LOG_NL("http_sess: reduce ley length to %zu bytes\n",
-			 sizeof(sticky->key));
-	len = max_t(size_t, len, sizeof(sticky->key));
-#endif
 	if (!len) {
 		tfw_get_random_bytes(secret, sizeof(secret));
 		len = sizeof(secret);
@@ -589,9 +583,6 @@ tfw_cfgop_sticky_secret_set(TfwStickyCookie *sticky, const char *secret_str,
 	else {
 		secret_buf = secret_str;
 	}
-#ifdef DEBUG
-	memcpy(sticky->key, secret_buf, len);
-#endif
 
 	r = crypto_shash_setkey(sticky->shash, secret_buf, len);
 	if (r)


### PR DESCRIPTION
http_sess.h is included in many .c files, e.g. vhost.c and http_sess_conf.c. Meantime, before the include vhost.c redefines DEBUG to DBG_TLS, but http_sess_conf.c uses DEBUG. This leads to different tfw_http_cookie_t in the same object code, which corrupts memory.

Fixing the debugging code might be more expensive that to add it in case if anybody needs it.

I think we should never change data structures depending on DEBUG because we compile all the files with different options. Only executable code may depend on DEBUG.

Fix #2423