### PR TITLE
Fix NULL dereference when vhost is not found for health monitor requests

### DIFF
--- a/fw/http.c
+++ b/fw/http.c
@@ -7931,6 +7931,8 @@ tfw_http_hm_srv_send(TfwServer *srv, char *data, unsigned long len)
 
 	if (likely(req->vhost))
 		req->location = req->vhost->loc_dflt;
+	else
+		goto cleanup;
 
 	srv_conn = srv->sg->sched->sched_srv_conn((TfwMsg *)req, srv);
 	if (!srv_conn) {

--- a/fw/http_tbl.h
+++ b/fw/http_tbl.h
@@ -41,8 +41,8 @@ typedef struct {
 typedef struct {
 	unsigned char type;
 	union {
-	TfwVhost *vhost;
-	TfwHttpRedir redir;
+		TfwVhost *vhost;
+		TfwHttpRedir redir;
 	};
 } TfwHttpActionResult;
 

--- a/fw/server.c
+++ b/fw/server.c
@@ -98,12 +98,8 @@ void
 tfw_server_destroy(TfwServer *srv)
 {
 	WARN_ON(atomic_read(&srv->ctrl.recns_in_progress));
-	if (srv->cleanup)
-		srv->cleanup(srv);
-	/* Close all connections before freeing the server! */
 	BUG_ON(!list_empty(&srv->ctrl.recns_list));
 	BUG_ON(!list_empty(&srv->ctrl.failed_recns_list));
-	BUG_ON(!list_empty(&srv->conn_list));
 	BUG_ON(timer_pending(&srv->gs_timer));
 	/*
 	 * If timer is pending here, timer callback can be
@@ -112,7 +108,17 @@ tfw_server_destroy(TfwServer *srv)
 	 */
 	BUG_ON(timer_pending(&srv->rc_timer));
 
+	/*
+	 * Must be called before srv->cleanup(). Otherwise, a race is possible:
+	 * srv->cleanup() removes all server connections, then the APM timer
+	 * fires and attempts to send a health-monitor request through one of
+	 * the already removed connections, resulting in a use-after-free.
+	 */
 	tfw_apm_del_srv(srv);
+	if (srv->cleanup)
+		srv->cleanup(srv);
+	/* Close all connections before freeing the server! */
+	BUG_ON(!list_empty(&srv->conn_list));
 	if (srv->sg)
 		tfw_sg_put(srv->sg);
 	kmem_cache_free(srv_cache, srv);


### PR DESCRIPTION
The `http_tbl` module is initialized after the `sock_srv` module. When the number of `srv_group` entries is large and each group contains a `health` directive, Tempesta FW may start sending health monitor requests before the `active_table` is initialized.

In this case, req->vhost is not set (NULL), which later leads to a NULL dereference in the frang module.

This patch prevents scheduling health monitor requests when vhost is NULL, avoiding the crash instead of sending such requests.