### PR TITLE
Update linux kernel patch

### DIFF
--- a/linux-6.12.12.patch
+++ b/linux-6.12.12.patch
@@ -400,7 +400,7 @@ index bfd177a43..bd5ac02c1 100644
  		type &= frontend->maskclear;
  		mask &= frontend->maskclear;
 diff --git a/crypto/cryptd.c b/crypto/cryptd.c
-index 31d022d47..7ab5a2867 100644
+index 31d022d47..11e2bccbc 100644
 --- a/crypto/cryptd.c
 +++ b/crypto/cryptd.c
 @@ -27,6 +27,10 @@
@@ -414,13 +414,13 @@ index 31d022d47..7ab5a2867 100644
  static unsigned int cryptd_max_cpu_qlen = 1000;
  module_param(cryptd_max_cpu_qlen, uint, 0);
  MODULE_PARM_DESC(cryptd_max_cpu_qlen, "Set cryptd Max queue depth");
-@@ -946,6 +950,75 @@ static struct crypto_template cryptd_tmpl = {
+@@ -946,6 +950,101 @@ static struct crypto_template cryptd_tmpl = {
  	.module = THIS_MODULE,
  };
  
 +#ifdef CONFIG_SECURITY_TEMPESTA
 +
-+#define MAX_CACHED_ALG_COUNT	8
++#define MAX_CACHED_ALG_COUNT	32
 +struct alg_cache {
 +	int n;
 +	spinlock_t lock;
@@ -436,6 +436,23 @@ index 31d022d47..7ab5a2867 100644
 +static struct alg_cache ahash_alg_cache;
 +static struct alg_cache aead_alg_cache;
 +
++static inline struct crypto_alg *
++__cryptd_find_alg(const char *cryptd_alg_name, u32 type, u32 mask,
++		  struct alg_cache *__restrict ac)
++{
++	int k;
++
++	for (k = 0; k < ac->n; k++) {
++		if (strcmp(ac->a[k].alg_name, cryptd_alg_name) == 0
++		    && ac->a[k].type == type && ac->a[k].mask == mask)
++		{
++			return ac->a[k].alg;
++		}
++	}
++
++	return NULL;
++}
++
 +/*
 + * Finds a previously allocated algorithm or allocates a new one. In any case,
 + * returned alg holds at least one reference to its module.
@@ -446,18 +463,12 @@ index 31d022d47..7ab5a2867 100644
 +		       struct alg_cache *__restrict ac)
 +{
 +	struct crypto_alg *alg;
-+	int k;
 +
 +	spin_lock(&ac->lock);
-+	for (k = 0; k < ac->n; k++) {
-+		if (strcmp(ac->a[k].alg_name, cryptd_alg_name) == 0
-+		    && ac->a[k].type == type && ac->a[k].mask == mask)
-+		{
-+			spin_unlock(&ac->lock);
-+			return ac->a[k].alg;
-+		}
-+	}
++	alg = __cryptd_find_alg(cryptd_alg_name, type, mask, ac);
 +	spin_unlock(&ac->lock);
++	if (likely(alg))
++		return alg;
 +
 +	/* Searching for the algorithm may sleep, so warn about it. */
 +	WARN_ON_ONCE(in_serving_softirq());
@@ -467,6 +478,21 @@ index 31d022d47..7ab5a2867 100644
 +		return alg;
 +
 +	spin_lock(&ac->lock);
++
++	/*
++	 * We unlock spinlock during searching for the algorithm.
++	 * So there is a chance that two separate threads not
++	 * find algorithm in cache and will be here and add the
++	 * same algorithm to the cache. To prevent it check
++	 * algorithm presense in cache again.
++	 */
++	if (unlikely(__cryptd_find_alg(cryptd_alg_name, type,
++				       mask, ac) == alg))
++	{
++		spin_unlock(&ac->lock);
++		return alg;
++	}
++
 +	if (ac->n >= MAX_CACHED_ALG_COUNT) {
 +		spin_unlock(&ac->lock);
 +		BUG();
@@ -490,7 +516,7 @@ index 31d022d47..7ab5a2867 100644
  struct cryptd_skcipher *cryptd_alloc_skcipher(const char *alg_name,
  					      u32 type, u32 mask)
  {
-@@ -957,7 +1030,20 @@ struct cryptd_skcipher *cryptd_alloc_skcipher(const char *alg_name,
+@@ -957,7 +1056,20 @@ struct cryptd_skcipher *cryptd_alloc_skcipher(const char *alg_name,
  		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
  		return ERR_PTR(-EINVAL);
  
@@ -511,7 +537,7 @@ index 31d022d47..7ab5a2867 100644
  	if (IS_ERR(tfm))
  		return ERR_CAST(tfm);
  
-@@ -1008,7 +1094,21 @@ struct cryptd_ahash *cryptd_alloc_ahash(const char *alg_name,
+@@ -1008,7 +1120,21 @@ struct cryptd_ahash *cryptd_alloc_ahash(const char *alg_name,
  	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
  		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
  		return ERR_PTR(-EINVAL);
@@ -533,7 +559,7 @@ index 31d022d47..7ab5a2867 100644
  	if (IS_ERR(tfm))
  		return ERR_CAST(tfm);
  	if (tfm->base.__crt_alg->cra_module != THIS_MODULE) {
-@@ -1065,7 +1165,21 @@ struct cryptd_aead *cryptd_alloc_aead(const char *alg_name,
+@@ -1065,7 +1191,21 @@ struct cryptd_aead *cryptd_alloc_aead(const char *alg_name,
  	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
  		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
  		return ERR_PTR(-EINVAL);
@@ -555,7 +581,7 @@ index 31d022d47..7ab5a2867 100644
  	if (IS_ERR(tfm))
  		return ERR_CAST(tfm);
  	if (tfm->base.__crt_alg->cra_module != THIS_MODULE) {
-@@ -1109,6 +1223,12 @@ static int __init cryptd_init(void)
+@@ -1109,6 +1249,12 @@ static int __init cryptd_init(void)
  {
  	int err;
  
@@ -1381,7 +1407,7 @@ index 000000000..4f9e9f4ef
 +/**
 + *		Tempesta Memory Reservation
 + *
-+ * Copyright (C) 2015-2025 Tempesta Technologies, Inc.
++ * Copyright (C) 2015-2024 Tempesta Technologies, Inc.
 + *
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fix finding crypto algorithm in cache:
- Increase `MAX_CACHED_ALG_COUNT` from 8 to 32. (Count of algorithm is equal to 22, but we set MAX_CACHED_ALG_COUNT to 32 to fix potencial problem in later versions of the linux kernel)
- Fix potencial race during adding algorithm to cache.

Closes #2419