### PR TITLE
Fix premature socket destruction caused by nested SS_IN_USE_PROTECT

### DIFF
--- a/fw/connection.c
+++ b/fw/connection.c
@@ -245,19 +245,6 @@ tfw_connection_unlink_to_sk(TfwConn *conn)
 	ss_sock_put(sk);
 }
 
-static inline int
-tfw_connection_shutdown(TfwConn *conn)
-{
-	struct sock *sk = conn->sk;
-
-	SS_IN_USE_PROTECT({
-		tcp_shutdown(sk, SEND_SHUTDOWN);
-	});
-	if (unlikely(sk->sk_state == TCP_CLOSE))
-		return -ENOMEM;
-	return 0;
-}
-
 int
 tfw_connection_fill_sk_write_queue(TfwConn *conn, unsigned int mss_now)
 {
@@ -296,9 +283,9 @@ tfw_connection_fill_sk_write_queue(TfwConn *conn, unsigned int mss_now)
 		if (unlikely(!conn->write_queue)) {
 			sock_reset_flag(sk, SOCK_TEMPESTA_HAS_DATA);
 			if (unlikely(SS_CONN_TYPE(sk) & Conn_Shutdown))
-				r = tfw_connection_shutdown(conn);
+				tcp_shutdown(sk, SEND_SHUTDOWN);
 		}
-		return r;
+		return 0;
 	}
 
 	r = tfw_h2_make_frames(sk, h2, mss_now, snd_wnd);
@@ -314,10 +301,10 @@ tfw_connection_fill_sk_write_queue(TfwConn *conn, unsigned int mss_now)
 		    && (!h2->error
 			|| tfw_h2_conn_or_stream_wnd_is_exceeded(h2,
 								 h2->error)))
-			r = tfw_connection_shutdown(conn);
+			tcp_shutdown(sk, SEND_SHUTDOWN);
 		if (!tfw_h2_is_ready_to_send(h2))
 			sock_reset_flag(sk, SOCK_TEMPESTA_HAS_DATA);
 	}
 
-	return r;
+	return 0;
 }

--- a/fw/sock.c
+++ b/fw/sock.c
@@ -578,9 +578,6 @@ ss_do_send(struct sock *sk, struct sk_buff **skb_head, int flags)
 	if (ss_skb_on_send(conn, skb_head))
 		goto cleanup;
 
-	if (flags & SS_F_CONN_CLOSE)
-		return;
-
 	/*
 	 * We set SOCK_TEMPESTA_HAS_DATA when we add some skb in our
 	 * scheduler tree or connection write queue.
@@ -1296,6 +1293,8 @@ ss_tcp_state_change(struct sock *sk)
 		 */
 		if (!skb_queue_empty(&sk->sk_receive_queue))
 			ss_tcp_process_data(sk);
+
+		SS_STATE_PROCESS_RETURN(sk);
 		T_DBG2("[%d]: Peer connection closing\n", smp_processor_id());
 		/*
 		 * Closing a socket should go through the queue and should be
@@ -1622,13 +1621,6 @@ EXPORT_SYMBOL(ss_getpeername);
 static void
 __sk_close_locked(struct sock *sk, int flags)
 {
-	int size, mss_now = tcp_send_mss(sk, &size, MSG_DONTWAIT);
-
-	if (sk->sk_fill_write_queue(sk, mss_now)) {
-		ss_linkerror(sk, 0);
-		bh_unlock_sock(sk);
-		return;
-	}
 	ss_do_close(sk, flags);
 	if (!sk_stream_closing(sk)) {
 		ss_conn_drop_guard_exit(sk);
@@ -1649,16 +1641,18 @@ __sk_close_locked(struct sock *sk, int flags)
 static inline void
 ss_do_shutdown(struct sock *sk)
 {
-	int size, mss_now = tcp_send_mss(sk, &size, MSG_DONTWAIT);
 	/*
-	 * `tcp_shutdown` will ne called from `sk->sk_fill_write_queue`
+	 * `tcp_shutdown` will be called from `sk->sk_fill_write_queue`
 	 * after sending all pending data.
 	 */
 	SS_CONN_TYPE(sk) |= Conn_Shutdown;
-	if (sk->sk_fill_write_queue(sk, mss_now))
-		ss_linkerror(sk, 0);
-	else
-		SS_CALL(connection_on_shutdown, sk->sk_user_data);
+	if (!sock_flag(sk, SOCK_TEMPESTA_HAS_DATA)) {
+		SS_IN_USE_PROTECT({
+			tcp_shutdown(sk, SEND_SHUTDOWN);
+		});
+		SS_STATE_PROCESS_RETURN(sk);
+	}
+	SS_CALL(connection_on_shutdown, sk->sk_user_data);
 }
 
 static inline bool

--- a/fw/sync_socket.h
+++ b/fw/sync_socket.h
@@ -204,9 +204,13 @@ int ss_skb_tcp_entail_list(struct sock *sk, struct sk_buff **skb_head,
  */
 #define SS_IN_USE_PROTECT(lambda)					\
 do {									\
+	bool already_in_use =						\
+		WARN_ON(sock_flag(sk, SOCK_TEMPESTA_IN_USE));		\
+									\
 	sock_set_flag(sk, SOCK_TEMPESTA_IN_USE);			\
 	lambda;								\
-	sock_reset_flag(sk, SOCK_TEMPESTA_IN_USE);			\
+	if (likely(!already_in_use))					\
+		sock_reset_flag(sk, SOCK_TEMPESTA_IN_USE);		\
 } while (0)
 
 


### PR DESCRIPTION
Bug #2264 occurred when `ss_tcp_process_data` was called from `ss_tcp_state_change` while the socket was already in the `TCP_CLOSE` state. During the execution of `ss_tcp_process_data`, the `connection_recv_finish` callback invoked `tfw_h2_conn_recv_finish`, which eventually called `tcp_push_pending_frames`. Before calling `tcp_push_pending_frames`, Tempesta FW always sets the `SOCK_TEMPESTA_IN_USE` flag to prevent `tcp_done` execution from Tempesta FW code. However, `tfw_h2_conn_recv_finish` could call `tfw_connection_shutdown`, which internally set and then cleared the same flag. Since the socket was already in the `TCP_CLOSE` state, `tfw_connection_shutdown` immediately returned an error, but the `SOCK_TEMPESTA_IN_USE` flag had already been cleared. As a result, when `tcp_push_pending_frames` later handled an error, `tcp_done` is invoked causing the socket prematurely destruction.

It was possible to allow nested `SS_IN_USE_PROTECT` sections and keep the flag set until the outermost invocation completed. However, this approach hides incorrect usage and may mask programming errors. Instead, the following changes were made:

- `ss_do_send` now flushes pending data even when the `SS_F_CONN_CLOSE` flag is set. There is no practical difference between sending the data immediately and postponing it until socket closing/shutdown.
- `tfw_connection_shutdown` has been removed. Tempesta FW no longer calls `sk_fill_write_queue` directly. Instead, all packet transmission goes through `tcp_push_pending_frames`, which is always wrapped with `SS_IN_USE_PROTECT`. Socket state is always handled after the call by `SS_STATE_PROCESS_RETURN` macros at the appropriate places.
- `SS_IN_USE_PROTECT` now contains a `WARN_ON` check to verify that the `SOCK_TEMPESTA_IN_USE` flag is not already set when entering the protected section. This helps detect incorrect nested usage during development.
- `SS_STATE_PROCESS_RETURN` is now also executed after `ss_tcp_process_data` in the `TCP_CLOSE_WAIT` state, since processing received data may change the socket state.

Closes #2664