### PR TITLE
Trap `SIGINT` during start/stop Tempesta FW

### DIFF
--- a/scripts/tempesta.sh
+++ b/scripts/tempesta.sh
@@ -19,6 +19,10 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59
 # Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+set +e
+trap '' SIGINT
+trap 'trap - SIGINT' EXIT
+
 if [ -z "$TFW_SYSTEMD" ]; then
 	if [ "${TEMPESTA_LCK}" != "$0" ]; then
 		env TEMPESTA_LCK="$0" flock -n -E 254 "/tmp/tempesta-lock-file" "$0" "$@"


### PR DESCRIPTION
There are a lot of cases when system remaning in
incorrect state, when tempesta.sh script interrupted and stopped by SIGINT. So trap signal at the beginning of script to prevent it's termination by Ctrl + C