### PR TITLE
build(clickhouse-cpp): pin version to v2.6.2

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -55,7 +55,7 @@ clickhouse: $(CLICKHOUSE_DIR)
 	cd $(CLICKHOUSE_DIR)/build && cmake .. && $(MAKE)
 
 $(CLICKHOUSE_DIR):
-	git clone $(CLICKHOUSE_REPO_URL) $(CLICKHOUSE_DIR)
+	git clone --branch v2.6.2 --depth 1 $(CLICKHOUSE_REPO_URL) $(CLICKHOUSE_DIR)
 
 clickhouse_install:
 	$(MAKE) -C $(CLICKHOUSE_BUILD_DIR) install


### PR DESCRIPTION
- Updated `utils/Makefile` to clone clickhouse-cpp using `--branch v2.6.2` and `--depth 1`.
- This ensures reproducible builds and shields the project from untracked breaking changes in the upstream master branch.