### PR TITLE
Fix BUG in case of allocation fail.

### DIFF
--- a/tls/mpool.c
+++ b/tls/mpool.c
@@ -399,8 +399,11 @@ ttls_mpool_exit(void)
 
 	for_each_online_cpu(i) {
 		mp = per_cpu(g_tmp_mpool, i);
-		ttls_bzero_safe(MPI_POOL_DATA(mp), mp->curr - sizeof(*mp));
-		free_pages((unsigned long)mp, mp->order);
+		if (mp) {
+			ttls_bzero_safe(MPI_POOL_DATA(mp),
+					mp->curr - sizeof(*mp));
+			free_pages((unsigned long)mp, mp->order);
+		}
 	}
 }
 


### PR DESCRIPTION
We should check that TlsMpiPool was allocated during `ttls_mpool_exit`