### PR TITLE
fix: Large mmap buffer allocation

### DIFF
--- a/fw/mmap_buffer.h
+++ b/fw/mmap_buffer.h
@@ -83,7 +83,7 @@
  * at module start and freed at module stop, so repeated initialization or
  * freeing is not expected.
  *
- * Copyright (C) 2024-2025 Tempesta Technologies, Inc.
+ * Copyright (C) 2024-2026 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -158,15 +158,6 @@ typedef struct {
 #ifdef __KERNEL__
 
 /**
- * @buf_page	- Pages allocated for buffer metadata;
- * @data_page	- pages allocated for data storage.
- */
-typedef struct {
-	struct page	*buf_page;
-	struct page	*data_page;
-} TfwMMapBufferMem;
-
-/**
  * @buf			- Per CPU pointers to store pointers to buffers;
  * @dev_name		- name of the device in /dev;
  * @size		- size of the memory allocated to every buffer;
@@ -176,7 +167,8 @@ typedef struct {
  * @dev			- device structure of the device in /dev;
  * @dev_major		- the major number of the device in /dev;
  * @dev_class		- the class of the device;
- * @mem			- array of structures descripting allocated memory.
+ * @mem			- array of allocated pages. The first page is metada
+ *                        page the rest are data pages.
  */
 typedef struct {
 	TfwMmapBuffer __percpu	**buf;
@@ -187,7 +179,7 @@ typedef struct {
 	struct device		*dev;
 	int			dev_major;
 	struct class		*dev_class;
-	TfwMMapBufferMem	mem[];
+	DECLARE_FLEX_ARRAY(struct page **, mem);
 } TfwMmapBufferHolder;
 
 /*

--- a/fw/t/unit/test_mmap_buffer.c
+++ b/fw/t/unit/test_mmap_buffer.c
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2024-2025 Tempesta Technologies, Inc.
+ * Copyright (C) 2024-2026 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -91,6 +91,9 @@ TEST(tfw_mmap_buffer, create)
 	EXPECT_NULL(tfw_mmap_buffer_create(NULL, TFW_MMAP_BUFFER_MIN_SIZE + 1));
 	EXPECT_NULL(tfw_mmap_buffer_create(NULL, TFW_MMAP_BUFFER_MAX_SIZE * 2));
 	holder = tfw_mmap_buffer_create(NULL, TFW_MMAP_BUFFER_MIN_SIZE);
+	EXPECT_NOT_NULL(holder);
+	tfw_mmap_buffer_free(holder);
+	holder = tfw_mmap_buffer_create(NULL, TFW_MMAP_BUFFER_MAX_SIZE);
 	EXPECT_NOT_NULL(holder);
 	tfw_mmap_buffer_free(holder);
 }


### PR DESCRIPTION
This patch allows to allocate large mmap buffer, up to 128M. Tempesta tries to allocate non-contiguous high order pages, when it fails rollbacks to order-0 pages. All array of pointers to allocated pages are stored in `struct TfwMmapBufferHolder`, they are freed on Tempesta unloading