### PR TITLE
Fix deadlock during server connection release.

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -3002,6 +3002,52 @@ tfw_http_conn_release(TfwConn *conn)
 	}
 }
 
+static inline void
+tfw_http_free_req_carefully(TfwHttpReq *req, struct list_head *resp_del_queue)
+{
+	TfwHttpResp *resp = req->resp;
+
+	/*
+	 * If `resp->conn` is not zero and response keeps the last
+	 * reference to the connection, we can't free this response
+	 * under the `cli_conn->seq_qlock` or `cli->ret_qlock`.
+	 * If response will be freed here, server connection will be
+	 * released here and all requests from `fwd_list` will be freed
+	 * or resent (depends on `ss_active`). Such requests are freed
+	 * under the `cli_conn->seq_qlock` or resent under the
+	 * `cli->ret_qlock`, where `cli_conn` is a appropriate client
+	 * connection, which can be the same as current `cli_conn`.
+	 */
+	if (!resp->conn
+	    || !__tfw_connection_get_if_last_ref(resp->conn))
+	{
+		tfw_http_resp_pair_free(req);
+	} else {
+		TfwHttpMsg *hmreq = (TfwHttpMsg *)req;
+
+		list_add_tail(&resp->msg.seq_list, resp_del_queue);
+		if (req->conn)
+			tfw_http_conn_msg_unlink_conn(hmreq);
+		tfw_http_msg_free(hmreq);
+	}
+}
+
+static inline void
+tfw_http_clear_resp_del_queue(struct list_head *resp_del_queue)
+{
+	TfwHttpResp *resp, *tmp_resp;
+	/*
+	 * TODO #687 Should be removed during reworking current architecture of
+	 * the locking of `seq_queue` in client connections and `fwd_queue`
+	 * in server connection.
+	 */
+	list_for_each_entry_safe(resp, tmp_resp, resp_del_queue, msg.seq_list) {
+		tfw_connection_put(resp->conn);
+		tfw_http_conn_msg_unlink_conn((TfwHttpMsg *)resp);
+		tfw_http_msg_free((TfwHttpMsg *)resp);
+	}
+}
+
 /*
  * Drop client connection's resources.
  *
@@ -3021,7 +3067,6 @@ static void
 tfw_http_conn_cli_drop(TfwCliConn *cli_conn)
 {
 	TfwHttpReq *req, *tmp_req;
-	TfwHttpResp *resp, *tmp_resp;
 	LIST_HEAD(resp_del_queue);
 	struct list_head *seq_queue = &cli_conn->seq_queue;
 
@@ -3051,50 +3096,13 @@ tfw_http_conn_cli_drop(TfwCliConn *cli_conn)
 		smp_mb__before_atomic();
 		set_bit(TFW_HTTP_B_REQ_DROP, req->flags);
 		if (unused) {
-			resp = req->resp;
-
-			/*
-			 * If `resp->conn` is not zero and response keeps the
-			 * last reference to the connection, we can't free
-			 * this response under the `cli_conn->seq_qlock`.
-			 * If response will be freed here, server connection
-			 * will be released here and all requests from
-			 * `fwd_list` will be freed. Such requests are freed
-			 * under the `cli_conn->seq_qlock`, where `cli_conn`
-			 * is a appropriate client connection, which can be
-			 * the same as current `cli_conn`.
-			 */
-			if (!resp->conn
-			    || !__tfw_connection_get_if_last_ref(resp->conn))
-			{
-				tfw_http_resp_pair_free(req);
-			} else {
-				TfwHttpMsg *hmreq = (TfwHttpMsg *)req;
-
-				list_add_tail(&resp->msg.seq_list,
-					      &resp_del_queue);
-				if (req->conn)
-					tfw_http_conn_msg_unlink_conn(hmreq);
-				tfw_http_msg_free(hmreq);
-			 }
-
+			tfw_http_free_req_carefully(req, &resp_del_queue);			
 			TFW_INC_STAT_BH(serv.msgs_otherr);
 		}
 	}
 	spin_unlock(&cli_conn->seq_qlock);
 
-	/*
-	 * TODO #687 Should be removed during reworking current architecture of
-	 * the locking of `seq_queue` in client connections and `fwd_queue`
-	 * in server connection.
-	 */
-	list_for_each_entry_safe(resp, tmp_resp, &resp_del_queue,
-				 msg.seq_list)
-		{
-		tfw_connection_put(resp->conn);
-		tfw_http_conn_msg_unlink_conn((TfwHttpMsg *)resp);
-		tfw_http_msg_free((TfwHttpMsg *)resp);
-	}
+	tfw_http_clear_resp_del_queue(&resp_del_queue);
 }
 
 /*
@@ -4733,7 +4741,8 @@ clean:
  * responses are taken care of by the caller.
  */
 static void
-__tfw_http_resp_fwd(TfwCliConn *cli_conn, struct list_head *ret_queue)
+__tfw_http_resp_fwd(TfwCliConn *cli_conn, struct list_head *ret_queue,
+		    struct list_head *resp_del_queue)
 {
 	TfwHttpReq *req, *tmp;
 
@@ -4754,7 +4763,7 @@ __tfw_http_resp_fwd(TfwCliConn *cli_conn, struct list_head *ret_queue)
 		tfw_inc_global_hm_stats(req->resp->status);
 		list_del_init(&req->msg.seq_list);
 		if (!send_cont)
-			tfw_http_resp_pair_free(req);
+			tfw_http_free_req_carefully(req, resp_del_queue);
 		else
 			tfw_http_msg_free(req->pair);
 	}
@@ -4781,6 +4790,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 	struct list_head *seq_queue = &cli_conn->seq_queue;
 	struct list_head *req_retent = NULL;
 	LIST_HEAD(ret_queue);
+	LIST_HEAD(resp_del_queue);
 
 	T_DBG2("%s: req=[%p], resp=[%p]\n", __func__, req, resp);
 	WARN_ON_ONCE(req->resp != resp);
@@ -4809,9 +4819,9 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 		 */
 		__tfw_http_ws_connection_put(cli_conn);
 		tfw_connection_close(req->conn, true);
-		tfw_http_resp_pair_free(req);
+		tfw_http_free_req_carefully(req, &resp_del_queue);
 		TFW_INC_STAT_BH(serv.msgs_otherr);
-		return;
+		goto clear_del_queue;
 	}
 	BUG_ON(list_empty(&req->msg.seq_list));
 	set_bit(TFW_HTTP_B_RESP_READY, resp->flags);
@@ -4861,7 +4871,7 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 	spin_lock_bh(&cli_conn->ret_qlock);
 	spin_unlock_bh(&cli_conn->seq_qlock);
 
-	__tfw_http_resp_fwd(cli_conn, &ret_queue);
+	__tfw_http_resp_fwd(cli_conn, &ret_queue, &resp_del_queue);
 
 	/* Zap request/responses that were not sent due to an error. */
 	if (!list_empty(&ret_queue)) {
@@ -4873,15 +4883,21 @@ tfw_http_resp_fwd(TfwHttpResp *resp)
 			list_del_init(&req->msg.seq_list);
 			if (!test_bit(TFW_HTTP_B_CONTINUE_RESP,
 				     req->resp->flags))
-				tfw_http_resp_pair_free(req);
-			else
+			{
+				tfw_http_free_req_carefully(req,
+							    &resp_del_queue);
+			} else {
 				tfw_http_msg_free(req->pair);
+			}
 			TFW_INC_STAT_BH(serv.msgs_otherr);
 		}
 	}
 
 	spin_unlock_bh(&cli_conn->ret_qlock);
 	tfw_connection_put((TfwConn *)(cli_conn));
+
+clear_del_queue:
+	tfw_http_clear_resp_del_queue(&resp_del_queue);
 }
 
 int


### PR DESCRIPTION
If server connection releases and `TFW_CONN_B_DEL` is set, Tempesta FW reschedule all requests to other backend servers and send error responses to clients.
Responses are sended under the `req_qlock` of appropriate client connection, and also deleted under this lock. If response held the last referense on the appropriate server connection it can be released under the `ret_qlock` also. If such server connection contains requests from appropriate client connetion (which `ret_qlock` is locked) Tempesta FW try to lock already locked spin_lock. To fix this problem use the same solution as we use during client connection release - add responses which held last reference on server connection to special queue and free them later, when `req_qlock` or `seq_qlock` is unlocked.

Fix 2564