### PR TITLE
Update linux kernel patch

### DIFF
--- a/linux-5.10.35.patch
+++ b/linux-5.10.35.patch
@@ -117,7 +117,7 @@ index 38f493604..4c244d605 100644
  extern void kernel_fpu_end(void);
  extern bool irq_fpu_usable(void);
 diff --git a/arch/x86/kernel/fpu/core.c b/arch/x86/kernel/fpu/core.c
-index 571220ac8..a7ce7c357 100644
+index 571220ac8..66e8f76c6 100644
 --- a/arch/x86/kernel/fpu/core.c
 +++ b/arch/x86/kernel/fpu/core.c
 @@ -76,6 +76,10 @@ static bool interrupted_user_mode(void)
@@ -143,7 +143,7 @@ index 571220ac8..a7ce7c357 100644
  	WARN_ON_FPU(!irq_fpu_usable());
  	WARN_ON_FPU(this_cpu_read(in_kernel_fpu));
  
-@@ -148,14 +150,46 @@ void kernel_fpu_begin_mask(unsigned int kfpu_mask)
+@@ -148,14 +150,48 @@ void kernel_fpu_begin_mask(unsigned int kfpu_mask)
  	if (unlikely(kfpu_mask & KFPU_387) && boot_cpu_has(X86_FEATURE_FPU))
  		asm volatile ("fninit");
  }
@@ -160,7 +160,8 @@ index 571220ac8..a7ce7c357 100644
 +	 * preciseely that softirq uses FPU, so we have to disable softirq as
 +	 * well as task preemption.
 +	 */
-+	local_bh_disable();
++	if (!irqs_disabled())
++		local_bh_disable();
 +#endif
 +	preempt_disable();
 +
@@ -186,7 +187,8 @@ index 571220ac8..a7ce7c357 100644
 +
  	preempt_enable();
 +#ifdef CONFIG_SECURITY_TEMPESTA
-+	local_bh_enable();
++	if (!irqs_disabled())
++		local_bh_enable();
 +#endif
  }
  EXPORT_SYMBOL_GPL(kernel_fpu_end);


### PR DESCRIPTION
Do not call `local_bh_(enable/disable)()` when IRQ is disabled When IRQ is disabled Tempesta must not call BH enable/disable to not trigger SoftIRQ work in section where IRQ is disabled. `extract_entropy` protected with spinlock and disabled IRQ prevents `extract_entropy()` from SoftIRQ triggering/scheduling, but Tempesta's patch breaks this logic enabling SoftIRQ in `kernel_fpu_end()`, that fixed it this patch.