### PR TITLE
add check for pkgconf in Makefile

### DIFF
--- a/libtus/t/Makefile
+++ b/libtus/t/Makefile
@@ -16,6 +16,10 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+ifeq ($(shell which pkgconf), )
+$(error "pkgconf not found in $(PATH)")
+endif
+
 CXX := g++
 CXXFLAGS := -std=c++23 -Wall -Wextra -g -O0
 CXXFLAGS += -I/usr/include

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -16,6 +16,10 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+ifeq ($(shell which pkgconf), )
+$(error "pkgconf not found in $(PATH)")
+endif
+
 # We don't need to build clickhouse - it would be build by access_log_plugin as .a
 SUBDIRS := access_log_plugin
 

--- a/logger/access_log_plugin/Makefile
+++ b/logger/access_log_plugin/Makefile
@@ -16,6 +16,10 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+ifeq ($(shell which pkgconf), )
+$(error "pkgconf not found in $(PATH)")
+endif
+
 CLICKHOUSE_DIR := ../clickhouse
 
 LDFLAGS += $(shell pkgconf --libs spdlog)

--- a/logger/t/Makefile
+++ b/logger/t/Makefile
@@ -16,6 +16,10 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+ifeq ($(shell which pkgconf), )
+$(error "pkgconf not found in $(PATH)")
+endif
+
 CXX := g++
 CXXFLAGS := -std=c++23 -Wall -Wextra -g -O0
 CXXFLAGS += -I/usr/include


### PR DESCRIPTION
Check whether `pkgconf` exists in the system. Check added to each module that can be built separately.