### PR TITLE
Stop module if it failed to start

### DIFF
--- a/fw/main.c
+++ b/fw/main.c
@@ -233,6 +233,10 @@ tfw_mods_start(void)
 		if ((ret = mod->start())) {
 			T_ERR_NL("Unable to start module '%s': %d\n",
 				 mod->name, ret);
+			if (mod->stop) {
+				mod->stop();
+				mod->started = 0;
+			}
 			return ret;
 		}
 		mod->started = 1;


### PR DESCRIPTION
There a lot of cases when we should stop one of Tempesta FW modules when it failed to start to prevent BUG. For example if `sock_clnt` failed to start `tfw_sock_clnt_stop` is not called. If we start listen several ports (80, 443 and 8000) and listening on port 8000 failed, we continue listen on ports 80 and 443, but destroy and free sockets, which are not stop listen. The same problem for `sock_srv` module. This patch fix this behaviour - we stop module, which failed to start.

Closes #2566