### PR TITLE
distribute IRQs by queue index instead of IRQ number

### DIFF
--- a/scripts/tfw_lib.sh
+++ b/scripts/tfw_lib.sh
@@ -94,7 +94,7 @@ irqbalance_ban_irqs()
 # This function prepares cpu mask for RSS and RPS.
 # It takes into account that we can't calculate
 # value, which is greater when (1 << 63) and can't
-# wtite in the rps_cpus/smp_affinity value, which
+# write in the rps_cpus/smp_affinity value, which
 # is greater then (1 << 32) -1 (we need to write it
 # using comma).
 make_cpu_mask()
@@ -149,7 +149,7 @@ make_cpu_rps_mask()
 	# enable all CPUs, which is less than (1 << delta) - 1
 	mask32="ffffffff"
 	# used to calculate (1 << delta) - $val to
-	# implement only one common functionfor RPS and RSS
+	# implement only one common function for RPS and RSS
 	val=1
 	cond=1
 
@@ -189,15 +189,18 @@ distribute_queues()
 	# for device (not assigned to any of the queues).
 	irqs=(${irqs[@]:1})
 	irq0=${irqs[0]}
-	for i in ${irqs[@]}; do
-		# Wrap around CPU mask if number of queues is
-		# larger than CPUS_N.
-		if [[ $(calc "$i - $irq0") -gt $CPUS_N ]]; then
-			irq0=$i;
+	cpu=0
+
+	for irq in "${irqs[@]}"; do
+        	mask=$(make_cpu_rss_mask "$cpu")
+		if ! echo "$mask" > "/proc/irq/$irq/smp_affinity"; then
+			log "Error: cannot bind IRQ $irq to CPU $cpu, mask=$mask"
 		fi
-		delta=$(( i - irq0 ))
-		mask=`make_cpu_rss_mask $delta`
-		echo "$mask" > "/proc/irq/$i/smp_affinity"
+
+        	cpu=$((cpu + 1))
+        	if [[ $cpu -ge $CPUS_N ]]; then
+        	        cpu=0
+        	fi
 	done
 
 	IRQS_GLOB_LIST=(${irqs[@]})


### PR DESCRIPTION
The previous IRQ affinity setup derived the target CPU from the difference between the current IRQ number and the first IRQ number:

```
cpu = irq - first_irq
```

This assumed that queue IRQ numbers were contiguous. However, IRQ numbers are allocated globally and may contain large gaps even for queues belonging to the same network device.

For example, a device may have IRQs such as:

```
382, 445, 446, 447, ...
```

With the old logic, the second queue was assigned to CPU 63 instead of CPU 1. Subsequent queues could be assigned to CPUs outside the valid CPU range, producing invalid affinity masks and causing writes to `smp_affinity` to fail with:

```
write error: Value too large for defined data type
```

The existing wraparound check did not solve the problem because it was still based on the numeric distance between IRQ values. It also used `-gt` instead of `-ge`, allowing a mask to be generated for CPU `CPUS_N`, while valid CPU indices are in the range:

```
0 .. CPUS_N - 1
```

Replace the IRQ-number-based calculation with an independent CPU counter. IRQs are now assigned sequentially to CPUs and the counter is wrapped after reaching `CPUS_N`:

```
IRQ[0] -> CPU0
IRQ[1] -> CPU1
...
IRQ[N] -> CPU(N % CPUS_N)
```

This makes IRQ distribution independent of how IRQ numbers are allocated and guarantees that generated affinity masks always refer to a valid CPU.

Also check failures when writing `smp_affinity` and report the IRQ, target CPU, and generated mask to simplify diagnostics.

Finally, fix minor comment formatting and spelling issues.