### PR TITLE
Fix bug in case of `sock_srv` module failed to start.

### DIFF
--- a/fw/sock_srv.c
+++ b/fw/sock_srv.c
@@ -2222,8 +2222,10 @@ tfw_sock_srv_stop(void)
 	 * Wait until all connections will be shut down gracefully
 	 * and abort all pending connections.
 	 */
-	if (!ss_synchronize())
+	if (!ss_synchronize()) {
+		tfw_sg_for_each_srv_reconfig(tfw_sock_srv_abort_srv);
 		tfw_sg_for_each_srv(NULL, tfw_sock_srv_abort_srv);
+	}
 
 	tfw_sg_release_all();
 }


### PR DESCRIPTION
During `tfw_sock_srv_stop` we call both `tfw_sg_for_each_srv_reconfig` and `tfw_sg_for_each_srv` for disconnection. If disconnect fails we also call `tfw_sg_for_each_srv` to abort connections. We should also call `tfw_sg_for_each_srv_reconfig` to abort.