### PR TITLE
Drop server connection if client connection is dropped

### DIFF
--- a/fw/access_log.c
+++ b/fw/access_log.c
@@ -529,14 +529,6 @@ do_access_log_req(TfwHttpReq *req, int resp_status,
 		do_access_log_req_dmesg(req, resp_status, resp_content_length);
 }
 
-void
-do_access_log(TfwHttpResp *resp)
-{
-	do_access_log_req(resp->req, resp->status,
-			  resp->content_length ? :
-			  TFW_HTTP_RESP_CUT_BODY_SZ(resp));
-}
-
 static int
 cfg_access_log_set(TfwCfgSpec *cs, TfwCfgEntry *ce)
 {

--- a/fw/access_log.h
+++ b/fw/access_log.h
@@ -104,7 +104,6 @@ static inline int tfw_mmap_log_field_len(TfwBinLogFields field)
 int tfw_access_log_init(void);
 void tfw_access_log_exit(void);
 void do_access_log_req(TfwHttpReq *req, int status, unsigned long content_length);
-void do_access_log(TfwHttpResp *resp);
 
 #endif
 

--- a/fw/http.c
+++ b/fw/http.c
@@ -7348,11 +7348,19 @@ tfw_http_resp_process(TfwConn *conn, TfwStream *stream, struct sk_buff *skb,
 	 * until all data in the SKB is processed.
 	 */
 next_msg:
-	conn_stop = false;
 	parsed = 0;
 	hmsib = NULL;
 	hmresp = (TfwHttpMsg *)stream->msg;
 	cli_conn = (TfwCliConn *)hmresp->req->conn;
+	/* `cli_conn` is equal to zero for health monitor requests. */
+	if (likely(cli_conn)) {
+		if (TFW_FSM_TYPE(cli_conn->proto.type) == TFW_FSM_H2)
+			conn_stop = !hmresp->req->stream;
+		else
+			conn_stop = test_bit(TFW_HTTP_B_REQ_DROP, hmresp->req->flags);
+	} else {
+		conn_stop = false;
+	}
 
 	r = ss_skb_process(skb, tfw_http_parse_resp, hmresp, &chunks_unused,
 			   &parsed);
@@ -7419,7 +7427,7 @@ next_msg:
 		 * just supply data for parsing. They only want to know
 		 * if processing of a message should continue or not.
 		 */
-		return T_OK;
+		return likely(!conn_stop) ? T_OK : T_BAD;
 	case T_OK:
 		/*
 		 * The response is fully parsed, fall through and
@@ -7433,6 +7441,8 @@ next_msg:
 			goto bad_msg;
 		}
 	}
+
+	conn_stop = false;
 
 	/*
 	 * The message is fully parsed, the rest of the data in the

--- a/fw/http.c
+++ b/fw/http.c
@@ -3015,7 +3015,7 @@ tfw_http_conn_release(TfwConn *conn)
  * Disintegrate the client connection's @seq_list. Requests without a paired
  * response have not been answered yet. They are held in the lists of server
  * connections until responses come. A paired response may be in use until
- * TFW_HTTP_B_RESP_READY flag is not set.  Don't free any of those requests.
+ * TFW_HTTP_B_REQ_RESP_READY flag is not set.  Don't free any of those requests.
  *
  * If a response comes or gets ready to forward after @seq_list is
  * disintegrated, then both the request and the response are dropped at the
@@ -3052,12 +3052,12 @@ tfw_http_cli_conn_drop(TfwCliConn *cli_conn)
 		 * immediately after REQ_DROP flag is set, the request-response
 		 * pair can be destroyed in other thread.
 		 */
-		bool unused = req->resp
-			&& test_bit(TFW_HTTP_B_RESP_READY, req->resp->flags);
+		bool unused = test_bit(TFW_HTTP_B_REQ_RESP_READY, req->flags);
 		list_del_init(&req->msg.seq_list);
 		smp_mb__before_atomic();
 		if (unused) {
 			resp = req->resp;
+			BUG_ON(!resp);
 
 			/*
 			 * If `resp->conn` is not zero and response keeps the
@@ -4827,14 +4827,11 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 		return;
 	}
 	BUG_ON(list_empty(&req->msg.seq_list));
-	set_bit(TFW_HTTP_B_RESP_READY, resp->flags);
+	set_bit(TFW_HTTP_B_REQ_RESP_READY, req->flags);
 	/* Move consecutive requests with @req->resp to @ret_queue. */
 	list_for_each_entry(req, seq_queue, msg.seq_list) {
-		if (!req->resp
-		    || !test_bit(TFW_HTTP_B_RESP_READY, req->resp->flags))
-		{
+		if (!test_bit(TFW_HTTP_B_REQ_RESP_READY, req->flags))
 			break;
-		}
 		req_retent = &req->msg.seq_list;
 	}
 	if (!req_retent) {
@@ -6381,6 +6378,7 @@ tfw_http_del_continuation_seq_queue(TfwCliConn *cli_conn, TfwHttpReq *req)
 	 * that under @seq_qlock.
 	 */
 	spin_lock_bh(&cli_conn->seq_qlock);
+	clear_bit(TFW_HTTP_B_REQ_RESP_READY, req->flags);
 	list_for_each_entry(queued_req, seq_queue, msg.seq_list) {
 		if (queued_req != req)
 			continue;
@@ -6447,7 +6445,7 @@ tfw_http_send_continuation(TfwCliConn *cli_conn, TfwHttpReq *req)
 	} else {
 		set_bit(TFW_HTTP_B_CONTINUE_QUEUED, req->flags);
 		set_bit(TFW_HTTP_B_CONTINUE_RESP, resp->flags);
-		set_bit(TFW_HTTP_B_RESP_READY, resp->flags);
+		set_bit(TFW_HTTP_B_REQ_RESP_READY, req->flags);
 		list_add_tail(&req->msg.seq_list, seq_queue);
 		spin_unlock_bh(&cli_conn->seq_qlock);
 	}

--- a/fw/http_msg.c
+++ b/fw/http_msg.c
@@ -931,12 +931,15 @@ tfw_http_msg_unpair(TfwHttpMsg *msg)
 void
 tfw_http_msg_free(TfwHttpMsg *m)
 {
+	struct sk_buff *skb_head;
+
 	T_DBG3("Free msg=%p\n", m);
 	if (!m)
 		return;
 
+	skb_head = arch_xchg(&m->msg.skb_head, NULL);
 	tfw_http_msg_unpair(m);
-	ss_skb_queue_purge(&m->msg.skb_head);
+	ss_skb_queue_purge(&skb_head);
 
 	if (m->destructor)
 		m->destructor(m);

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -270,6 +270,7 @@ tfw_h2_stream_unlink_nolock(TfwH2Ctx *ctx, TfwStream *stream)
 {
 	TfwHttpMsg *hmreq = (TfwHttpMsg *)stream->msg;
 
+	assert_spin_locked(&ctx->lock);
 	tfw_h2_stream_del_from_queue_nolock(stream);
 
 	if (hmreq) {
@@ -290,9 +291,10 @@ tfw_h2_stream_unlink_nolock(TfwH2Ctx *ctx, TfwStream *stream)
 			TfwHttpReq *req = (TfwHttpReq *)hmreq;
 			struct sk_buff *skb_head;
 
-			req->msg.ss_flags &= ~SS_F_KEEP_SKB;
+			set_bit(__TFW_HTTP_B_REQ_DROP, req->flags);
 			skb_head = arch_xchg(&req->msg.skb_head, NULL);
 			ss_skb_queue_purge(&skb_head);
+			
 		}
 	}
 }

--- a/fw/http_stream.c
+++ b/fw/http_stream.c
@@ -284,8 +284,16 @@ tfw_h2_stream_unlink_nolock(TfwH2Ctx *ctx, TfwStream *stream)
 		 * cases controlled by server connection side (after adding to
 		 * @fwd_queue): successful response sending, eviction etc.
 		 */
-		if (!test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags))
+		if (!test_bit(TFW_HTTP_B_FULLY_PARSED, hmreq->flags)) {
 			tfw_http_conn_msg_free(hmreq);
+		} else {
+			TfwHttpReq *req = (TfwHttpReq *)hmreq;
+			struct sk_buff *skb_head;
+
+			req->msg.ss_flags &= ~SS_F_KEEP_SKB;
+			skb_head = arch_xchg(&req->msg.skb_head, NULL);
+			ss_skb_queue_purge(&skb_head);
+		}
 	}
 }
 

--- a/fw/http_types.h
+++ b/fw/http_types.h
@@ -110,6 +110,11 @@ enum {
          * from cache.
          */
         TFW_HTTP_B_JS_NOT_SUPPORTED,
+        /*
+         * Response is fully processed and ready to be
+         * forwarded to the client.
+         */
+        TFW_HTTP_B_REQ_RESP_READY,
 
 	/*
 	 * Rewrite method from HEAD to GET. Applicable only to request that can
@@ -130,11 +135,6 @@ enum {
         TFW_HTTP_B_HDR_DATE,
         /* Response has header 'Last-Modified:'. */
         TFW_HTTP_B_HDR_LMODIFIED,
-        /*
-         * Response is fully processed and ready to be
-         * forwarded to the client.
-         */
-        TFW_HTTP_B_RESP_READY,
         /*
          * Response has header 'Etag: ' and this header is
          * not enclosed in double quotes.

--- a/fw/http_types.h
+++ b/fw/http_types.h
@@ -102,6 +102,8 @@ enum {
         TFW_HTTP_B_HMONITOR,
         /* Client was disconnected, drop the request. */
         TFW_HTTP_B_REQ_DROP,
+        /* Same as previous, but used for internal synchronization. */
+        __TFW_HTTP_B_REQ_DROP,
         /* Request is PURGE with an 'X-Tempesta-Cache: get' header. */
         TFW_HTTP_B_PURGE_GET,
         /*

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -584,7 +584,7 @@ ss_send(struct sock *sk, struct sk_buff **skb_head, int flags)
 
 	/* The queue could be purged in previous call. */
 	if (unlikely(!head))
-		return 0;
+		return -EFAULT;
 
 	cpu = sk->sk_incoming_cpu;
 

--- a/fw/t/unit/helpers.c
+++ b/fw/t/unit/helpers.c
@@ -415,11 +415,6 @@ tfw_server_destroy(TfwServer *srv)
 }
 
 void
-do_access_log(TfwHttpResp *resp)
-{
-}
-
-void
 do_access_log_req(TfwHttpReq *req, int status, unsigned long content_length)
 {
 }


### PR DESCRIPTION
There was a problem with processing responses for requests with already dropped client connection. If some malicious client requests large response and then immediatly closes connection, Tempesta FW continue to receive large response for a long time. If such client does this action in the loop, this leads to huge memory consumption and overload of the server connections queues.
To solve this problem, the simplest possible solution was proposed - during processing response Tempesta FW checks that appropriated request belongs to already dropped client connection, we immediately drop server connection. During server conenction reestabling, we dropped all requests with already dropped client connections and resend all other requests.
In current architecture (with several different locks) there is no good solution to immediately rescheduling requests during dropping client connection, because it should be done under the `fwd_queue` lock of server connection (to which such request belongs to). Moreover we should access such server conenction also under the lock, because it can be deleted at the same time.