### PR TITLE
Fix bug during restoring cache-control header from hpack.

### DIFF
--- a/fw/http_parser.c
+++ b/fw/http_parser.c
@@ -7402,6 +7402,14 @@ do {									\
 	parser->cstate.is_set = 1;					\
 } while(0)
 
+/*
+ * RFC 9111 does not explicitly define the behavior of caches when multiple
+ * identical Cache-Control directives are present within a single request
+ * (e.g., "Cache-Control: max-age=1, max-age=5").
+ * Empirical testing of the Apache HTTP Server indicates that, in such cases,
+ * it prioritizes the last occurrence of the directive (in this example,
+ * max-age=5). We follow the same behavior.
+ */
 #define __SET_CACHE_CTL_FIELD(field, val, flag)				\
 do {									\
 	req->cache_ctl.field = val;					\
@@ -7444,6 +7452,14 @@ __h2_dump_state_cache_ctl(const TfwCachedHeaderState *cstate)
 void
 h2_set_hdr_cache_control(TfwHttpReq *req, const TfwCachedHeaderState *cstate)
 {
+/*
+ * RFC 9111 does not explicitly define the behavior of caches when multiple
+ * identical Cache-Control directives are present within a single request
+ * (e.g., "Cache-Control: max-age=1, max-age=5").
+ * Empirical testing of the Apache HTTP Server indicates that, in such cases,
+ * it prioritizes the last occurrence of the directive (in this example,
+ * max-age=5). We follow the same behavior.
+ */
 #define SET_HDR_CACHE_CONTROL_FIELD(field, flag)			\
 do {									\
 	if (cstate->cache_ctl.flags & flag)				\
@@ -7454,10 +7470,6 @@ do {									\
 		return;
 
 	__h2_dump_state_cache_ctl(cstate);
-	BUG_ON((req->cache_ctl.flags & TFW_HTTP_CC_MAX_AGE) ||
-	       (req->cache_ctl.flags & TFW_HTTP_CC_MAX_STALE) ||
-	       (req->cache_ctl.flags & TFW_HTTP_CC_MIN_FRESH) ||
-	       (req->cache_ctl.flags & TFW_HTTP_CC_STALE_IF_ERROR));
 	SET_HDR_CACHE_CONTROL_FIELD(max_age, TFW_HTTP_CC_MAX_AGE);
 	SET_HDR_CACHE_CONTROL_FIELD(max_stale, TFW_HTTP_CC_MAX_STALE);
 	SET_HDR_CACHE_CONTROL_FIELD(min_fresh, TFW_HTTP_CC_MIN_FRESH);

--- a/fw/http_parser.h
+++ b/fw/http_parser.h
@@ -161,21 +161,21 @@ bool tfw_http_parse_is_done(TfwHttpMsg *hm);
 void tfw_idx_hdr_parse_host_port(TfwHttpReq *req, TfwStr *hdr);
 void h2_set_hdr_accept(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 int h2_set_hdr_if_mod_since(TfwHttpReq *req,
-                            const TfwCachedHeaderState *cstate);
+			    const TfwCachedHeaderState *cstate);
 void h2_set_method(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_authority(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_if_nmatch(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_cache_control(TfwHttpReq *req,
-                              const TfwCachedHeaderState *cstate);
+			      const TfwCachedHeaderState *cstate);
 void h2_set_hdr_authorization(TfwHttpReq *req,
-                              const TfwCachedHeaderState *cstate);
+			      const TfwCachedHeaderState *cstate);
 void h2_set_hdr_content_length(TfwHttpReq *req,
-                               const TfwCachedHeaderState *cstate);
+			       const TfwCachedHeaderState *cstate);
 int h2_set_hdr_content_type(TfwHttpReq *req,
-                            const TfwCachedHeaderState *cstate);
+			    const TfwCachedHeaderState *cstate);
 void h2_set_hdr_forwarded(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_x_method_override(TfwHttpReq *req,
-                                  const TfwCachedHeaderState *cstate);
+				  const TfwCachedHeaderState *cstate);
 void h2_set_hdr_pragma(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_referer(TfwHttpReq *req, const TfwCachedHeaderState *cstate);
 void h2_set_hdr_cookie(TfwHttpReq *req, const TfwCachedHeaderState *cstate);


### PR DESCRIPTION
Previously there was a BUG_ON if we already restore cache-control header from hpack, but it was a mistake, because we check dublicate headers later in `tfw_http_msg_hdr_close` after restoring it. So all requests which contain dublicate cache-control headers, like cache-control: max-age=1
cache-control: max-age=1
trigger this BUG_ON. Fix this problem, now we immediately return T_DROP and drop request, with such dublicate headers.