### PR TITLE
FIx memory corruption during cofiguration

### DIFF
--- a/fw/client.c
+++ b/fw/client.c
@@ -38,7 +38,7 @@
 
 static struct {
 	const char	*db_path;
-	unsigned int	db_size;
+	unsigned long	db_size;
 	unsigned int	lru_size;
 } client_cfg __read_mostly;
 


### PR DESCRIPTION
`tfw_cfg_set_mem` set unsigned long value by pointer, not unsigned int, so we should use unsigned long size as a target value, otherwise the next value (`lru_size`) will be overwritten.