### PR TITLE
proposal: type-safe Error class with compile-time categories and enums.

### DIFF
--- a/logger/clickhouse/clickhouse_error.hh
+++ b/logger/clickhouse/clickhouse_error.hh
@@ -1,7 +1,7 @@
 /**
  *		Tempesta FW
  *
- * Copyright (C) 2025 Tempesta Technologies, Inc.
+ * Copyright (C) 2024-2025 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -17,11 +17,25 @@
  * this program; if not, write to the Free Software Foundation, Inc., 59
  * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
-#include "error.hh"
+#pragma once
+#include "../../libtus/error.hh"
 
-const std::error_category &
-tus::tfw_error_category()
+enum ClickhouseErrorEnum : uint16_t {
+	DB_SRV_FATAL		= 1,
+	DB_CLT_TRANSIENT	= 2,
+};
+
+static constexpr std::string_view message(ClickhouseErrorEnum e)
 {
-	static tus::ErrorCategory instance;
-	return instance;
+	using namespace std::literals;
+
+	switch (e) {
+	case ClickhouseErrorEnum::DB_SRV_FATAL:
+		return "Database unrecoverable server error"sv;
+	case ClickhouseErrorEnum::DB_CLT_TRANSIENT:
+		return "Database recoverable client error"sv;
+	}
+	return {};
 }
+
+using ClickhouseError = tus::Error<ClickhouseErrorEnum, tus::TfwCategory>;

--- a/logger/tfw_logger.cc
+++ b/logger/tfw_logger.cc
@@ -127,8 +127,7 @@ event_loop(std::vector<std::unique_ptr<IPluginProcessor>> &&processors) noexcept
 			const int err = processor->consume(&consumed);
 			if (err) [[unlikely]] {
 				spdlog::error("Processor {} error: {}",
-					processor->name(),
-					tus::make_error_code_from_int(err).message());
+					processor->name(), tus::code_to_hex(err));
        				++it;
 				continue;
 			}


### PR DESCRIPTION
The current implementation provides a type-safe framework for representing and propagating errors in a modular C++ system. Each error is associated with a specific enum and a category, and each category is defined via ErrorCategoryBase with a compile-time stable ID and name. The Error class combines the category ID and the enum value into a single integer code, which can be returned from a module or used for logging.

The error class provides convenient methods to retrieve the category name, the message for the specific enum, and a hexadecimal representation of the code. The operator<< is overloaded to print the full error as Category: Message (0xCODE). A helper function code_to_hex allows formatting the code in hex while preserving the sign if negative.

Modules can define their own categories and enums without changing the core error class. The framework also integrates well with std::expected<T, Error> and can be used to propagate errors or throw exceptions while preserving full traceability and diagnostic information.


NOTE:
Still need a mechanism to recover an error in another module from the integer code. 
It would also be useful to integrate this with std::expected to throw detailed 
exceptions carrying the typed error for propagation outside the module.

Update: I was thinking about adding constructor to Except(Error) and member std::shared_ptr < Error>. In that case we would be able to write detailed info on what(). But maybe we don't need to mix this 2 approaches. Or we can just construct Except with what from Error and forget about Error after it