### PR TITLE
Fix write size of response_content_length in mmap access log

### DIFF
--- a/fw/access_log.c
+++ b/fw/access_log.c
@@ -257,7 +257,7 @@ no_buffer_space:
 
 static void
 do_access_log_req_mmap(TfwHttpReq *req, u16 resp_status,
-		       u32 resp_content_length)
+		       u64 resp_content_length)
 {
 	u64 *dropped = this_cpu_ptr(&mmap_log_dropped);
 	TfwBinLogEvent *event;

--- a/fw/access_log.h
+++ b/fw/access_log.h
@@ -86,7 +86,7 @@ static inline int tfw_mmap_log_field_len(TfwBinLogFields field)
 		[TFW_MMAP_LOG_METHOD] = 1,
 		[TFW_MMAP_LOG_VERSION] = 1,
 		[TFW_MMAP_LOG_STATUS] = 2,
-		[TFW_MMAP_LOG_RESP_CONT_LEN] = 4,
+		[TFW_MMAP_LOG_RESP_CONT_LEN] = 8,
 		[TFW_MMAP_LOG_RESP_TIME] = 4,
 		[TFW_MMAP_LOG_VHOST] = 0, /* 0 - string */
 		[TFW_MMAP_LOG_URI] = 0,


### PR DESCRIPTION
We moved to 64-bit response length field in Clickhouse table, but were still writing only 32 bit values to the ring buffer.

Thanks to tfw_mmap_log_field_len() we were reading 32 bits, so this patch only fixes the maximum allowed values, but there were no data corruptions.