### PR TITLE
hotfix: fix NULL dereference in `sk_fill_write_queue`

### DIFF
--- a/fw/sock.c
+++ b/fw/sock.c
@@ -578,9 +578,6 @@ ss_do_send(struct sock *sk, struct sk_buff **skb_head, int flags)
 	if (ss_skb_on_send(conn, skb_head))
 		goto cleanup;
 
-	if (flags & SS_F_CONN_CLOSE)
-		return;
-
 	/*
 	 * We set SOCK_TEMPESTA_HAS_DATA when we add some skb in our
 	 * scheduler tree or connection write queue.
@@ -1622,13 +1619,6 @@ EXPORT_SYMBOL(ss_getpeername);
 static void
 __sk_close_locked(struct sock *sk, int flags)
 {
-	int size, mss_now = tcp_send_mss(sk, &size, MSG_DONTWAIT);
-
-	if (sk->sk_fill_write_queue(sk, mss_now)) {
-		ss_linkerror(sk, 0);
-		bh_unlock_sock(sk);
-		return;
-	}
 	ss_do_close(sk, flags);
 	if (!sk_stream_closing(sk)) {
 		ss_conn_drop_guard_exit(sk);


### PR DESCRIPTION
We can't call `sk->sk_fill_write_queue` from `__sk_close_locked` for server connections. We disconnect server connection in `tfw_sock_srv_disconnect` in process context. We increment connection reference counter in `__tfw_connection_get_if_not_death` and decrement it after calling `tfw_connection_close`. Connection can be closed on other cpu from `ss_tx_action->__sk_closed_locked` and can be already released here! So we access connection with zero reference counter and `conn->sk == NULL`.
We don't need to call it at all! We don't need to return `flags & SS_F_CONN_CLOSE` in `ss_do_send`, we can call `tcp_push_pending_frames` and don't do anything in `__sk_close_locked`. (If `__sk_close_locked` is called from SS_CLOSE state we should not call sk->sk_fill_write_queue at all!).