### PR TITLE
Prevent double free of per-CPU queue heads on init failure

### DIFF
--- a/fw/cache.c
+++ b/fw/cache.c
@@ -3717,8 +3717,12 @@ tfw_cache_wq_clear(int cpu)
 {
 	TfwWorkTasklet *ct = &per_cpu(cache_wq, cpu);
 
-	tasklet_kill(&ct->tasklet);
+
+	if (!ct->wq.heads && !ct->wq.array)
+		return;
+
 	irq_work_sync(&ct->ipi_work);
+	tasklet_kill(&ct->tasklet);
 	tfw_wq_destroy(&ct->wq);
 }
 

--- a/fw/work_queue.c
+++ b/fw/work_queue.c
@@ -52,6 +52,7 @@ tfw_wq_init(TfwRBQueue *q, size_t qsize, int node)
 	q->array = tfw_kvmalloc_node(qsize * WQ_ITEM_SZ, GFP_KERNEL, node);
 	if (!q->array) {
 		free_percpu(q->heads);
+		q->heads = NULL;
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
A fault-injection failure during work queue initialization exposed memory corruption in unrelated process RSS counters.

`tfw_wq_init` first allocates the per-CPU `q->heads` object and then allocates the queue array. If the array allocation failed, `q->heads` was freed, but the pointer was left unchanged.

The module-level error path subsequently called the regular queue cleanup routine for all CPUs. For the CPU where initialization had failed, `tfw_wq_destroy` received the stale non-NULL `q->heads` pointer and called `free_percpu` on it for the second time.

This double free corrupted the per-CPU allocator state. The already freed address could be reassigned to an unrelated allocation, while the second `free_percpu` marked that new owner's memory as free again. In the observed failure, the same per-CPU area was shared between a live process's RSS counters and a Tempesta FW work queue (which was already freed!).

Fix the failure path by clearing `q->heads` immediately after freeing it. Also skip cache work queue cleanup when neither the per-CPU heads nor the queue array was initialized. This avoids calling `tasklet_kill`, `irq_work_sync`, and `tfw_wq_destroy` for an uninitialized queue. (This doesn't lead to BUG, on current kernel, but it is not ok to call `tasklet_kill` for not initialized tasklet).

Additionally, synchronize pending IRQ work before killing the tasklet so that an IRQ work callback cannot schedule the tasklet again after it has already been stopped.