### PR TITLE
Fix race in `tfw_connection_abort`

### DIFF
--- a/fw/tls.c
+++ b/fw/tls.c
@@ -764,7 +764,7 @@ tfw_tls_conn_send(TfwConn *c, TfwMsg *msg)
 	 */
 	int ss_flags = READ_ONCE(msg->ss_flags);
 
-	/* for the tls reference after ss_send */
+	/* For the tls reference after ss_send */
 	tfw_connection_get(c);
 
 	tls = tfw_tls_context(c);


### PR DESCRIPTION
Previously we use `tfw_connection_get` in `tfw_connection_abort` to prevent (when `tfw_connection_abort` is called
from process context) connection destruction in running in parallel softirq. But there is one more race when we abort hung server connection - if backend sends TCP RST at the time when we call `tfw_connection_abort` (from process context), connection reference counter will be decremented on other cpu and connection will be released. In this case we call `tfw_connection_get` for connection with reference counter which is equal to zero and release connection second time, that can lead to several bugs. So call `__tfw_connection_get_if_not_death` to prevent aborting already released server connection. For client connection we have no such problems, because we call `tfw_connection_unlink_from_peer` when client connection released, this function lock peer `conn_lock`, which already locked during aborting hung connections, so client connection will never destroyed on other cpu.

Closed #2345