### PR TITLE
Fix use after free.

### DIFF
--- a/fw/sock.c
+++ b/fw/sock.c
@@ -556,7 +556,8 @@ ss_send(struct sock *sk, struct sk_buff **skb_head, int flags)
 	 */
 	if (unlikely(!ss_sock_active(sk))) {
 		T_DBG2("Attempt to send on inactive socket %p\n", sk);
-		ss_skb_queue_purge(skb_head);
+		if (!(flags & SS_F_KEEP_SKB))
+			ss_skb_queue_purge(skb_head);
 		return -EBADF;
 	}
 


### PR DESCRIPTION
In case when `SS_F_KEEP_SKB` flag is set, but socket is inactive we should not destroy `skb_head` in `ss_send` function. We set `SS_F_KEEP_SKB` flag for requests to save request skbs, if `ss_send` fails we should not destroy request skbs, because such request will be resent later.

Closes #2502